### PR TITLE
engine: only call GetContainerForBuild if we have an image

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -156,7 +156,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 // populates each BuildState with its corresponding containerID
 func (u Upper) populateContainersForBuildStates(ctx context.Context, buildStates map[model.ServiceName]BuildState) {
 	for serv, state := range buildStates {
-		if !state.LastResult.HasContainer() {
+		if !state.LastResult.HasContainer() && state.LastResult.HasImage() {
 			cID, err := u.b.GetContainerForBuild(ctx, state.LastResult)
 			if err != nil {
 				logger.Get(ctx).Infof(

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -29,8 +29,7 @@ type fakeBuildAndDeployer struct {
 	t     *testing.T
 	calls chan buildAndDeployCall
 
-	buildCount                int
-	getContainerForBuildCount int
+	buildCount int
 
 	// Set this to simulate the build failing
 	nextBuildFailure error
@@ -62,8 +61,8 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 }
 
 func (b *fakeBuildAndDeployer) GetContainerForBuild(ctx context.Context, build BuildResult) (k8s.ContainerID, error) {
-	b.getContainerForBuildCount++
 	if build.Image == nil {
+		b.t.Error("Tried to get container for BuildResult with no image")
 		return "", fmt.Errorf("can't get container for BuildResult with no image")
 	}
 	return k8s.ContainerID("testcontainer"), nil
@@ -278,7 +277,6 @@ func TestFirstBuildFailsWhileWatching(t *testing.T) {
 	}()
 	err := f.upper.CreateServices(f.Ctx(), []model.Service{service}, true)
 	assert.Equal(t, endToken, err)
-	assert.Equal(t, f.b.getContainerForBuildCount, 0)
 }
 
 func TestFirstBuildFailsWhileNotWatching(t *testing.T) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -29,7 +29,8 @@ type fakeBuildAndDeployer struct {
 	t     *testing.T
 	calls chan buildAndDeployCall
 
-	buildCount int
+	buildCount                int
+	getContainerForBuildCount int
 
 	// Set this to simulate the build failing
 	nextBuildFailure error
@@ -61,6 +62,7 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, service model
 }
 
 func (b *fakeBuildAndDeployer) GetContainerForBuild(ctx context.Context, build BuildResult) (k8s.ContainerID, error) {
+	b.getContainerForBuildCount++
 	if build.Image == nil {
 		return "", fmt.Errorf("can't get container for BuildResult with no image")
 	}
@@ -276,6 +278,7 @@ func TestFirstBuildFailsWhileWatching(t *testing.T) {
 	}()
 	err := f.upper.CreateServices(f.Ctx(), []model.Service{service}, true)
 	assert.Equal(t, endToken, err)
+	assert.Equal(t, f.b.getContainerForBuildCount, 0)
 }
 
 func TestFirstBuildFailsWhileNotWatching(t *testing.T) {


### PR DESCRIPTION
If there's no image, we can't find the pod.

https://app.clubhouse.io/windmill/story/147/segfault-in-incremental-build