### PR TITLE
engine: demote gc errors to debug logs

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -116,7 +116,7 @@ func (u Upper) CreateServices(ctx context.Context, services []model.Service, wat
 		go func() {
 			err := u.reapOldWatchBuilds(ctx, services, time.Now())
 			if err != nil {
-				logger.Get(ctx).Infof("Error garbage collecting builds: %v", err)
+				logger.Get(ctx).Debugf("Error garbage collecting builds: %v", err)
 			}
 		}()
 


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/error:

28f63586ab378a16ecb796df21de3dadca102a64 (2018-09-13 14:35:44 -0400)
engine: demote gc errors to debug logs