### PR TITLE
landism/yaml generation

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -5,6 +5,8 @@ import (
 	"github.com/google/skylark"
 	"github.com/windmilleng/tilt/internal/proto"
 	"io/ioutil"
+	"os/exec"
+	"github.com/pkg/errors"
 )
 
 type Tiltfile struct {
@@ -33,6 +35,25 @@ func makeSkylarkK8Service(thread *skylark.Thread, fn *skylark.Builtin, args skyl
 	return k8sService{yaml, *dockerImage}, nil
 }
 
+func runLocalCmd(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var command string
+	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "command", &command)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := exec.Command("bash", "-c", command).Output()
+	if err != nil {
+		errorMessage := fmt.Sprintf("command '%v' failed.\nerror: '%v'\nstdout: '%v'", command, err, string(out))
+		exitError, ok := err.(*exec.ExitError)
+		if ok {
+			errorMessage += fmt.Sprintf("\nstderr: '%v'", string(exitError.Stderr))
+		}
+		return nil, errors.New(errorMessage)
+	}
+	return skylark.String(out), nil
+}
+
 func Load(filename string) (*Tiltfile, error) {
 	thread := &skylark.Thread{
 		Print: func(_ *skylark.Thread, msg string) { fmt.Println(msg) },
@@ -41,6 +62,7 @@ func Load(filename string) (*Tiltfile, error) {
 	predeclared := skylark.StringDict{
 		"build_docker_image": skylark.NewBuiltin("build_docker_image", makeSkylarkDockerImage),
 		"k8s_service":        skylark.NewBuiltin("k8s_service", makeSkylarkK8Service),
+		"local":        skylark.NewBuiltin("local", runLocalCmd),
 	}
 
 	globals, err := skylark.ExecFile(thread, filename, nil, predeclared)

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -3,10 +3,10 @@ package tiltfile
 import (
 	"fmt"
 	"github.com/google/skylark"
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/proto"
 	"io/ioutil"
 	"os/exec"
-	"github.com/pkg/errors"
 )
 
 type Tiltfile struct {
@@ -62,7 +62,7 @@ func Load(filename string) (*Tiltfile, error) {
 	predeclared := skylark.StringDict{
 		"build_docker_image": skylark.NewBuiltin("build_docker_image", makeSkylarkDockerImage),
 		"k8s_service":        skylark.NewBuiltin("k8s_service", makeSkylarkK8Service),
-		"local":        skylark.NewBuiltin("local", runLocalCmd),
+		"local":              skylark.NewBuiltin("local", runLocalCmd),
 	}
 
 	globals, err := skylark.ExecFile(thread, filename, nil, predeclared)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -161,7 +161,7 @@ func TestGetServiceConfigLocalReturnsNon0(t *testing.T) {
 	// "foo bar" and "baz quu" are separated above so that the match below only matches the strings in the output,
 	// not in the command
 	for _, s := range []string{"blorgly2", "exit status 1", "foo bar", "baz quu"} {
-		assert.True(t, strings.Contains(err.Error(), s), "error message '%V' did not contain '%V'", err.Error(), s)
+		assert.True(t, strings.Contains(err.Error(), s), "error message '%v' did not contain '%v'", err.Error(), s)
 	}
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -148,5 +148,44 @@ func TestGetServiceConfigReturnsWrongType(t *testing.T) {
 	for _, s := range []string{"blorgly2", "string", "k8s_service"} {
 		assert.True(t, strings.Contains(err.Error(), s), "error message '%V' did not contain '%V'", err.Error(), s)
 	}
+}
 
+func TestGetServiceConfigLocalReturnsNon0(t *testing.T) {
+	file := tempFile(
+		`def blorgly2():
+			local('echo "foo" "bar" && echo "baz" "quu" >&2 && exit 1')`) // index out of range
+	defer os.Remove(file)
+	tiltConfig, err := Load(file)
+	assert.Nil(t, err)
+	_, err = tiltConfig.GetServiceConfig("blorgly2")
+	// "foo bar" and "baz quu" are separated above so that the match below only matches the strings in the output,
+	// not in the command
+	for _, s := range []string{"blorgly2", "exit status 1", "foo bar", "baz quu"} {
+		assert.True(t, strings.Contains(err.Error(), s), "error message '%V' did not contain '%V'", err.Error(), s)
+	}
+}
+
+func TestGetServiceConfigWithLocalCmd(t *testing.T) {
+	dockerfile := tempFile("docker text")
+	file := tempFile(
+		fmt.Sprintf(`def blorgly():
+  image = build_docker_image("%v", "docker tag")
+  print(image.file_name)
+  image.add_cmd("go install github.com/windmilleng/blorgly-frontend/server/...")
+  image.add_cmd("echo hi")
+  yaml = local('echo yaaaaaaaaml')
+  return k8s_service(yaml, image)
+`, dockerfile))
+	defer os.Remove(file)
+	defer os.Remove(dockerfile)
+	tiltconfig, err := Load(file)
+	assert.Nil(t, err)
+	serviceConfig, err := tiltconfig.GetServiceConfig("blorgly")
+	assert.Nil(t, err)
+	assert.Equal(t, "docker text", serviceConfig.DockerfileText)
+	assert.Equal(t, "docker tag", serviceConfig.DockerfileTag)
+	assert.Equal(t, "yaaaaaaaaml\n", serviceConfig.K8SYaml)
+	assert.Equal(t, 2, len(serviceConfig.Steps))
+	assert.Equal(t, []string{"bash", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, serviceConfig.Steps[0].Argv)
+	assert.Equal(t, []string{"bash", "-c", "echo hi"}, serviceConfig.Steps[1].Argv)
 }


### PR DESCRIPTION
can now generate yaml from local commands, e.g.:
```
def blorg_backend():
  image = build_docker_image('Dockerfile', 'gcr.io/blorg-dev/blorg-backend:dev-landism')
  yaml = local('./populate_config_template.py argiuherg && cat k8s-conf.generated.yaml')
  return k8s_service(yaml, image)
```