### PR TITLE
tilt: add functions enabling us to find a synclet's pod

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -234,3 +234,11 @@ func (c *FakeK8sClient) PodWithImage(ctx context.Context, image reference.NamedT
 func (c *FakeK8sClient) applyWasCalled() bool {
 	return c.yaml != ""
 }
+
+func (c *FakeK8sClient) FindAppByNode(ctx context.Context, appName string, nodeID k8s.NodeID) (k8s.PodID, error) {
+	return k8s.PodID("pod2"), nil
+}
+
+func (c *FakeK8sClient) GetNodeForPod(ctx context.Context, podID k8s.PodID) (k8s.NodeID, error) {
+	return k8s.NodeID("node"), nil
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -100,15 +100,15 @@ func (k KubectlClient) Apply(ctx context.Context, entities []K8sEntity) error {
 	defer span.Finish()
 	// TODO(dmiller) validate that the string is YAML and give a good error
 	logger.Get(ctx).Infof("%sApplying via kubectl", logger.Tab)
-	stderrBuf, err := k.kubectlRunner.cli(ctx, "apply", entities...)
+	_, stderr, err := k.kubectlRunner.cli(ctx, "apply", entities...)
 	if err != nil {
-		return fmt.Errorf("kubectl apply: %v\nstderr: %s", err, stderrBuf.String())
+		return fmt.Errorf("kubectl apply: %v\nstderr: %s", err, stderr)
 	}
 	return nil
 }
 
 func (k KubectlClient) Delete(ctx context.Context, entities []K8sEntity) error {
-	_, err := k.kubectlRunner.cli(ctx, "delete", entities...)
+	_, _, err := k.kubectlRunner.cli(ctx, "delete", entities...)
 	_, isExitErr := err.(*exec.ExitError)
 	if isExitErr {
 		// In general, an exit error is ok for our purposes.

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1,10 +1,8 @@
 package k8s
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -13,11 +11,11 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/browser"
 	"github.com/windmilleng/tilt/internal/logger"
-	"github.com/windmilleng/tilt/internal/output"
 )
 
 type PodID string
 type ContainerID string
+type NodeID string
 
 func (pID PodID) String() string { return string(pID) }
 
@@ -29,11 +27,19 @@ func (cID ContainerID) ShortStr() string {
 	return string(cID)
 }
 
+func (nID NodeID) String() string { return string(nID) }
+
 type Client interface {
 	Apply(ctx context.Context, entities []K8sEntity) error
 	Delete(ctx context.Context, entities []K8sEntity) error
 
 	PodWithImage(ctx context.Context, image reference.NamedTagged) (PodID, error)
+
+	// Gets the ID for the Node on which the specified Pod is running
+	GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error)
+
+	// Finds the PodID for the instance of appName running on the same node as podID
+	FindAppByNode(ctx context.Context, appName string, nodeID NodeID) (PodID, error)
 
 	// Waits for the LoadBalancer to get a publicly available URL,
 	// then opens that URL in a web browser.
@@ -41,8 +47,11 @@ type Client interface {
 }
 
 type KubectlClient struct {
-	env Env
+	env           Env
+	kubectlRunner kubectlRunner
 }
+
+var _ Client = KubectlClient{}
 
 func NewKubectlClient(ctx context.Context, env Env) KubectlClient {
 	// TODO(nick): I'm not happy about the way that pkg/browser uses global writers.
@@ -91,7 +100,7 @@ func (k KubectlClient) Apply(ctx context.Context, entities []K8sEntity) error {
 	defer span.Finish()
 	// TODO(dmiller) validate that the string is YAML and give a good error
 	logger.Get(ctx).Infof("%sApplying via kubectl", logger.Tab)
-	stderrBuf, err := k.cli(ctx, "apply", entities)
+	stderrBuf, err := k.kubectlRunner.cli(ctx, "apply", entities...)
 	if err != nil {
 		return fmt.Errorf("kubectl apply: %v\nstderr: %s", err, stderrBuf.String())
 	}
@@ -99,7 +108,7 @@ func (k KubectlClient) Apply(ctx context.Context, entities []K8sEntity) error {
 }
 
 func (k KubectlClient) Delete(ctx context.Context, entities []K8sEntity) error {
-	_, err := k.cli(ctx, "delete", entities)
+	_, err := k.kubectlRunner.cli(ctx, "delete", entities...)
 	_, isExitErr := err.(*exec.ExitError)
 	if isExitErr {
 		// In general, an exit error is ok for our purposes.
@@ -111,25 +120,4 @@ func (k KubectlClient) Delete(ctx context.Context, entities []K8sEntity) error {
 		return fmt.Errorf("kubectl delete: %v", err)
 	}
 	return err
-}
-
-func (k KubectlClient) cli(ctx context.Context, cmd string, entities []K8sEntity) (*bytes.Buffer, error) {
-	rawYAML, err := SerializeYAML(entities)
-	if err != nil {
-		return nil, fmt.Errorf("kubectl %s: %v", cmd, err)
-	}
-
-	c := exec.CommandContext(ctx, "kubectl", cmd, "-f", "-")
-	r := bytes.NewReader([]byte(rawYAML))
-	c.Stdin = r
-
-	writer := output.Get(ctx).Writer()
-
-	c.Stdout = writer
-
-	stderrBuf := &bytes.Buffer{}
-
-	c.Stderr = io.MultiWriter(stderrBuf, writer)
-
-	return stderrBuf, c.Run()
 }

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,0 +1,40 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+type fakeKubectlRunner struct {
+	output *bytes.Buffer
+	err    error
+}
+
+func (f fakeKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sEntity) (*bytes.Buffer, error) {
+	return f.output, f.err
+}
+
+var _ kubectlRunner = fakeKubectlRunner{}
+
+type clientTestFixture struct {
+	t      *testing.T
+	client KubectlClient
+	runner *fakeKubectlRunner
+}
+
+func newClientTestFixture(t *testing.T) *clientTestFixture {
+	ret := &clientTestFixture{}
+	ret.t = t
+	ret.runner = &fakeKubectlRunner{}
+	ret.client = KubectlClient{EnvUnknown, ret.runner}
+	return ret
+}
+
+func (c clientTestFixture) setOutput(s string) {
+	c.runner.output = bytes.NewBufferString(s)
+}
+
+func (c clientTestFixture) setError(err error) {
+	c.runner.err = err
+}

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,18 +1,18 @@
 package k8s
 
 import (
-	"bytes"
 	"context"
 	"testing"
 )
 
 type fakeKubectlRunner struct {
-	output *bytes.Buffer
+	stdout string
+	stderr string
 	err    error
 }
 
-func (f fakeKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sEntity) (*bytes.Buffer, error) {
-	return f.output, f.err
+func (f fakeKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sEntity) (stdout string, stderr string, err error) {
+	return f.stdout, f.stderr, f.err
 }
 
 var _ kubectlRunner = fakeKubectlRunner{}
@@ -32,7 +32,7 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 }
 
 func (c clientTestFixture) setOutput(s string) {
-	c.runner.output = bytes.NewBufferString(s)
+	c.runner.stdout = s
 }
 
 func (c clientTestFixture) setError(err error) {

--- a/internal/k8s/kubectl_runner.go
+++ b/internal/k8s/kubectl_runner.go
@@ -11,14 +11,14 @@ import (
 )
 
 type kubectlRunner interface {
-	cli(ctx context.Context, cmd string, entities ...K8sEntity) (*bytes.Buffer, error)
+	cli(ctx context.Context, cmd string, entities ...K8sEntity) (stdout string, stderr string, err error)
 }
 
 type realKubectlRunner struct{}
 
 var _ kubectlRunner = realKubectlRunner{}
 
-func (k realKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sEntity) (*bytes.Buffer, error) {
+func (k realKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sEntity) (stdout string, stderr string, err error) {
 	args := []string{cmd}
 
 	if len(entities) > 0 {
@@ -30,7 +30,7 @@ func (k realKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sE
 	if len(entities) > 0 {
 		rawYAML, err := SerializeYAML(entities)
 		if err != nil {
-			return nil, fmt.Errorf("kubectl %s: %v", cmd, err)
+			return "", "", fmt.Errorf("kubectl %s: %v", cmd, err)
 		}
 		r := bytes.NewReader([]byte(rawYAML))
 		c.Stdin = r
@@ -38,11 +38,11 @@ func (k realKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sE
 
 	writer := output.Get(ctx).Writer()
 
-	c.Stdout = writer
+	stdoutBuf := &bytes.Buffer{}
+	c.Stdout = io.MultiWriter(stdoutBuf, writer)
 
 	stderrBuf := &bytes.Buffer{}
-
 	c.Stderr = io.MultiWriter(stderrBuf, writer)
 
-	return stderrBuf, c.Run()
+	return stdoutBuf.String(), stderrBuf.String(), c.Run()
 }

--- a/internal/k8s/kubectl_runner.go
+++ b/internal/k8s/kubectl_runner.go
@@ -1,0 +1,48 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/windmilleng/tilt/internal/output"
+)
+
+type kubectlRunner interface {
+	cli(ctx context.Context, cmd string, entities ...K8sEntity) (*bytes.Buffer, error)
+}
+
+type realKubectlRunner struct{}
+
+var _ kubectlRunner = realKubectlRunner{}
+
+func (k realKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sEntity) (*bytes.Buffer, error) {
+	args := []string{cmd}
+
+	if len(entities) > 0 {
+		args = append(args, "-f", "-")
+	}
+
+	c := exec.CommandContext(ctx, "kubectl", args...)
+
+	if len(entities) > 0 {
+		rawYAML, err := SerializeYAML(entities)
+		if err != nil {
+			return nil, fmt.Errorf("kubectl %s: %v", cmd, err)
+		}
+		r := bytes.NewReader([]byte(rawYAML))
+		c.Stdin = r
+	}
+
+	writer := output.Get(ctx).Writer()
+
+	c.Stdout = writer
+
+	stderrBuf := &bytes.Buffer{}
+
+	c.Stderr = io.MultiWriter(stderrBuf, writer)
+
+	return stderrBuf, c.Run()
+}

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os/exec"
@@ -67,24 +68,18 @@ func imgPodMapFromOutput(output string) (map[string][]PodID, error) {
 
 func (k KubectlClient) GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error) {
 	jsonPath := "-o=jsonpath={.spec.nodeName}"
-	b, err := k.kubectlRunner.cli(ctx, fmt.Sprintf("get pods %s '%s'", podID.String(), jsonPath))
-
-	out := b.String()
+	stdout, stderr, err := k.kubectlRunner.cli(ctx, fmt.Sprintf("get pods %s '%s'", podID.String(), jsonPath))
 
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			return NodeID(""), fmt.Errorf("imagesToPods: stderr: %s)", exitError.Stderr)
-		} else {
-			return NodeID(""), fmt.Errorf("imagesToPods: %v", err.Error())
-		}
+		return NodeID(""), fmt.Errorf("error finding node for pod '%s': %v, stderr: '%s'", podID.String(), err.Error(), stderr)
 	}
 
-	lines := nonEmptyLines(out)
+	lines := nonEmptyLines(stdout)
 
 	if len(lines) == 0 {
-		return NodeID(""), fmt.Errorf("kubectl output did not contain a node name for pod '%s': '%s'", podID, out)
+		return NodeID(""), fmt.Errorf("kubectl output did not contain a node name for pod '%s': '%s'", podID, stdout)
 	} else if len(lines) > 1 {
-		return NodeID(""), fmt.Errorf("kubectl returned multiple nodes for pod '%s': '%s'", podID, out)
+		return NodeID(""), fmt.Errorf("kubectl returned multiple nodes for pod '%s': '%s'", podID, stdout)
 	} else {
 		return NodeID(lines[0]), nil
 	}
@@ -92,37 +87,31 @@ func (k KubectlClient) GetNodeForPod(ctx context.Context, podID PodID) (NodeID, 
 
 func (k KubectlClient) FindAppByNode(ctx context.Context, appName string, nodeID NodeID) (PodID, error) {
 	jsonPath := fmt.Sprintf(`-o=jsonpath={range .items[?(@.spec.nodeName=="%s")]}{.metadata.name}{"\n"}`, nodeID)
-	b, err := k.kubectlRunner.cli(ctx, fmt.Sprintf("get pods --namespace=kube-system -l=app=%s '%s'", appName, jsonPath))
-
-	out := b.String()
+	stdout, stderr, err := k.kubectlRunner.cli(ctx, fmt.Sprintf("get pods --namespace=kube-system -l=app=%s '%s'", appName, jsonPath))
 
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			return PodID(""), fmt.Errorf("imagesToPods: stderr: %s)", exitError.Stderr)
-		} else {
-			return PodID(""), fmt.Errorf("imagesToPods: %v", err.Error())
-		}
+		return PodID(""), fmt.Errorf("error finding app '%s' on node '%s': %v, stderr: '%s'", appName, nodeID.String(), err.Error(), stderr)
 	}
 
-	lines := nonEmptyLines(out)
+	lines := nonEmptyLines(stdout)
 
 	if len(lines) == 0 {
 		return PodID(""), fmt.Errorf("unable to find any apps named '%s' on node '%s'", appName, nodeID)
 	} else if len(lines) > 1 {
-		return PodID(""), fmt.Errorf("found multiple apps named '%s' on node '%s': '%s'", appName, nodeID, out)
+		return PodID(""), fmt.Errorf("found multiple apps named '%s' on node '%s': '%s'", appName, nodeID, stdout)
 	} else {
 		return PodID(lines[0]), nil
 	}
 }
 
 func nonEmptyLines(s string) []string {
-	lines := strings.Split(s, "\n")
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	scanner.Split(bufio.ScanWords)
 
 	var ret []string
-	for _, line := range lines {
-		if len(line) > 0 {
-			ret = append(ret, line)
-		}
+
+	for scanner.Scan() {
+		ret = append(ret, scanner.Text())
 	}
 
 	return ret

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -1,7 +1,10 @@
 package k8s
 
 import (
+	"context"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -43,4 +46,94 @@ func TestMultipleContainersOnePod(t *testing.T) {
 		"debian": []PodID{PodID("two-containers")},
 	}
 	assert.Equal(t, expected, podImgMap)
+}
+
+func (c clientTestFixture) FindAppByNodeWithOutput(output string) (PodID, error) {
+	c.setOutput(output)
+	return c.client.FindAppByNode(context.Background(), "synclet", NodeID("foo"))
+}
+
+func (c clientTestFixture) FindAppByNodeWithError(err error) (PodID, error) {
+	c.setError(err)
+	return c.client.FindAppByNode(context.Background(), "synclet", NodeID("foo"))
+}
+
+func TestFindAppByNode(t *testing.T) {
+	f := newClientTestFixture(t)
+	podId, err := f.FindAppByNodeWithOutput("foobar")
+	if assert.NoError(t, err) {
+		assert.Equal(t, PodID("foobar"), podId)
+	}
+}
+
+func TestFindAppByNodeNotFound(t *testing.T) {
+	f := newClientTestFixture(t)
+	_, err := f.FindAppByNodeWithOutput("")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "unable to find")
+	}
+}
+
+func TestFindAppByNodeMultipleFound(t *testing.T) {
+	f := newClientTestFixture(t)
+	output := "foobar\nbazquu\n"
+	_, err := f.FindAppByNodeWithOutput(output)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "multiple")
+		assert.Contains(t, err.Error(), output)
+	}
+}
+
+func TestFindAppByNodeKubectlError(t *testing.T) {
+	f := newClientTestFixture(t)
+	e := errors.New("asdffdsa")
+	_, err := f.FindAppByNodeWithError(e)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), e.Error())
+	}
+}
+
+func (c clientTestFixture) GetNodeForPodWithOutput(output string) (NodeID, error) {
+	c.setOutput(output)
+	return c.client.GetNodeForPod(context.Background(), PodID("foo"))
+}
+
+func (c clientTestFixture) GetNodeForPodWithError(err error) (NodeID, error) {
+	c.setError(err)
+	return c.client.GetNodeForPod(context.Background(), PodID("foo"))
+}
+
+func TestGetNodeForPod(t *testing.T) {
+	f := newClientTestFixture(t)
+	nodeID, err := f.GetNodeForPodWithOutput("foobar")
+	if assert.NoError(t, err) {
+		assert.Equal(t, NodeID("foobar"), nodeID)
+	}
+}
+
+func TestGetNodeForPodNotFound(t *testing.T) {
+	f := newClientTestFixture(t)
+	_, err := f.GetNodeForPodWithOutput("")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "did not contain")
+	}
+}
+
+func TestGetNodeForPodMultipleFound(t *testing.T) {
+	f := newClientTestFixture(t)
+	output := "foobar\nbazquu\n"
+	_, err := f.GetNodeForPodWithOutput(output)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "multiple")
+		assert.Contains(t, err.Error(), output)
+	}
+}
+
+func TestGetNodeForPodKubectlError(t *testing.T) {
+	f := newClientTestFixture(t)
+	e := errors.New("asdffdsa")
+	_, err := f.GetNodeForPodWithError(e)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), e.Error())
+	}
 }


### PR DESCRIPTION
1. pull the actual exec out of KubectlClient so that we can fake it for tests
2. add GetNodeForPod and FindAppByNode so that given a service's PodID, we can find the PodID of the synclet running on the same node