### PR TITLE
tiltd: use the typed api instead of the string api

### DIFF
--- a/internal/tiltd/tiltd_server/tiltd.go
+++ b/internal/tiltd/tiltd_server/tiltd.go
@@ -78,7 +78,7 @@ func (d *Daemon) CreateService(ctx context.Context, k8sYaml string, dockerfile s
 	didReplace := false
 	newK8sEntities := []k8s.K8sEntity{}
 	for _, e := range entities {
-		newK8s, replaced, err := k8s.InjectImageDigestWithStrings(e, dockerfileTag, string(pushedDigest))
+		newK8s, replaced, err := k8s.InjectImageDigest(e, name, pushedDigest)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/digests:

3cb7386a387508bbebba38f7b3a2c1af40af0ce2 (2018-08-15 13:11:31 -0400)
tiltd: use the typed api instead of the string api