### PR TITLE
engine: automatically port-forward on minikube/gke like docker-for-desktop does

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"context"
 
-	"github.com/docker/docker/client"
 	"github.com/google/go-cloud/wire"
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/engine"
@@ -24,7 +23,7 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 		k8s.DefaultClient,
 		image.NewImageHistory,
 		build.DefaultDockerClient,
-		wire.Bind(new(build.DockerClient), new(client.Client)),
+		wire.Bind(new(build.DockerClient), new(build.DockerCli)),
 		build.DefaultBuilder,
 		build.NewLocalDockerBuilder,
 		engine.NewUpper,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -23,13 +23,13 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := build.DefaultDockerClient(ctx, env)
+	dockerCli, err := build.DefaultDockerClient(ctx, env)
 	if err != nil {
 		return nil, err
 	}
-	localDockerBuilder := build.NewLocalDockerBuilder(client)
+	localDockerBuilder := build.NewLocalDockerBuilder(dockerCli)
 	builder := build.DefaultBuilder(localDockerBuilder)
-	client2 := k8s.DefaultClient()
+	client := k8s.DefaultClient()
 	windmillDir, err := dirs.UseWindmillDir()
 	if err != nil {
 		return nil, err
@@ -38,11 +38,11 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 	if err != nil {
 		return nil, err
 	}
-	buildAndDeployer, err := engine.NewLocalBuildAndDeployer(builder, client2, imageHistory, env)
+	buildAndDeployer, err := engine.NewLocalBuildAndDeployer(builder, client, imageHistory, env)
 	if err != nil {
 		return nil, err
 	}
-	upper, err := engine.NewUpper(ctx, buildAndDeployer)
+	upper, err := engine.NewUpper(ctx, buildAndDeployer, client)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -50,3 +50,79 @@ var SanchoService = model.Service{
 	},
 	Entrypoint: model.Cmd{Argv: []string{"/go/bin/sancho"}},
 }
+
+const BlorgBackendYAML = `
+# Template should be populated using populate_config_template.py
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: devel-nick-lb-blorg-be
+  labels:
+    app: blorg
+    owner: nick
+    environment: devel
+    tier: backend
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    app: blorg
+    owner: nick
+    environment: devel
+    tier: backend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: devel-nick-blorg-be
+spec:
+  selector:
+    matchLabels:
+      app: blorg
+      owner: nick
+      environment: devel
+      tier: backend
+  template:
+    metadata:
+      name: devel-nick-blorg-be
+      labels:
+        app: blorg
+        owner: nick
+        environment: devel
+        tier: backend
+    spec:
+      containers:
+      - name: backend
+        imagePullPolicy: Always
+        image: gcr.io/blorg-dev/blorg-backend:devel-nick
+        command: [
+          "/app/server",
+          "--dbAddr", "hissing-cockroach-cockroachdb:26257"
+        ]
+        ports:
+        - containerPort: 8080
+`
+
+const BlorgBackendDockerfile = `
+FROM go:1.10
+`
+
+var BlorgBackendService = model.Service{
+	Name:           "blorg-backend",
+	DockerfileTag:  "gcr.io/blorg-dev/blorg-backend",
+	K8sYaml:        BlorgBackendYAML,
+	DockerfileText: BlorgBackendDockerfile,
+	Mounts: []model.Mount{
+		model.Mount{
+			Repo:          model.LocalGithubRepo{LocalPath: "blorg-backend"},
+			ContainerPath: "/go/src/github.com/windmilleng/blorg-backend",
+		},
+	},
+	Steps: []model.Cmd{
+		model.Cmd{Argv: []string{"go", "install", "github.com/windmilleng/blorg-backend"}},
+	},
+	Entrypoint: model.Cmd{Argv: []string{"/go/bin/blorg-backend"}},
+}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -291,7 +291,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	timerMaker := makeFakeTimerMaker(t)
 
-	upper := Upper{b, watcherMaker, timerMaker.maker()}
+	upper := Upper{b, watcherMaker, timerMaker.maker(), &FakeK8sClient{}}
 	ctx := testutils.CtxForTest()
 	return &testFixture{t, upper, b, watcher, ctx, &timerMaker}
 }

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -10,7 +10,6 @@ import (
 	build "github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/image"
 	k8s "github.com/windmilleng/tilt/internal/k8s"
-	service "github.com/windmilleng/tilt/internal/service"
 	dirs "github.com/windmilleng/wmclient/pkg/dirs"
 )
 
@@ -21,11 +20,9 @@ func provideBuildAndDeployer(
 	dir *dirs.WindmillDir,
 	env k8s.Env) (BuildAndDeployer, error) {
 	wire.Build(
-		service.ProvideMemoryManager,
 		image.NewImageHistory,
 		build.DefaultBuilder,
 		build.NewLocalDockerBuilder,
-		NewUpper,
 		NewLocalBuildAndDeployer)
 	return nil, nil
 }


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/forward3:

71055c2e58ada9264bb62e7548f1e5db32b5a169 (2018-08-28 18:16:14 -0400)
engine: automatically port-forward on minikube/gke like docker-for-desktop does