### PR TITLE
output: summary includes path

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/output"
+	"github.com/windmilleng/tilt/internal/summary"
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
@@ -76,7 +77,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 		}
 	}
 
-	s := output.NewSummary()
+	s := summary.NewSummary()
 	s.Gather(services)
 
 	lbs := make([]k8s.LoadBalancer, 0)

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -107,7 +107,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 
 	logger.Get(ctx).Debugf("[timing.py] finished initial build") // hook for timing.py
 
-	output.Get(ctx).Summary(watchMounts, s)
+	output.Get(ctx).Printf("%s", s.Output())
 
 	if watchMounts {
 		go func() {
@@ -155,7 +155,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 				}
 				logger.Get(ctx).Debugf("[timing.py] finished build from file change") // hook for timing.py
 
-				output.Get(ctx).Summary(watchMounts, s)
+				output.Get(ctx).Printf("%s", s.Output())
 
 			case err := <-sw.errs:
 				return err

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -154,6 +154,8 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 				}
 				logger.Get(ctx).Debugf("[timing.py] finished build from file change") // hook for timing.py
 
+				output.Get(ctx).PrintSummary(watchMounts, s)
+
 			case err := <-sw.errs:
 				return err
 			}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -106,7 +106,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 
 	logger.Get(ctx).Debugf("[timing.py] finished initial build") // hook for timing.py
 
-	output.Get(ctx).PrintSummary(watchMounts, s)
+	output.Get(ctx).Summary(watchMounts, s)
 
 	if watchMounts {
 		go func() {
@@ -154,7 +154,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 				}
 				logger.Get(ctx).Debugf("[timing.py] finished build from file change") // hook for timing.py
 
-				output.Get(ctx).PrintSummary(watchMounts, s)
+				output.Get(ctx).Summary(watchMounts, s)
 
 			case err := <-sw.errs:
 				return err

--- a/internal/output/outputter.go
+++ b/internal/output/outputter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/windmilleng/tilt/internal/logger"
+	"github.com/windmilleng/tilt/internal/summary"
 )
 
 const (
@@ -124,12 +125,12 @@ func (o *Outputter) StartBuildStep(format string, a ...interface{}) {
 	o.curBuildStep++
 }
 
-func (o *Outputter) Summary(watchMounts bool, summary *Summary) {
+func (o *Outputter) Summary(watchMounts bool, summary *summary.Summary) {
 	o.logger.Infof("%s", o.blue().Sprint("\n──┤ Services Built … ├────────────────────────────────────────"))
 
-	for _, svc := range summary.services {
-		o.logger.Infof("  • %s", svc.name)
-		o.logger.Infof("    (%s)", svc.path)
+	for _, svc := range summary.Services {
+		o.logger.Infof("  • %s", svc.Name)
+		o.logger.Infof("    (%s)", svc.Path)
 	}
 
 	if watchMounts {

--- a/internal/output/outputter.go
+++ b/internal/output/outputter.go
@@ -124,10 +124,12 @@ func (o *Outputter) StartBuildStep(format string, a ...interface{}) {
 	o.curBuildStep++
 }
 
-func (o *Outputter) PrintSummary(watchMounts bool, summary *summary) {
-	o.logger.Infof("%s", o.blue().Sprint("──┤ Services Built … ├────────────────────────────────────────"))
+func (o *Outputter) Summary(watchMounts bool, summary *Summary) {
+	o.logger.Infof("%s", o.blue().Sprint("\n──┤ Services Built … ├────────────────────────────────────────"))
+
 	for _, svc := range summary.services {
-		o.logger.Infof("  • %s", svc)
+		o.logger.Infof("  • %s", svc.name)
+		o.logger.Infof("    (%s)", svc.path)
 	}
 
 	if watchMounts {

--- a/internal/output/outputter.go
+++ b/internal/output/outputter.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/windmilleng/tilt/internal/logger"
-	"github.com/windmilleng/tilt/internal/summary"
 )
 
 const (
@@ -123,19 +122,6 @@ func (o *Outputter) EndPipelineStep() {
 func (o *Outputter) StartBuildStep(format string, a ...interface{}) {
 	o.logger.Infof("  → %s", fmt.Sprintf(format, a...))
 	o.curBuildStep++
-}
-
-func (o *Outputter) Summary(watchMounts bool, summary *summary.Summary) {
-	o.logger.Infof("%s", o.blue().Sprint("\n──┤ Services Built … ├────────────────────────────────────────"))
-
-	for _, svc := range summary.Services {
-		o.logger.Infof("  • %s", svc.Name)
-		o.logger.Infof("    (%s)", svc.Path)
-	}
-
-	if watchMounts {
-		o.logger.Infof("%s", o.green().Sprint("\nWatching for changes…"))
-	}
 }
 
 func (o *Outputter) Printf(format string, a ...interface{}) {

--- a/internal/output/summary.go
+++ b/internal/output/summary.go
@@ -5,20 +5,30 @@ import (
 )
 
 // Summary contains data to be printed at the end of the build process
-type summary struct {
-	services []string
+type Summary struct {
+	services []*service
+}
+
+type service struct {
+	name string
+	path string
 }
 
 // NewSummary returns summary state
-func NewSummary() *summary {
-	return &summary{
-		services: []string{},
+func NewSummary() *Summary {
+	return &Summary{
+		services: []*service{},
 	}
 }
 
 // Gather collates data into Summary
-func (s *summary) Gather(services []model.Service) {
+func (s *Summary) Gather(services []model.Service) {
+
 	for _, svc := range services {
-		s.services = append(s.services, string(svc.Name))
+		s.services = append(s.services, &service{
+			name: string(svc.Name),
+			// Assume that, in practice, there is only one mount
+			path: string(svc.Mounts[0].Repo.LocalPath),
+		})
 	}
 }

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -1,4 +1,4 @@
-package output
+package summary
 
 import (
 	"github.com/windmilleng/tilt/internal/model"
@@ -6,18 +6,18 @@ import (
 
 // Summary contains data to be printed at the end of the build process
 type Summary struct {
-	services []*service
+	Services []*Service
 }
 
-type service struct {
-	name string
-	path string
+type Service struct {
+	Name string
+	Path string
 }
 
 // NewSummary returns summary state
 func NewSummary() *Summary {
 	return &Summary{
-		services: []*service{},
+		Services: []*Service{},
 	}
 }
 
@@ -25,10 +25,10 @@ func NewSummary() *Summary {
 func (s *Summary) Gather(services []model.Service) {
 
 	for _, svc := range services {
-		s.services = append(s.services, &service{
-			name: string(svc.Name),
+		s.Services = append(s.Services, &Service{
+			Name: string(svc.Name),
 			// Assume that, in practice, there is only one mount
-			path: string(svc.Mounts[0].Repo.LocalPath),
+			Path: string(svc.Mounts[0].Repo.LocalPath),
 		})
 	}
 }

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -1,6 +1,8 @@
 package summary
 
 import (
+	"fmt"
+
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -25,10 +27,27 @@ func NewSummary() *Summary {
 func (s *Summary) Gather(services []model.Service) {
 
 	for _, svc := range services {
+		var path string
+		// Assume that, in practice, there is only one mount
+		if len(svc.Mounts) > 0 {
+			path = svc.Mounts[0].Repo.LocalPath
+		} else {
+			path = ""
+		}
 		s.Services = append(s.Services, &Service{
 			Name: string(svc.Name),
-			// Assume that, in practice, there is only one mount
-			Path: string(svc.Mounts[0].Repo.LocalPath),
+			Path: path,
 		})
 	}
+}
+
+func (s *Summary) Output() string {
+	ret := "\n──┤ Services Built … ├────────────────────────────────────────\n"
+
+	for _, svc := range s.Services {
+		ret += fmt.Sprintf("  • %s\n", svc.Name)
+		ret += fmt.Sprintf("    (%s)\n", svc.Path)
+	}
+
+	return ret
 }


### PR DESCRIPTION
Admittedly, this might be only minimally helpful to see the path in the summary. But this is part of a larger effort to add various data tidbits in here. Once we have this raw material in, it can then be refined and groomed.

<img width="957" alt="paths" src="https://user-images.githubusercontent.com/20349/45371723-40784080-b5b9-11e8-90ce-abeb32ea44d6.png">
