### PR TITLE
build: throw error if base Dockerfile contains an ENTRYPOINT

### DIFF
--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -29,6 +29,9 @@ import (
 // Tilt always pushes to the same tag. We never push to latest.
 const pushTag = "wm-tilt"
 
+var ErrEntrypointInDockerfile = errors.New("base Dockerfile contains an ENTRYPOINT, " +
+	"which is not currently supported -- provide an entrypoint in your Tiltfile")
+
 type localDockerBuilder struct {
 	dcli *client.Client
 }
@@ -175,8 +178,7 @@ func (l *localDockerBuilder) buildBaseWithMounts(ctx context.Context, baseDocker
 // TODO: extract the ENTRYPOINT line from the Dockerfile and reapply it later.
 func checkDockerfileForEntrypoint(df string) error {
 	if strings.Contains(df, "ENTRYPOINT") {
-		return fmt.Errorf("base Dockerfile contains an ENTRYPOINT, which is not " +
-			"currently suported -- provide an entrypoint in your Tiltfile")
+		return ErrEntrypointInDockerfile
 	}
 	return nil
 }

--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -171,8 +171,8 @@ func (l *localDockerBuilder) buildBaseWithMounts(ctx context.Context, baseDocker
 
 // NOTE(maia): currently just returns an error if Dockerfile contains an ENTRYPOINT,
 // which is illegal in Tilt right now (an ENTRYPOINT overrides a ContainerCreate Cmd,
-// which we rely on). In future, we may want to extract the ENTRYPOINT line from the
-// Dockerfile and reapply it later?
+// which we rely on).
+// TODO: extract the ENTRYPOINT line from the Dockerfile and reapply it later.
 func checkDockerfileForEntrypoint(df string) error {
 	if strings.Contains(df, "ENTRYPOINT") {
 		return fmt.Errorf("base Dockerfile contains an ENTRYPOINT, which is not " +

--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -248,6 +248,10 @@ ENTRYPOINT ["sleep", "100000"]`
 	if err == nil {
 		t.Fatal("expected an err b/c dockerfile contains an ENTRYPOINT")
 	}
+	if !strings.Contains(err.Error(), ErrEntrypointInDockerfile.Error()) {
+		t.Fatalf("error '%v' did not contain expected string '%v'",
+			err.Error(), ErrEntrypointInDockerfile.Error())
+	}
 }
 
 // TODO(maia): test mount err cases

--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -224,6 +224,7 @@ func TestBuildMultipleSteps(t *testing.T) {
 func TestEntrypoint(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.teardown()
+
 	entrypoint := tiltd.Cmd{Argv: []string{"sh", "-c", "echo hello >> hi"}}
 	d, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{}, []tiltd.Cmd{}, entrypoint)
 	if err != nil {
@@ -234,6 +235,19 @@ func TestEntrypoint(t *testing.T) {
 		pathContent{path: "hi", contents: "hello"},
 	}
 	f.assertFilesInImageWithContents(string(d), contents)
+}
+
+func TestDockerfileWithEntrypointNotPermitted(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.teardown()
+
+	df := `FROM alpine
+ENTRYPOINT ["sleep", "100000"]`
+
+	_, err := f.b.BuildDocker(context.Background(), df, []tiltd.Mount{}, []tiltd.Cmd{}, tiltd.Cmd{})
+	if err == nil {
+		t.Fatal("expected an err b/c dockerfile contains an ENTRYPOINT")
+	}
 }
 
 // TODO(maia): test mount err cases

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -18,6 +18,8 @@ type Tiltfile struct {
 }
 
 func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	// TODO(maia): `entrypoint` should be an optional arg; user should be able to declare
+	// it in base Dockerfile and Tilt should be able to parse it out and apply it.
 	var dockerfileName, entrypoint, dockerfileTag string
 	err := skylark.UnpackArgs(fn.Name(), args, kwargs,
 		"docker_file_name", &dockerfileName,


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/enforce-entrypoint:

4f1930fde10b254191d5c2cd83d5ecb405a02c63 (2018-08-14 17:03:49 -0400)
build: throw error if base Dockerfile contains an ENTRYPOINT