### PR TITLE
testutils: break apart tempdir and output ctx in to separate packages

### DIFF
--- a/internal/build/container_updater_test.go
+++ b/internal/build/container_updater_test.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 func TestContainerIdForPodOneMatch(t *testing.T) {
@@ -111,7 +112,7 @@ func TestUpdateInContainerRestartsContainer(t *testing.T) {
 }
 
 type mockContainerUpdaterFixture struct {
-	*testutils.TempDirFixture
+	*tempdir.TempDirFixture
 	t    testing.TB
 	ctx  context.Context
 	dcli *FakeDockerClient
@@ -125,9 +126,9 @@ func newRemoteDockerFixture(t testing.TB) *mockContainerUpdaterFixture {
 	}
 
 	return &mockContainerUpdaterFixture{
-		TempDirFixture: testutils.NewTempDirFixture(t),
+		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
-		ctx:            testutils.CtxForTest(),
+		ctx:            output.CtxForTest(),
 		dcli:           fakeCli,
 		cu:             cu,
 	}

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -21,7 +21,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 const simpleDockerfile = Dockerfile("FROM alpine")
@@ -79,7 +80,7 @@ func TestDigestFromPushOutput(t *testing.T) {
 }
 
 type dockerBuildFixture struct {
-	*testutils.TempDirFixture
+	*tempdir.TempDirFixture
 	t            testing.TB
 	ctx          context.Context
 	dcli         *DockerCli
@@ -90,7 +91,7 @@ type dockerBuildFixture struct {
 }
 
 func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
-	ctx := testutils.CtxForTest()
+	ctx := output.CtxForTest()
 	dcli, err := DefaultDockerClient(ctx, k8s.EnvGKE)
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +101,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 		TestImage: "1",
 	})
 	return &dockerBuildFixture{
-		TempDirFixture: testutils.NewTempDirFixture(t),
+		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
 		ctx:            ctx,
 		dcli:           dcli,

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 func TestFilesToPathMappings(t *testing.T) {
-	f := testutils.NewTempDirFixture(t)
+	f := tempdir.NewTempDirFixture(t)
 	defer f.TearDown()
 
 	paths := []string{
@@ -81,7 +81,7 @@ func TestRelativeRepoPathsThrowError(t *testing.T) {
 }
 
 func TestFileNotInMountThrowsErr(t *testing.T) {
-	f := testutils.NewTempDirFixture(t)
+	f := tempdir.NewTempDirFixture(t)
 	defer f.TearDown()
 
 	files := []string{f.JoinPath("not/a/mount/fileA")}

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -7,7 +7,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 func TestArchiveDf(t *testing.T) {
@@ -78,16 +79,16 @@ func TestLen(t *testing.T) {
 }
 
 type fixture struct {
-	*testutils.TempDirFixture
+	*tempdir.TempDirFixture
 	t   *testing.T
 	ctx context.Context
 }
 
 func newFixture(t *testing.T) *fixture {
-	ctx := testutils.CtxForTest()
+	ctx := output.CtxForTest()
 
 	return &fixture{
-		TempDirFixture: testutils.NewTempDirFixture(t),
+		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
 		ctx:            ctx,
 	}

--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 func TestMatches(t *testing.T) {
@@ -61,14 +61,14 @@ func TestNoDockerignoreFile(t *testing.T) {
 }
 
 type testFixture struct {
-	repoRoot *testutils.TempDirFixture
+	repoRoot *tempdir.TempDirFixture
 	t        *testing.T
 	tester   model.PathMatcher
 }
 
 func newTestFixture(t *testing.T, dockerignores ...string) *testFixture {
 	tf := testFixture{}
-	tempDir := testutils.NewTempDirFixture(t)
+	tempDir := tempdir.NewTempDirFixture(t)
 	tf.repoRoot = tempDir
 	ignoreText := strings.Builder{}
 	for _, rule := range dockerignores {

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
@@ -46,7 +47,7 @@ func TestGKEDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	_, err := f.bd.BuildAndDeploy(f.Ctx(), SanchoService, BuildStateClean)
+	_, err := f.bd.BuildAndDeploy(output.CtxForTest(), SanchoService, BuildStateClean)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,7 @@ func TestDockerForMacDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop)
 	defer f.TearDown()
 
-	_, err := f.bd.BuildAndDeploy(f.Ctx(), SanchoService, BuildStateClean)
+	_, err := f.bd.BuildAndDeploy(output.CtxForTest(), SanchoService, BuildStateClean)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +93,7 @@ func TestIncrementalBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop)
 	defer f.TearDown()
 
-	_, err := f.bd.BuildAndDeploy(f.Ctx(), SanchoService, NewBuildState(alreadyBuilt))
+	_, err := f.bd.BuildAndDeploy(output.CtxForTest(), SanchoService, NewBuildState(alreadyBuilt))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +121,7 @@ func TestFallBackToImageDeploy(t *testing.T) {
 	defer f.TearDown()
 	f.docker.ExecErrorToThrow = errors.New("some random error")
 
-	_, err := f.bd.BuildAndDeploy(f.Ctx(), SanchoService, NewBuildState(alreadyBuilt))
+	_, err := f.bd.BuildAndDeploy(output.CtxForTest(), SanchoService, NewBuildState(alreadyBuilt))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +142,7 @@ func TestNoFallbackForCertainErrors(t *testing.T) {
 
 	// Malformed service (it's missing fields) will trip a validate error; we
 	// should NOT fall back to image build, but rather, return the error.
-	_, err := f.bd.BuildAndDeploy(f.Ctx(), SanchoService, NewBuildState(alreadyBuilt))
+	_, err := f.bd.BuildAndDeploy(output.CtxForTest(), SanchoService, NewBuildState(alreadyBuilt))
 	if err == nil {
 		t.Errorf("Expected bad service error to propogate back up")
 	}
@@ -159,7 +160,7 @@ func TestNoFallbackForCertainErrors(t *testing.T) {
 // are likely to change in the future. So we test them together, using
 // a fake DockerClient and K8sClient
 type bdFixture struct {
-	*testutils.TempDirFixture
+	*tempdir.TempDirFixture
 	docker *build.FakeDockerClient
 	k8s    *FakeK8sClient
 	bd     BuildAndDeployer
@@ -173,7 +174,7 @@ func shouldFallBack(err error) bool {
 }
 
 func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
-	f := testutils.NewTempDirFixture(t)
+	f := tempdir.NewTempDirFixture(t)
 	dir := dirs.NewWindmillDirAt(f.Path())
 	docker := build.NewFakeDockerClient()
 	docker.ContainerListOutput = map[string][]types.Container{
@@ -184,7 +185,7 @@ func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
 		},
 	}
 	k8s := &FakeK8sClient{}
-	bd, err := provideBuildAndDeployer(f.Ctx(), docker, k8s, dir, env, shouldFallBack)
+	bd, err := provideBuildAndDeployer(output.CtxForTest(), docker, k8s, dir, env, shouldFallBack)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/up_watch_test.go
+++ b/internal/engine/up_watch_test.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
@@ -51,7 +52,7 @@ type serviceWatcherTestFixture struct {
 	sw              *serviceWatcher
 	watcherMaker    watcherMaker
 	ctx             context.Context
-	tempDirs        []*testutils.TempDirFixture
+	tempDirs        []*tempdir.TempDirFixture
 	services        []model.Service
 	watchers        []*fakeNotify
 	timerMaker      fakeTimerMaker
@@ -72,9 +73,9 @@ func makeServiceWatcherTestFixture(t *testing.T, serviceCount int) *serviceWatch
 	}
 
 	var services []model.Service
-	var tempDirs []*testutils.TempDirFixture
+	var tempDirs []*tempdir.TempDirFixture
 	for i := 0; i < serviceCount; i++ {
-		tempDir := testutils.NewTempDirFixture(t)
+		tempDir := tempdir.NewTempDirFixture(t)
 		services = append(services,
 			model.Service{
 				Name:   model.ServiceName(fmt.Sprintf("service%v", i)),
@@ -87,7 +88,7 @@ func makeServiceWatcherTestFixture(t *testing.T, serviceCount int) *serviceWatch
 
 	timerMaker := makeFakeTimerMaker(t)
 
-	ctx := testutils.CtxForTest()
+	ctx := output.CtxForTest()
 
 	sw, err := makeServiceWatcher(ctx, watcherMaker, timerMaker.maker(), services)
 

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 func TestGitIgnoreTester_Simple(t *testing.T) {
@@ -20,10 +21,10 @@ func TestGitIgnoreTester_Simple(t *testing.T) {
 }
 
 func TestNewGitIgnoreTester_NoGitignore(t *testing.T) {
-	tempDir := testutils.NewTempDirFixture(t)
+	tempDir := tempdir.NewTempDirFixture(t)
 	defer tempDir.TearDown()
 
-	g, err := NewGitIgnoreTester(testutils.CtxForTest(), tempDir.Path())
+	g, err := NewGitIgnoreTester(output.CtxForTest(), tempDir.Path())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +76,7 @@ func TestRepoIgnoreTester_MatchesRelativePath(t *testing.T) {
 }
 
 type testFixture struct {
-	repoRoots []*testutils.TempDirFixture
+	repoRoots []*tempdir.TempDirFixture
 	tester    model.PathMatcher
 	ctx       context.Context
 	t         *testing.T
@@ -85,7 +86,7 @@ type testFixture struct {
 func newTestFixture(t *testing.T, gitignores ...string) *testFixture {
 	tf := testFixture{}
 	for _, gitignore := range gitignores {
-		tempDir := testutils.NewTempDirFixture(t)
+		tempDir := tempdir.NewTempDirFixture(t)
 		tempDir.WriteFile(".gitignore", gitignore)
 		tf.repoRoots = append(tf.repoRoots, tempDir)
 	}
@@ -96,7 +97,7 @@ func newTestFixture(t *testing.T, gitignores ...string) *testFixture {
 }
 
 func (tf *testFixture) UseGitIgnoreTester() {
-	tester, err := NewGitIgnoreTester(testutils.CtxForTest(), tf.repoRoots[0].Path())
+	tester, err := NewGitIgnoreTester(output.CtxForTest(), tf.repoRoots[0].Path())
 	if err != nil {
 		tf.t.Fatal(err)
 	}

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 func TestChild(t *testing.T) {
@@ -51,13 +51,13 @@ func TestIsBrokenSymlink(t *testing.T) {
 }
 
 type OspathFixture struct {
-	*testutils.TempDirFixture
+	*tempdir.TempDirFixture
 	t *testing.T
 }
 
 func NewOspathFixture(t *testing.T) *OspathFixture {
 	return &OspathFixture{
-		TempDirFixture: testutils.NewTempDirFixture(t),
+		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
 	}
 }

--- a/internal/testutils/output/context.go
+++ b/internal/testutils/output/context.go
@@ -1,4 +1,4 @@
-package testutils
+package output
 
 import (
 	"context"

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -1,7 +1,6 @@
-package testutils
+package tempdir
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 
 type TempDirFixture struct {
 	t   testing.TB
-	ctx context.Context
 	dir *temp.TempDir
 }
 
@@ -24,17 +22,12 @@ func NewTempDirFixture(t testing.TB) *TempDirFixture {
 
 	return &TempDirFixture{
 		t:   t,
-		ctx: CtxForTest(),
 		dir: dir,
 	}
 }
 
 func (f *TempDirFixture) T() testing.TB {
 	return f.t
-}
-
-func (f *TempDirFixture) Ctx() context.Context {
-	return f.ctx
 }
 
 func (f *TempDirFixture) Path() string {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
 func tempFile(content string) string {
@@ -336,7 +336,7 @@ func TestGetServiceConfigWithLocalCmd(t *testing.T) {
 }
 
 func TestRunTrigger(t *testing.T) {
-	td := testutils.NewTempDirFixture(t)
+	td := tempdir.NewTempDirFixture(t)
 	defer td.TearDown()
 	oldWD, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
... to avoid circular dependencies in test