### PR TITLE
docker: set the version explicitly instead of negotiating from the env

### DIFF
--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -37,6 +37,10 @@ type localDockerBuilder struct {
 	dcli *client.Client
 }
 
+func NewLocalDockerBuilder(cli *client.Client) *localDockerBuilder {
+	return &localDockerBuilder{cli}
+}
+
 // NOTE(dmiller): not fully implemented yet
 func (l *localDockerBuilder) BuildDocker(ctx context.Context, baseDockerfile string, mounts []Mount, cmds []Cmd, tag string) (string, error) {
 	baseTag, err := l.buildBase(ctx, baseDockerfile, tag)
@@ -104,3 +108,5 @@ func getDigestFromOutput(output string) (string, error) {
 	}
 	return res[1], nil
 }
+
+var _ DockerBuilder = &localDockerBuilder{}

--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -96,7 +96,14 @@ func newTestFixture(t *testing.T) *testFixture {
 	if err != nil {
 		t.Fatalf("Error making temp dir: %v", err)
 	}
-	dcli, err := client.NewEnvClient()
+
+	opts := make([]func(*client.Client) error, 0)
+	opts = append(opts, client.FromEnv)
+
+	// Use client for docker 17
+	// https://docs.docker.com/develop/sdk/#api-version-matrix
+	opts = append(opts, client.WithVersion("1.26"))
+	dcli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,9 +135,7 @@ func (f *testFixture) writeFile(pathInRepo string, contents string) {
 }
 
 func (f *testFixture) newBuilderForTesting() *localDockerBuilder {
-	return &localDockerBuilder{
-		dcli: f.dcli,
-	}
+	return NewLocalDockerBuilder(f.dcli)
 }
 
 func (f *testFixture) assertFileInImage(tag string, path string) {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/version:

883e0265edcb6868ecf8763c3a1cbd62b9af7022 (2018-08-10 14:14:43 -0400)
docker: set the version explicitly instead of negotiating from the env