### PR TITLE
watch: fix a flaky test by ignoring spurious events correctly

### DIFF
--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -231,6 +231,7 @@ func TestSingleFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	f.fsync()
 
 	d2 := []byte("hello\nworld\n")
 	err = ioutil.WriteFile(path, d2, 0644)

--- a/internal/watch/watcher_darwin.go
+++ b/internal/watch/watcher_darwin.go
@@ -34,7 +34,7 @@ func (d *darwinNotify) isTrackingPath(path string) bool {
 }
 
 func (d *darwinNotify) loop() {
-	ignoredSpuriousEvent := false
+	ignoredSpuriousEvents := make(map[string]bool, 0)
 	for {
 		select {
 		case <-d.stop:
@@ -50,8 +50,8 @@ func (d *darwinNotify) loop() {
 				// ignore the first event that says the watched directory
 				// has been created. these are fired spuriously on initiation.
 				if e.Flags&fsevents.ItemCreated == fsevents.ItemCreated {
-					if d.isTrackingPath(e.Path) && !ignoredSpuriousEvent {
-						ignoredSpuriousEvent = true
+					if !ignoredSpuriousEvents[e.Path] && d.isTrackingPath(e.Path) {
+						ignoredSpuriousEvents[e.Path] = true
 						continue
 					}
 				}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/singlefile:

88e1b156c90a528b89f7d3e812e5dfda723c3af6 (2018-08-23 11:36:11 -0400)
watch: fix a flaky test by ignoring spurious events correctly