### PR TITLE
watch: simplify the fileEvent interface to only contain paths

### DIFF
--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -1,10 +1,12 @@
 package watch
 
-import "github.com/windmilleng/fsnotify"
+type FileEvent struct {
+	Path string
+}
 
 type Notify interface {
 	Close() error
 	Add(name string) error
-	Events() chan fsnotify.Event
+	Events() chan FileEvent
 	Errors() chan error
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/watch:

e1ef01b3555ebad66b601bdb3ea1f124c360dfa8 (2018-08-22 15:24:28 -0400)
watch: simplify the fileEvent interface to only contain paths