### PR TITLE
build: don't return nil if we couldn't decode any output from Docker

### DIFF
--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -314,6 +314,9 @@ func readDockerOutput(ctx context.Context, reader io.Reader) (*json.RawMessage, 
 			result = message.Aux
 		}
 	}
+	if result == nil {
+		return nil, fmt.Errorf("No JSON docker output found")
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
I was writing a test and noticed that if we can't read any JSON output from docker we return a nil pointer, which then causes a nil pointer exception. This error is less catastrophic.