### PR TITLE
minikube: add status messaging when minikube is stuck

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -61,7 +61,10 @@ func (k KubectlClient) OpenService(ctx context.Context, lb LoadBalancer) error {
 	}
 
 	if k.env == EnvMinikube {
+		logger.Get(ctx).Infof("Waiting on minikube to load service: %s", lb.Name)
 		cmd := exec.CommandContext(ctx, "minikube", "service", lb.Name, "--url")
+		cmd.Stderr = logger.Get(ctx).Writer(logger.InfoLvl)
+
 		out, err := cmd.Output()
 		if err != nil {
 			return fmt.Errorf("OpenService: %v", err)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/browser3:

762cd3052419f8541770a9df456b2853b6cd3951 (2018-08-31 17:43:49 -0400)
minikube: add status messaging when minikube is stuck