### PR TITLE
k8s: simplify Apply to read from stdin instead of file

### DIFF
--- a/internal/k8s/apply.go
+++ b/internal/k8s/apply.go
@@ -1,26 +1,16 @@
 package k8s
 
 import (
+	"bytes"
 	"context"
-	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
 )
 
 func Apply(ctx context.Context, rawYAML string) error {
 	// TODO(dmiller) validate that the string is YAML and give a good error
-	dir, err := ioutil.TempDir("", "tilt")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(dir)
+	c := exec.CommandContext(ctx, "kubectl", "apply", "-f", "-")
+	r := bytes.NewReader([]byte(rawYAML))
+	c.Stdin = r
 
-	tmpf := filepath.Join(dir, "tilt.yaml")
-	contents := []byte(rawYAML)
-	if err := ioutil.WriteFile(tmpf, contents, 0666); err != nil {
-		return err
-	}
-	c := exec.CommandContext(ctx, "kubectl", "apply", "-f", tmpf)
 	return c.Run()
 }


### PR DESCRIPTION
Good idea @maiamcc!

Tested with this script again:

```go
package main

import (
	"context"
	"fmt"
	"os"

	"github.com/windmilleng/tilt/internal/k8s"
)

func main() {
	yaml := `apiVersion: v1
kind: Service
metadata:
  name: hello-kubernetes
spec:
  type: LoadBalancer
  ports:
  - port: 80
    targetPort: 8080
  selector:
    app: hello-kubernetes
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: hello-kubernetes
spec:
  replicas: 3
  template:
    metadata:
      labels:
        app: hello-kubernetes
    spec:
      containers:
      - name: hello-kubernetes
        image: paulbouwer/hello-kubernetes:1.4
        ports:
        - containerPort: 8080`

	err := k8s.Apply(context.Background(), yaml)
	if err != nil {
		fmt.Println(err.Error())
		os.Exit(1)
	} else {
		fmt.Println("It worked!")
	}
}
```