### PR TITLE
build: fix bug where tar treated all top level files as directories

### DIFF
--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -54,6 +54,7 @@ func tarPath(ctx context.Context, tarWriter *tar.Writer, source, dest string) er
 	span.SetTag("dest", dest)
 	defer span.Finish()
 	sourceInfo, err := os.Stat(source)
+
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -84,11 +85,10 @@ func tarPath(ctx context.Context, tarWriter *tar.Writer, source, dest string) er
 		if sourceIsDir {
 			// Name of file in tar should be relative to source directory...
 			header.Name = strings.TrimPrefix(path, source)
-		}
-
-		if dest != "" {
-			// ...and live inside `dest` (if given)
+			// ...and live inside `dest`
 			header.Name = filepath.Join(dest, header.Name)
+		} else {
+			header.Name = dest
 		}
 
 		err = tarWriter.WriteHeader(header)


### PR DESCRIPTION
Huge caveat here: I spent most of the morning trying to write a test for this and I was unable to. Here's how I tested it manually to verify that it is fixed.

1. `make install`
2. `cd ../blorg-tilt`
3.  `tilt up blorg_frontend --watch`
4. Wait for it to come up
5. `cd ../blorg-frontend`
6. Modify main.go

At this point in the old world if you looked at the container on the pod you would see `/go/src/github.com/windmilleng/blorg-frontend/main.go/main.go`. Note the incorrect path. In the new world: you'd see `/go/src/github.com/windmilleng/blorg-frontend/main.go` with the correct, updated contents.