### PR TITLE
build: if build output is nil then error

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -226,6 +226,9 @@ func (l *dockerImageBuilder) buildFromDf(ctx context.Context, df Dockerfile, pat
 	if err != nil {
 		return nil, fmt.Errorf("ImageBuild: %v", err)
 	}
+	if result == nil {
+		return nil, fmt.Errorf("Unable to read docker output: result is nil")
+	}
 
 	digest, err := getDigestFromAux(*result)
 	if err != nil {


### PR DESCRIPTION
note that ... I don't understand why this fixes the problem. =\

What I expected to happen after making this change is that I'd see the error printed instead of getting the segfault. Instead, afaict no error is printed.