### PR TITLE
build: use buildkit

### DIFF
--- a/internal/build/container.go
+++ b/internal/build/container.go
@@ -1,8 +1,8 @@
 package build
 
 import (
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/container"
-	digest "github.com/opencontainers/go-digest"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -11,7 +11,7 @@ type execID string
 
 // Get a container config to run a container with a given command instead of
 // the existing entrypoint. If cmd is nil, we run nothing.
-func containerConfigRunCmd(imgRef digest.Digest, cmd model.Cmd) *container.Config {
+func containerConfigRunCmd(imgRef reference.NamedTagged, cmd model.Cmd) *container.Config {
 	config := containerConfig(imgRef)
 
 	// In Docker, both the Entrypoint and the Cmd are used to determine what
@@ -32,6 +32,6 @@ func containerConfigRunCmd(imgRef digest.Digest, cmd model.Cmd) *container.Confi
 }
 
 // Get a container config to run a container as-is.
-func containerConfig(imgRef digest.Digest) *container.Config {
-	return &container.Config{Image: string(imgRef)}
+func containerConfig(imgRef reference.NamedTagged) *container.Config {
+	return &container.Config{Image: imgRef.String()}
 }

--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -208,12 +207,8 @@ func (l *localDockerBuilder) buildFromDf(ctx context.Context, df Dockerfile, pat
 	imageBuildResponse, err := l.dcli.ImageBuild(
 		ctx,
 		archive,
-		types.ImageBuildOptions{
-			Context:    archive,
-			Dockerfile: "Dockerfile",
-			Remove:     shouldRemoveImage(),
-			Version:    types.BuilderBuildKit,
-		})
+		Options(archive),
+	)
 	spanBuild.Finish()
 	if err != nil {
 		return nil, err
@@ -377,13 +372,6 @@ func getDigestFromAux(aux json.RawMessage) (digest.Digest, error) {
 		return "", fmt.Errorf("getDigestFromAux: ID not found")
 	}
 	return digest.Digest(id), nil
-}
-
-func shouldRemoveImage() bool {
-	if flag.Lookup("test.v") == nil {
-		return false
-	}
-	return true
 }
 
 func digestAsTag(d digest.Digest) (string, error) {

--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -99,12 +99,12 @@ func (l *localDockerBuilder) buildDocker(ctx context.Context, baseDockerfile Doc
 	}
 
 	// We have the Dockerfile! Kick off the docker build.
-	resultDigest, err := l.buildFromDf(ctx, df, paths, ref)
+	namedTagged, err := l.buildFromDf(ctx, df, paths, ref)
 	if err != nil {
 		return nil, fmt.Errorf("buildDocker#buildFromDf: %v", err)
 	}
 
-	return resultDigest, nil
+	return namedTagged, nil
 }
 
 // Tag the digest with the given name and wm-tilt tag.

--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -217,6 +217,7 @@ func (l *localDockerBuilder) buildFromDf(ctx context.Context, df Dockerfile, pat
 			Context:    archive,
 			Dockerfile: "Dockerfile",
 			Remove:     shouldRemoveImage(),
+			Version:    types.BuilderBuildKit,
 		})
 	spanBuild.Finish()
 	if err != nil {
@@ -315,7 +316,7 @@ func readDockerOutput(ctx context.Context, reader io.Reader) (*json.RawMessage, 
 			return nil, errors.New(message.Error.Message)
 		}
 
-		if message.Aux != nil {
+		if message.Aux != nil && message.ID != "moby.buildkit.trace" {
 			result = message.Aux
 		}
 	}

--- a/internal/build/docker_benchmark_test.go
+++ b/internal/build/docker_benchmark_test.go
@@ -20,7 +20,7 @@ func BenchmarkBuildTenSteps(b *testing.B) {
 			steps = append(steps, model.ToShellCmd(fmt.Sprintf("echo -n %d > hi", i)))
 		}
 
-		digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+		ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -28,7 +28,7 @@ func BenchmarkBuildTenSteps(b *testing.B) {
 		expected := []expectedFile{
 			expectedFile{path: "hi", contents: "9"},
 		}
-		f.assertFilesInImage(digest, expected)
+		f.assertFilesInImage(ref, expected)
 	}
 	for i := 0; i < b.N; i++ {
 		run()
@@ -48,7 +48,7 @@ func BenchmarkBuildTenStepsInOne(b *testing.B) {
 		oneCmd := strings.Join(allCmds, " && ")
 
 		steps := []model.Cmd{model.ToShellCmd(oneCmd)}
-		digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+		ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -56,7 +56,7 @@ func BenchmarkBuildTenStepsInOne(b *testing.B) {
 		expected := []expectedFile{
 			expectedFile{path: "hi", contents: "9"},
 		}
-		f.assertFilesInImage(digest, expected)
+		f.assertFilesInImage(ref, expected)
 	}
 	for i := 0; i < b.N; i++ {
 		run()
@@ -67,7 +67,7 @@ func BenchmarkIterativeBuildTenTimes(b *testing.B) {
 	f := newDockerBuildFixture(b)
 	defer f.teardown()
 	steps := []model.Cmd{model.ToShellCmd("echo 1 >> hi")}
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func BenchmarkIterativeBuildTenTimes(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 10; j++ {
-			digest, err = f.b.BuildDockerFromExisting(f.ctx, digest, nil, steps)
+			ref, err = f.b.BuildDockerFromExisting(f.ctx, ref, nil, steps)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/internal/build/docker_benchmark_test.go
+++ b/internal/build/docker_benchmark_test.go
@@ -20,7 +20,7 @@ func BenchmarkBuildTenSteps(b *testing.B) {
 			steps = append(steps, model.ToShellCmd(fmt.Sprintf("echo -n %d > hi", i)))
 		}
 
-		digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+		digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -48,7 +48,7 @@ func BenchmarkBuildTenStepsInOne(b *testing.B) {
 		oneCmd := strings.Join(allCmds, " && ")
 
 		steps := []model.Cmd{model.ToShellCmd(oneCmd)}
-		digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+		digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -67,7 +67,7 @@ func BenchmarkIterativeBuildTenTimes(b *testing.B) {
 	f := newDockerBuildFixture(b)
 	defer f.teardown()
 	steps := []model.Cmd{model.ToShellCmd("echo 1 >> hi")}
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/build/docker_benchmark_test.go
+++ b/internal/build/docker_benchmark_test.go
@@ -28,7 +28,7 @@ func BenchmarkBuildTenSteps(b *testing.B) {
 		expected := []expectedFile{
 			expectedFile{path: "hi", contents: "9"},
 		}
-		f.assertFilesInImage(string(digest), expected)
+		f.assertFilesInImage(digest, expected)
 	}
 	for i := 0; i < b.N; i++ {
 		run()
@@ -56,7 +56,7 @@ func BenchmarkBuildTenStepsInOne(b *testing.B) {
 		expected := []expectedFile{
 			expectedFile{path: "hi", contents: "9"},
 		}
-		f.assertFilesInImage(string(digest), expected)
+		f.assertFilesInImage(digest, expected)
 	}
 	for i := 0; i < b.N; i++ {
 		run()

--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -94,7 +94,7 @@ func TestMount(t *testing.T) {
 		ContainerPath: "/src",
 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestMount(t *testing.T) {
 		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
 		expectedFile{path: "/src/sup", contents: "my name is dan"},
 	}
-	f.assertFilesInImage(digest, pcs)
+	f.assertFilesInImage(ref, pcs)
 }
 
 func TestMultipleMounts(t *testing.T) {
@@ -123,7 +123,7 @@ func TestMultipleMounts(t *testing.T) {
 		ContainerPath: "goodbye_there",
 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{m1, m2}, []model.Cmd{}, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{m1, m2}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestMultipleMounts(t *testing.T) {
 		expectedFile{path: "/hello_there/hello", contents: "hi hello"},
 		expectedFile{path: "/goodbye_there/ciao/goodbye", contents: "bye laterz"},
 	}
-	f.assertFilesInImage(digest, pcs)
+	f.assertFilesInImage(ref, pcs)
 }
 
 func TestMountCollisions(t *testing.T) {
@@ -154,7 +154,7 @@ func TestMountCollisions(t *testing.T) {
 		ContainerPath: "/hello_there",
 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{m1, m2}, []model.Cmd{}, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{m1, m2}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestMountCollisions(t *testing.T) {
 	pcs := []expectedFile{
 		expectedFile{path: "/hello_there/hello", contents: "bye laterz"},
 	}
-	f.assertFilesInImage(digest, pcs)
+	f.assertFilesInImage(ref, pcs)
 }
 
 func TestPush(t *testing.T) {
@@ -185,12 +185,12 @@ func TestPush(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, name, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, name, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	namedTagged, err := f.b.PushDocker(f.ctx, digest)
+	namedTagged, err := f.b.PushDocker(f.ctx, ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,12 +215,12 @@ func TestPushInvalid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, name, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, name, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = f.b.PushDocker(f.ctx, digest)
+	_, err = f.b.PushDocker(f.ctx, ref)
 	if err == nil || !strings.Contains(err.Error(), "PushDocker#getDigestFromPushOutput") {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestBuildOneStep(t *testing.T) {
 		model.ToShellCmd("echo -n hello >> hi"),
 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +242,7 @@ func TestBuildOneStep(t *testing.T) {
 	expected := []expectedFile{
 		expectedFile{path: "hi", contents: "hello"},
 	}
-	f.assertFilesInImage(digest, expected)
+	f.assertFilesInImage(ref, expected)
 }
 
 func TestBuildMultipleSteps(t *testing.T) {
@@ -254,7 +254,7 @@ func TestBuildMultipleSteps(t *testing.T) {
 		model.ToShellCmd("echo -n sup >> hi2"),
 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestBuildMultipleSteps(t *testing.T) {
 		expectedFile{path: "hi", contents: "hello"},
 		expectedFile{path: "hi2", contents: "sup"},
 	}
-	f.assertFilesInImage(digest, expected)
+	f.assertFilesInImage(ref, expected)
 }
 
 func TestBuildMultipleStepsRemoveFiles(t *testing.T) {
@@ -276,7 +276,7 @@ func TestBuildMultipleStepsRemoveFiles(t *testing.T) {
 		model.Cmd{Argv: []string{"sh", "-c", "rm hi"}},
 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
+	ref, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func TestBuildMultipleStepsRemoveFiles(t *testing.T) {
 		expectedFile{path: "hi2", contents: "sup"},
 		expectedFile{path: "hi", missing: true},
 	}
-	f.assertFilesInImage(digest, expected)
+	f.assertFilesInImage(ref, expected)
 }
 
 func TestBuildFailingStep(t *testing.T) {
@@ -375,7 +375,7 @@ func TestSelectiveAddFilesToExisting(t *testing.T) {
 		f.t.Fatal("FilesToPathMappings:", err)
 	}
 
-	digest, err := f.b.BuildDockerFromExisting(f.ctx, existing, pms, []model.Cmd{})
+	ref, err := f.b.BuildDockerFromExisting(f.ctx, existing, pms, []model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +386,7 @@ func TestSelectiveAddFilesToExisting(t *testing.T) {
 		expectedFile{path: "/src/nested/sup", missing: true}, // should have deleted whole directory
 		expectedFile{path: "/src/unchanged", contents: "should be unchanged"},
 	}
-	f.assertFilesInImage(digest, pcs)
+	f.assertFilesInImage(ref, pcs)
 }
 
 func TestExecStepsOnExisting(t *testing.T) {
@@ -406,7 +406,7 @@ func TestExecStepsOnExisting(t *testing.T) {
 
 	step := model.ToShellCmd("echo -n foo contains: $(cat /src/foo) >> /src/bar")
 
-	digest, err := f.b.BuildDockerFromExisting(f.ctx, existing, MountsToPathMappings([]model.Mount{m}), []model.Cmd{step})
+	ref, err := f.b.BuildDockerFromExisting(f.ctx, existing, MountsToPathMappings([]model.Mount{m}), []model.Cmd{step})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +415,7 @@ func TestExecStepsOnExisting(t *testing.T) {
 		expectedFile{path: "/src/foo", contents: "hello world"},
 		expectedFile{path: "/src/bar", contents: "foo contains: hello world"},
 	}
-	f.assertFilesInImage(digest, pcs)
+	f.assertFilesInImage(ref, pcs)
 }
 
 func TestBuildDockerFromExistingPreservesEntrypoint(t *testing.T) {
@@ -438,7 +438,7 @@ func TestBuildDockerFromExistingPreservesEntrypoint(t *testing.T) {
 	// will change the contents of `bar`
 	f.WriteFile("foo", "a whole new world")
 
-	digest, err := f.b.BuildDockerFromExisting(f.ctx, existing, MountsToPathMappings([]model.Mount{m}), []model.Cmd{})
+	ref, err := f.b.BuildDockerFromExisting(f.ctx, existing, MountsToPathMappings([]model.Mount{m}), []model.Cmd{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,7 +449,7 @@ func TestBuildDockerFromExistingPreservesEntrypoint(t *testing.T) {
 	}
 
 	// Start container WITHOUT overriding entrypoint (which assertFilesInImage... does)
-	cID := f.startContainer(f.ctx, containerConfig(digest))
+	cID := f.startContainer(f.ctx, containerConfig(ref))
 	f.assertFilesInContainer(f.ctx, cID, expected)
 }
 
@@ -474,7 +474,7 @@ func TestBuildDockerWithStepsFromExistingPreservesEntrypoint(t *testing.T) {
 	// will change the contents of `bar`
 	f.WriteFile("foo", "a whole new world")
 
-	digest, err := f.b.BuildDockerFromExisting(f.ctx, existing, MountsToPathMappings([]model.Mount{m}), []model.Cmd{step})
+	ref, err := f.b.BuildDockerFromExisting(f.ctx, existing, MountsToPathMappings([]model.Mount{m}), []model.Cmd{step})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -486,7 +486,7 @@ func TestBuildDockerWithStepsFromExistingPreservesEntrypoint(t *testing.T) {
 	}
 
 	// Start container WITHOUT overriding entrypoint (which assertFilesInImage... does)
-	cID := f.startContainer(f.ctx, containerConfig(digest))
+	cID := f.startContainer(f.ctx, containerConfig(ref))
 	f.assertFilesInContainer(f.ctx, cID, expected)
 }
 

--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -298,7 +299,11 @@ func TestBuildFailingStep(t *testing.T) {
 	_, err := f.b.BuildDockerFromScratch(f.ctx, f.getNameFromTest(), simpleDockerfile, []model.Mount{}, steps, model.Cmd{})
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "hello")
-		assert.Contains(t, err.Error(), "exit code 1")
+		if runtime.GOOS == "darwin" {
+			assert.Contains(t, err.Error(), "exit code 1")
+		} else {
+			assert.Contains(t, err.Error(), "returned a non-zero code: 1")
+		}
 	}
 }
 

--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -101,7 +101,7 @@ func TestMount(t *testing.T) {
 		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
 		expectedFile{path: "/src/sup", contents: "my name is dan"},
 	}
-	f.assertFilesInImage(string(digest), pcs)
+	f.assertFilesInImage(digest, pcs)
 }
 
 func TestMultipleMounts(t *testing.T) {
@@ -130,7 +130,7 @@ func TestMultipleMounts(t *testing.T) {
 		expectedFile{path: "/hello_there/hello", contents: "hi hello"},
 		expectedFile{path: "/goodbye_there/ciao/goodbye", contents: "bye laterz"},
 	}
-	f.assertFilesInImage(string(digest), pcs)
+	f.assertFilesInImage(digest, pcs)
 }
 
 func TestMountCollisions(t *testing.T) {
@@ -160,63 +160,63 @@ func TestMountCollisions(t *testing.T) {
 	pcs := []expectedFile{
 		expectedFile{path: "/hello_there/hello", contents: "bye laterz"},
 	}
-	f.assertFilesInImage(string(digest), pcs)
+	f.assertFilesInImage(digest, pcs)
 }
 
-func TestPush(t *testing.T) {
-	f := newDockerBuildFixture(t)
-	defer f.teardown()
+// func TestPush(t *testing.T) {
+// 	f := newDockerBuildFixture(t)
+// 	defer f.teardown()
 
-	f.startRegistry()
+// 	f.startRegistry()
 
-	// write some files in to it
-	f.WriteFile("hi/hello", "hi hello")
-	f.WriteFile("sup", "my name is dan")
+// 	// write some files in to it
+// 	f.WriteFile("hi/hello", "hi hello")
+// 	f.WriteFile("sup", "my name is dan")
 
-	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
-		ContainerPath: "/src",
-	}
+// 	m := model.Mount{
+// 		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+// 		ContainerPath: "/src",
+// 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
-	if err != nil {
-		t.Fatal(err)
-	}
+// 	digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	name, _ := reference.ParseNormalizedNamed("localhost:5005/myimage")
-	namedTagged, err := f.b.PushDocker(f.ctx, name, digest)
-	if err != nil {
-		t.Fatal(err)
-	}
+// 	name, _ := reference.ParseNormalizedNamed("localhost:5005/myimage")
+// 	namedTagged, err := f.b.PushDocker(f.ctx, name, digest)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	pcs := []expectedFile{
-		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
-		expectedFile{path: "/src/sup", contents: "my name is dan"},
-	}
+// 	pcs := []expectedFile{
+// 		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
+// 		expectedFile{path: "/src/sup", contents: "my name is dan"},
+// 	}
 
-	f.assertFilesInImage(namedTagged.String(), pcs)
-}
+// 	f.assertFilesInImage(namedTagged.String(), pcs)
+// }
 
-func TestPushInvalid(t *testing.T) {
-	f := newDockerBuildFixture(t)
-	defer f.teardown()
+// func TestPushInvalid(t *testing.T) {
+// 	f := newDockerBuildFixture(t)
+// 	defer f.teardown()
 
-	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
-		ContainerPath: "/src",
-	}
+// 	m := model.Mount{
+// 		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+// 		ContainerPath: "/src",
+// 	}
 
-	digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
-	if err != nil {
-		t.Fatal(err)
-	}
+// 	digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	name, _ := reference.ParseNormalizedNamed("localhost:6666/myimage")
-	_, err = f.b.PushDocker(f.ctx, name, digest)
-	if err == nil || !strings.Contains(err.Error(), "PushDocker#getDigestFromPushOutput") {
-		t.Fatal(err)
-	}
-}
+// 	name, _ := reference.ParseNormalizedNamed("localhost:6666/myimage")
+// 	_, err = f.b.PushDocker(f.ctx, name, digest)
+// 	if err == nil || !strings.Contains(err.Error(), "PushDocker#getDigestFromPushOutput") {
+// 		t.Fatal(err)
+// 	}
+// }
 
 func TestBuildOneStep(t *testing.T) {
 	f := newDockerBuildFixture(t)
@@ -234,7 +234,7 @@ func TestBuildOneStep(t *testing.T) {
 	expected := []expectedFile{
 		expectedFile{path: "hi", contents: "hello"},
 	}
-	f.assertFilesInImage(string(digest), expected)
+	f.assertFilesInImage(digest, expected)
 }
 
 func TestBuildMultipleSteps(t *testing.T) {
@@ -255,7 +255,7 @@ func TestBuildMultipleSteps(t *testing.T) {
 		expectedFile{path: "hi", contents: "hello"},
 		expectedFile{path: "hi2", contents: "sup"},
 	}
-	f.assertFilesInImage(string(digest), expected)
+	f.assertFilesInImage(digest, expected)
 }
 
 func TestBuildMultipleStepsRemoveFiles(t *testing.T) {
@@ -277,7 +277,7 @@ func TestBuildMultipleStepsRemoveFiles(t *testing.T) {
 		expectedFile{path: "hi2", contents: "sup"},
 		expectedFile{path: "hi", missing: true},
 	}
-	f.assertFilesInImage(string(digest), expected)
+	f.assertFilesInImage(digest, expected)
 }
 
 func TestBuildFailingStep(t *testing.T) {
@@ -374,7 +374,7 @@ func TestSelectiveAddFilesToExisting(t *testing.T) {
 		expectedFile{path: "/src/nested/sup", missing: true}, // should have deleted whole directory
 		expectedFile{path: "/src/unchanged", contents: "should be unchanged"},
 	}
-	f.assertFilesInImage(string(digest), pcs)
+	f.assertFilesInImage(digest, pcs)
 }
 
 func TestExecStepsOnExisting(t *testing.T) {
@@ -403,7 +403,7 @@ func TestExecStepsOnExisting(t *testing.T) {
 		expectedFile{path: "/src/foo", contents: "hello world"},
 		expectedFile{path: "/src/bar", contents: "foo contains: hello world"},
 	}
-	f.assertFilesInImage(string(digest), pcs)
+	f.assertFilesInImage(digest, pcs)
 }
 
 func TestBuildDockerFromExistingPreservesEntrypoint(t *testing.T) {
@@ -556,8 +556,8 @@ type expectedFile struct {
 	missing bool
 }
 
-func (f *dockerBuildFixture) assertFilesInImage(ref string, expectedFiles []expectedFile) {
-	cID := f.startContainer(f.ctx, containerConfigRunCmd(digest.Digest(ref), model.Cmd{}))
+func (f *dockerBuildFixture) assertFilesInImage(ref reference.NamedTagged, expectedFiles []expectedFile) {
+	cID := f.startContainer(f.ctx, containerConfigRunCmd(ref, model.Cmd{}))
 	f.assertFilesInContainer(f.ctx, cID, expectedFiles)
 }
 

--- a/internal/build/docker_test.go
+++ b/internal/build/docker_test.go
@@ -164,60 +164,66 @@ func TestMountCollisions(t *testing.T) {
 	f.assertFilesInImage(digest, pcs)
 }
 
-// func TestPush(t *testing.T) {
-// 	f := newDockerBuildFixture(t)
-// 	defer f.teardown()
+func TestPush(t *testing.T) {
+	f := newDockerBuildFixture(t)
+	defer f.teardown()
 
-// 	f.startRegistry()
+	f.startRegistry()
 
-// 	// write some files in to it
-// 	f.WriteFile("hi/hello", "hi hello")
-// 	f.WriteFile("sup", "my name is dan")
+	// write some files in to it
+	f.WriteFile("hi/hello", "hi hello")
+	f.WriteFile("sup", "my name is dan")
 
-// 	m := model.Mount{
-// 		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
-// 		ContainerPath: "/src",
-// 	}
+	m := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		ContainerPath: "/src",
+	}
 
-// 	digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	name, err := reference.WithName("localhost:5005/myimage")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	name, _ := reference.ParseNormalizedNamed("localhost:5005/myimage")
-// 	namedTagged, err := f.b.PushDocker(f.ctx, name, digest)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	digest, err := f.b.BuildDockerFromScratch(f.ctx, name, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	pcs := []expectedFile{
-// 		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
-// 		expectedFile{path: "/src/sup", contents: "my name is dan"},
-// 	}
+	namedTagged, err := f.b.PushDocker(f.ctx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	f.assertFilesInImage(namedTagged.String(), pcs)
-// }
+	pcs := []expectedFile{
+		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
+		expectedFile{path: "/src/sup", contents: "my name is dan"},
+	}
 
-// func TestPushInvalid(t *testing.T) {
-// 	f := newDockerBuildFixture(t)
-// 	defer f.teardown()
+	f.assertFilesInImage(namedTagged, pcs)
+}
 
-// 	m := model.Mount{
-// 		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
-// 		ContainerPath: "/src",
-// 	}
+func TestPushInvalid(t *testing.T) {
+	f := newDockerBuildFixture(t)
+	defer f.teardown()
 
-// 	digest, err := f.b.BuildDockerFromScratch(f.ctx, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	m := model.Mount{
+		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		ContainerPath: "/src",
+	}
+	name, err := reference.WithName("localhost:5005/myimage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := f.b.BuildDockerFromScratch(f.ctx, name, simpleDockerfile, []model.Mount{m}, []model.Cmd{}, model.Cmd{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	name, _ := reference.ParseNormalizedNamed("localhost:6666/myimage")
-// 	_, err = f.b.PushDocker(f.ctx, name, digest)
-// 	if err == nil || !strings.Contains(err.Error(), "PushDocker#getDigestFromPushOutput") {
-// 		t.Fatal(err)
-// 	}
-// }
+	_, err = f.b.PushDocker(f.ctx, digest)
+	if err == nil || !strings.Contains(err.Error(), "PushDocker#getDigestFromPushOutput") {
+		t.Fatal(err)
+	}
+}
 
 func TestBuildOneStep(t *testing.T) {
 	f := newDockerBuildFixture(t)

--- a/internal/build/dockerfile.go
+++ b/internal/build/dockerfile.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	digest "github.com/opencontainers/go-digest"
+	"github.com/docker/distribution/reference"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -13,8 +13,8 @@ type Dockerfile string
 // DockerfileFromExisting creates a new Dockerfile that uses the supplied image
 // as its base image with a FROM statement. This is necessary for iterative
 // Docker builds.
-func DockerfileFromExisting(existing digest.Digest) Dockerfile {
-	return Dockerfile(fmt.Sprintf("FROM %s", existing.Encoded()))
+func DockerfileFromExisting(existing reference.NamedTagged) Dockerfile {
+	return Dockerfile(fmt.Sprintf("FROM %s", existing.String()))
 }
 
 func (d Dockerfile) join(s string) Dockerfile {

--- a/internal/build/options.go
+++ b/internal/build/options.go
@@ -14,7 +14,6 @@ func Options(archive *bytes.Reader) types.ImageBuildOptions {
 		Context:    archive,
 		Dockerfile: "Dockerfile",
 		Remove:     shouldRemoveImage(),
-		Version:    types.BuilderBuildKit,
 	}
 }
 

--- a/internal/build/options.go
+++ b/internal/build/options.go
@@ -1,0 +1,26 @@
+// +build !buildkit
+
+package build
+
+import (
+	"bytes"
+	"flag"
+
+	"github.com/docker/docker/api/types"
+)
+
+func Options(archive *bytes.Reader) types.ImageBuildOptions {
+	return types.ImageBuildOptions{
+		Context:    archive,
+		Dockerfile: "Dockerfile",
+		Remove:     shouldRemoveImage(),
+		Version:    types.BuilderBuildKit,
+	}
+}
+
+func shouldRemoveImage() bool {
+	if flag.Lookup("test.v") == nil {
+		return false
+	}
+	return true
+}

--- a/internal/build/options_buildkit.go
+++ b/internal/build/options_buildkit.go
@@ -1,0 +1,26 @@
+// +build buildkit
+
+package build
+
+import (
+	"bytes"
+	"flag"
+
+	"github.com/docker/docker/api/types"
+)
+
+func Options(archive *bytes.Reader) types.ImageBuildOptions {
+	return types.ImageBuildOptions{
+		Context:    archive,
+		Dockerfile: "Dockerfile",
+		Remove:     shouldRemoveImage(),
+		Version:    types.BuilderBuildKit,
+	}
+}
+
+func shouldRemoveImage() bool {
+	if flag.Lookup("test.v") == nil {
+		return false
+	}
+	return true
+}

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -101,17 +101,13 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	// 	return nil, err
 	// }
 
-	var refToInject reference.Named
-
 	// If we're using docker-for-desktop as our k8s backend,
 	// we don't need to push to the central registry.
 	// The k8s will use the image already available
 	// in the local docker daemon.
 	canSkipPush := l.env == k8s.EnvDockerDesktop || l.env == k8s.EnvMinikube
-	if canSkipPush {
-		refToInject = n
-	} else {
-		refToInject, err = l.b.PushDocker(ctx, n)
+	if !canSkipPush {
+		n, err = l.b.PushDocker(ctx, n)
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +139,7 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 		if canSkipPush {
 			policy = v1.PullNever
 		}
-		e, replaced, err := k8s.InjectImageDigest(e, refToInject, policy)
+		e, replaced, err := k8s.InjectImageDigest(e, n, policy)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -73,10 +73,10 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 		}
 		output.Get(ctx).StartPipelineStep("Building from scratch: [%s]", service.DockerfileTag)
 		newDigest, err := l.b.BuildDockerFromScratch(ctx, name, build.Dockerfile(service.DockerfileText), service.Mounts, service.Steps, service.Entrypoint)
+		output.Get(ctx).EndPipelineStep()
 		if err != nil {
 			return nil, err
 		}
-		output.Get(ctx).EndPipelineStep()
 		n = newDigest
 
 	} else {

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -69,18 +69,17 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	var name reference.Named
 	var d digest.Digest
 	if token.isEmpty() {
+		name, err = reference.ParseNormalizedNamed(service.DockerfileTag)
+		if err != nil {
+			return nil, err
+		}
 		output.Get(ctx).StartPipelineStep("Building from scratch: [%s]", service.DockerfileTag)
-		newDigest, err := l.b.BuildDockerFromScratch(ctx, build.Dockerfile(service.DockerfileText), service.Mounts, service.Steps, service.Entrypoint)
+		newDigest, err := l.b.BuildDockerFromScratch(ctx, name, build.Dockerfile(service.DockerfileText), service.Mounts, service.Steps, service.Entrypoint)
 		if err != nil {
 			return nil, err
 		}
 		output.Get(ctx).EndPipelineStep()
 		d = newDigest
-
-		name, err = reference.ParseNormalizedNamed(service.DockerfileTag)
-		if err != nil {
-			return nil, err
-		}
 
 	} else {
 		cf, err := build.FilesToPathMappings(changedFiles, service.Mounts)

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -58,6 +58,7 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	output.Get(ctx).StartPipeline(2)
 	defer output.Get(ctx).EndPipeline()
 
+	// TODO(dmiller) add back history
 	//checkpoint := l.history.CheckpointNow()
 	err := service.Validate()
 	if err != nil {
@@ -94,6 +95,7 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	}
 
 	logger.Get(ctx).Verbosef("(Adding checkpoint to history)")
+	// TODO(dmiller) add back history
 	// err = l.history.AddAndPersist(ctx, name, d, checkpoint, service)
 	// if err != nil {
 	// 	return nil, err

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -72,12 +72,12 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 			return nil, err
 		}
 		output.Get(ctx).StartPipelineStep("Building from scratch: [%s]", service.DockerfileTag)
-		newDigest, err := l.b.BuildDockerFromScratch(ctx, name, build.Dockerfile(service.DockerfileText), service.Mounts, service.Steps, service.Entrypoint)
+		ref, err := l.b.BuildDockerFromScratch(ctx, name, build.Dockerfile(service.DockerfileText), service.Mounts, service.Steps, service.Entrypoint)
 		output.Get(ctx).EndPipelineStep()
 		if err != nil {
 			return nil, err
 		}
-		n = newDigest
+		n = ref
 
 	} else {
 		cf, err := build.FilesToPathMappings(changedFiles, service.Mounts)
@@ -86,12 +86,12 @@ func (l localBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 		}
 
 		output.Get(ctx).StartPipelineStep("Building from existing: [%s]", service.DockerfileTag)
-		newDigest, err := l.b.BuildDockerFromExisting(ctx, token.n, cf, service.Steps)
+		ref, err := l.b.BuildDockerFromExisting(ctx, token.n, cf, service.Steps)
 		output.Get(ctx).EndPipelineStep()
 		if err != nil {
 			return nil, err
 		}
-		n = newDigest
+		n = ref
 	}
 
 	logger.Get(ctx).Verbosef("(Adding checkpoint to history)")


### PR DESCRIPTION
I apologize for the size of this diff, I tried to break it out in to sensible commits below.

This diff replaces all instances of `digest.Digest` with `reference.NamedTagged`. This is necessary for BuildKit to work since it doesn't allow you to use digests in `FROM` statements in Dockerfiles anymore. Doing this touched a lot of files and involved changing not just building from existing docker files, but also from scratch, pushing, and more.

I pass the Buildkit flag in `ImageBuildOptions`.

Instead of returning a Digest from build, I tag the digest immediately and return the `reference.NamedTagged`.

Things that are broken:
1. History. I'm going to fix this in a later diff.
2. Streaming output.