### PR TITLE
tracing: add tags to spans (passable as command line args); add to timing.py

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -2,6 +2,8 @@ package tracer
 
 import (
 	"io"
+	"log"
+	"strings"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	config "github.com/uber/jaeger-client-go/config"
@@ -23,4 +25,23 @@ func Init() (io.Closer, error) {
 	opentracing.SetGlobalTracer(tracer)
 
 	return closer, nil
+}
+
+// TagStrToMap converts a user-passed string of tags of the form `key1=val1,key2=val2` to a map.
+func TagStrToMap(tagStr string) map[string]string {
+	if tagStr == "" {
+		return nil
+	}
+
+	res := make(map[string]string)
+	pairs := strings.Split(tagStr, ",")
+	for _, p := range pairs {
+		elems := strings.Split(strings.TrimSpace(p), "=")
+		if len(elems) != 2 {
+			log.Printf("got malformed trace tag: %s", p)
+			continue
+		}
+		res[elems[0]] = elems[1]
+	}
+	return res
 }

--- a/internal/tracer/tracer_test.go
+++ b/internal/tracer/tracer_test.go
@@ -1,0 +1,32 @@
+package tracer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTagStrToMap(t *testing.T) {
+	s := "key1=val1,key2=val2"
+	expected := map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+	}
+
+	res := TagStrToMap(s)
+	if !reflect.DeepEqual(expected, res) {
+		t.Errorf("Expected result %v, got: %v", expected, res)
+	}
+}
+
+func TestTagStrToMapIgnoresMalformedEntries(t *testing.T) {
+	s := "key1=val1,malformed,key2=val2"
+	expected := map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+	}
+
+	res := TagStrToMap(s)
+	if !reflect.DeepEqual(expected, res) {
+		t.Errorf("Expected result %v, got: %v", expected, res)
+	}
+}

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -102,7 +102,7 @@ class Case:
     def run(self):
         os.chdir(self.serv.work_dir)
         print()
-        print('~~ RUNNING CASE: {}'.format(self.name))
+        print(bold('~~ RUNNING CASE: {}'.format(self.name)))
         self.time_seconds = self.func(self.serv, self.name)
 
 
@@ -460,6 +460,10 @@ def tags_for_case_name(case: str) -> str:
     """Given name of test case, return str of tag(s) passable to `tilt up --traceTags`
     (of the form: `key1=val1,key2=val2`)."""
     return "case={}".format(case)
+
+
+def bold(s: str) -> str:
+    return "\033[1m{}\033[0m".format(s)
 
 
 if __name__ == "__main__":

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -98,6 +98,9 @@ class K8sEnv(Enum):
 
 class Case:
     def __init__(self, name: str, serv: Service, func: Callable[[Service, str], float]):
+        if ',' in name:
+            raise Exception('found comma in case name: "{}". Pls don\'t, it '
+                            'makes the trace tags sad.'.format(name))
         self.name = name
         self.serv = serv
         self.func = func
@@ -137,12 +140,12 @@ def main():
 
     cases = [
         Case('tilt up 1x', DOGGOS, test_tilt_up_once),
-        Case('tilt up again, no change', DOGGOS, test_tilt_up_again_no_change),
-        Case('tilt up again, new file', DOGGOS, test_tilt_up_again_new_file),
+        Case('tilt up again no change', DOGGOS, test_tilt_up_again_no_change),
+        Case('tilt up again new file', DOGGOS, test_tilt_up_again_new_file),
         Case('watch build from new file', DOGGOS, test_watch_build_from_new_file),
         Case('watch build from many changed files', DOGGOS, test_watch_build_from_many_changed_files),
         Case('watch build from changed go file', DOGGOS, test_watch_build_from_changed_go_file),
-        Case('tilt up, big file (5MB)', DOGGOS, test_tilt_up_big_file),
+        Case('tilt up big file (5MB)', DOGGOS, test_tilt_up_big_file),
 
         # TODO(maia): refactor these with Service object/servantes
         # Case('tilt up, new file, checking frontend', test_tilt_up_fe, wd=BLORG_FRONTEND_DIR),


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/trace-tags:

9b2314823277974ee2a546885f9f6191c45819b2 (2018-09-05 15:33:41 -0400)
tilt calls from timing.py pass trace tags

38d8891ca9f48ae339a31cdb5e35d8e0ae6eee4d (2018-09-05 15:25:20 -0400)
tracer: implement span tags

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics