### PR TITLE
k8s: fix nil pointer exception -- make sure client has a kubectlRunner

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -60,7 +60,8 @@ func NewKubectlClient(ctx context.Context, env Env) KubectlClient {
 	browser.Stderr = writer
 
 	return KubectlClient{
-		env: env,
+		env:           env,
+		kubectlRunner: realKubectlRunner{},
 	}
 }
 


### PR DESCRIPTION
idk if there's a reason to pass the runner via wire right now, but we can always implement that later if needed?