### PR TITLE
image: history shouldn't grow exponentially

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -107,7 +107,7 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	}
 
 	logger.Get(ctx).Verbosef("- (Adding checkpoint to history)")
-	err := l.history.Add(ctx, name, d, checkpoint)
+	err := l.history.AddAndPersist(ctx, name, d, checkpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/image/history.go
+++ b/internal/image/history.go
@@ -63,10 +63,7 @@ func NewImageHistory(ctx context.Context, dir *dirs.WindmillDir) (ImageHistory, 
 		}
 
 		for _, entry := range entries {
-			err = history.Add(ctx, name, entry.Digest, entry.CheckpointID)
-			if err != nil {
-				return ImageHistory{}, err
-			}
+			history.Load(ctx, name, entry.Digest, entry.CheckpointID)
 		}
 	}
 
@@ -81,7 +78,7 @@ func (h ImageHistory) CheckpointNow() CheckpointID {
 	return CheckpointID(time.Now())
 }
 
-func (h ImageHistory) Add(ctx context.Context, name reference.Named, digest digest.Digest, checkpoint CheckpointID) error {
+func (h ImageHistory) Load(ctx context.Context, name reference.Named, digest digest.Digest, checkpoint CheckpointID) (refKey, historyEntry) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -100,6 +97,13 @@ func (h ImageHistory) Add(ctx context.Context, name reference.Named, digest dige
 	if entry.After(bucket.mostRecent.CheckpointID) {
 		bucket.mostRecent = entry
 	}
+
+	return key, entry
+}
+
+func (h ImageHistory) AddAndPersist(ctx context.Context, name reference.Named, digest digest.Digest, checkpoint CheckpointID) error {
+	key, entry := h.Load(ctx, name, digest, checkpoint)
+
 	return addHistoryToFS(ctx, h.dir, key, entry)
 }
 

--- a/internal/image/history.go
+++ b/internal/image/history.go
@@ -63,7 +63,7 @@ func NewImageHistory(ctx context.Context, dir *dirs.WindmillDir) (ImageHistory, 
 		}
 
 		for _, entry := range entries {
-			history.Load(ctx, name, entry.Digest, entry.CheckpointID)
+			history.load(ctx, name, entry.Digest, entry.CheckpointID)
 		}
 	}
 
@@ -78,7 +78,7 @@ func (h ImageHistory) CheckpointNow() CheckpointID {
 	return CheckpointID(time.Now())
 }
 
-func (h ImageHistory) Load(ctx context.Context, name reference.Named, digest digest.Digest, checkpoint CheckpointID) (refKey, historyEntry) {
+func (h ImageHistory) load(ctx context.Context, name reference.Named, digest digest.Digest, checkpoint CheckpointID) (refKey, historyEntry) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -102,7 +102,7 @@ func (h ImageHistory) Load(ctx context.Context, name reference.Named, digest dig
 }
 
 func (h ImageHistory) AddAndPersist(ctx context.Context, name reference.Named, digest digest.Digest, checkpoint CheckpointID) error {
-	key, entry := h.Load(ctx, name, digest, checkpoint)
+	key, entry := h.load(ctx, name, digest, checkpoint)
 
 	return addHistoryToFS(ctx, h.dir, key, entry)
 }

--- a/internal/image/history_test.go
+++ b/internal/image/history_test.go
@@ -37,7 +37,7 @@ func TestCheckpointOne(t *testing.T) {
 	n1, _ := reference.ParseNormalizedNamed("image-name-1")
 	d1 := digest.FromString("digest1")
 	c1 := history.CheckpointNow()
-	history.Load(f.ctx, n1, d1, c1)
+	history.load(f.ctx, n1, d1, c1)
 
 	d, c, ok := history.MostRecent(n1)
 	if !ok || d != d1 || c != c1 {
@@ -53,13 +53,13 @@ func TestCheckpointAfter(t *testing.T) {
 
 	d1 := digest.FromString("digest1")
 	c1 := history.CheckpointNow()
-	history.Load(f.ctx, n1, d1, c1)
+	history.load(f.ctx, n1, d1, c1)
 
 	time.Sleep(time.Millisecond)
 
 	d2 := digest.FromString("digest2")
 	c2 := history.CheckpointNow()
-	history.Load(f.ctx, n1, d2, c2)
+	history.load(f.ctx, n1, d2, c2)
 
 	d, c, ok := history.MostRecent(n1)
 	if !ok || d != d2 || c != c2 {
@@ -78,8 +78,8 @@ func TestCheckpointBefore(t *testing.T) {
 
 	d1 := digest.FromString("digest1")
 	c1 := history.CheckpointNow()
-	history.Load(f.ctx, n1, d1, c1)
-	history.Load(f.ctx, n1, d0, c0)
+	history.load(f.ctx, n1, d1, c1)
+	history.load(f.ctx, n1, d0, c0)
 
 	d, c, ok := history.MostRecent(n1)
 	if !ok || d != d1 || c != c1 {

--- a/internal/image/history_test.go
+++ b/internal/image/history_test.go
@@ -33,10 +33,8 @@ func TestCheckpointOne(t *testing.T) {
 	n1, _ := reference.ParseNormalizedNamed("image-name-1")
 	d1 := digest.FromString("digest1")
 	c1 := history.CheckpointNow()
-	err := history.Add(f.ctx, n1, d1, c1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	history.Load(f.ctx, n1, d1, c1)
+
 	d, c, ok := history.MostRecent(n1)
 	if !ok || d != d1 || c != c1 {
 		t.Errorf("Expected most recent image (%v, %v). Actual: (%v, %v)", c1, d1, c, d)
@@ -51,19 +49,13 @@ func TestCheckpointAfter(t *testing.T) {
 
 	d1 := digest.FromString("digest1")
 	c1 := history.CheckpointNow()
-	err := history.Add(f.ctx, n1, d1, c1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	history.Load(f.ctx, n1, d1, c1)
 
 	time.Sleep(time.Millisecond)
 
 	d2 := digest.FromString("digest2")
 	c2 := history.CheckpointNow()
-	err = history.Add(f.ctx, n1, d2, c2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	history.Load(f.ctx, n1, d2, c2)
 
 	d, c, ok := history.MostRecent(n1)
 	if !ok || d != d2 || c != c2 {
@@ -82,14 +74,8 @@ func TestCheckpointBefore(t *testing.T) {
 
 	d1 := digest.FromString("digest1")
 	c1 := history.CheckpointNow()
-	err := history.Add(f.ctx, n1, d1, c1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = history.Add(f.ctx, n1, d0, c0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	history.Load(f.ctx, n1, d1, c1)
+	history.Load(f.ctx, n1, d0, c0)
 
 	d, c, ok := history.MostRecent(n1)
 	if !ok || d != d1 || c != c1 {
@@ -105,7 +91,7 @@ func TestPersistence(t *testing.T) {
 
 	d1 := digest.FromString("digest1")
 	c1 := history.CheckpointNow()
-	err := history.Add(f.ctx, n1, d1, c1)
+	err := history.AddAndPersist(f.ctx, n1, d1, c1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +100,7 @@ func TestPersistence(t *testing.T) {
 
 	d2 := digest.FromString("digest2")
 	c2 := history.CheckpointNow()
-	err = history.Add(f.ctx, n1, d2, c2)
+	err = history.AddAndPersist(f.ctx, n1, d2, c2)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Prior to this patch when we loaded the existing history from disk
(in `NewImageHistory`) we would _re-persist_ all of the images that had
already been persisted.

To prevent this, I broke out `history.Add` in to two functions:
1. `history.Load` now adds an image to the in memory store
2. `history.AddAndPersist` loads an image and persists it to disk

We just call `history.Load` in `NewImageHistory` to prevent the exponential
hsitory problem.