### PR TITLE
tilt: move code out of tiltd, add --watch that just loops

### DIFF
--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/windmilleng/tilt/internal/model"
 	"io"
 	"io/ioutil"
 	"log"
@@ -21,8 +22,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	digest "github.com/opencontainers/go-digest"
-	"github.com/windmilleng/tilt/internal/tiltd"
+	"github.com/opencontainers/go-digest"
 	"github.com/windmilleng/wmclient/pkg/os/temp"
 )
 
@@ -80,12 +80,12 @@ func TestMount(t *testing.T) {
 	f.writeFile("hi/hello", "hi hello")
 	f.writeFile("sup", "my name is dan")
 
-	m := tiltd.Mount{
-		Repo:          tiltd.LocalGithubRepo{LocalPath: f.repo.Path()},
+	m := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: f.repo.Path()},
 		ContainerPath: "/src",
 	}
 
-	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{m}, []tiltd.Cmd{}, tiltd.Cmd{})
+	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,16 +105,16 @@ func TestMultipleMounts(t *testing.T) {
 	f.writeFile("hi/hello", "hi hello")
 	f.writeFile("bye/ciao/goodbye", "bye laterz")
 
-	m1 := tiltd.Mount{
-		Repo:          tiltd.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "hi")},
+	m1 := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "hi")},
 		ContainerPath: "/hello_there",
 	}
-	m2 := tiltd.Mount{
-		Repo:          tiltd.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "bye")},
+	m2 := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "bye")},
 		ContainerPath: "goodbye_there",
 	}
 
-	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{m1, m2}, []tiltd.Cmd{}, tiltd.Cmd{})
+	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{m1, m2}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,16 +136,16 @@ func TestMountCollisions(t *testing.T) {
 
 	// Mounting two files to the same place in the container -- expect the second mount
 	// to take precedence (file should contain "bye laterz")
-	m1 := tiltd.Mount{
-		Repo:          tiltd.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "hi")},
+	m1 := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "hi")},
 		ContainerPath: "/hello_there",
 	}
-	m2 := tiltd.Mount{
-		Repo:          tiltd.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "bye")},
+	m2 := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: filepath.Join(f.repo.Path(), "bye")},
 		ContainerPath: "/hello_there",
 	}
 
-	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{m1, m2}, []tiltd.Cmd{}, tiltd.Cmd{})
+	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{m1, m2}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,12 +166,12 @@ func TestPush(t *testing.T) {
 	f.writeFile("hi/hello", "hi hello")
 	f.writeFile("sup", "my name is dan")
 
-	m := tiltd.Mount{
-		Repo:          tiltd.LocalGithubRepo{LocalPath: f.repo.Path()},
+	m := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: f.repo.Path()},
 		ContainerPath: "/src",
 	}
 
-	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{m}, []tiltd.Cmd{}, tiltd.Cmd{})
+	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,12 +194,12 @@ func TestPushInvalid(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.teardown()
 
-	m := tiltd.Mount{
-		Repo:          tiltd.LocalGithubRepo{LocalPath: f.repo.Path()},
+	m := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: f.repo.Path()},
 		ContainerPath: "/src",
 	}
 
-	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{m}, []tiltd.Cmd{}, tiltd.Cmd{})
+	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,11 +215,11 @@ func TestBuildOneStep(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.teardown()
 
-	steps := []tiltd.Cmd{
-		tiltd.Cmd{Argv: []string{"sh", "-c", "echo hello >> hi"}},
+	steps := []model.Cmd{
+		model.Cmd{Argv: []string{"sh", "-c", "echo hello >> hi"}},
 	}
 
-	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{}, steps, tiltd.Cmd{})
+	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,12 +234,12 @@ func TestBuildMultipleSteps(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.teardown()
 
-	steps := []tiltd.Cmd{
-		tiltd.Cmd{Argv: []string{"sh", "-c", "echo hello >> hi"}},
-		tiltd.Cmd{Argv: []string{"sh", "-c", "echo sup >> hi2"}},
+	steps := []model.Cmd{
+		model.Cmd{Argv: []string{"sh", "-c", "echo hello >> hi"}},
+		model.Cmd{Argv: []string{"sh", "-c", "echo sup >> hi2"}},
 	}
 
-	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{}, steps, tiltd.Cmd{})
+	digest, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,11 +255,11 @@ func TestBuildFailingStep(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.teardown()
 
-	steps := []tiltd.Cmd{
-		tiltd.Cmd{Argv: []string{"sh", "-c", "echo hello && exit 1"}},
+	steps := []model.Cmd{
+		model.Cmd{Argv: []string{"sh", "-c", "echo hello && exit 1"}},
 	}
 
-	_, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{}, steps, tiltd.Cmd{})
+	_, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "hello")
 		assert.Contains(t, err.Error(), "exit code 1")
@@ -270,8 +270,8 @@ func TestEntrypoint(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.teardown()
 
-	entrypoint := tiltd.Cmd{Argv: []string{"sh", "-c", "echo hello >> hi"}}
-	d, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []tiltd.Mount{}, []tiltd.Cmd{}, entrypoint)
+	entrypoint := model.Cmd{Argv: []string{"sh", "-c", "echo hello >> hi"}}
+	d, err := f.b.BuildDocker(context.Background(), simpleDockerfile, []model.Mount{}, []model.Cmd{}, entrypoint)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +289,7 @@ func TestDockerfileWithEntrypointNotPermitted(t *testing.T) {
 	df := `FROM alpine
 ENTRYPOINT ["sleep", "100000"]`
 
-	_, err := f.b.BuildDocker(context.Background(), df, []tiltd.Mount{}, []tiltd.Cmd{}, tiltd.Cmd{})
+	_, err := f.b.BuildDocker(context.Background(), df, []model.Mount{}, []model.Cmd{}, model.Cmd{})
 	if err == nil {
 		t.Fatal("expected an err b/c dockerfile contains an ENTRYPOINT")
 	}
@@ -400,7 +400,7 @@ type pathContent struct {
 	contents string
 }
 
-func (f *testFixture) startContainerWithOutput(ctx context.Context, ref string, cmd *tiltd.Cmd) string {
+func (f *testFixture) startContainerWithOutput(ctx context.Context, ref string, cmd *model.Cmd) string {
 	cId, err := f.b.startContainer(ctx, ref, cmd)
 	if err != nil {
 		f.t.Fatal(err)
@@ -426,7 +426,7 @@ func (f *testFixture) startContainerWithOutput(ctx context.Context, ref string, 
 
 func (f *testFixture) assertFilesInImageWithContents(ref string, contents []pathContent) {
 	ctx := context.Background()
-	cId, err := f.b.startContainer(ctx, ref, &tiltd.Cmd{Argv: []string{"sh"}})
+	cId, err := f.b.startContainer(ctx, ref, &model.Cmd{Argv: []string{"sh"}})
 	if err != nil {
 		f.t.Fatal(err)
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5,7 +5,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/windmilleng/tilt/internal/proto"
 	"github.com/windmilleng/tilt/internal/tiltd"
-	"github.com/windmilleng/tilt/internal/tiltd/tiltd_server"
 	"google.golang.org/grpc"
 	"log"
 	"net"
@@ -31,14 +30,9 @@ func (c *daemonCmd) run(args []string) error {
 		log.Fatalf("failed to listen: %v", err)
 	}
 
-	d, err := tiltd_server.NewDaemon()
-	if err != nil {
-		log.Fatalf("failed to make tiltd: %v", err)
-	}
-
 	s := grpc.NewServer()
 
-	proto.RegisterDaemonServer(s, proto.NewGRPCServer(d))
+	proto.RegisterDaemonServer(s, proto.NewGRPCServer())
 
 	err = s.Serve(l)
 	if err != nil {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -24,7 +24,7 @@ func (c *upCmd) register() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().BoolVar(&c.watch, "watch", false, "any started services will be automatically redeployed when files in their repos change")
+	cmd.Flags().BoolVar(&c.watch, "watch", false, "any started services will be automatically rebuilt and redeployed when files in their repos change")
 
 	return cmd
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"log"
-
 	"github.com/spf13/cobra"
 	"github.com/windmilleng/tilt/internal/proto"
 	"github.com/windmilleng/tilt/internal/tiltd/tiltd_client"
@@ -12,9 +10,12 @@ import (
 	"github.com/windmilleng/tilt/internal/tiltfile"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"log"
 )
 
-type upCmd struct{}
+type upCmd struct {
+	watch bool
+}
 
 func (c *upCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
@@ -22,6 +23,8 @@ func (c *upCmd) register() *cobra.Command {
 		Short: "stand up a service",
 		Args:  cobra.ExactArgs(1),
 	}
+
+	cmd.Flags().BoolVar(&c.watch, "watch", false, "any started services will be automatically redeployed when files in their repos change")
 
 	return cmd
 }
@@ -58,7 +61,7 @@ func (c *upCmd) run(args []string) error {
 		return err
 	}
 
-	err = dCli.CreateService(ctx, proto.CreateServiceRequest{Service: service})
+	err = dCli.CreateService(ctx, proto.CreateServiceRequest{Service: service, Watch: c.watch})
 	s, ok := status.FromError(err)
 	if ok && s.Code() == codes.Unknown {
 		return errors.New(s.Message())

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -1,0 +1,107 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/client"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/image"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/wmclient/pkg/dirs"
+	"os"
+)
+
+type BuildToken interface{}
+
+type BuildAndDeployer interface {
+	BuildAndDeploy(ctx context.Context, service model.Service, token BuildToken) (BuildToken, error)
+}
+
+var _ BuildAndDeployer = localBuildAndDeployer{}
+
+type localBuildAndDeployer struct {
+	b       build.Builder
+	history image.ImageHistory
+}
+
+func NewLocalBuildAndDeployer() (BuildAndDeployer, error) {
+	opts := make([]func(*client.Client) error, 0)
+	opts = append(opts, client.FromEnv)
+
+	// Use client for docker 17
+	// https://docs.docker.com/develop/sdk/#api-version-matrix
+	// API version 1.30 is the first version where the full digest
+	// shows up in the API output of BuildImage
+	opts = append(opts, client.WithVersion("1.30"))
+	dcli, err := client.NewClientWithOpts(opts...)
+	if err != nil {
+		return nil, err
+	}
+	b := build.NewLocalDockerBuilder(dcli)
+	dir, err := dirs.UseWindmillDir()
+	if err != nil {
+		return nil, err
+	}
+	history, err := image.NewImageHistory(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return localBuildAndDeployer{
+		b:       b,
+		history: history,
+	}, nil
+}
+
+func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model.Service, token BuildToken) (BuildToken, error) {
+	checkpoint := l.history.CheckpointNow()
+	name, err := reference.ParseNormalizedNamed(service.DockerfileTag)
+	if err != nil {
+		return nil, err
+	}
+
+	digest, err := l.b.BuildDocker(ctx, service.DockerfileText, service.Mounts, service.Steps, service.Entrypoint)
+
+	if err != nil {
+		return nil, err
+	}
+
+	l.history.Add(name, digest, checkpoint)
+
+	pushedDigest, err := l.b.PushDocker(ctx, name, digest)
+	if err != nil {
+		return nil, err
+	}
+
+	entities, err := k8s.ParseYAMLFromString(service.K8sYaml)
+	if err != nil {
+		return nil, err
+	}
+
+	didReplace := false
+	newK8sEntities := []k8s.K8sEntity{}
+	for _, e := range entities {
+		newK8s, replaced, err := k8s.InjectImageDigest(e, name, pushedDigest)
+		if err != nil {
+			return nil, err
+		}
+		if replaced {
+			didReplace = true
+		}
+		newK8sEntities = append(newK8sEntities, newK8s)
+	}
+
+	if !didReplace {
+		return nil, fmt.Errorf("Docker image missing from yaml: %s", service.DockerfileTag)
+	}
+
+	newYAMLString, err := k8s.SerializeYAML(newK8sEntities)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(matt) wire up logging to the grpc stream and drop the stdout/stderr args here
+	return nil, k8s.Apply(ctx, newYAMLString, os.Stdout, os.Stderr)
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -1,0 +1,16 @@
+package engine
+
+import (
+	"context"
+	"github.com/windmilleng/tilt/internal/model"
+	"io"
+)
+
+func UpService(ctx context.Context, service model.Service, stdout io.Writer, stderr io.Writer) error {
+	bad, err := NewLocalBuildAndDeployer()
+	if err != nil {
+		return err
+	}
+	_, err = bad.BuildAndDeploy(ctx, service, nil)
+	return err
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -6,11 +6,20 @@ import (
 	"io"
 )
 
-func UpService(ctx context.Context, service model.Service, stdout io.Writer, stderr io.Writer) error {
+func UpService(ctx context.Context, service model.Service, watch bool, stdout io.Writer, stderr io.Writer) error {
 	bad, err := NewLocalBuildAndDeployer()
 	if err != nil {
 		return err
 	}
-	_, err = bad.BuildAndDeploy(ctx, service, nil)
+	buildToken, err := bad.BuildAndDeploy(ctx, service, nil)
+	if watch {
+		for {
+			// TODO(matt) actually wait for a file to change instead of building on a loop
+			buildToken, err = bad.BuildAndDeploy(ctx, service, buildToken)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return err
 }

--- a/internal/model/service.go
+++ b/internal/model/service.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Service struct {
+	K8sYaml        string
+	DockerfileText string
+	Mounts         []Mount
+	Steps          []Cmd
+	Entrypoint     Cmd
+	DockerfileTag  string
+	Name           string
+}
+
+type Mount struct {
+	// TODO(dmiller) make this more generic
+	Repo          LocalGithubRepo
+	ContainerPath string
+}
+
+type Repo interface {
+	IsRepo()
+}
+
+type LocalGithubRepo struct {
+	LocalPath string
+}
+
+func (LocalGithubRepo) IsRepo() {}
+
+type Cmd struct {
+	Argv []string
+}
+
+func (c Cmd) EntrypointStr() string {
+	return fmt.Sprintf("ENTRYPOINT [\"%s\"]", strings.Join(c.Argv, "\", \""))
+}

--- a/internal/proto/server_adaptor.go
+++ b/internal/proto/server_adaptor.go
@@ -4,16 +4,14 @@ import (
 	"github.com/windmilleng/tilt/internal/debug"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/tiltd"
-	context "golang.org/x/net/context"
+	"golang.org/x/net/context"
 )
 
 type GRPCServer struct {
-	del tiltd.TiltD
 }
 
-func NewGRPCServer(del tiltd.TiltD) *GRPCServer {
-	return &GRPCServer{del: del}
+func NewGRPCServer() *GRPCServer {
+	return &GRPCServer{}
 }
 
 var _ DaemonServer = &GRPCServer{}

--- a/internal/proto/server_adaptor.go
+++ b/internal/proto/server_adaptor.go
@@ -25,7 +25,7 @@ func (s *GRPCServer) CreateService(req *CreateServiceRequest, d Daemon_CreateSer
 
 	outputStream := MakeStdoutStderrWriter(sendOutput)
 
-	err := engine.UpService(d.Context(), serviceP2D(req.Service), outputStream.stdout, outputStream.stderr)
+	err := engine.UpService(d.Context(), serviceP2D(req.Service), req.Watch, outputStream.stdout, outputStream.stderr)
 
 	return err
 }

--- a/internal/proto/server_adaptor.go
+++ b/internal/proto/server_adaptor.go
@@ -1,6 +1,9 @@
 package proto
 
 import (
+	"github.com/windmilleng/tilt/internal/debug"
+	"github.com/windmilleng/tilt/internal/engine"
+	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/tiltd"
 	context "golang.org/x/net/context"
 )
@@ -22,22 +25,18 @@ func (s *GRPCServer) CreateService(req *CreateServiceRequest, d Daemon_CreateSer
 
 	outputStream := MakeStdoutStderrWriter(sendOutput)
 
-	service := req.Service
-
-	err := s.del.CreateService(d.Context(), service.K8SYaml, service.DockerfileText,
-		mountsP2D(service.Mounts), cmdsP2D(service.Steps), cmdP2D(service.Entrypoint),
-		service.DockerfileTag, outputStream.stdout, outputStream.stderr)
+	err := engine.UpService(d.Context(), serviceP2D(req.Service), outputStream.stdout, outputStream.stderr)
 
 	return err
 }
 
-func (s *GRPCServer) SetDebug(ctx context.Context, debug *Debug) (*DebugReply, error) {
-	s.del.SetDebug(ctx, debug.Mode)
+func (s *GRPCServer) SetDebug(ctx context.Context, d *Debug) (*DebugReply, error) {
+	debug.SetDebugMode(d.Mode)
 	return &DebugReply{}, nil
 }
 
-func mountsP2D(mounts []*Mount) []tiltd.Mount {
-	r := []tiltd.Mount{}
+func mountsP2D(mounts []*Mount) []model.Mount {
+	r := []model.Mount{}
 
 	for _, m := range mounts {
 		r = append(r, mountP2D(m))
@@ -46,8 +45,8 @@ func mountsP2D(mounts []*Mount) []tiltd.Mount {
 	return r
 }
 
-func mountP2D(mount *Mount) tiltd.Mount {
-	return tiltd.Mount{
+func mountP2D(mount *Mount) model.Mount {
+	return model.Mount{
 		Repo:          repoP2D(mount.Repo),
 		ContainerPath: mount.ContainerPath,
 	}
@@ -55,15 +54,15 @@ func mountP2D(mount *Mount) tiltd.Mount {
 
 // TODO(dmiller): right now this only supports github repos
 // if we add other types we'll have to change this
-func repoP2D(repo *Repo) tiltd.LocalGithubRepo {
+func repoP2D(repo *Repo) model.LocalGithubRepo {
 	githubRepo := repo.GetGitRepo()
-	return tiltd.LocalGithubRepo{
+	return model.LocalGithubRepo{
 		LocalPath: githubRepo.LocalPath,
 	}
 }
 
-func cmdsP2D(cmds []*Cmd) []tiltd.Cmd {
-	r := []tiltd.Cmd{}
+func cmdsP2D(cmds []*Cmd) []model.Cmd {
+	r := []model.Cmd{}
 
 	for _, c := range cmds {
 		r = append(r, cmdP2D(c))
@@ -72,8 +71,20 @@ func cmdsP2D(cmds []*Cmd) []tiltd.Cmd {
 	return r
 }
 
-func cmdP2D(cmd *Cmd) tiltd.Cmd {
-	return tiltd.Cmd{
+func cmdP2D(cmd *Cmd) model.Cmd {
+	return model.Cmd{
 		Argv: cmd.Argv,
+	}
+}
+
+func serviceP2D(service *Service) model.Service {
+	return model.Service{
+		K8sYaml:        service.K8SYaml,
+		DockerfileText: service.DockerfileText,
+		Mounts:         mountsP2D(service.Mounts),
+		Steps:          cmdsP2D(service.Steps),
+		Entrypoint:     cmdP2D(service.Entrypoint),
+		DockerfileTag:  service.DockerfileTag,
+		Name:           service.Name,
 	}
 }

--- a/internal/tiltd/tiltd.go
+++ b/internal/tiltd/tiltd.go
@@ -1,44 +1,9 @@
 package tiltd
 
-import (
-	"context"
-	"fmt"
-	"io"
-	"strings"
-)
-
 const Port = 10000
 
-type TiltD interface {
-	CreateService(ctx context.Context, k8sYaml string, dockerFileText string, mounts []Mount,
-		steps []Cmd, entryfile Cmd, dockerfileTag string, stdout io.Writer, stderr io.Writer) error
-	SetDebug(ctx context.Context, mode bool)
-}
+type TiltD interface{}
 
 type Debug struct {
 	Mode bool
-}
-
-type Mount struct {
-	// TODO(dmiller) make this more generic
-	Repo          LocalGithubRepo
-	ContainerPath string
-}
-
-type Repo interface {
-	IsRepo()
-}
-
-type LocalGithubRepo struct {
-	LocalPath string
-}
-
-func (LocalGithubRepo) IsRepo() {}
-
-type Cmd struct {
-	Argv []string
-}
-
-func (c Cmd) EntrypointStr() string {
-	return fmt.Sprintf("ENTRYPOINT [\"%s\"]", strings.Join(c.Argv, "\", \""))
 }

--- a/internal/tiltd/tiltd_server/tiltd.go
+++ b/internal/tiltd/tiltd_server/tiltd.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"os/exec"
 
-				"github.com/windmilleng/tilt/internal/tiltd"
-	)
+	"github.com/windmilleng/tilt/internal/tiltd"
+)
 
 type Daemon struct {
 }

--- a/internal/tiltd/tiltd_server/tiltd.go
+++ b/internal/tiltd/tiltd_server/tiltd.go
@@ -4,18 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
-
-	"github.com/windmilleng/tilt/internal/tiltd"
 )
-
-type Daemon struct {
-}
-
-var _ tiltd.TiltD = &Daemon{}
-
-func NewDaemon() (*Daemon, error) {
-	return &Daemon{}, nil
-}
 
 func RunDaemon(ctx context.Context) (*os.Process, error) {
 	cmd := exec.CommandContext(ctx, os.Args[0], "daemon")

--- a/internal/tiltd/tiltd_server/tiltd.go
+++ b/internal/tiltd/tiltd_server/tiltd.go
@@ -2,111 +2,19 @@ package tiltd_server
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"os"
 	"os/exec"
 
-	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/client"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/debug"
-	"github.com/windmilleng/tilt/internal/image"
-	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/tiltd"
-	"github.com/windmilleng/wmclient/pkg/dirs"
-)
+				"github.com/windmilleng/tilt/internal/tiltd"
+	)
 
 type Daemon struct {
-	b       build.Builder
-	history image.ImageHistory
 }
 
 var _ tiltd.TiltD = &Daemon{}
 
 func NewDaemon() (*Daemon, error) {
-	opts := make([]func(*client.Client) error, 0)
-	opts = append(opts, client.FromEnv)
-
-	// Use client for docker 17
-	// https://docs.docker.com/develop/sdk/#api-version-matrix
-	// API version 1.30 is the first version where the full digest
-	// shows up in the API output of BuildImage
-	opts = append(opts, client.WithVersion("1.30"))
-	dcli, err := client.NewClientWithOpts(opts...)
-	if err != nil {
-		return nil, err
-	}
-	b := build.NewLocalDockerBuilder(dcli)
-	dir, err := dirs.UseWindmillDir()
-	if err != nil {
-		return nil, err
-	}
-	history, err := image.NewImageHistory(dir)
-	if err != nil {
-		return nil, err
-	}
-	return &Daemon{
-		b:       b,
-		history: history,
-	}, nil
-}
-
-func (d *Daemon) SetDebug(ctx context.Context, mode bool) {
-	debug.SetDebugMode(mode)
-}
-
-func (d *Daemon) CreateService(ctx context.Context, k8sYaml string, dockerfile string,
-	mounts []tiltd.Mount, steps []tiltd.Cmd, entrypoint tiltd.Cmd,
-	dockerfileTag string, stdout, stderr io.Writer) error {
-	checkpoint := d.history.CheckpointNow()
-	name, err := reference.ParseNormalizedNamed(dockerfileTag)
-	if err != nil {
-		return err
-	}
-
-	digest, err := d.b.BuildDocker(ctx, dockerfile, mounts, steps, entrypoint)
-
-	if err != nil {
-		return err
-	}
-
-	d.history.Add(name, digest, checkpoint)
-
-	pushedDigest, err := d.b.PushDocker(ctx, name, digest)
-	if err != nil {
-		return err
-	}
-
-	entities, err := k8s.ParseYAMLFromString(k8sYaml)
-	if err != nil {
-		return err
-	}
-
-	didReplace := false
-	newK8sEntities := []k8s.K8sEntity{}
-	for _, e := range entities {
-		newK8s, replaced, err := k8s.InjectImageDigest(e, name, pushedDigest)
-		if err != nil {
-			return err
-		}
-		if replaced {
-			didReplace = true
-		}
-		newK8sEntities = append(newK8sEntities, newK8s)
-	}
-
-	if !didReplace {
-		return fmt.Errorf("Docker image missing from yaml: %s", dockerfileTag)
-	}
-
-	newYAMLString, err := k8s.SerializeYAML(newK8sEntities)
-	if err != nil {
-		return err
-	}
-
-	return k8s.Apply(ctx, newYAMLString, stdout, stderr)
-
+	return &Daemon{}, nil
 }
 
 func RunDaemon(ctx context.Context) (*os.Process, error) {


### PR DESCRIPTION
Problems:
1. discussion with the Dans yesterday about the interface between the daemon and the builder for `--watch` got us to something approximating the new `BuildAndDeployer` interface
2. as I was implementing --watch, more logic and dependencies were going into tiltd.go, which already had too much code, and it felt weird that all the other packages had to reference `tiltd` to get `Mount`, `Cmd`, etc.

Solutions:
1. Move the various classes used to pass around service definitions into a new `model` package
2. Move the logic for combining all the work together into a new `engine` package
3. Create a new `BuildAndDeployer` interface at an attempt to draw a clean line in the code and reduce the chances of toe-stepping.

If I'd realized how big this diff would end up being, I'd have done them in separate PRs (so obviously I'm making up for the big PR by giving you even more to read in the PR's description). Almost all of the diff is just code-shifting, with the important things to review being upper.go and build_and_deployer.go (plus the package change).

I also lumped a dummy looping `--watch` implementation in the second commit, to motivate this PR.