### PR TITLE
engine: reap old images when starting a watch

### DIFF
--- a/internal/build/image_reaper.go
+++ b/internal/build/image_reaper.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
@@ -22,6 +23,10 @@ func FilterByLabel(label Label) filters.KeyValuePair {
 
 func FilterByLabelValue(label Label, val LabelValue) filters.KeyValuePair {
 	return filters.Arg("label", fmt.Sprintf("%s=%s", label, val))
+}
+
+func FilterByRefName(ref reference.Named) filters.KeyValuePair {
+	return filters.Arg("reference", fmt.Sprintf("%s:*", ref.Name()))
 }
 
 func NewImageReaper(docker DockerClient) ImageReaper {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -32,6 +32,7 @@ func wireServiceCreator(ctx context.Context, browser engine.BrowserMode) (model.
 		build.NewDockerImageBuilder,
 		engine.NewImageBuildAndDeployer,
 		wire.Value(build.Labels{}),
+		build.NewImageReaper,
 
 		// ContainerBuildAndDeployer ( = BuildAndDeployer)
 		wire.Bind(new(engine.BuildAndDeployer), new(engine.ContainerBuildAndDeployer)),

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -38,7 +38,8 @@ func wireServiceCreator(ctx context.Context, browser engine.BrowserMode) (model.
 	}
 	bool2 := engine.DefaultSkipContainer()
 	containerBuildAndDeployer := engine.NewContainerBuildAndDeployer(containerUpdater, env, kubectlClient, imageBuildAndDeployer, bool2)
-	upper := engine.NewUpper(ctx, containerBuildAndDeployer, kubectlClient, browser)
+	imageReaper := build.NewImageReaper(dockerCli)
+	upper := engine.NewUpper(ctx, containerBuildAndDeployer, kubectlClient, browser, imageReaper)
 	manager := service.ProvideMemoryManager()
 	serviceCreator := provideServiceCreator(upper, manager)
 	return serviceCreator, nil


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/reaper3:

a6a635487a69c109d4e31167685b4b335bcc79fa (2018-09-07 16:43:45 -0400)
engine: reap old images when starting a watch