### PR TITLE
tilt: add tiltfile support for mount points

### DIFF
--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -39,9 +39,15 @@ func (k8sService) Hash() (uint32, error) {
 	return 0, errors.New("unhashable type: k8sService")
 }
 
+type mount struct {
+	mount_point string
+	repo gitRepo
+}
+
 type dockerImage struct {
 	fileName skylark.String
 	fileTag  skylark.String
+	mounts	 []mount
 	cmds     []string
 }
 
@@ -63,6 +69,24 @@ func addDockerImageCmd(thread *skylark.Thread, fn *skylark.Builtin, args skylark
 		return nil, errors.New("internal error: skylarkCmd was not a string")
 	}
 	image.cmds = append(image.cmds, cmd)
+	return skylark.None, nil
+}
+
+func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var mountPoint string
+	var gitRepo gitRepo
+	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "mount_point", &mountPoint, "git_repo", &gitRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	image, ok := fn.Receiver().(*dockerImage)
+	if !ok {
+		return nil, errors.New("internal error: add_docker_image_cmd called on non-dockerImage")
+	}
+
+	image.mounts = append(image.mounts, mount{mountPoint, gitRepo})
+
 	return skylark.None, nil
 }
 
@@ -92,7 +116,9 @@ func (d *dockerImage) Attr(name string) (skylark.Value, error) {
 	case "file_tag":
 		return d.fileTag, nil
 	case "add_cmd":
-		return skylark.NewBuiltin("add_cmd", addDockerImageCmd).BindReceiver(d), nil
+		return skylark.NewBuiltin(name, addDockerImageCmd).BindReceiver(d), nil
+	case "add_mount":
+		return skylark.NewBuiltin(name, addMount).BindReceiver(d), nil
 	default:
 		return nil, nil
 	}
@@ -100,4 +126,29 @@ func (d *dockerImage) Attr(name string) (skylark.Value, error) {
 
 func (*dockerImage) AttrNames() []string {
 	return []string{"file_name", "file_tag", "add_cmd"}
+}
+
+type gitRepo struct {
+	path string
+}
+
+var _ skylark.Value = gitRepo{}
+
+func (gr gitRepo) String() string {
+	return fmt.Sprintf("[gitRepo] '%v'", gr.path)
+}
+
+func (gr gitRepo) Type() string {
+	return "gitRepo"
+}
+
+func (gr gitRepo) Freeze() {
+}
+
+func (gitRepo) Truth() skylark.Bool {
+	return true
+}
+
+func (gitRepo) Hash() (uint32, error) {
+	return 0, errors.New("unhashable type: gitRepo")
 }

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -40,7 +40,7 @@ func (k8sService) Hash() (uint32, error) {
 }
 
 type mount struct {
-	mount_point string
+	mountPoint string
 	repo gitRepo
 }
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -135,7 +135,7 @@ func (tiltfile Tiltfile) GetServiceConfig(serviceName string) (*proto.Service, e
 
 	mounts := make([]*proto.Mount, 0, len(service.dockerImage.mounts))
 	for _, mount := range service.dockerImage.mounts {
-		repo := proto.Repo{&proto.Repo_GitRepo{&proto.GitRepo{mount.repo.path}}}
+		repo := proto.Repo{RepoType: &proto.Repo_GitRepo{GitRepo: &proto.GitRepo{LocalPath: mount.repo.path}}}
 		mounts = append(mounts, &proto.Mount{Repo: &repo, ContainerPath: mount.mount_point})
 	}
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -19,7 +19,7 @@ func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args sk
 	if err != nil {
 		return nil, err
 	}
-	return &dockerImage{dockerfileName, dockerfileTag, []string{}}, nil
+	return &dockerImage{dockerfileName, dockerfileTag, []mount{}, []string{}}, nil
 }
 
 func makeSkylarkK8Service(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
@@ -33,6 +33,16 @@ func makeSkylarkK8Service(thread *skylark.Thread, fn *skylark.Builtin, args skyl
 	return k8sService{yaml, *dockerImage}, nil
 }
 
+func makeSkylarkGitRepo(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var path string
+	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "path", &path)
+	if err != nil {
+		return nil, err
+	}
+
+	return gitRepo{path}, nil
+}
+
 func Load(filename string) (*Tiltfile, error) {
 	thread := &skylark.Thread{
 		Print: func(_ *skylark.Thread, msg string) { fmt.Println(msg) },
@@ -41,6 +51,7 @@ func Load(filename string) (*Tiltfile, error) {
 	predeclared := skylark.StringDict{
 		"build_docker_image": skylark.NewBuiltin("build_docker_image", makeSkylarkDockerImage),
 		"k8s_service":        skylark.NewBuiltin("k8s_service", makeSkylarkK8Service),
+		"git_repo":			  skylark.NewBuiltin("git_repo", makeSkylarkGitRepo),
 	}
 
 	globals, err := skylark.ExecFile(thread, filename, nil, predeclared)
@@ -100,10 +111,16 @@ func (tiltfile Tiltfile) GetServiceConfig(serviceName string) (*proto.Service, e
 		return nil, fmt.Errorf("internal error: k8sService.dockerFileTag was not a string in '%v'", service)
 	}
 
+	mounts := make([]*proto.Mount, 0, len(service.dockerImage.mounts))
+	for _, mount := range service.dockerImage.mounts {
+		repo := proto.Repo{&proto.Repo_GitRepo{&proto.GitRepo{mount.repo.path}}}
+		mounts = append(mounts, &proto.Mount{Repo: &repo, ContainerPath: mount.mount_point})
+	}
+
 	dockerCmds := make([]*proto.Cmd, 0, len(service.dockerImage.cmds))
 	for _, cmd := range service.dockerImage.cmds {
 		dockerCmds = append(dockerCmds, &proto.Cmd{Argv: []string{"bash", "-c", cmd}})
 	}
 
-	return &proto.Service{K8SYaml: k8sYaml, DockerfileText: dockerFileText, Mounts: []*proto.Mount{}, Steps: dockerCmds, DockerfileTag: dockerFileTag}, nil
+	return &proto.Service{K8SYaml: k8sYaml, DockerfileText: dockerFileText, Mounts: mounts, Steps: dockerCmds, DockerfileTag: dockerFileTag}, nil
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -136,7 +136,7 @@ func (tiltfile Tiltfile) GetServiceConfig(serviceName string) (*proto.Service, e
 	mounts := make([]*proto.Mount, 0, len(service.dockerImage.mounts))
 	for _, mount := range service.dockerImage.mounts {
 		repo := proto.Repo{RepoType: &proto.Repo_GitRepo{GitRepo: &proto.GitRepo{LocalPath: mount.repo.path}}}
-		mounts = append(mounts, &proto.Mount{Repo: &repo, ContainerPath: mount.mount_point})
+		mounts = append(mounts, &proto.Mount{Repo: &repo, ContainerPath: mount.mountPoint})
 	}
 
 	dockerCmds := make([]*proto.Cmd, 0, len(service.dockerImage.cmds))

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -28,6 +28,7 @@ func TestGetServiceConfig(t *testing.T) {
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
   image = build_docker_image("%v", "docker tag")
+  image.add_mount('/mount_points/1', git_repo('.'))
   print(image.file_name)
   image.add_cmd("go install github.com/windmilleng/blorgly-frontend/server/...")
   image.add_cmd("echo hi")
@@ -42,6 +43,9 @@ func TestGetServiceConfig(t *testing.T) {
 	assert.Equal(t, "docker text", serviceConfig.DockerfileText)
 	assert.Equal(t, "docker tag", serviceConfig.DockerfileTag)
 	assert.Equal(t, "yaaaaaaaaml", serviceConfig.K8SYaml)
+	assert.Equal(t, 1, len(serviceConfig.Mounts))
+	assert.Equal(t, "/mount_points/1", serviceConfig.Mounts[0].ContainerPath)
+	assert.Equal(t, ".", serviceConfig.Mounts[0].Repo.GetGitRepo().LocalPath)
 	assert.Equal(t, 2, len(serviceConfig.Steps))
 	assert.Equal(t, []string{"bash", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, serviceConfig.Steps[0].Argv)
 	assert.Equal(t, []string{"bash", "-c", "echo hi"}, serviceConfig.Steps[1].Argv)


### PR DESCRIPTION
had been putting this off because I didn't understand this part of the spec

usage, e.g.:
```
  image = build_docker_image("%v", "docker tag")
  image.add_mount('/mount_points/1', git_repo('/mount_points/1/foo'))
```