### PR TITLE
engine: wire up container build and deployer

### DIFF
--- a/internal/build/client.go
+++ b/internal/build/client.go
@@ -32,7 +32,7 @@ type DockerClient interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerRestart(ctx context.Context, containerID string, timeout *time.Duration) error
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
-	ExecInContainer(ctx context.Context, cID containerID, cmd model.Cmd) error
+	ExecInContainer(ctx context.Context, cID k8s.ContainerID, cmd model.Cmd) error
 	ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error)
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImageTag(ctx context.Context, source, target string) error
@@ -118,7 +118,7 @@ func CreateClientOpts(env func(string) string) ([]func(client *client.Client) er
 	return result, nil
 }
 
-func (d *DockerCli) ExecInContainer(ctx context.Context, cID containerID, cmd model.Cmd) error {
+func (d *DockerCli) ExecInContainer(ctx context.Context, cID k8s.ContainerID, cmd model.Cmd) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ExecInContainer")
 	span.SetTag("cmd", strings.Join(cmd.Argv, " "))
 	defer span.Finish()

--- a/internal/build/container.go
+++ b/internal/build/container.go
@@ -7,16 +7,6 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 )
 
-type containerID string
-
-func (cID containerID) String() string { return string(cID) }
-func (cID containerID) ShortStr() string {
-	if len(string(cID)) > 10 {
-		return string(cID)[:10]
-	}
-	return string(cID)
-}
-
 // Get a container config to run a container with a given command instead of
 // the existing entrypoint. If cmd is nil, we run nothing.
 func containerConfigRunCmd(imgRef reference.NamedTagged, cmd model.Cmd) *container.Config {

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -76,12 +76,12 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID k8s.Contai
 // Expects to find exactly one matching container -- if not, return error.
 // TODO: support multiple matching container IDs, i.e. restarting multiple containers per pod
 // TODO(maia): move func to somewhere more useful (will need this eventually, but not on ContainerUpdater)
-func (r *ContainerUpdater) ContainerIDForPod(ctx context.Context, podName string) (k8s.ContainerID, error) {
+func (r *ContainerUpdater) ContainerIDForPod(ctx context.Context, podName k8s.PodID) (k8s.ContainerID, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-containerIdForPod")
 	defer span.Finish()
 
 	a := filters.NewArgs()
-	a.Add("name", podName)
+	a.Add("name", string(podName))
 	listOpts := types.ContainerListOptions{Filters: a}
 
 	containers, err := r.dcli.ContainerList(ctx, listOpts)

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -76,7 +76,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID k8s.Contai
 // Expects to find exactly one matching container -- if not, return error.
 // TODO: support multiple matching container IDs, i.e. restarting multiple containers per pod
 // TODO(maia): move func to somewhere more useful (will need this eventually, but not on ContainerUpdater)
-func (r *ContainerUpdater) containerIdForPod(ctx context.Context, podName string) (k8s.ContainerID, error) {
+func (r *ContainerUpdater) ContainerIdForPod(ctx context.Context, podName string) (k8s.ContainerID, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-containerIdForPod")
 	defer span.Finish()
 

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -76,7 +76,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID k8s.Contai
 // Expects to find exactly one matching container -- if not, return error.
 // TODO: support multiple matching container IDs, i.e. restarting multiple containers per pod
 // TODO(maia): move func to somewhere more useful (will need this eventually, but not on ContainerUpdater)
-func (r *ContainerUpdater) ContainerIdForPod(ctx context.Context, podName string) (k8s.ContainerID, error) {
+func (r *ContainerUpdater) ContainerIDForPod(ctx context.Context, podName string) (k8s.ContainerID, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-containerIdForPod")
 	defer span.Finish()
 

--- a/internal/build/container_updater_test.go
+++ b/internal/build/container_updater_test.go
@@ -13,7 +13,7 @@ import (
 func TestContainerIdForPodOneMatch(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	cID, err := f.cu.ContainerIdForPod(f.ctx, testPod)
+	cID, err := f.cu.ContainerIDForPod(f.ctx, testPod)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func TestContainerIdForPodOneMatch(t *testing.T) {
 func TestContainerIdForPodFiltersOutPauseCmd(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	cID, err := f.cu.ContainerIdForPod(f.ctx, "one-pause-cmd")
+	cID, err := f.cu.ContainerIDForPod(f.ctx, "one-pause-cmd")
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestContainerIdForPodFiltersOutPauseCmd(t *testing.T) {
 func TestContainerIdForPodTooManyMatches(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	_, err := f.cu.ContainerIdForPod(f.ctx, "too-many")
+	_, err := f.cu.ContainerIDForPod(f.ctx, "too-many")
 	if assert.NotNil(f.t, err) {
 		assert.Contains(f.t, err.Error(), "too many matching containers")
 	}
@@ -42,7 +42,7 @@ func TestContainerIdForPodTooManyMatches(t *testing.T) {
 func TestContainerIdForPodNoNonPause(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	_, err := f.cu.ContainerIdForPod(f.ctx, "all-pause")
+	_, err := f.cu.ContainerIDForPod(f.ctx, "all-pause")
 	if assert.NotNil(f.t, err) {
 		assert.Contains(f.t, err.Error(), "no matching non-'/pause' containers")
 	}

--- a/internal/build/container_updater_test.go
+++ b/internal/build/container_updater_test.go
@@ -13,7 +13,7 @@ import (
 func TestContainerIdForPodOneMatch(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	cID, err := f.cu.containerIdForPod(f.ctx, testPod)
+	cID, err := f.cu.ContainerIdForPod(f.ctx, testPod)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func TestContainerIdForPodOneMatch(t *testing.T) {
 func TestContainerIdForPodFiltersOutPauseCmd(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	cID, err := f.cu.containerIdForPod(f.ctx, "one-pause-cmd")
+	cID, err := f.cu.ContainerIdForPod(f.ctx, "one-pause-cmd")
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestContainerIdForPodFiltersOutPauseCmd(t *testing.T) {
 func TestContainerIdForPodTooManyMatches(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	_, err := f.cu.containerIdForPod(f.ctx, "too-many")
+	_, err := f.cu.ContainerIdForPod(f.ctx, "too-many")
 	if assert.NotNil(f.t, err) {
 		assert.Contains(f.t, err.Error(), "too many matching containers")
 	}
@@ -42,7 +42,7 @@ func TestContainerIdForPodTooManyMatches(t *testing.T) {
 func TestContainerIdForPodNoNonPause(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
-	_, err := f.cu.containerIdForPod(f.ctx, "all-pause")
+	_, err := f.cu.ContainerIdForPod(f.ctx, "all-pause")
 	if assert.NotNil(f.t, err) {
 		assert.Contains(f.t, err.Error(), "no matching non-'/pause' containers")
 	}

--- a/internal/build/fake_client.go
+++ b/internal/build/fake_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -116,7 +117,7 @@ func (c *FakeDockerClient) ContainerRestart(ctx context.Context, containerID str
 	return nil
 }
 
-func (c *FakeDockerClient) ExecInContainer(ctx context.Context, cID containerID, cmd model.Cmd) error {
+func (c *FakeDockerClient) ExecInContainer(ctx context.Context, cID k8s.ContainerID, cmd model.Cmd) error {
 	execCall := ExecCall{
 		Container: cID.String(),
 		Cmd:       cmd,

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -170,7 +170,7 @@ func (f *dockerBuildFixture) assertFilesInImage(ref reference.NamedTagged, expec
 }
 
 func (f *dockerBuildFixture) assertFilesInContainer(
-	ctx context.Context, cID containerID, expectedFiles []expectedFile) {
+	ctx context.Context, cID k8s.ContainerID, expectedFiles []expectedFile) {
 	for _, expectedFile := range expectedFiles {
 		reader, _, err := f.dcli.CopyFromContainer(ctx, cID.String(), expectedFile.path)
 		if expectedFile.missing {
@@ -217,7 +217,7 @@ func (f *dockerBuildFixture) assertFileInTar(tr *tar.Reader, expected expectedFi
 }
 
 // startContainer starts a container from the given config
-func (f *dockerBuildFixture) startContainer(ctx context.Context, config *container.Config) containerID {
+func (f *dockerBuildFixture) startContainer(ctx context.Context, config *container.Config) k8s.ContainerID {
 	resp, err := f.dcli.ContainerCreate(ctx, config, nil, nil, "")
 	if err != nil {
 		f.t.Fatalf("startContainer: %v", err)
@@ -229,7 +229,7 @@ func (f *dockerBuildFixture) startContainer(ctx context.Context, config *contain
 		f.t.Fatalf("startContainer: %v", err)
 	}
 
-	return containerID(cID)
+	return k8s.ContainerID(cID)
 }
 
 type threadSafeWriter struct {

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -28,11 +28,11 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 		return nil, err
 	}
 	containerUpdater := build.NewContainerUpdater(dockerCli)
+	kubectlClient := k8s.NewKubectlClient(ctx, env)
 	console := build.DefaultConsole()
 	writer := build.DefaultOut()
 	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
-	kubectlClient := k8s.NewKubectlClient(ctx, env)
 	windmillDir, err := dirs.UseWindmillDir()
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func wireServiceCreator(ctx context.Context) (model.ServiceCreator, error) {
 	if err != nil {
 		return nil, err
 	}
-	containerBuildAndDeployer := engine.NewContainerBuildAndDeployer(containerUpdater, env, imageBuildAndDeployer)
+	containerBuildAndDeployer := engine.NewContainerBuildAndDeployer(containerUpdater, env, kubectlClient, imageBuildAndDeployer)
 	upper := engine.NewUpper(ctx, containerBuildAndDeployer, kubectlClient)
 	manager := service.ProvideMemoryManager()
 	serviceCreator := provideServiceCreator(upper, manager)

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -125,7 +125,7 @@ func (c *FakeK8sClient) Delete(ctx context.Context, entities []k8s.K8sEntity) er
 	return nil
 }
 
-func (c *FakeK8sClient) PodWithImage(ctx context.Context, image reference.Named) (k8s.PodID, error) {
+func (c *FakeK8sClient) PodWithImage(ctx context.Context, image reference.NamedTagged) (k8s.PodID, error) {
 	return "", fmt.Errorf("TODO(maia): not implemented")
 }
 

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -54,7 +54,6 @@ func TestDockerForMacDeploy(t *testing.T) {
 	}
 }
 
-// TODO(maia): make this test go. (Expect it to call ContainerBuildAndDeployer stuff.)
 func TestIncrementalBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop)
 	defer f.TearDown()
@@ -64,14 +63,18 @@ func TestIncrementalBuild(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// if f.docker.PushCount != 0 {
-	// 	t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
-	// }
-	//
-	// expectedYaml := "image: gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	// if !strings.Contains(f.k8s.yaml, expectedYaml) {
-	// 	t.Errorf("Expected yaml to contain %q. Actual:\n%s", expectedYaml, f.k8s.yaml)
-	// }
+	if f.docker.PushCount != 0 {
+		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	}
+	if f.docker.CopyCount != 1 {
+		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.PushCount)
+	}
+	if len(f.docker.ExecCalls) != 1 {
+		t.Errorf("Expected 1 exec in container call, actual: %d", len(f.docker.ExecCalls))
+	}
+	if len(f.docker.RestartsByContainer) != 1 {
+		t.Errorf("Expected 1 container to be restarted, actual: %d", len(f.docker.RestartsByContainer))
+	}
 }
 
 // The API boundaries between BuildAndDeployer and the ImageBuilder aren't obvious and

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -1,16 +1,20 @@
 package engine
 
 import (
-	context "context"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
-	build "github.com/windmilleng/tilt/internal/build"
+	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/testutils"
-	dirs "github.com/windmilleng/wmclient/pkg/dirs"
+	"github.com/windmilleng/wmclient/pkg/dirs"
 )
+
+var cID = k8s.ContainerID("test_container")
+var alreadyBuilt = BuildResult{Container: cID}
 
 func TestGKEDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE)
@@ -48,6 +52,26 @@ func TestDockerForMacDeploy(t *testing.T) {
 	if !strings.Contains(f.k8s.yaml, expectedYaml) {
 		t.Errorf("Expected yaml to contain %q. Actual:\n%s", expectedYaml, f.k8s.yaml)
 	}
+}
+
+// TODO(maia): make this test go. (Expect it to call ContainerBuildAndDeployer stuff.)
+func TestIncrementalBuild(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+
+	_, err := f.bd.BuildAndDeploy(f.Ctx(), SanchoService, NewBuildState(alreadyBuilt))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// if f.docker.PushCount != 0 {
+	// 	t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	// }
+	//
+	// expectedYaml := "image: gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
+	// if !strings.Contains(f.k8s.yaml, expectedYaml) {
+	// 	t.Errorf("Expected yaml to contain %q. Actual:\n%s", expectedYaml, f.k8s.yaml)
+	// }
 }
 
 // The API boundaries between BuildAndDeployer and the ImageBuilder aren't obvious and
@@ -99,4 +123,12 @@ func (c *FakeK8sClient) Apply(ctx context.Context, entities []k8s.K8sEntity) err
 
 func (c *FakeK8sClient) Delete(ctx context.Context, entities []k8s.K8sEntity) error {
 	return nil
+}
+
+func (c *FakeK8sClient) PodWithImage(ctx context.Context, image reference.Named) (k8s.PodID, error) {
+	return "", fmt.Errorf("TODO(maia): not implemented")
+}
+
+func (c *FakeK8sClient) applyWasCalled() bool {
+	return c.yaml != ""
 }

--- a/internal/engine/container_build_and_deployer.go
+++ b/internal/engine/container_build_and_deployer.go
@@ -81,9 +81,7 @@ func (cbd *ContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, servic
 	}
 	logger.Get(ctx).Infof("Container updated")
 
-	// everything stays the same, but filesChangedSet gets reset
 	return BuildResult{
-		Image:     state.LastImage(),
 		Entities:  state.LastResult.Entities,
 		Container: cID,
 	}, nil

--- a/internal/engine/container_build_and_deployer.go
+++ b/internal/engine/container_build_and_deployer.go
@@ -60,7 +60,7 @@ func (cbd *ContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, servic
 		}
 		logger.Get(ctx).Infof("Deploying to pod: %s", pID)
 		// get containerID from pID (see container_updater.go --> containerIdForPod)
-		cID, err = cbd.cu.ContainerIDForPod(ctx, string(pID))
+		cID, err = cbd.cu.ContainerIDForPod(ctx, pID)
 		if err != nil {
 			logger.Get(ctx).Infof("Unable to find container, falling back to image deploy")
 			return cbd.ibd.BuildAndDeploy(ctx, service, state)

--- a/internal/engine/container_build_and_deployer.go
+++ b/internal/engine/container_build_and_deployer.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/windmilleng/tilt/internal/build"
@@ -12,20 +13,21 @@ import (
 var _ BuildAndDeployer = &ContainerBuildAndDeployer{}
 
 type ContainerBuildAndDeployer struct {
-	cu  *build.ContainerUpdater
-	env k8s.Env
+	cu        *build.ContainerUpdater
+	env       k8s.Env
+	k8sClient k8s.Client
 
 	// containerBD can't do initial build, so will call out to ibd for that.
 	// May also fall back to ibd for certain error cases.
 	ibd ImageBuildAndDeployer
 }
 
-// TODO(maia): wire this up
-func NewContainerBuildAndDeployer(cu *build.ContainerUpdater, env k8s.Env, ibd ImageBuildAndDeployer) *ContainerBuildAndDeployer {
+func NewContainerBuildAndDeployer(cu *build.ContainerUpdater, env k8s.Env, kCli k8s.Client, ibd ImageBuildAndDeployer) *ContainerBuildAndDeployer {
 	return &ContainerBuildAndDeployer{
-		cu:  cu,
-		env: env,
-		ibd: ibd,
+		cu:        cu,
+		env:       env,
+		k8sClient: kCli,
+		ibd:       ibd,
 	}
 }
 
@@ -33,6 +35,32 @@ func (cbd *ContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, servic
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ContainerBuildAndDeployer-BuildAndDeploy")
 	defer span.Finish()
 
-	// TODO(maia): implement containerUpdater-specific stuff!
-	return cbd.ibd.BuildAndDeploy(ctx, service, state)
+	// TODO(maia): proper output for this stuff
+
+	// TODO(maia): put service.Validate() upstream if we're gonna want to call it regardless
+	// of implementation of BuildAndDeploy?
+	err := service.Validate()
+	if err != nil {
+		return BuildResult{}, err
+	}
+
+	// ContainerBuildAndDeployer doesn't support initial build; call out to the ImageBuildAndDeployer
+	if state.IsEmpty() {
+		return cbd.ibd.BuildAndDeploy(ctx, service, state)
+	}
+	// Service has already been deployed; try to update in the running container
+
+	// If we don't know the pod that we just deployed to/container we just deployed, get it
+	if state.LastResult.Container.String() == "" {
+		pID, err := cbd.k8sClient.PodWithImage(ctx, state.LastResult.Image)
+		if err != nil {
+			return BuildResult{}, err
+		}
+		fmt.Println("pod id:", pID)
+		// get containerID from pID (see container_updater.go --> containerIdForPod)
+		// attach containerID to build result
+	}
+	// once have cID -- can call cbd.cu.UpdateContainer(...)
+
+	return BuildResult{}, fmt.Errorf("incremental build via containerBuildAndDeployer")
 }

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -10,12 +10,13 @@ import (
 
 // The results of a successful build.
 type BuildResult struct {
-	Image    reference.NamedTagged
-	Entities []k8s.K8sEntity
+	Image     reference.NamedTagged
+	Entities  []k8s.K8sEntity
+	Container k8s.ContainerID
 }
 
 func (b BuildResult) IsEmpty() bool {
-	return b.Image == nil
+	return b.Image == nil && b.Container == ""
 }
 
 // The state of the system since the last successful build.

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -29,6 +29,6 @@ func provideBuildAndDeployer(ctx context.Context, docker build.DockerClient, k8s
 	if err != nil {
 		return nil, err
 	}
-	containerBuildAndDeployer := NewContainerBuildAndDeployer(containerUpdater, env, imageBuildAndDeployer)
+	containerBuildAndDeployer := NewContainerBuildAndDeployer(containerUpdater, env, k8s2, imageBuildAndDeployer)
 	return containerBuildAndDeployer, nil
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -9,15 +9,29 @@ import (
 	"os/exec"
 	"strings"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/docker/distribution/reference"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/browser"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/output"
 )
 
+type PodID string
+type ContainerID string
+
+func (cID ContainerID) String() string { return string(cID) }
+func (cID ContainerID) ShortStr() string {
+	if len(string(cID)) > 10 {
+		return string(cID)[:10]
+	}
+	return string(cID)
+}
+
 type Client interface {
 	Apply(ctx context.Context, entities []K8sEntity) error
 	Delete(ctx context.Context, entities []K8sEntity) error
+
+	PodWithImage(ctx context.Context, image reference.Named) (PodID, error)
 
 	// Waits for the LoadBalancer to get a publicly available URL,
 	// then opens that URL in a web browser.

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -31,7 +31,7 @@ type Client interface {
 	Apply(ctx context.Context, entities []K8sEntity) error
 	Delete(ctx context.Context, entities []K8sEntity) error
 
-	PodWithImage(ctx context.Context, image reference.Named) (PodID, error)
+	PodWithImage(ctx context.Context, image reference.NamedTagged) (PodID, error)
 
 	// Waits for the LoadBalancer to get a publicly available URL,
 	// then opens that URL in a web browser.

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -125,3 +125,16 @@ func extractContainers(obj interface{}) ([]*v1.Container, error) {
 	}
 	return result, nil
 }
+
+func ParseNamedTagged(s string) (reference.NamedTagged, error) {
+	ref, err := reference.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %v", s, err)
+	}
+
+	nt, ok := ref.(reference.NamedTagged)
+	if !ok {
+		return nil, fmt.Errorf("could not parse ref %s as NamedTagged", ref)
+	}
+	return nt, nil
+}

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/docker/distribution/reference"
+)
+
+// PodWithImage returns the ID of the pod running the given image. We expect exactly one
+// matching pod: if too many or too few matches, throw an error.
+func (k KubectlClient) PodWithImage(ctx context.Context, image reference.NamedTagged) (PodID, error) {
+	_, err := imagesToPods(ctx)
+	if err != nil {
+		return PodID(""), err
+	}
+	// pods := imgPodMap[image.String()]
+	return PodID(""), nil
+}
+
+func imagesToPods(ctx context.Context) (map[reference.NamedTagged][]PodID, error) {
+	c := exec.CommandContext(ctx, "kubectl", "get", "pods", "-o=jsonpath={range .items[*]}{\"\\n\"}{.metadata.name}{\"\\t\"}{range .spec.containers[*]}{.image}")
+	stdoutBuf, stderrBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	c.Stdout = stdoutBuf
+	c.Stderr = stderrBuf
+
+	err := c.Run()
+	if err != nil {
+		return nil, fmt.Errorf("imagesToPods: %v (stderr: %s)", err, stderrBuf.String())
+	}
+
+	fmt.Printf(stdoutBuf.String())
+	return imgPodMapFromOutput(stdoutBuf.String())
+}
+
+func imgPodMapFromOutput(output string) (map[reference.NamedTagged][]PodID, error) {
+	imgsToPods := make(map[reference.NamedTagged][]PodID)
+	lns := strings.Split(output, "\n")
+	for _, ln := range lns {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+
+		pair := strings.Split(ln, "\t")
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("could not split line in two on tab: %s", ln)
+		}
+
+		nt, err := ParseNamedTagged(pair[1])
+		if err != nil {
+			return nil, err
+		}
+
+		imgsToPods[nt] = append(imgsToPods[nt], PodID(pair[0]))
+	}
+	return imgsToPods, nil
+}

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"testing"
 
-	"github.com/docker/distribution/reference"
 	"github.com/magiconair/properties/assert"
 )
 
@@ -18,17 +17,9 @@ func TestPodImgMapFromOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := map[reference.NamedTagged][]PodID{
-		mustParseNamedTagged(t, "blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f"): []PodID{PodID("blorg-fe-6b4477ffcd-xf98f")},
-		mustParseNamedTagged(t, "cockroachdb/cockroach:v2.0.5"):                           []PodID{PodID("cockroachdb-0"), PodID("cockroachdb-1"), PodID("cockroachdb-2")},
+	expected := map[string][]PodID{
+		"blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f": []PodID{PodID("blorg-fe-6b4477ffcd-xf98f")},
+		"cockroachdb/cockroach:v2.0.5":                           []PodID{PodID("cockroachdb-0"), PodID("cockroachdb-1"), PodID("cockroachdb-2")},
 	}
 	assert.Equal(t, expected, podImgMap)
-}
-
-func mustParseNamedTagged(t *testing.T, s string) reference.NamedTagged {
-	nt, err := ParseNamedTagged(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return nt
 }

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var podsToImagesOut = `blorg-fe-6b4477ffcd-xf98f	blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -1,0 +1,34 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/docker/distribution/reference"
+	"github.com/magiconair/properties/assert"
+)
+
+var podsToImagesOut = `blorg-fe-6b4477ffcd-xf98f	blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f
+cockroachdb-0	cockroachdb/cockroach:v2.0.5
+cockroachdb-1	cockroachdb/cockroach:v2.0.5
+cockroachdb-2	cockroachdb/cockroach:v2.0.5
+`
+
+func TestPodImgMapFromOutput(t *testing.T) {
+	podImgMap, err := imgPodMapFromOutput(podsToImagesOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := map[reference.NamedTagged][]PodID{
+		mustParseNamedTagged(t, "blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f"): []PodID{PodID("blorg-fe-6b4477ffcd-xf98f")},
+		mustParseNamedTagged(t, "cockroachdb/cockroach:v2.0.5"):                           []PodID{PodID("cockroachdb-0"), PodID("cockroachdb-1"), PodID("cockroachdb-2")},
+	}
+	assert.Equal(t, expected, podImgMap)
+}
+
+func mustParseNamedTagged(t *testing.T, s string) reference.NamedTagged {
+	nt, err := ParseNamedTagged(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nt
+}


### PR DESCRIPTION
Mostly getting this up to get some eyes on it. I wouldn't merge this in yet.

Involved writing some code to wrangle which pod we need to be talking to, which @maiamcc wrote.

Currently updating the container takes more than 5 seconds. =\

Three outstanding issues:
1) The output currently looks terrible
```
files changed. rebuilding blorg_frontend. observed 1 changes: [/Users/dan/go/src/github.com/windmilleng/blorg-frontend/main.go]
Deploying to pod: blorg-fe-6f9cddf8cf-ggq9j
Got container ID for pod: 5393f4a83f7d25124249fcfc132ca6f3b01e617d554d04f441f8382ec0dfaebe
Updating container...
Container updated
```
2) ~~We only succesfully update one time, after which it throws this error:~~ Fixed!
```
Updating container...
build failed: Error: No such container:path: :/
```

3) Do we want to have a flag for this behavior?

I think it might be a bug with how we're handling the pathMappings?
