### PR TITLE
engine: get containerID earlier in pipeline

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -14,4 +15,10 @@ type BuildAndDeployer interface {
 	// BuildResult can be used to construct a BuildState, which contains
 	// the last successful build and the files changed since that build.
 	BuildAndDeploy(ctx context.Context, service model.Service, currentState BuildState) (BuildResult, error)
+
+	// BaD needs to be able to get the container that a given build affected, so that
+	// it can do incremental builds on that container if needed.
+	// NOTE(maia): this isn't quite relevant to ImageBuildAndDeployer,
+	// consider putting elsewhere or renaming (`Warm`?).
+	GetContainerForBuild(ctx context.Context, build BuildResult) (k8s.ContainerID, error)
 }

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -109,34 +109,6 @@ func TestFallBackToImageDeploy(t *testing.T) {
 	}
 }
 
-func TestGetPodIfMissing(t *testing.T) {
-	f := newBDFixture(t, k8s.EnvDockerDesktop)
-	defer f.TearDown()
-
-	f.setPodExists(true)
-
-	nt, err := k8s.ParseNamedTagged("gcr.io/some-project-162817/sancho:foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	br := BuildResult{
-		Image: nt,
-	}
-
-	newBR, err := f.bd.BuildAndDeploy(f.Ctx(), SanchoService, NewBuildState(br))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if f.docker.PushCount != 0 {
-		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
-	}
-
-	if newBR.Container != k8s.ContainerID("testcontainer") {
-		t.Errorf("Expected container ID to be %s, got %s", k8s.ContainerID("testcontainer"), newBR.Container)
-	}
-}
-
 // The API boundaries between BuildAndDeployer and the ImageBuilder aren't obvious and
 // are likely to change in the future. So we test them together, using
 // a fake DockerClient and K8sClient
@@ -170,10 +142,6 @@ func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
 		k8s:            k8s,
 		bd:             bd,
 	}
-}
-
-func (f *bdFixture) setPodExists(val bool) {
-	f.k8s.podWithImageExists = val
 }
 
 type FakeK8sClient struct {

--- a/internal/engine/container_build_and_deployer.go
+++ b/internal/engine/container_build_and_deployer.go
@@ -66,7 +66,7 @@ func (cbd *ContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, servic
 	// Otherwise, service has already been deployed; try to update in the running container
 
 	// (Unless we don't know what container it's running in, in which case fall back to image deploy.)
-	if state.LastResult.NoContainer() {
+	if !state.LastResult.HasContainer() {
 		logger.Get(ctx).Infof("Unknown container, falling back to image deploy")
 		return cbd.ibd.BuildAndDeploy(ctx, service, state)
 	}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -65,7 +65,8 @@ func (ibd ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, service mod
 func (ibd ImageBuildAndDeployer) build(ctx context.Context, service model.Service, state BuildState) (reference.NamedTagged, error) {
 	checkpoint := ibd.history.CheckpointNow()
 	var n reference.NamedTagged
-	if state.IsEmpty() {
+	if !state.HasImage() {
+		// No existing image to build off of, need to build from scratch
 		name, err := reference.ParseNormalizedNamed(service.DockerfileTag)
 		if err != nil {
 			return nil, err

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -172,3 +172,8 @@ func (ibd ImageBuildAndDeployer) deploy(ctx context.Context, service model.Servi
 func (ibd ImageBuildAndDeployer) canSkipPush() bool {
 	return ibd.env == k8s.EnvDockerDesktop || ibd.env == k8s.EnvMinikube
 }
+
+func (ibd ImageBuildAndDeployer) GetContainerForBuild(ctx context.Context, build BuildResult) (k8s.ContainerID, error) {
+	// NOTE(maia): no-op, as ibd has no knowledge of pods or containers.
+	return "", nil
+}

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -19,6 +19,10 @@ func (b BuildResult) IsEmpty() bool {
 	return b.Image == nil && b.Container == ""
 }
 
+func (b BuildResult) NoContainer() bool {
+	return b.Container == ""
+}
+
 // The state of the system since the last successful build.
 // This data structure should be considered immutable.
 // All methods that return a new BuildState should first clone the existing build state.

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -19,8 +19,12 @@ func (b BuildResult) IsEmpty() bool {
 	return b.Image == nil && b.Container == ""
 }
 
-func (b BuildResult) NoContainer() bool {
-	return b.Container == ""
+func (b BuildResult) HasImage() bool {
+	return b.Image != nil
+}
+
+func (b BuildResult) HasContainer() bool {
+	return b.Container != ""
 }
 
 // The state of the system since the last successful build.
@@ -98,6 +102,10 @@ func (b BuildState) OnlySpuriousChanges() (bool, error) {
 // A build state is empty if there are no previous results.
 func (b BuildState) IsEmpty() bool {
 	return b.LastResult.IsEmpty()
+}
+
+func (b BuildState) HasImage() bool {
+	return b.LastResult.HasImage()
 }
 
 var BuildStateClean = BuildState{}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -149,7 +149,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 // populates each BuildState with its corresponding containerID
 func (u Upper) populateContainersForBuildStates(ctx context.Context, buildStates map[model.ServiceName]BuildState) {
 	for serv, state := range buildStates {
-		if state.LastResult.NoContainer() {
+		if !state.LastResult.HasContainer() {
 			cID, err := u.b.GetContainerForBuild(ctx, state.LastResult)
 			if err != nil {
 				logger.Get(ctx).Infof(

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/testutils"
 	"github.com/windmilleng/tilt/internal/watch"
@@ -56,6 +57,10 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 	}
 
 	return b.nextBuildResult(), nil
+}
+
+func (b *fakeBuildAndDeployer) GetContainerForBuild(ctx context.Context, build BuildResult) (k8s.ContainerID, error) {
+	return "", nil
 }
 
 func newFakeBuildAndDeployer(t *testing.T) *fakeBuildAndDeployer {

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -394,7 +394,7 @@ def test_watch_build_from_new_file(serv: Service, case: str) -> float:
     tilt_proc = run_and_wait_for_stdout(serv.tilt_up_watch_cmd(case), '[timing.py] finished initial build')
 
     # wait a sec for the pod to come up so we can do a container update
-    time.sleep(1.5)
+    time.sleep(2)
 
     # write a new file (does not affect go build)
     serv.write_file(100 * KB)  # 100KB total
@@ -412,7 +412,7 @@ def test_watch_build_from_many_changed_files(serv: Service, case: str) -> float:
     tilt_proc = run_and_wait_for_stdout(serv.tilt_up_watch_cmd(case), '[timing.py] finished initial build')
 
     # wait a sec for the pod to come up so we can do a container update
-    time.sleep(1.5)
+    time.sleep(2)
 
     for _ in range(100):  # 100KB total
         serv.write_file(KB)
@@ -430,7 +430,7 @@ def test_watch_build_from_changed_go_file(serv: Service, case: str) -> float:
     tilt_proc = run_and_wait_for_stdout(serv.tilt_up_watch_cmd(case), '[timing.py] finished initial build')
 
     # wait a sec for the pod to come up so we can do a container update
-    time.sleep(1.5)
+    time.sleep(2)
 
     # change a go file
     serv.change_main_go()


### PR DESCRIPTION
re: https://app.clubhouse.io/windmill/story/126/get-container-id-as-soon-as-initial-deploy-finishes

behavior works, interface-ing is sorta janky, feedback welcome. lmk if this is too ugly to land.