### PR TITLE
docker: negotiate api version up to 1.30

### DIFF
--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -102,7 +102,9 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	// Use client for docker 17
 	// https://docs.docker.com/develop/sdk/#api-version-matrix
-	opts = append(opts, client.WithVersion("1.26"))
+	// API version 1.30 is the first version where the full digest
+	// shows up in the API output of BuildImage
+	opts = append(opts, client.WithVersion("1.30"))
 	dcli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/tests:

63783402e3bb7839cacdc91b39b64b85a5b8b310 (2018-08-10 14:54:21 -0400)
docker: negotiate api version up to 1.30