### PR TITLE
tilt: git_repo becomes local_git_repo per README

### DIFF
--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -102,7 +102,7 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 	if len(fn.Receiver().(*dockerImage).cmds) > 0 {
 		return nil, errors.New("add mount before run command")
 	}
-	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "mount_point", &mountPoint, "git_repo", &gitRepo)
+	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "mount_point", &mountPoint, "local_git_repo", &gitRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -103,7 +103,7 @@ func Load(filename string) (*Tiltfile, error) {
 	predeclared := skylark.StringDict{
 		"build_docker_image": skylark.NewBuiltin("build_docker_image", makeSkylarkDockerImage),
 		"k8s_service":        skylark.NewBuiltin("k8s_service", makeSkylarkK8Service),
-		"git_repo":           skylark.NewBuiltin("git_repo", makeSkylarkGitRepo),
+		"local_git_repo":     skylark.NewBuiltin("local_git_repo", makeSkylarkGitRepo),
 		"local":              skylark.NewBuiltin("local", runLocalCmd),
 		"composite_service":  skylark.NewBuiltin("composite_service", makeSkylarkCompositeService),
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -29,7 +29,7 @@ func TestGetServiceConfig(t *testing.T) {
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
   image = build_docker_image("%v", "docker tag", "the entrypoint")
-  image.add('/mount_points/1', git_repo('.'))
+  image.add('/mount_points/1', local_git_repo('.'))
   print(image.file_name)
   image.run("go install github.com/windmilleng/blorgly-frontend/server/...")
   image.run("echo hi")


### PR DESCRIPTION
see: https://github.com/windmilleng/tilt/pull/146/files

q: should I update the blorg and blorgly tiltfiles with these new names?