### PR TITLE
build: remove previous mounts when building from existing

### DIFF
--- a/internal/build/docker_benchmark_test.go
+++ b/internal/build/docker_benchmark_test.go
@@ -76,7 +76,7 @@ func BenchmarkIterativeBuildTenTimes(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 10; j++ {
-			digest, err = f.b.BuildDockerFromExisting(f.ctx, digest, nil, steps)
+			digest, err = f.b.BuildDockerFromExisting(f.ctx, digest, nil, steps, []model.Mount{})
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -19,6 +19,7 @@ import (
 type buildToken struct {
 	d digest.Digest
 	n reference.Named
+	m []model.Mount
 }
 
 func (b *buildToken) isEmpty() bool {
@@ -71,8 +72,7 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 		}
 
 	} else {
-		// TODO(dmiller): in the future this shouldn't do a push, or a k8s apply, but for now it does
-		newDigest, err := l.b.BuildDockerFromExisting(ctx, token.d, build.MountsToPath(service.Mounts), service.Steps)
+		newDigest, err := l.b.BuildDockerFromExisting(ctx, token.d, build.MountsToPath(service.Mounts), service.Steps, token.m)
 		if err != nil {
 			return nil, err
 		}
@@ -147,5 +147,5 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 		return nil, err
 	}
 
-	return &buildToken{d: d, n: name}, l.k8sClient.Apply(ctx, newYAMLString)
+	return &buildToken{d: d, n: name, m: service.Mounts}, l.k8sClient.Apply(ctx, newYAMLString)
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -29,7 +29,7 @@ type fakeBuildAndDeployer struct {
 
 var _ BuildAndDeployer = &fakeBuildAndDeployer{}
 
-var dummyBuildToken = &buildToken{digest.Digest("foo"), nil}
+var dummyBuildToken = &buildToken{digest.Digest("foo"), nil, []model.Mount{}}
 
 func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model.Service, token *buildToken, changedFiles []string) (*buildToken, error) {
 	select {


### PR DESCRIPTION
`BuildDockerFromExisting` now takes the previous service's mounts, which it gets from the build token.