### PR TITLE
cli: error handling when the daemon exists unexpectedly. also fixes the case where you're talking to an old daemon

### DIFF
--- a/internal/tiltd/tiltd_server/tiltd.go
+++ b/internal/tiltd/tiltd_server/tiltd.go
@@ -2,15 +2,19 @@ package tiltd_server
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 )
 
-func RunDaemon(ctx context.Context) (*os.Process, error) {
+func RunDaemon(ctx context.Context, out io.Writer) (*exec.Cmd, error) {
 	cmd := exec.CommandContext(ctx, os.Args[0], "daemon")
+	cmd.Stdout = out
+	cmd.Stderr = out
+
 	err := cmd.Start()
 	if err != nil {
 		return nil, err
 	}
-	return cmd.Process, nil
+	return cmd, nil
 }


### PR DESCRIPTION
Hello @pmt, @landism,

Please review the following commits I made in branch nicks/errors2:

f42b533e363e069fc7831e9b9b858b5c89022f0f (2018-08-22 13:13:45 -0400)
cli: error handling when the daemon exists unexpectedly. also fixes the case where you're talking to an old daemon