### PR TITLE
up: wait a bit before responding to SIGINT/SIGTERM to give tracing time to flush

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -73,6 +73,8 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 	if watchMounts {
 		for {
 			select {
+			case <-ctx.Done():
+				return ctx.Err()
 			case event := <-sw.events:
 				var changedPathsToPrint []string
 				if len(event.files) > maxChangedFilesToPrint {


### PR DESCRIPTION
Hello @jazzdan, @nicks,

Please review the following commits I made in branch maiamcc/signal-trap:

db9589bffba0885276df09e5c098ce3fe610c5e0 (2018-08-27 11:02:39 -0400)
up: wait a bit before responding to SIGINT/SIGTERM to give tracing time to flush

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics