### PR TITLE
engine: re-wire to make a containerUpdater build-and-deployer (no-op)

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -458,7 +458,7 @@ func TestUpdateInContainerE2E(t *testing.T) {
 	}
 	touchBar := model.ToShellCmd("touch /src/bar")
 
-	cUpdater := containerUpdater{dcli: f.dcli}
+	cUpdater := ContainerUpdater{dcli: f.dcli}
 	err = cUpdater.UpdateInContainer(f.ctx, cID, paths, []model.Cmd{touchBar})
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -15,17 +15,15 @@ import (
 
 const pauseCmd = "/pause"
 
-type ContainerUpdater interface {
-	UpdateInContainer(ctx context.Context, cID containerID, paths []pathMapping, steps []model.Cmd) error
-}
-
-var _ ContainerUpdater = &containerUpdater{}
-
-type containerUpdater struct {
+type ContainerUpdater struct {
 	dcli DockerClient
 }
 
-func (r *containerUpdater) UpdateInContainer(ctx context.Context, cID containerID, paths []pathMapping, steps []model.Cmd) error {
+func NewContainerUpdater(dcli DockerClient) *ContainerUpdater {
+	return &ContainerUpdater{dcli: dcli}
+}
+
+func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID containerID, paths []pathMapping, steps []model.Cmd) error {
 	// rm files from container
 	toRemove, err := missingLocalPaths(ctx, paths)
 	if err != nil {
@@ -88,7 +86,7 @@ func ArchivePathsIfExist(ctx context.Context, paths []pathMapping) (*bytes.Buffe
 // Expects to find exactly one matching container -- if not, return error.
 // TODO: support multiple matching container IDs, i.e. restarting multiple containers per pod
 // TODO(maia): move func to somewhere more useful (will need this eventually, but not on ContainerUpdater)
-func (r *containerUpdater) containerIdForPod(ctx context.Context, podName string) (containerID, error) {
+func (r *ContainerUpdater) containerIdForPod(ctx context.Context, podName string) (containerID, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-containerIdForPod")
 	defer span.Finish()
 
@@ -126,7 +124,7 @@ func (r *containerUpdater) containerIdForPod(ctx context.Context, podName string
 	return "", fmt.Errorf("no matching non-'/pause' containers")
 }
 
-func (r *containerUpdater) RmPathsFromContainer(ctx context.Context, cID containerID, paths []pathMapping) error {
+func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID containerID, paths []pathMapping) error {
 	if len(paths) == 0 {
 		return nil
 	}

--- a/internal/build/container_updater_test.go
+++ b/internal/build/container_updater_test.go
@@ -118,12 +118,12 @@ type mockContainerUpdaterFixture struct {
 	t    testing.TB
 	ctx  context.Context
 	dcli *FakeDockerClient
-	cu   *containerUpdater
+	cu   *ContainerUpdater
 }
 
 func newRemoteDockerFixture(t testing.TB) *mockContainerUpdaterFixture {
 	fakeCli := NewFakeDockerClient()
-	cu := &containerUpdater{
+	cu := &ContainerUpdater{
 		dcli: fakeCli,
 	}
 

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -64,7 +64,7 @@ type pushOutput struct {
 
 var _ ImageBuilder = &dockerImageBuilder{}
 
-func NewLocalDockerBuilder(dcli DockerClient, console console.Console, out io.Writer) *dockerImageBuilder {
+func NewDockerImageBuilder(dcli DockerClient, console console.Console, out io.Writer) *dockerImageBuilder {
 	return &dockerImageBuilder{dcli: dcli, console: console, out: out}
 }
 

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -97,7 +97,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 		t:              t,
 		ctx:            ctx,
 		dcli:           dcli,
-		b:              NewLocalDockerBuilder(dcli, DefaultConsole(), DefaultOut()),
+		b:              NewDockerImageBuilder(dcli, DefaultConsole(), DefaultOut()),
 	}
 }
 

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -13,7 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/service"
-	"github.com/windmilleng/wmclient/pkg/dirs"
+	dirs "github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
@@ -24,23 +24,25 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 		k8s.NewKubectlClient,
 		wire.Bind(new(k8s.Client), k8s.KubectlClient{}),
 
+		dirs.UseWindmillDir,
 		image.NewImageHistory,
 
 		build.DefaultDockerClient,
 		wire.Bind(new(build.DockerClient), new(build.DockerCli)),
 
+		// dockerImageBuilder ( = ImageBuilder)
 		build.DefaultConsole,
 		build.DefaultOut,
 		build.DefaultImageBuilder,
 		build.NewDockerImageBuilder,
 		engine.NewImageBuildAndDeployer,
 
+		// ContainerBuildAndDeployer ( = BuildAndDeployer)
 		wire.Bind(new(engine.BuildAndDeployer), new(engine.ContainerBuildAndDeployer)),
 		engine.NewContainerBuildAndDeployer,
 		build.NewContainerUpdater,
-		engine.NewUpper,
 
-		dirs.UseWindmillDir,
+		engine.NewUpper,
 		provideServiceCreator,
 	)
 	return nil, nil

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -20,18 +20,28 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 	wire.Build(
 		service.ProvideMemoryManager,
 		k8s.DetectEnv,
+
 		k8s.NewKubectlClient,
 		wire.Bind(new(k8s.Client), k8s.KubectlClient{}),
+
 		image.NewImageHistory,
+
 		build.DefaultDockerClient,
 		wire.Bind(new(build.DockerClient), new(build.DockerCli)),
+
+		build.DefaultConsole,
+		build.DefaultOut,
 		build.DefaultImageBuilder,
-		build.NewLocalDockerBuilder,
+		build.NewDockerImageBuilder,
+		engine.NewImageBuildAndDeployer,
+
+		wire.Bind(new(engine.BuildAndDeployer), new(engine.ContainerBuildAndDeployer)),
+		engine.NewContainerBuildAndDeployer,
+		build.NewContainerUpdater,
 		engine.NewUpper,
-		engine.NewLocalBuildAndDeployer,
+
 		dirs.UseWindmillDir,
 		provideServiceCreator,
-		build.DefaultConsole,
-		build.DefaultOut)
+	)
 	return nil, nil
 }

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -21,10 +21,16 @@ func provideBuildAndDeployer(
 	env k8s.Env) (BuildAndDeployer, error) {
 	wire.Build(
 		image.NewImageHistory,
+
 		build.DefaultImageBuilder,
-		build.NewLocalDockerBuilder,
-		NewLocalBuildAndDeployer,
+		build.NewDockerImageBuilder,
+		NewImageBuildAndDeployer,
 		build.DefaultConsole,
-		build.DefaultOut)
+		build.DefaultOut,
+
+		wire.Bind(new(BuildAndDeployer), new(ContainerBuildAndDeployer)),
+		NewContainerBuildAndDeployer,
+		build.NewContainerUpdater,
+	)
 	return nil, nil
 }

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -22,12 +22,15 @@ func provideBuildAndDeployer(
 	wire.Build(
 		image.NewImageHistory,
 
+		// dockerImageBuilder ( = ImageBuilder)
 		build.DefaultImageBuilder,
 		build.NewDockerImageBuilder,
-		NewImageBuildAndDeployer,
 		build.DefaultConsole,
 		build.DefaultOut,
 
+		NewImageBuildAndDeployer,
+
+		// ContainerBuildAndDeployer ( = BuildAndDeployer)
 		wire.Bind(new(BuildAndDeployer), new(ContainerBuildAndDeployer)),
 		NewContainerBuildAndDeployer,
 		build.NewContainerUpdater,

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -65,11 +65,11 @@ def main():
 
     cases = [
         Case('tilt up 1x', test_tilt_up_once),
-        # Case('tilt up again, no change', test_tilt_up_again_no_change),
-        # Case('tilt up again, new file', test_tilt_up_again_new_file),
-        # Case('watch build from changed file', test_watch_build_from_changed_file),
-        # Case('watch build from many changed files', test_watch_build_from_many_changed_files),
-        # Case('tilt up, big file (5MB)', test_tilt_up_big_file),
+        Case('tilt up again, no change', test_tilt_up_again_no_change),
+        Case('tilt up again, new file', test_tilt_up_again_new_file),
+        Case('watch build from changed file', test_watch_build_from_changed_file),
+        Case('watch build from many changed files', test_watch_build_from_many_changed_files),
+        Case('tilt up, big file (5MB)', test_tilt_up_big_file),
 
         # Leave this commented out unless you particularly want it, it's damn slow.
         # Case('tilt up, REALLY big file (500MB)', test_tilt_up_really_big_file),

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -65,11 +65,11 @@ def main():
 
     cases = [
         Case('tilt up 1x', test_tilt_up_once),
-        Case('tilt up again, no change', test_tilt_up_again_no_change),
-        Case('tilt up again, new file', test_tilt_up_again_new_file),
-        Case('watch build from changed file', test_watch_build_from_changed_file),
-        Case('watch build from many changed files', test_watch_build_from_many_changed_files),
-        Case('tilt up, big file (5MB)', test_tilt_up_big_file),
+        # Case('tilt up again, no change', test_tilt_up_again_no_change),
+        # Case('tilt up again, new file', test_tilt_up_again_new_file),
+        # Case('watch build from changed file', test_watch_build_from_changed_file),
+        # Case('watch build from many changed files', test_watch_build_from_many_changed_files),
+        # Case('tilt up, big file (5MB)', test_tilt_up_big_file),
 
         # Leave this commented out unless you particularly want it, it's damn slow.
         # Case('tilt up, REALLY big file (500MB)', test_tilt_up_really_big_file),


### PR DESCRIPTION
should be a no-op -- containerBuildAndDeployer has an imageBuildAndDeployer on it, currently just calls that one. this PR is the set-up for actually hooking up container-based incremental builds