### PR TITLE
tracer: doesn't log

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -12,6 +12,7 @@ func Init() error {
 			Param: 1,
 		},
 	}
+	// TODO(dmiller) log output to a file?
 	tracer, _, err := cfg.New("tilt")
 	if err != nil {
 		return err

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -2,7 +2,6 @@ package tracer
 
 import (
 	opentracing "github.com/opentracing/opentracing-go"
-	jaeger "github.com/uber/jaeger-client-go"
 	config "github.com/uber/jaeger-client-go/config"
 )
 
@@ -13,7 +12,7 @@ func Init() error {
 			Param: 1,
 		},
 	}
-	tracer, _, err := cfg.New("tilt", config.Logger(jaeger.StdLogger))
+	tracer, _, err := cfg.New("tilt")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Tested by killing the jaeger container, and running `tilt up blorgly_frontend` and observing that there were no longer any errors printed.