### PR TITLE
k8s: do a deep copy of entity objects to avoid weird half-mutated objects

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -20,6 +20,16 @@ func (e K8sEntity) ImmutableOnceCreated() bool {
 	return false
 }
 
+func (e K8sEntity) DeepCopy() K8sEntity {
+	// GroupVersionKind is a struct of string values, so dereferencing the pointer
+	// is an adequate copy.
+	kind := *e.Kind
+	return K8sEntity{
+		Obj:  e.Obj.DeepCopyObject(),
+		Kind: &kind,
+	}
+}
+
 func ImmutableEntities(entities []K8sEntity) []K8sEntity {
 	result := make([]K8sEntity, 0)
 	for _, e := range entities {

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -11,6 +11,7 @@ import (
 // Iterate through the fields of a k8s entity and
 // replace the image pull policy on all images.
 func InjectImagePullPolicy(entity K8sEntity, policy v1.PullPolicy) (K8sEntity, error) {
+	entity = entity.DeepCopy()
 	containers, err := extractContainers(&entity)
 	if err != nil {
 		return K8sEntity{}, err
@@ -31,6 +32,8 @@ func InjectImagePullPolicy(entity K8sEntity, policy v1.PullPolicy) (K8sEntity, e
 //
 // Returns: the new entity, whether the image was replaced, and an error.
 func InjectImageDigest(entity K8sEntity, injectRef reference.Named, policy v1.PullPolicy) (K8sEntity, bool, error) {
+	entity = entity.DeepCopy()
+
 	// NOTE(nick): For some reason, if you have a reference with a digest,
 	// kubernetes will never find it in the local registry and always tries to do a
 	// pull. It's not clear to me why it behaves this way.


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/deepcopy:

6aff581c8a686ab6acdf7320b2ce586c14fefc9a (2018-09-04 15:30:48 -0400)
k8s: do a deep copy of entity objects to avoid weird half-mutated objects