### PR TITLE
lint: verify no improper defers of PipelineEnd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ install:
 
 lint:
 	go vet -all -printfuncs=Verbosef,Infof,Debugf ./...
-
+    ! grep --include=\*.go -rn . -e '^[^/].*defer [^ ]*EndPipeline(' # linting for improperly deferred EndPipeline calls; should be in closure, i.e. `defer func() { ...EndPipeline(err) }()`
+    
 test:
 	go test -timeout 60s ./...
 

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ install:
 
 lint:
 	go vet -all -printfuncs=Verbosef,Infof,Debugf ./...
-    ! grep --include=\*.go -rn . -e '^[^/].*defer [^ ]*EndPipeline(' # linting for improperly deferred EndPipeline calls; should be in closure, i.e. `defer func() { ...EndPipeline(err) }()`
-    
+	! grep --include=\*.go -rn . -e '^[^/].*defer [^ ]*EndPipeline(' # linting for improperly deferred EndPipeline calls; should be in closure, i.e. `defer func() { ...EndPipeline(err) }()`
+
 test:
 	go test -timeout 60s ./...
 


### PR DESCRIPTION
Hello @dbentley, @nicks,

Please review the following commits I made in branch maiamcc/lint-improper-pipeline-end:

70e7bbf6bc0b3fe51dc28588598a50d56ece599e (2018-09-07 13:01:05 -0400)
lint: verify no improper defers of PipelineEnd

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics