### PR TITLE
tilt: synclet: hardcode unknown k8s env

### DIFF
--- a/cmd/synclet/main.go
+++ b/cmd/synclet/main.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net"
 
+	"github.com/windmilleng/tilt/internal/k8s"
+
 	"github.com/windmilleng/tilt/internal/synclet"
 	"github.com/windmilleng/tilt/internal/synclet/proto"
 	"google.golang.org/grpc"
@@ -26,7 +28,7 @@ func main() {
 
 	serv := grpc.NewServer()
 
-	s, err := synclet.WireSynclet(ctx)
+	s, err := synclet.WireSynclet(ctx, k8s.EnvUnknown)
 	if err != nil {
 		log.Fatalf("failed to wire synclet: %v", err)
 	}

--- a/cmd/synclet/main.go
+++ b/cmd/synclet/main.go
@@ -28,6 +28,8 @@ func main() {
 
 	serv := grpc.NewServer()
 
+	// TODO(Matt) fix this so either we don't need an k8s env to instantiate a synclet, or
+	// so that we can still detect env inside of containers w/o kubectl
 	s, err := synclet.WireSynclet(ctx, k8s.EnvUnknown)
 	if err != nil {
 		log.Fatalf("failed to wire synclet: %v", err)

--- a/internal/synclet/wire.go
+++ b/internal/synclet/wire.go
@@ -11,9 +11,8 @@ import (
 	"github.com/windmilleng/tilt/internal/k8s"
 )
 
-func WireSynclet(ctx context.Context) (*Synclet, error) {
+func WireSynclet(ctx context.Context, env k8s.Env) (*Synclet, error) {
 	wire.Build(
-		k8s.DetectEnv,
 		build.DefaultDockerClient,
 		wire.Bind(new(build.DockerClient), new(build.DockerCli)),
 

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -13,11 +13,7 @@ import (
 
 // Injectors from wire.go:
 
-func WireSynclet(ctx context.Context) (*Synclet, error) {
-	env, err := k8s.DetectEnv()
-	if err != nil {
-		return nil, err
-	}
+func WireSynclet(ctx context.Context, env k8s.Env) (*Synclet, error) {
 	dockerCli, err := build.DefaultDockerClient(ctx, env)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is mildly ugly, but:

1. we're currently only using env to pass to DockerClient, which only uses it to override the method to read environment variables when in minikube
2. we don't expect people to be running this in minikube