### PR TITLE
build: support removing directories via dockerfile

### DIFF
--- a/internal/build/dockerfile.go
+++ b/internal/build/dockerfile.go
@@ -36,9 +36,9 @@ func (d Dockerfile) Entrypoint(cmd model.Cmd) Dockerfile {
 func (d Dockerfile) RmPaths(pathsToRm []pathMapping) Dockerfile {
 	var newDf string
 	if len(pathsToRm) > 0 {
-		// Add 'rm' statements; if changed file was deleted locally, remove if from container
+		// Add 'rm' statements; if changed path was deleted locally, remove if from container
 		rmCmd := strings.Builder{}
-		rmCmd.WriteString("rm") // sh -c?
+		rmCmd.WriteString("rm -rf")
 		for _, p := range pathsToRm {
 			rmCmd.WriteString(fmt.Sprintf(" %s", p.ContainerPath))
 		}

--- a/internal/testutils/temp_dir_fixture.go
+++ b/internal/testutils/temp_dir_fixture.go
@@ -76,14 +76,14 @@ func (f *TempDirFixture) TouchFiles(paths []string) {
 
 func (f *TempDirFixture) Rm(pathInRepo string) {
 	fullPath := filepath.Join(f.Path(), pathInRepo)
-	err := os.Remove(fullPath)
+	err := os.RemoveAll(fullPath)
 	if err != nil {
 		f.t.Fatal(err)
 	}
 }
 
-func (tempDir *TempDirFixture) NewFile(prefix string) (f *os.File, err error) {
-	return ioutil.TempFile(tempDir.dir.Path(), prefix)
+func (f *TempDirFixture) NewFile(prefix string) (*os.File, error) {
+	return ioutil.TempFile(f.dir.Path(), prefix)
 }
 
 func (f *TempDirFixture) TearDown() {


### PR DESCRIPTION
addresses bug that @landism encountered: if user deletes a directory, we get the directory as the "changed path", which means dockerfile calls `RUN rf <dir>`, which obviously doesn't work if there's stuff in it hehhh.