### PR TITLE
proto: rewire dependencies to avoid lots of logic in the server adaptor

### DIFF
--- a/internal/engine/creator.go
+++ b/internal/engine/creator.go
@@ -1,0 +1,34 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/service"
+)
+
+type upperServiceCreator struct {
+	manager service.Manager
+	env     k8s.Env
+}
+
+func NewUpperServiceCreator(manager service.Manager, env k8s.Env) upperServiceCreator {
+	return upperServiceCreator{manager: manager, env: env}
+}
+
+func (c upperServiceCreator) CreateServices(ctx context.Context, svcs []model.Service, watch bool) error {
+	upper, err := NewUpper(ctx, c.manager, c.env)
+	if err != nil {
+		return err
+	}
+
+	err = upper.Up(ctx, svcs, watch)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+var _ model.ServiceCreator = upperServiceCreator{}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -29,6 +29,8 @@ const watchBufferMaxTimeInMs = 10000
 var watchBufferMinRestDuration = watchBufferMinRestInMs * time.Millisecond
 var watchBufferMaxDuration = watchBufferMaxTimeInMs * time.Millisecond
 
+// TODO(nick): maybe this should be called 'BuildEngine' or something?
+// Upper seems like a poor and undescriptive name.
 type Upper struct {
 	b            BuildAndDeployer
 	watcherMaker func() (watch.Notify, error)

--- a/internal/model/service.go
+++ b/internal/model/service.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -15,6 +16,10 @@ type Service struct {
 	Entrypoint     Cmd
 	DockerfileTag  string
 	Name           ServiceName
+}
+
+type ServiceCreator interface {
+	CreateServices(ctx context.Context, svcs []Service, watch bool) error
 }
 
 type Mount struct {

--- a/internal/proto/server_adaptor.go
+++ b/internal/proto/server_adaptor.go
@@ -1,21 +1,16 @@
 package proto
 
 import (
-	"github.com/windmilleng/tilt/internal/engine"
-	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/service"
 )
 
 type grpcServer struct {
-	sm  service.Manager
-	env k8s.Env
+	delegate model.ServiceCreator
 }
 
-func NewGRPCServer(env k8s.Env) *grpcServer {
-	sm := service.NewMemoryManager()
-	return &grpcServer{sm: sm, env: env}
+func NewGRPCServer(delegate model.ServiceCreator) *grpcServer {
+	return &grpcServer{delegate: delegate}
 }
 
 var _ DaemonServer = &grpcServer{}
@@ -34,23 +29,7 @@ func (s *grpcServer) CreateService(req *CreateServiceRequest, d Daemon_CreateSer
 		svcArray = append(svcArray, serviceP2D(req.Services[i]))
 	}
 
-	upper, err := engine.NewUpper(ctx, s.sm, s.env)
-	if err != nil {
-		return err
-	}
-
-	err = upper.Up(ctx, svcArray, req.Watch)
-	if err != nil {
-		return err
-	}
-
-	for j := range req.Services {
-		err := s.sm.Add(svcArray[j])
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return s.delegate.CreateServices(ctx, svcArray, req.Watch)
 }
 
 func mountsP2D(mounts []*Mount) []model.Mount {

--- a/internal/service/creator.go
+++ b/internal/service/creator.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+
+	"github.com/windmilleng/tilt/internal/model"
+)
+
+// A creator that adds all new services to the manager.
+type trackingCreator struct {
+	delegate model.ServiceCreator
+	manager  Manager
+}
+
+func TrackServices(delegate model.ServiceCreator, manager Manager) trackingCreator {
+	return trackingCreator{delegate: delegate, manager: manager}
+}
+
+func (c trackingCreator) CreateServices(ctx context.Context, svcs []model.Service, watch bool) error {
+	err := c.delegate.CreateServices(ctx, svcs, watch)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range svcs {
+		err := c.manager.Add(s)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var _ model.ServiceCreator = trackingCreator{}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/deps:

c7c19612d76038ea2cc642158ba58b6ad7fa103e (2018-08-21 15:21:36 -0400)
proto: rewire dependencies to avoid lots of logic in the server adaptor