### PR TITLE
k8s: tighten the api to use ref.Canonical, which includes both name and digest

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -101,7 +101,7 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	if err != nil {
 		return nil, err
 	}
-	pushedDigest, err := l.b.PushDocker(ctx, name, d)
+	pushedRef, err := l.b.PushDocker(ctx, name, d)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	didReplace := false
 	newK8sEntities := []k8s.K8sEntity{}
 	for _, e := range entities {
-		newK8s, replaced, err := k8s.InjectImageDigest(e, name, pushedDigest)
+		newK8s, replaced, err := k8s.InjectImageDigest(e, pushedRef)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/k8s:

394109d79d6f7338e6e8317afa23641af26a8758 (2018-08-20 12:35:45 -0400)
k8s: tighten the api to use ref.Canonical, which includes both name and digest