### PR TITLE
mill: enforce repo is absolute path

### DIFF
--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -27,15 +27,7 @@ func FilesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, e
 			// Open Q: can you mount inside of mounts?! o_0
 			// TODO(maia): are symlinks etc. gonna kick our asses here? If so, will
 			// need ospath.RealChild -- but then can't deal with deleted local files.
-			// NOTE(dmiller) file events come in as absolute paths, so repo path needs
-			// to be absolute as well
-			// TODO(dmiller) delete this if/when we guarantee absolute paths further up
-			// the stack
-			absRepoPath, err := filepath.Abs(m.Repo.LocalPath)
-			if err != nil {
-				return nil, fmt.Errorf("error getting absolute path of %s: %s", m.Repo.LocalPath, err)
-			}
-			relPath, isChild := ospath.Child(absRepoPath, f)
+			relPath, isChild := ospath.Child(m.Repo.LocalPath, f)
 			if isChild {
 				foundMount = true
 				pms = append(pms, pathMapping{

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -26,7 +26,7 @@ func FilesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, e
 		for _, m := range mounts {
 			if !filepath.IsAbs(m.Repo.LocalPath) {
 				return nil, fmt.Errorf(
-					"[FilesToPathMappints] mount.Repo.LocalPath must be an absolute path (got: %s)",
+					"[FilesToPathMappings] mount.Repo.LocalPath must be an absolute path (got: %s)",
 					m.Repo.LocalPath)
 			}
 			// Open Q: can you mount inside of mounts?! o_0

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -24,6 +24,11 @@ func FilesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, e
 	for _, f := range files {
 		foundMount := false
 		for _, m := range mounts {
+			if !filepath.IsAbs(m.Repo.LocalPath) {
+				return nil, fmt.Errorf(
+					"[FilesToPathMappints] mount.Repo.LocalPath must be an absolute path (got: %s)",
+					m.Repo.LocalPath)
+			}
 			// Open Q: can you mount inside of mounts?! o_0
 			// TODO(maia): are symlinks etc. gonna kick our asses here? If so, will
 			// need ospath.RealChild -- but then can't deal with deleted local files.

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -66,40 +65,19 @@ func TestFilesToPathMappings(t *testing.T) {
 	assert.ElementsMatch(t, expected, actual)
 }
 
-func TestRelativeRepoPathsBecomeAbsolute(t *testing.T) {
-	f := testutils.NewTempDirFixture(t)
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(oldWd)
-	err = os.Chdir(f.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.TearDown()
-
-	files := []string{filepath.Join(f.Path(), "timing_script-W3imtct67O")}
+func TestRelativeRepoPathsThrowError(t *testing.T) {
+	files := []string{"/foo/bar.baz"}
 	mounts := []model.Mount{
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: "."},
-			ContainerPath: "/go/src/github.com/windmilleng/blorgly-backend",
+			Repo:          model.LocalGithubRepo{LocalPath: "./hello"},
+			ContainerPath: "/src",
 		},
 	}
 
-	actual, err := FilesToPathMappings(files, mounts)
-	if err != nil {
-		t.Fatal(err)
+	_, err := FilesToPathMappings(files, mounts)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "must be an absolute path")
 	}
-
-	expected := []pathMapping{
-		pathMapping{
-			LocalPath:     filepath.Join(f.Path(), "timing_script-W3imtct67O"),
-			ContainerPath: "/go/src/github.com/windmilleng/blorgly-backend/timing_script-W3imtct67O",
-		},
-	}
-
-	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestFileNotInMountThrowsErr(t *testing.T) {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
@@ -80,7 +81,8 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 					changedPathsToPrint = event.files
 				}
 
-				logger.Get(ctx).Infof("files changed. rebuilding %v. observed changes: %v", event.service.Name, changedPathsToPrint)
+				logger.Get(ctx).Infof("files changed. rebuilding %v. observed changes: %v",
+					event.service.Name, ospath.TryAsCwdChildren(changedPathsToPrint))
 
 				var err error
 				token, err := u.b.BuildAndDeploy(

--- a/internal/ospath/ospath.go
+++ b/internal/ospath/ospath.go
@@ -79,3 +79,25 @@ func IsDir(path string) bool {
 
 	return f.Mode().IsDir()
 }
+
+// TryAsCwdChildren converts the given absolute paths to children of the CWD,
+// if possible (otherwise, leaves them as absolute paths).
+func TryAsCwdChildren(absPaths []string) []string {
+	wd, err := os.Getwd()
+	if err != nil {
+		// This is just a util for printing right now, so don't actually throw an
+		// error, just return back all the absolute paths
+		return absPaths[:]
+	}
+
+	res := make([]string, len(absPaths))
+	for i, abs := range absPaths {
+		rel, isChild := Child(wd, abs)
+		if isChild {
+			res[i] = rel
+		} else {
+			res[i] = abs
+		}
+	}
+	return res
+}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/google/skylark"
 	"github.com/windmilleng/tilt/internal/model"
@@ -83,7 +84,12 @@ func makeSkylarkGitRepo(thread *skylark.Thread, fn *skylark.Builtin, args skylar
 		return nil, err
 	}
 
-	return gitRepo{path}, nil
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("filepath.Abs: %v", err)
+	}
+
+	return gitRepo{absPath}, nil
 }
 
 func runLocalCmd(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -48,16 +48,21 @@ func TestGetServiceConfig(t *testing.T) {
 		t.Fatal("getting service config:", err)
 	}
 
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("couldn't get working directory:", err)
+	}
+
 	service := serviceConfig[0]
 	assert.Equal(t, "docker text", service.DockerfileText)
 	assert.Equal(t, "docker tag", service.DockerfileTag)
 	assert.Equal(t, "yaaaaaaaaml", service.K8sYaml)
-	assert.Equal(t, 1, len(service.Mounts))
+	assert.Equal(t, 1, len(service.Mounts), "number of mounts")
 	assert.Equal(t, "/mount_points/1", service.Mounts[0].ContainerPath)
-	assert.Equal(t, ".", service.Mounts[0].Repo.LocalPath)
-	assert.Equal(t, 2, len(service.Steps))
-	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, service.Steps[0].Argv)
-	assert.Equal(t, []string{"sh", "-c", "echo hi"}, service.Steps[1].Argv)
+	assert.Equal(t, wd, service.Mounts[0].Repo.LocalPath, "repo path")
+	assert.Equal(t, 2, len(service.Steps), "number of steps")
+	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, service.Steps[0].Argv, "first step")
+	assert.Equal(t, []string{"sh", "-c", "echo hi"}, service.Steps[1].Argv, "second step")
 	assert.Equal(t, []string{"sh", "-c", "the entrypoint"}, service.Entrypoint.Argv)
 }
 


### PR DESCRIPTION
Hello @landism, @dmiller,

Please review the following commits I made in branch maiamcc/enforce-abs-repo:

82f8ab53ff1890c62dd166ee29efc0d270458d85 (2018-08-24 12:11:28 -0400)
mill: enforce repo is absolute path

e62010ab1889ca34c5b74a9275540fe2f331b93d (2018-08-24 11:51:23 -0400)
wip

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics