### PR TITLE
build: first pass at builder interface

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -1,0 +1,19 @@
+package build
+
+import (
+	"context"
+	"os/exec"
+)
+
+type Builder interface {
+	Build(ctx context.Context, pathToFS string, cmds []Cmd) ([]Output, string, error)
+}
+
+type Output struct {
+	CombinedOutput []byte
+	Error          exec.ExitError
+}
+
+type Cmd struct {
+	Argv []string
+}


### PR DESCRIPTION
A builder takes a path on the FS, runs a cmd in them, and returns a new
path on the file system with those commands run, the output of those cmds,
and an error.

There could be different builder implementations: one for building locally,
one for remotely, one that just makes new directories, one that makes new
layers in overlayFS, etc.