### PR TITLE
outputter: fix a broken call to Infof, change Print to Printf so that go vet checks it

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -313,7 +313,7 @@ func (l *dockerImageBuilder) readDockerOutput(ctx context.Context, reader io.Rea
 		go func() {
 			err := progressui.DisplaySolveStatus(ctx, "", l.console, l.out, displayCh)
 			if err != nil {
-				output.Get(ctx).Print("Error printing progressui: %s", err)
+				output.Get(ctx).Printf("Error printing progressui: %s", err)
 			}
 		}()
 	}
@@ -335,7 +335,7 @@ func (l *dockerImageBuilder) readDockerOutput(ctx context.Context, reader io.Rea
 
 		if len(message.Stream) > 0 && message.Stream != "\n" {
 			msg := strings.TrimSuffix(message.Stream, "\n")
-			output.Get(ctx).Print("%+v", msg)
+			output.Get(ctx).Printf("%+v", msg)
 			if strings.HasPrefix(msg, "Step") || strings.HasPrefix(msg, "Running") {
 				innerSpan, ctx = opentracing.StartSpanFromContext(ctx, msg)
 			}

--- a/internal/output/outputter.go
+++ b/internal/output/outputter.go
@@ -88,9 +88,9 @@ func (o *Outputter) StartBuildStep(format string, a ...interface{}) {
 	o.curBuildStep++
 }
 
-func (o *Outputter) Print(format string, a ...interface{}) {
+func (o *Outputter) Printf(format string, a ...interface{}) {
 	if o.curBuildStep == 0 {
-		o.logger.Infof(format, a)
+		o.logger.Infof(format, a...)
 	} else {
 		o.logger.Infof("%s%s", buildStepOutputPrefix, fmt.Sprintf(format, a...))
 	}


### PR DESCRIPTION
Hello @yuindustries,

Please review the following commits I made in branch nicks/printf:

576e4932c86e9e8bf9810cd2dd76352e51d9f421 (2018-08-29 12:07:05 -0400)
outputter: fix a broken call to Infof, change Print to Printf so that go vet checks it