### PR TITLE
makefile: put shorter commands at front of 'all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all proto install lint test wire-check wire ensure
 
-all: lint errcheck test verify_gofmt wire-check
+all: lint errcheck verify_gofmt wire-check test
 
 proto:
 	docker build -t tilt-protogen -f Dockerfile.protogen .


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/reorder-make-all:

fc89ace7609f41afb93b80014b7dee2d000e920a (2018-09-11 16:36:06 -0400)
makefile: put shorter commands at front of 'all'

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics