### PR TITLE
minikube: add a helper function for reading the docker client from minikube

### DIFF
--- a/internal/minikube/docker.go
+++ b/internal/minikube/docker.go
@@ -1,0 +1,43 @@
+package minikube
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+)
+
+// This isn't perfect (because it won't unquote the value right) but
+// it's good enough for 99% of cases.
+var envMatcher = regexp.MustCompile(`export (\w+)="([^"]+)"`)
+
+func DockerEnv(ctx context.Context) (map[string]string, error) {
+	cmd := exec.CommandContext(ctx, "minikube", "docker-env", "--shell", "sh")
+	output, err := cmd.Output()
+	if err != nil {
+		exitErr, isExitErr := err.(*exec.ExitError)
+		if isExitErr {
+			return nil, fmt.Errorf("Could not read docker env from minikube.\n%s", string(exitErr.Stderr))
+		}
+
+		return nil, fmt.Errorf("Could not read docker env from minikube: %v", err)
+	}
+	return dockerEnvFromOutput(output)
+}
+
+func dockerEnvFromOutput(output []byte) (map[string]string, error) {
+	result := make(map[string]string, 0)
+	scanner := bufio.NewScanner(bytes.NewBuffer(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		match := envMatcher.FindStringSubmatch(line)
+		if len(match) > 0 {
+			result[match[1]] = match[2]
+		}
+	}
+
+	return result, nil
+}

--- a/internal/minikube/docker_test.go
+++ b/internal/minikube/docker_test.go
@@ -1,0 +1,27 @@
+package minikube
+
+import "testing"
+
+func TestDockerEnv(t *testing.T) {
+	output := []byte(`
+export DOCKER_TLS_VERIFY="1"
+export DOCKER_HOST="tcp://192.168.99.100:2376"
+export DOCKER_CERT_PATH="/home/nick/.minikube/certs"
+export DOCKER_API_VERSION="1.35"
+# Run this command to configure your shell:
+# eval $(minikube docker-env)
+`)
+
+	env, err := dockerEnvFromOutput(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(env) != 4 ||
+		env["DOCKER_TLS_VERIFY"] != "1" ||
+		env["DOCKER_HOST"] != "tcp://192.168.99.100:2376" ||
+		env["DOCKER_CERT_PATH"] != "/home/nick/.minikube/certs" ||
+		env["DOCKER_API_VERSION"] != "1.35" {
+		t.Errorf("Unexpected env: %+v", env)
+	}
+}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/minikube2:

d582d9c1e874ccc95932635cb23beef69294399d (2018-08-23 17:58:52 -0400)
minikube: add a helper function for reading the docker client from minikube