### PR TITLE
build: relative local repo paths need to be absolute

### DIFF
--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -355,9 +355,9 @@ func TestSelectiveAddFilesToExisting(t *testing.T) {
 	f.WriteFile("hi/hello", "hello world") // change contents
 	f.Rm("sup")
 	files := []string{"hi/hello", "sup"}
-	pms, err := filesToPathMappings(f.JoinPaths(files), mounts)
+	pms, err := FilesToPathMappings(f.JoinPaths(files), mounts)
 	if err != nil {
-		f.t.Fatal("filesToPathMappings:", err)
+		f.t.Fatal("FilesToPathMappings:", err)
 	}
 
 	digest, err := f.b.BuildDockerFromExisting(f.ctx, existing, pms, []model.Cmd{})

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -17,9 +17,9 @@ type pathMapping struct {
 	ContainerPath string
 }
 
-// filesToPathMappings converts a list of absolute local filepaths into FileOps (i.e.
+// FilesToPathMappings converts a list of absolute local filepaths into pathMappings (i.e.
 // associates local filepaths with their mounts and destination paths).
-func filesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, error) {
+func FilesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, error) {
 	var pms []pathMapping
 	for _, f := range files {
 		foundMount := false
@@ -27,7 +27,15 @@ func filesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, e
 			// Open Q: can you mount inside of mounts?! o_0
 			// TODO(maia): are symlinks etc. gonna kick our asses here? If so, will
 			// need ospath.RealChild -- but then can't deal with deleted local files.
-			relPath, isChild := ospath.Child(m.Repo.LocalPath, f)
+			// NOTE(dmiller) file events come in as absolute paths, so repo path needs
+			// to be absolute as well
+			// TODO(dmiller) delete this if/when we guarantee absolute paths further up
+			// the stack
+			absRepoPath, err := filepath.Abs(m.Repo.LocalPath)
+			if err != nil {
+				return nil, fmt.Errorf("error getting absolute path of %s: %s", m.Repo.LocalPath, err)
+			}
+			relPath, isChild := ospath.Child(absRepoPath, f)
 			if isChild {
 				foundMount = true
 				pms = append(pms, pathMapping{


### PR DESCRIPTION
This is due to the fact that file events come in as absolute paths.