### PR TITLE
skylark: GetServiceConfig returns domain objects (model.Service, not proto.Service)

### DIFF
--- a/internal/model/service.go
+++ b/internal/model/service.go
@@ -8,6 +8,8 @@ import (
 
 type ServiceName string
 
+func (s ServiceName) String() string { return string(s) }
+
 type Service struct {
 	K8sYaml        string
 	DockerfileText string

--- a/internal/model/service.go
+++ b/internal/model/service.go
@@ -66,3 +66,11 @@ func (c Cmd) Empty() bool {
 func ToShellCmd(cmd string) Cmd {
 	return Cmd{Argv: []string{"sh", "-c", cmd}}
 }
+
+func ToShellCmds(cmds []string) []Cmd {
+	res := make([]Cmd, len(cmds))
+	for i, cmd := range cmds {
+		res[i] = ToShellCmd(cmd)
+	}
+	return res
+}

--- a/internal/proto/server_adaptor.go
+++ b/internal/proto/server_adaptor.go
@@ -25,7 +25,7 @@ func (s *grpcServer) CreateService(req *CreateServiceRequest, d Daemon_CreateSer
 
 	var svcArray []model.Service
 	for i := range req.Services {
-		svcArray = append(svcArray, ServiceP2D(req.Services[i]))
+		svcArray = append(svcArray, serviceP2D(req.Services[i]))
 	}
 
 	return s.delegate.CreateServices(ctx, svcArray, req.Watch)
@@ -78,7 +78,7 @@ func serviceNameP2D(s string) model.ServiceName {
 }
 
 // NOTE(maia): public b/c we're hacking out the daemon and will likely put it back soon.
-func ServiceP2D(service *Service) model.Service {
+func serviceP2D(service *Service) model.Service {
 	return model.Service{
 		K8sYaml:        service.K8SYaml,
 		DockerfileText: service.DockerfileText,

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 
 	"github.com/google/skylark"
-	"github.com/windmilleng/tilt/internal/proto"
+	"github.com/windmilleng/tilt/internal/model"
 )
 
 type Tiltfile struct {
@@ -116,7 +116,7 @@ func Load(filename string) (*Tiltfile, error) {
 	return &Tiltfile{globals, filename, thread}, nil
 }
 
-func (tiltfile Tiltfile) GetServiceConfig(serviceName string) ([]*proto.Service, error) {
+func (tiltfile Tiltfile) GetServiceConfigs(serviceName string) ([]model.Service, error) {
 	f, ok := tiltfile.globals[serviceName]
 
 	if !ok {
@@ -140,64 +140,60 @@ func (tiltfile Tiltfile) GetServiceConfig(serviceName string) ([]*proto.Service,
 
 	switch service := val.(type) {
 	case compService:
-		var protoServ []*proto.Service
+		var servs []model.Service
 
 		for _, cServ := range service.cService {
-			s, err := skylarkServiceToProto(cServ)
+			s, err := skylarkServiceToDomain(cServ)
 			if err != nil {
 				return nil, err
 			}
 
-			protoServ = append(protoServ, s)
+			servs = append(servs, s)
 		}
-		return protoServ, nil
+		return servs, nil
 	case k8sService:
-		s, err := skylarkServiceToProto(service)
+		s, err := skylarkServiceToDomain(service)
 		if err != nil {
 			return nil, err
 		}
-		s.Name = serviceName
-		return []*proto.Service{s}, nil
+		s.Name = model.ServiceName(serviceName)
+		return []model.Service{s}, nil
 
 	default:
 		return nil, fmt.Errorf("'%v' returned a '%v', but it needs to return a k8s_service or composite_service", serviceName, val.Type())
 	}
 }
 
-func skylarkServiceToProto(service k8sService) (*proto.Service, error) {
+func skylarkServiceToDomain(service k8sService) (model.Service, error) {
 	k8sYaml, ok := skylark.AsString(service.k8sYaml)
 	if !ok {
-		return nil, fmt.Errorf("internal error: k8sService.k8sYaml was not a string in '%v'", service)
+		return model.Service{}, fmt.Errorf("internal error: k8sService.k8sYaml was not a string in '%v'", service)
 	}
 
 	dockerFileBytes, err := ioutil.ReadFile(service.dockerImage.fileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open dockerfile '%v': %v", service.dockerImage.fileName, err)
+		return model.Service{}, fmt.Errorf("failed to open dockerfile '%v': %v", service.dockerImage.fileName, err)
 	}
 
-	mounts := make([]*proto.Mount, 0, len(service.dockerImage.mounts))
-	for _, mount := range service.dockerImage.mounts {
-		repo := proto.Repo{RepoType: &proto.Repo_GitRepo{GitRepo: &proto.GitRepo{LocalPath: mount.repo.path}}}
-		mounts = append(mounts, &proto.Mount{Repo: &repo, ContainerPath: mount.mountPoint})
-	}
-
-	dockerCmds := make([]*proto.Cmd, 0, len(service.dockerImage.cmds))
-	for _, cmd := range service.dockerImage.cmds {
-		dockerCmds = append(dockerCmds, toShellCmd(cmd))
-	}
-
-	return &proto.Service{
-		K8SYaml:        k8sYaml,
+	return model.Service{
+		K8sYaml:        k8sYaml,
 		DockerfileText: string(dockerFileBytes),
-		Mounts:         mounts,
-		Steps:          dockerCmds,
-		Entrypoint:     toShellCmd(service.dockerImage.entrypoint),
+		Mounts:         skylarkMountsToDomain(service.dockerImage.mounts),
+		Steps:          model.ToShellCmds(service.dockerImage.cmds),
+		Entrypoint:     model.ToShellCmd(service.dockerImage.entrypoint),
 		DockerfileTag:  service.dockerImage.fileTag,
-		Name:           service.name,
+		Name:           model.ServiceName(service.name),
 	}, nil
 
 }
 
-func toShellCmd(cmd string) *proto.Cmd {
-	return &proto.Cmd{Argv: []string{"sh", "-c", cmd}}
+func skylarkMountsToDomain(sMounts []mount) []model.Mount {
+	dMounts := make([]model.Mount, len(sMounts))
+	for i, m := range sMounts {
+		dMounts[i] = model.Mount{
+			Repo:          model.LocalGithubRepo{LocalPath: m.repo.path},
+			ContainerPath: m.mountPoint,
+		}
+	}
+	return dMounts
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -43,7 +43,7 @@ func TestGetServiceConfig(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	serviceConfig, err := tiltconfig.GetServiceConfig("blorgly")
+	serviceConfig, err := tiltconfig.GetServiceConfigs("blorgly")
 	if err != nil {
 		t.Fatal("getting service config:", err)
 	}
@@ -77,7 +77,7 @@ func TestGetServiceConfigMissingDockerFile(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltconfig.GetServiceConfig("blorgly")
+	_, err = tiltconfig.GetServiceConfigs("blorgly")
 	if assert.NotNil(t, err, "expected error from missing dockerfile") {
 		for _, s := range []string{"asfaergiuhaeriguhaergiu", "no such file or directory"} {
 			assert.True(t, strings.Contains(err.Error(), s),
@@ -137,7 +137,7 @@ def blorgly_frontend():
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	serviceConfig, err := tiltConfig.GetServiceConfig("blorgly")
+	serviceConfig, err := tiltConfig.GetServiceConfigs("blorgly")
 	if err != nil {
 		t.Fatal("getting service config:", err)
 	}
@@ -158,7 +158,7 @@ func TestGetServiceConfigUndefined(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfig("blorgly2")
+	_, err = tiltConfig.GetServiceConfigs("blorgly2")
 	if err == nil {
 		t.Fatal("expected error b/c of undefined service config:")
 	}
@@ -177,8 +177,8 @@ func TestGetServiceConfigNonFunction(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfig("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfig did not return an error") {
+	_, err = tiltConfig.GetServiceConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "function", "int"} {
 			assert.True(t, strings.Contains(err.Error(), s))
 		}
@@ -197,8 +197,8 @@ func TestGetServiceConfigTakesArgs(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfig("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfig did not return an error") {
+	_, err = tiltConfig.GetServiceConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "0 arguments"} {
 			assert.True(t, strings.Contains(err.Error(), s))
 		}
@@ -216,8 +216,8 @@ func TestGetServiceConfigRaisesError(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfig("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfig did not return an error") {
+	_, err = tiltConfig.GetServiceConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "string index", "out of range"} {
 			assert.True(t, strings.Contains(err.Error(), s), "error message '%V' did not contain '%V'", err.Error(), s)
 		}
@@ -235,8 +235,8 @@ func TestGetServiceConfigReturnsWrongType(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfig("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfig did not return an error") {
+	_, err = tiltConfig.GetServiceConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "string", "k8s_service"} {
 			assert.True(t, strings.Contains(err.Error(), s), "error message '%V' did not contain '%V'", err.Error(), s)
 		}
@@ -254,8 +254,8 @@ func TestGetServiceConfigLocalReturnsNon0(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfig("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfig did not return an error") {
+	_, err = tiltConfig.GetServiceConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
 		// "foo bar" and "baz quu" are separated above so that the match below only matches the strings in the output,
 		// not in the command
 		for _, s := range []string{"blorgly2", "exit status 1", "foo bar", "baz quu"} {
@@ -283,7 +283,7 @@ func TestGetServiceConfigWithLocalCmd(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	serviceConfig, err := tiltconfig.GetServiceConfig("blorgly")
+	serviceConfig, err := tiltconfig.GetServiceConfigs("blorgly")
 	if err != nil {
 		t.Fatal("getting service config:", err)
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -51,10 +51,10 @@ func TestGetServiceConfig(t *testing.T) {
 	service := serviceConfig[0]
 	assert.Equal(t, "docker text", service.DockerfileText)
 	assert.Equal(t, "docker tag", service.DockerfileTag)
-	assert.Equal(t, "yaaaaaaaaml", service.K8SYaml)
+	assert.Equal(t, "yaaaaaaaaml", service.K8sYaml)
 	assert.Equal(t, 1, len(service.Mounts))
 	assert.Equal(t, "/mount_points/1", service.Mounts[0].ContainerPath)
-	assert.Equal(t, ".", service.Mounts[0].Repo.GetGitRepo().LocalPath)
+	assert.Equal(t, ".", service.Mounts[0].Repo.LocalPath)
 	assert.Equal(t, 2, len(service.Steps))
 	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, service.Steps[0].Argv)
 	assert.Equal(t, []string{"sh", "-c", "echo hi"}, service.Steps[1].Argv)
@@ -142,8 +142,8 @@ def blorgly_frontend():
 		t.Fatal("getting service config:", err)
 	}
 
-	assert.Equal(t, "blorgly_backend", serviceConfig[0].Name)
-	assert.Equal(t, "blorgly_frontend", serviceConfig[1].Name)
+	assert.Equal(t, "blorgly_backend", serviceConfig[0].Name.String())
+	assert.Equal(t, "blorgly_frontend", serviceConfig[1].Name.String())
 }
 
 func TestGetServiceConfigUndefined(t *testing.T) {
@@ -291,7 +291,7 @@ func TestGetServiceConfigWithLocalCmd(t *testing.T) {
 	service := serviceConfig[0]
 	assert.Equal(t, "docker text", service.DockerfileText)
 	assert.Equal(t, "docker tag", service.DockerfileTag)
-	assert.Equal(t, "yaaaaaaaaml\n", service.K8SYaml)
+	assert.Equal(t, "yaaaaaaaaml\n", service.K8sYaml)
 	assert.Equal(t, 2, len(service.Steps))
 	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, service.Steps[0].Argv)
 	assert.Equal(t, []string{"sh", "-c", "echo hi"}, service.Steps[1].Argv)


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/skylark-returns-domain-services:

148f850e5e26e994e791d703ba998d6dc6075e9a (2018-08-22 16:43:23 -0400)
skylark: GetServiceConfig returns domain objects (model.Service, not proto.Service)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics