### PR TITLE
tiltfile: turn on nested functions so i can use them in servantes

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -82,7 +82,7 @@ func (c *upCmd) run(args []string) error {
 
 	logOutput(fmt.Sprintf("Starting Tilt (built %s)…", buildDateStamp()))
 
-	tf, err := tiltfile.Load("Tiltfile")
+	tf, err := tiltfile.Load("Tiltfile", os.Stdout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hello @landism, @yuindustries,

Please review the following commits I made in branch nicks/syntax:

693afaa4e73906813a991c153d5afe04bce349bc (2018-09-12 14:26:52 -0400)
tiltfile: turn on nested functions so i can use them in servantes