### PR TITLE
tilt: make gitignore tests prettier

### DIFF
--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -94,17 +94,11 @@ func (r repoIgnoreTester) IsIgnored(f string, isDir bool) (bool, error) {
 }
 
 func NewRepoIgnoreTester(ctx context.Context, repoRoot string) (IgnoreTester, error) {
-	absRepoRoot, err := filepath.Abs(repoRoot)
+	g, err := NewGitIgnoreTester(ctx, repoRoot)
 	if err != nil {
 		return nil, err
 	}
-
-	g, err := NewGitIgnoreTester(ctx, absRepoRoot)
-	if err != nil {
-		return nil, err
-	}
-
-	return &repoIgnoreTester{absRepoRoot, g}, nil
+	return &repoIgnoreTester{repoRoot, g}, nil
 }
 
 type compositeIgnoreTester struct {

--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -94,11 +94,17 @@ func (r repoIgnoreTester) IsIgnored(f string, isDir bool) (bool, error) {
 }
 
 func NewRepoIgnoreTester(ctx context.Context, repoRoot string) (IgnoreTester, error) {
-	g, err := NewGitIgnoreTester(ctx, repoRoot)
+	absRepoRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
 		return nil, err
 	}
-	return &repoIgnoreTester{repoRoot, g}, nil
+
+	g, err := NewGitIgnoreTester(ctx, absRepoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &repoIgnoreTester{absRepoRoot, g}, nil
 }
 
 type compositeIgnoreTester struct {

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -1,6 +1,9 @@
 package git
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,15 +14,9 @@ func TestGitIgnoreTester_Simple(t *testing.T) {
 	tf := newTestFixture(t, ".*.swp")
 	defer tf.TearDown()
 
-	g, err := NewGitIgnoreTester(testutils.CtxForTest(), tf.repoRoots[0].Path())
-	if err != nil {
-		t.Fatal(err)
-	}
+	tf.UseGitIgnoreTester()
 
-	ret, err := g.IsIgnored(tf.repoRoots[0].JoinPath("a", "b", ".foo.swp"), false)
-	if assert.NoError(t, err) {
-		assert.True(t, ret)
-	}
+	tf.AssertResult(tf.JoinPath(0, "a", "b", ".foo.swp"), true, false)
 }
 
 func TestNewGitIgnoreTester_NoGitignore(t *testing.T) {
@@ -47,66 +44,58 @@ func TestGitIgnoreTester_FileOutsideOfRepo(t *testing.T) {
 	tf := newTestFixture(t, ".*.swp")
 	defer tf.TearDown()
 
-	g, err := NewGitIgnoreTester(testutils.CtxForTest(), tf.repoRoots[0].Path())
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	ret, err := g.IsIgnored("/tmp/.foo.swp", false)
-	if assert.NoError(t, err) {
-		assert.False(t, ret)
-	}
+	tf.UseSingleRepoTester()
+	tf.AssertResult(filepath.Join("/tmp", ".foo.swp"), false, false)
 }
 
 func TestGitIgnoreTester_GitDirIsIgnored(t *testing.T) {
 	tf := newTestFixture(t, ".*.swp")
 	defer tf.TearDown()
 
-	g, err := NewRepoIgnoreTester(testutils.CtxForTest(), tf.repoRoots[0].Path())
+	tf.UseSingleRepoTester()
+	tf.AssertResult(tf.JoinPath(0, ".git", "foo", "bar"), true, false)
+}
+
+func TestGitIgnoreTester_GitDirIsIgnoredRelativeRepoRoot(t *testing.T) {
+	tf := newTestFixture(t, ".*.swp")
+	defer tf.TearDown()
+
+	origDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
+	repoRoot := tf.repoRoots[0].Path()
+	os.Chdir(tf.repoRoots[0].JoinPath(".."))
+	defer os.Chdir(origDir)
 
-	ret, err := g.IsIgnored(tf.repoRoots[0].JoinPath(".git/foo/bar"), false)
-	if assert.NoError(t, err) {
-		assert.True(t, ret)
-	}
+	tf.UseSingleRepoTesterWithPath(filepath.Base(repoRoot))
+
+	tf.AssertResult(tf.JoinPath(0, ".git", "foo", "bar"), true, false)
 }
 
 func TestNewMultiRepoIgnoreTester(t *testing.T) {
 	tf := newTestFixture(t, ".*.swp", "a.out")
 	defer tf.TearDown()
 
-	g, err := NewMultiRepoIgnoreTester(testutils.CtxForTest(), []string{tf.repoRoots[0].Path(), tf.repoRoots[1].Path()})
-	if err != nil {
-		t.Fatal(err)
-	}
+	tf.UseMultiRepoTester()
 
-	ret, err := g.IsIgnored(tf.repoRoots[0].JoinPath(".git/foo/bar"), false)
-	if assert.NoError(t, err) {
-		assert.True(t, ret)
-	}
+	tf.AssertResult(tf.JoinPath(0, ".git", "foo", "bar"), true, false)
+	tf.AssertResult(tf.JoinPath(0, ".foo.swp"), true, false)
+	tf.AssertResult(tf.JoinPath(1, "a.out"), true, false)
+	tf.AssertResult(tf.JoinPath(1, ".foo.swp"), false, false)
+}
 
-	ret, err = g.IsIgnored(tf.repoRoots[0].JoinPath(".foo.swp"), false)
-	if assert.NoError(t, err) {
-		assert.True(t, ret)
-	}
-
-	ret, err = g.IsIgnored(tf.repoRoots[1].JoinPath("a.out"), false)
-	if assert.NoError(t, err) {
-		assert.True(t, ret)
-	}
-
-	ret, err = g.IsIgnored(tf.repoRoots[1].JoinPath(".foo.swp"), false)
-	if assert.NoError(t, err) {
-		assert.False(t, ret)
-	}
+func TestRepoIgnoreTester_IsIgnoredRelativePath(t *testing.T) {
+	tf := newTestFixture(t, "")
+	defer tf.TearDown()
 
 }
 
 type testFixture struct {
 	repoRoots []*testutils.TempDirFixture
+	tester    IgnoreTester
+	ctx       context.Context
+	t         *testing.T
 }
 
 // initializes `tf.repoRoots` to be an array with one dir per gitignore
@@ -117,7 +106,60 @@ func newTestFixture(t *testing.T, gitignores ...string) *testFixture {
 		tempDir.WriteFile(".gitignore", gitignore)
 		tf.repoRoots = append(tf.repoRoots, tempDir)
 	}
+
+	tf.ctx = context.Background()
+	tf.t = t
 	return &tf
+}
+
+func (tf *testFixture) UseGitIgnoreTester() {
+	tester, err := NewGitIgnoreTester(testutils.CtxForTest(), tf.repoRoots[0].Path())
+	if err != nil {
+		tf.t.Fatal(err)
+	}
+
+	tf.tester = tester
+}
+
+func (tf *testFixture) UseSingleRepoTester() {
+	tf.UseSingleRepoTesterWithPath(tf.repoRoots[0].Path())
+}
+
+func (tf *testFixture) UseSingleRepoTesterWithPath(path string) {
+	tester, err := NewRepoIgnoreTester(tf.ctx, path)
+	if err != nil {
+		tf.t.Fatal(err)
+	}
+	tf.tester = tester
+}
+
+func (tf *testFixture) UseMultiRepoTester() {
+	var rootDirs []string
+	for _, dir := range tf.repoRoots {
+		rootDirs = append(rootDirs, dir.Path())
+	}
+
+	tester, err := NewMultiRepoIgnoreTester(tf.ctx, rootDirs)
+	if err != nil {
+		tf.t.Fatal(err)
+	}
+
+	tf.tester = tester
+}
+
+func (tf *testFixture) JoinPath(repoNum int, path ...string) string {
+	return tf.repoRoots[repoNum].JoinPath(path...)
+}
+
+func (tf *testFixture) AssertResult(path string, expectedIsIgnored bool, expectError bool) {
+	isIgnored, err := tf.tester.IsIgnored(path, false)
+	if expectError {
+		assert.Error(tf.t, err)
+	} else {
+		if assert.NoError(tf.t, err) {
+			assert.Equal(tf.t, expectedIsIgnored, isIgnored)
+		}
+	}
 }
 
 func (tf *testFixture) TearDown() {

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -53,23 +52,6 @@ func TestGitIgnoreTester_GitDirIsIgnored(t *testing.T) {
 	defer tf.TearDown()
 
 	tf.UseSingleRepoTester()
-	tf.AssertResult(tf.JoinPath(0, ".git", "foo", "bar"), true, false)
-}
-
-func TestGitIgnoreTester_GitDirIsIgnoredRelativeRepoRoot(t *testing.T) {
-	tf := newTestFixture(t, ".*.swp")
-	defer tf.TearDown()
-
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	repoRoot := tf.repoRoots[0].Path()
-	os.Chdir(tf.repoRoots[0].JoinPath(".."))
-	defer os.Chdir(origDir)
-
-	tf.UseSingleRepoTesterWithPath(filepath.Base(repoRoot))
-
 	tf.AssertResult(tf.JoinPath(0, ".git", "foo", "bar"), true, false)
 }
 


### PR DESCRIPTION
1. ignoring .git was failing because we were comparing against relative paths, so use absolute paths when setting up gitignore testers, add a unit test for that case
2. refactor gitignore tests so that they're less tedious