### PR TITLE
k8s: more generic kubectlRunner so we can use it for more things, test better

### DIFF
--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,9 +1,9 @@
 package k8s
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"testing"
 )
@@ -21,7 +21,7 @@ type fakeKubectlRunner struct {
 	calls []call
 }
 
-func (f fakeKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin *bytes.Reader) (stdout string, stderr string, err error) {
+func (f fakeKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin io.Reader) (stdout string, stderr string, err error) {
 	b, err := ioutil.ReadAll(stdin)
 	if err != nil {
 		return "", "", fmt.Errorf("reading stdin: %v", err)

--- a/internal/k8s/kubectl_runner.go
+++ b/internal/k8s/kubectl_runner.go
@@ -11,7 +11,7 @@ import (
 
 type kubectlRunner interface {
 	exec(ctx context.Context, argv []string) (stdout string, stderr string, err error)
-	execWithStdin(ctx context.Context, argv []string, stdin *bytes.Reader) (stdout string, stderr string, err error)
+	execWithStdin(ctx context.Context, argv []string, stdin io.Reader) (stdout string, stderr string, err error)
 }
 
 type realKubectlRunner struct{}
@@ -32,7 +32,7 @@ func (k realKubectlRunner) exec(ctx context.Context, args []string) (stdout stri
 	return stdoutBuf.String(), stderrBuf.String(), c.Run()
 }
 
-func (k realKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin *bytes.Reader) (stdout string, stderr string, err error) {
+func (k realKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin io.Reader) (stdout string, stderr string, err error) {
 	c := exec.CommandContext(ctx, "kubectl", args...)
 	c.Stdin = stdin
 

--- a/internal/k8s/kubectl_runner.go
+++ b/internal/k8s/kubectl_runner.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os/exec"
 
@@ -11,30 +10,31 @@ import (
 )
 
 type kubectlRunner interface {
-	cli(ctx context.Context, cmd string, entities ...K8sEntity) (stdout string, stderr string, err error)
+	exec(ctx context.Context, argv []string) (stdout string, stderr string, err error)
+	execWithStdin(ctx context.Context, argv []string, stdin *bytes.Reader) (stdout string, stderr string, err error)
 }
 
 type realKubectlRunner struct{}
 
 var _ kubectlRunner = realKubectlRunner{}
 
-func (k realKubectlRunner) cli(ctx context.Context, cmd string, entities ...K8sEntity) (stdout string, stderr string, err error) {
-	args := []string{cmd}
-
-	if len(entities) > 0 {
-		args = append(args, "-f", "-")
-	}
-
+func (k realKubectlRunner) exec(ctx context.Context, args []string) (stdout string, stderr string, err error) {
 	c := exec.CommandContext(ctx, "kubectl", args...)
 
-	if len(entities) > 0 {
-		rawYAML, err := SerializeYAML(entities)
-		if err != nil {
-			return "", "", fmt.Errorf("kubectl %s: %v", cmd, err)
-		}
-		r := bytes.NewReader([]byte(rawYAML))
-		c.Stdin = r
-	}
+	writer := output.Get(ctx).Writer()
+
+	stdoutBuf := &bytes.Buffer{}
+	c.Stdout = io.MultiWriter(stdoutBuf, writer)
+
+	stderrBuf := &bytes.Buffer{}
+	c.Stderr = io.MultiWriter(stderrBuf, writer)
+
+	return stdoutBuf.String(), stderrBuf.String(), c.Run()
+}
+
+func (k realKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin *bytes.Reader) (stdout string, stderr string, err error) {
+	c := exec.CommandContext(ctx, "kubectl", args...)
+	c.Stdin = stdin
 
 	writer := output.Get(ctx).Writer()
 

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -68,7 +68,7 @@ func imgPodMapFromOutput(output string) (map[string][]PodID, error) {
 
 func (k KubectlClient) GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error) {
 	jsonPath := "-o=jsonpath={.spec.nodeName}"
-	stdout, stderr, err := k.kubectlRunner.cli(ctx, fmt.Sprintf("get pods %s '%s'", podID.String(), jsonPath))
+	stdout, stderr, err := k.kubectlRunner.exec(ctx, []string{"get", "pods", podID.String(), jsonPath})
 
 	if err != nil {
 		return NodeID(""), fmt.Errorf("error finding node for pod '%s': %v, stderr: '%s'", podID.String(), err.Error(), stderr)
@@ -87,7 +87,8 @@ func (k KubectlClient) GetNodeForPod(ctx context.Context, podID PodID) (NodeID, 
 
 func (k KubectlClient) FindAppByNode(ctx context.Context, appName string, nodeID NodeID) (PodID, error) {
 	jsonPath := fmt.Sprintf(`-o=jsonpath={range .items[?(@.spec.nodeName=="%s")]}{.metadata.name}{"\n"}`, nodeID)
-	stdout, stderr, err := k.kubectlRunner.cli(ctx, fmt.Sprintf("get pods --namespace=kube-system -l=app=%s '%s'", appName, jsonPath))
+	stdout, stderr, err := k.kubectlRunner.exec(ctx,
+		[]string{"get", "pods", "--namespace=kube-system", fmt.Sprintf("-l=app=%s", appName), jsonPath})
 
 	if err != nil {
 		return PodID(""), fmt.Errorf("error finding app '%s' on node '%s': %v, stderr: '%s'", appName, nodeID.String(), err.Error(), stderr)


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/more-generic-kubectlRunner:

930c223ccb35c2223f06dc330fc8e09abdf6f84d (2018-09-13 16:09:46 -0400)
k8s: more generic kubectlRunner so we can use it for more things, test better

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics