### PR TITLE
test: use t.Helper in assert functions

### DIFF
--- a/internal/build/container_updater_test.go
+++ b/internal/build/container_updater_test.go
@@ -119,6 +119,7 @@ type mockContainerUpdaterFixture struct {
 }
 
 func newRemoteDockerFixture(t testing.TB) *mockContainerUpdaterFixture {
+	t.Helper()
 	fakeCli := NewFakeDockerClient()
 	cu := &ContainerUpdater{
 		dcli: fakeCli,

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -171,6 +171,7 @@ type expectedFile struct {
 }
 
 func (f *dockerBuildFixture) assertImageExists(ref reference.NamedTagged) {
+	f.t.Helper()
 	_, _, err := f.dcli.ImageInspectWithRaw(f.ctx, ref.String())
 	if err != nil {
 		f.t.Errorf("Expected image %q to exist, got: %v", ref, err)
@@ -178,6 +179,7 @@ func (f *dockerBuildFixture) assertImageExists(ref reference.NamedTagged) {
 }
 
 func (f *dockerBuildFixture) assertImageNotExists(ref reference.NamedTagged) {
+	f.t.Helper()
 	_, _, err := f.dcli.ImageInspectWithRaw(f.ctx, ref.String())
 	if err == nil || !client.IsErrNotFound(err) {
 		f.t.Errorf("Expected image %q to fail with ErrNotFound, got: %v", ref, err)
@@ -185,12 +187,14 @@ func (f *dockerBuildFixture) assertImageNotExists(ref reference.NamedTagged) {
 }
 
 func (f *dockerBuildFixture) assertFilesInImage(ref reference.NamedTagged, expectedFiles []expectedFile) {
+	f.t.Helper()
 	cID := f.startContainer(f.ctx, containerConfigRunCmd(ref, model.Cmd{}))
 	f.assertFilesInContainer(f.ctx, cID, expectedFiles)
 }
 
 func (f *dockerBuildFixture) assertFilesInContainer(
 	ctx context.Context, cID k8s.ContainerID, expectedFiles []expectedFile) {
+	f.t.Helper()
 	for _, expectedFile := range expectedFiles {
 		reader, _, err := f.dcli.CopyFromContainer(ctx, cID.String(), expectedFile.path)
 		if expectedFile.missing {
@@ -212,6 +216,7 @@ func (f *dockerBuildFixture) assertFilesInContainer(
 }
 
 func (f *dockerBuildFixture) assertFileInTar(tr *tar.Reader, expected expectedFile) {
+	f.t.Helper()
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -88,6 +88,7 @@ type dockerBuildFixture struct {
 }
 
 func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
+	t.Helper()
 	ctx := testutils.CtxForTest()
 	dcli, err := DefaultDockerClient(ctx, k8s.EnvGKE)
 	if err != nil {

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -95,6 +95,7 @@ func (f *fixture) tearDown() {
 }
 
 func (f *fixture) assertFileInTarWithContents(buf *bytes.Buffer, path, expected string) {
+	f.t.Helper()
 	tr := tar.NewReader(buf)
 	found := false
 	for {
@@ -123,6 +124,7 @@ func (f *fixture) assertFileInTarWithContents(buf *bytes.Buffer, path, expected 
 }
 
 func (f *fixture) assertFileNotInTar(buf *bytes.Buffer, path string) {
+	f.t.Helper()
 	tr := tar.NewReader(buf)
 	found := false
 	for {

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -81,6 +81,7 @@ type fixture struct {
 }
 
 func newFixture(t *testing.T) *fixture {
+	t.Helper()
 	ctx := testutils.CtxForTest()
 
 	return &fixture{

--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -59,6 +59,7 @@ type testFixture struct {
 }
 
 func newTestFixture(t *testing.T, dockerignores ...string) *testFixture {
+	t.Helper()
 	tf := testFixture{}
 	tempDir := testutils.NewTempDirFixture(t)
 	tf.repoRoot = tempDir

--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -85,6 +85,7 @@ func (tf *testFixture) JoinPath(path ...string) string {
 }
 
 func (tf *testFixture) AssertResult(path string, expectedIsIgnored bool) {
+	tf.t.Helper()
 	isIgnored, err := tf.tester.IsIgnored(path, false)
 	if err != nil {
 		tf.t.Fatal(err)

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -120,6 +120,7 @@ type bdFixture struct {
 }
 
 func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
+	t.Helper()
 	f := testutils.NewTempDirFixture(t)
 	dir := dirs.NewWindmillDirAt(f.Path())
 	docker := build.NewFakeDockerClient()

--- a/internal/engine/up_watch_test.go
+++ b/internal/engine/up_watch_test.go
@@ -60,6 +60,7 @@ type serviceWatcherTestFixture struct {
 }
 
 func makeServiceWatcherTestFixture(t *testing.T, serviceCount int) *serviceWatcherTestFixture {
+	t.Helper()
 	var watchers []*fakeNotify
 	nextWatcher := 0
 	watcherMaker := func() (watch.Notify, error) {

--- a/internal/engine/up_watch_test.go
+++ b/internal/engine/up_watch_test.go
@@ -142,10 +142,12 @@ func (s *serviceWatcherTestFixture) readEvents(numExpectedEvents int) []testServ
 }
 
 func (s *serviceWatcherTestFixture) AssertNextEvent(serviceNumber int, files []string) bool {
+	s.t.Helper()
 	return s.AssertNextEvents([]testServiceFilesChangedEvent{{serviceNumber, files}})
 }
 
 func (s *serviceWatcherTestFixture) AssertNextEvents(expectedEvents []testServiceFilesChangedEvent) bool {
+	s.t.Helper()
 	actualEvents := s.readEvents(len(expectedEvents))
 	return assert.ElementsMatch(s.t, expectedEvents, actualEvents)
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -435,6 +435,7 @@ type testFixture struct {
 }
 
 func newTestFixture(t *testing.T) *testFixture {
+	t.Helper()
 	f := testutils.NewTempDirFixture(t)
 	watcher := newFakeNotify()
 	watcherMaker := makeFakeWatcherMaker(watcher)

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -83,6 +83,7 @@ type testFixture struct {
 
 // initializes `tf.repoRoots` to be an array with one dir per gitignore
 func newTestFixture(t *testing.T, gitignores ...string) *testFixture {
+	t.Helper()
 	tf := testFixture{}
 	for _, gitignore := range gitignores {
 		tempDir := testutils.NewTempDirFixture(t)

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -135,6 +135,7 @@ func (tf *testFixture) JoinPath(repoNum int, path ...string) string {
 }
 
 func (tf *testFixture) AssertResult(path string, expectedIsIgnored bool, expectError bool) {
+	tf.t.Helper()
 	isIgnored, err := tf.tester.IsIgnored(path, false)
 	if expectError {
 		assert.Error(tf.t, err)

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -64,6 +64,7 @@ func NewOspathFixture(t *testing.T) *OspathFixture {
 
 // pass `expectedRelative` = "" to indicate that `file` is NOT a child of `dir`
 func (f *OspathFixture) assertChild(dir, file, expectedRel string) {
+	f.t.Helper()
 	rel, isChild := Child(dir, file)
 	if expectedRel == "" {
 		if isChild {
@@ -91,6 +92,7 @@ func (f *OspathFixture) symlink(oldPath, newPath string) {
 }
 
 func (f *OspathFixture) assertBrokenSymlink(file string, expected bool) {
+	f.t.Helper()
 	broken, err := IsBrokenSymlink(path.Join(f.Path(), file))
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -56,6 +56,7 @@ type OspathFixture struct {
 }
 
 func NewOspathFixture(t *testing.T) *OspathFixture {
+	t.Helper()
 	return &OspathFixture{
 		TempDirFixture: testutils.NewTempDirFixture(t),
 		t:              t,

--- a/internal/output/outputter_test.go
+++ b/internal/output/outputter_test.go
@@ -127,5 +127,6 @@ func (p prefixedWriterTestFixture) Write(s string) {
 }
 
 func (p prefixedWriterTestFixture) AssertContentsEqual(expected string) {
+	p.t.Helper()
 	assert.Equal(p.t, expected, p.buf.String())
 }

--- a/internal/output/outputter_test.go
+++ b/internal/output/outputter_test.go
@@ -113,6 +113,7 @@ type prefixedWriterTestFixture struct {
 }
 
 func newPrefixedWriterTestFixture(t *testing.T, prefix string) prefixedWriterTestFixture {
+	t.Helper()
 	buf := bytes.NewBuffer(make([]byte, 0))
 	return prefixedWriterTestFixture{writer: newPrefixedWriter(prefix, buf), buf: buf, t: t}
 }

--- a/internal/service/manager_test.go
+++ b/internal/service/manager_test.go
@@ -132,6 +132,7 @@ type serviceManagerFixture struct {
 }
 
 func newServiceManagerFixture(t *testing.T) *serviceManagerFixture {
+	t.Helper()
 	sm := service.NewMemoryManager()
 
 	return &serviceManagerFixture{

--- a/internal/service/manager_test.go
+++ b/internal/service/manager_test.go
@@ -141,5 +141,6 @@ func newServiceManagerFixture(t *testing.T) *serviceManagerFixture {
 }
 
 func (f *serviceManagerFixture) AssertServiceList(s []model.Service) {
+	f.t.Helper()
 	assert.ElementsMatch(f.t, f.sm.List(), s)
 }

--- a/internal/testutils/temp_dir_fixture.go
+++ b/internal/testutils/temp_dir_fixture.go
@@ -17,6 +17,7 @@ type TempDirFixture struct {
 }
 
 func NewTempDirFixture(t testing.TB) *TempDirFixture {
+	t.Helper()
 	dir, err := temp.NewDir(t.Name())
 	if err != nil {
 		t.Fatalf("Error making temp dir: %v", err)

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -315,6 +315,7 @@ func newNotifyFixture(t *testing.T) *notifyFixture {
 }
 
 func (f *notifyFixture) assertEvents(expected ...string) {
+	f.t.Helper()
 	f.fsync()
 
 	if len(f.events) != len(expected) {

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -286,6 +286,7 @@ type notifyFixture struct {
 }
 
 func newNotifyFixture(t *testing.T) *notifyFixture {
+	t.Helper()
 	SetLimitChecksEnabled(false)
 	notify, err := NewWatcher()
 	if err != nil {


### PR DESCRIPTION
`t.Helper` is a function in the testing package that omits functions that contain calls to it from stack traces. This is useful for assert functions since we don't care that the assert failed per se, but in which test case the assert failed.