### PR TITLE
output: indicate when pipeline errored

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -49,9 +49,10 @@ func addCommand(parent *cobra.Command, child tiltCmd) {
 	cobraChild.Run = func(_ *cobra.Command, args []string) {
 		err := child.run(args)
 		if err != nil {
-			_, err := fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			if err != nil {
-				panic(err)
+			// TODO(maia): this shouldn't print if we've already pretty-printed it
+			_, printErr := fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			if printErr != nil {
+				panic(printErr)
 			}
 			os.Exit(1)
 		}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -33,15 +33,15 @@ func NewImageBuildAndDeployer(b build.ImageBuilder, k8sClient k8s.Client, histor
 	}, nil
 }
 
-func (ibd ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model.Service, state BuildState) (BuildResult, error) {
+func (ibd ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model.Service, state BuildState) (br BuildResult, err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuildAndDeployer-BuildAndDeploy")
 	defer span.Finish()
 
 	// TODO - currently hardcoded that we have 2 pipeline steps. This might end up being dynamic? drop it from the output?
 	output.Get(ctx).StartPipeline(2)
-	defer output.Get(ctx).EndPipeline()
+	defer func() { output.Get(ctx).EndPipeline(err) }()
 
-	err := service.Validate()
+	err = service.Validate()
 	if err != nil {
 		return BuildResult{}, err
 	}

--- a/internal/output/outputter_test.go
+++ b/internal/output/outputter_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,14 +36,15 @@ func TestPrefixedWriterNewlineInMiddle(t *testing.T) {
 }
 
 func TestPipeline(t *testing.T) {
+	var err error
 	out := &bytes.Buffer{}
-	logger := logger.NewLogger(logger.InfoLvl, out)
-	o := NewOutputter(logger)
+	l := logger.NewLogger(logger.InfoLvl, out)
+	o := NewOutputter(l)
 	o.StartPipeline(1)
 	o.StartPipelineStep("%s %s", "hello", "world")
 	o.Printf("in ur step")
 	o.EndPipelineStep()
-	o.EndPipeline()
+	o.EndPipeline(err)
 
 	result := out.String()
 	assert.Equal(t, `──┤ Pipeline Starting … ├────────────────────────────────────────
@@ -55,15 +57,38 @@ STEP 1/1 — hello world
 `, result)
 }
 
-func TestMultilinePrintInPipeline(t *testing.T) {
+func TestErroredPipeline(t *testing.T) {
+	err := fmt.Errorf("oh noes")
 	out := &bytes.Buffer{}
-	logger := logger.NewLogger(logger.InfoLvl, out)
-	o := NewOutputter(logger)
+	l := logger.NewLogger(logger.InfoLvl, out)
+	o := NewOutputter(l)
+	o.StartPipeline(1)
+	o.StartPipelineStep("%s %s", "hello", "world")
+	o.Printf("in ur step")
+	o.EndPipelineStep()
+	o.EndPipeline(err)
+
+	result := out.String()
+	assert.Equal(t, `──┤ Pipeline Starting … ├────────────────────────────────────────
+STEP 1/1 — hello world
+    ╎ in ur step
+    (Done 0.000s)
+
+──┤ ︎Pipeline FAILED in 0.000s 😢 ︎├───────────────────────────────────
+  → ︎ERROR: oh noes
+`, result)
+}
+
+func TestMultilinePrintInPipeline(t *testing.T) {
+	var err error
+	out := &bytes.Buffer{}
+	l := logger.NewLogger(logger.InfoLvl, out)
+	o := NewOutputter(l)
 	o.StartPipeline(1)
 	o.StartPipelineStep("%s %s", "hello", "world")
 	o.Printf("line 1\nline 2\n")
 	o.EndPipelineStep()
-	o.EndPipeline()
+	o.EndPipeline(err)
 
 	result := out.String()
 	assert.Equal(t, `──┤ Pipeline Starting … ├────────────────────────────────────────


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch maiamcc/ch136/good-err-output:

2fbd65bf3b7de7277a884b2650e8da23d504b8fa (2018-09-07 11:35:36 -0400)
output: indicate when pipeline errored

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics