### PR TITLE
tilt: synclet: use rm -rf instead of rm

### DIFF
--- a/internal/synclet/synclet.go
+++ b/internal/synclet/synclet.go
@@ -74,7 +74,7 @@ func (s Synclet) rmFiles(ctx context.Context, containerId k8s.ContainerID, files
 		return nil
 	}
 
-	cmd := model.Cmd{Argv: append([]string{"rm"}, filesToDelete...)}
+	cmd := model.Cmd{Argv: append([]string{"rm", "-rf"}, filesToDelete...)}
 
 	return s.dcli.ExecInContainer(ctx, containerId, cmd)
 }


### PR DESCRIPTION
this was causing failures when ephemeral files were deleted before tilt could pick them up (though maybe we should change the calling code to not pass those in the first place?)