### PR TITLE
tilt: get imageHistory via wire

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -9,6 +9,7 @@ import (
 	context "context"
 	build "github.com/windmilleng/tilt/internal/build"
 	engine "github.com/windmilleng/tilt/internal/engine"
+	image "github.com/windmilleng/tilt/internal/image"
 	k8s "github.com/windmilleng/tilt/internal/k8s"
 	model "github.com/windmilleng/tilt/internal/model"
 	service "github.com/windmilleng/tilt/internal/service"
@@ -31,7 +32,11 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 	if err != nil {
 		return nil, err
 	}
-	buildAndDeployer, err := engine.NewLocalBuildAndDeployer(ctx, client, windmillDir, manager, env)
+	imageHistory, err := image.NewImageHistory(ctx, windmillDir)
+	if err != nil {
+		return nil, err
+	}
+	buildAndDeployer, err := engine.NewLocalBuildAndDeployer(ctx, client, windmillDir, manager, env, imageHistory)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -45,12 +45,8 @@ type localBuildAndDeployer struct {
 	env     k8s.Env
 }
 
-func NewLocalBuildAndDeployer(ctx context.Context, docker *client.Client, dir *dirs.WindmillDir, m service.Manager, env k8s.Env) (BuildAndDeployer, error) {
+func NewLocalBuildAndDeployer(ctx context.Context, docker *client.Client, dir *dirs.WindmillDir, m service.Manager, env k8s.Env, history image.ImageHistory) (BuildAndDeployer, error) {
 	b := build.NewLocalDockerBuilder(docker)
-	history, err := image.NewImageHistory(ctx, dir)
-	if err != nil {
-		return nil, err
-	}
 
 	return localBuildAndDeployer{
 		b:       b,

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -8,6 +8,7 @@ package engine
 import (
 	context "context"
 	build "github.com/windmilleng/tilt/internal/build"
+	image "github.com/windmilleng/tilt/internal/image"
 	k8s "github.com/windmilleng/tilt/internal/k8s"
 	service "github.com/windmilleng/tilt/internal/service"
 	dirs "github.com/windmilleng/wmclient/pkg/dirs"
@@ -21,7 +22,11 @@ func ProvideUpperForTesting(ctx context.Context, dir *dirs.WindmillDir, env k8s.
 		return Upper{}, err
 	}
 	manager := service.ProvideMemoryManager()
-	buildAndDeployer, err := NewLocalBuildAndDeployer(ctx, client, dir, manager, env)
+	imageHistory, err := image.NewImageHistory(ctx, dir)
+	if err != nil {
+		return Upper{}, err
+	}
+	buildAndDeployer, err := NewLocalBuildAndDeployer(ctx, client, dir, manager, env, imageHistory)
 	if err != nil {
 		return Upper{}, err
 	}


### PR DESCRIPTION
`make wire` was failing on my machine:
`go/src/github.com/windmilleng/tilt/internal/engine/wire.go:17:1: inject ProvideUpperForTesting: unused provider "NewImageHistory"`