### PR TITLE
tilt: pull daemon into main tilt binary

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -14,6 +14,7 @@ func Execute() {
 	}
 
 	addCommand(rootCmd, &upCmd{})
+	addCommand(rootCmd, &daemonCmd{})
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1,17 +1,29 @@
-package main
+package cli
 
 import (
 	"fmt"
-	"log"
-	"net"
-
+	"github.com/spf13/cobra"
 	"github.com/windmilleng/tilt/internal/proto"
 	"github.com/windmilleng/tilt/internal/tiltd"
 	"github.com/windmilleng/tilt/internal/tiltd/tiltd_server"
 	"google.golang.org/grpc"
+	"log"
+	"net"
 )
 
-func main() {
+type daemonCmd struct{}
+
+func (c *daemonCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "daemon",
+		Short:  "start the daemon",
+		Hidden: true,
+	}
+
+	return cmd
+}
+
+func (c *daemonCmd) run(args []string) error {
 	addr := fmt.Sprintf("127.0.0.1:%d", tiltd.Port)
 	log.Printf("Running tiltd listening on %s", addr)
 	l, err := net.Listen("tcp", addr)
@@ -32,4 +44,5 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
+	return nil
 }

--- a/internal/tiltd/tiltd_server/tiltd.go
+++ b/internal/tiltd/tiltd_server/tiltd.go
@@ -22,7 +22,6 @@ func (d *Daemon) CreateService(ctx context.Context, k8sYaml string) error {
 }
 
 func RunDaemon(ctx context.Context) (*os.Process, error) {
-	// Relies on having the latest tiltd go install'd.
 	cmd := exec.CommandContext(ctx, os.Args[0], "daemon")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/tiltd/tiltd_server/tiltd.go
+++ b/internal/tiltd/tiltd_server/tiltd.go
@@ -23,7 +23,7 @@ func (d *Daemon) CreateService(ctx context.Context, k8sYaml string) error {
 
 func RunDaemon(ctx context.Context) (*os.Process, error) {
 	// Relies on having the latest tiltd go install'd.
-	cmd := exec.CommandContext(ctx, "tiltd")
+	cmd := exec.CommandContext(ctx, os.Args[0], "daemon")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Start()


### PR DESCRIPTION
now instead of running `tiltd`, one runs `tilt daemon` (and `go install cmd/tilt` instead of `go install cmd/tilt && go install cmd/tiltd`)

this is mostly to reduce the chance that we're running inconsistent versions of `tilt` and `tiltd`