### PR TITLE
tiltfile: partial rename service -> manifest without changing syntax

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -31,13 +31,13 @@ type upCmd struct {
 
 func (c *upCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "up <servicename>",
-		Short: "stand up a service",
+		Use:   "up <name>",
+		Short: "stand up a manifest",
 		Args:  cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().BoolVar(&c.watch, "watch", false, "any started services will be automatically rebuilt and redeployed when files in their repos change")
-	cmd.Flags().Var(&c.browserMode, "browser", "open a browser when the service first starts")
+	cmd.Flags().BoolVar(&c.watch, "watch", false, "any started manifests will be automatically rebuilt and redeployed when files in their repos change")
+	cmd.Flags().Var(&c.browserMode, "browser", "open a browser when the manifest first starts")
 	cmd.Flags().StringVar(&c.traceTags, "traceTags", "", "tags to add to spans for easy querying, of the form: key1=val1,key2=val2")
 
 	return cmd
@@ -91,18 +91,18 @@ func (c *upCmd) run(args []string) error {
 		return err
 	}
 
-	serviceName := args[0]
-	services, err := tf.GetServiceConfigs(serviceName)
+	manifestName := args[0]
+	manifests, err := tf.GetManifestConfigs(manifestName)
 	if err != nil {
 		return err
 	}
 
-	serviceCreator, err := wireServiceCreator(ctx, c.browserMode)
+	manifestCreator, err := wireManifestCreator(ctx, c.browserMode)
 	if err != nil {
 		return err
 	}
 
-	err = serviceCreator.CreateManifests(ctx, services, c.watch)
+	err = manifestCreator.CreateManifests(ctx, manifests, c.watch)
 	s, ok := status.FromError(err)
 	if ok && s.Code() == codes.Unknown {
 		return errors.New(s.Message())

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -13,7 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 )
 
-func wireServiceCreator(ctx context.Context, browser engine.BrowserMode) (model.ManifestCreator, error) {
+func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model.ManifestCreator, error) {
 	wire.Build(
 		k8s.DetectEnv,
 

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	context "context"
+
 	build "github.com/windmilleng/tilt/internal/build"
 	engine "github.com/windmilleng/tilt/internal/engine"
 	k8s "github.com/windmilleng/tilt/internal/k8s"
@@ -15,7 +16,7 @@ import (
 
 // Injectors from wire.go:
 
-func wireServiceCreator(ctx context.Context, browser engine.BrowserMode) (model.ManifestCreator, error) {
+func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model.ManifestCreator, error) {
 	env, err := k8s.DetectEnv()
 	if err != nil {
 		return nil, err

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -32,19 +32,19 @@ func (m Manifest) Validate() error {
 
 func (m Manifest) validate() *ValidateErr {
 	if m.Name == "" {
-		return validateErrf("[validate] service missing name: %+v", m)
+		return validateErrf("[validate] manifest missing name: %+v", m)
 	}
 
 	if m.DockerfileTag == nil {
-		return validateErrf("[validate] service %q missing image tag", m.Name)
+		return validateErrf("[validate] manifest %q missing image tag", m.Name)
 	}
 
 	if m.K8sYaml == "" {
-		return validateErrf("[validate] service %q missing YAML file", m.Name)
+		return validateErrf("[validate] manifest %q missing YAML file", m.Name)
 	}
 
 	if m.Entrypoint.Empty() {
-		return validateErrf("[validate] service %q missing Entrypoint", m.Name)
+		return validateErrf("[validate] manifest %q missing Entrypoint", m.Name)
 	}
 
 	return nil

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -14,59 +14,59 @@ import (
 
 const oldMountSyntaxError = "The syntax for `add` has changed. Before it was `.add(dest, src)`. Now it is `.add(src, dest)`."
 
-type compService struct {
-	cService []k8sService
+type compManifest struct {
+	cManifest []k8sManifest
 }
 
-var _ skylark.Value = compService{}
+var _ skylark.Value = compManifest{}
 
-func (s compService) String() string {
-	return fmt.Sprintf("composite service: %+v", s.cService)
+func (s compManifest) String() string {
+	return fmt.Sprintf("composite manifest: %+v", s.cManifest)
 }
-func (s compService) Type() string {
-	return "compService"
+func (s compManifest) Type() string {
+	return "compManifest"
 }
-func (s compService) Freeze() {
+func (s compManifest) Freeze() {
 }
-func (compService) Truth() skylark.Bool {
+func (compManifest) Truth() skylark.Bool {
 	return true
 }
-func (compService) Hash() (uint32, error) {
-	return 0, errors.New("unhashable type: composite service")
+func (compManifest) Hash() (uint32, error) {
+	return 0, errors.New("unhashable type: composite manifest")
 }
 
-type k8sService struct {
+type k8sManifest struct {
 	k8sYaml     skylark.String
 	dockerImage dockerImage
 	name        string
 }
 
-var _ skylark.Value = k8sService{}
+var _ skylark.Value = k8sManifest{}
 
-func (s k8sService) String() string {
+func (s k8sManifest) String() string {
 	shortYaml := s.k8sYaml.String()
 	const maxYamlCharsToInclude = 40
 	if len(shortYaml) > maxYamlCharsToInclude {
 		shortYaml = shortYaml[:maxYamlCharsToInclude]
 	}
-	return fmt.Sprintf("[k8sService] yaml: '%v' dockerImage: '%v'", shortYaml, s.dockerImage)
+	return fmt.Sprintf("[k8sManifest] yaml: '%v' dockerImage: '%v'", shortYaml, s.dockerImage)
 }
 
-func (s k8sService) Type() string {
-	return "k8sService"
+func (s k8sManifest) Type() string {
+	return "k8sManifest"
 }
 
-func (s k8sService) Freeze() {
+func (s k8sManifest) Freeze() {
 	s.k8sYaml.Freeze()
 	s.dockerImage.Freeze()
 }
 
-func (k8sService) Truth() skylark.Bool {
+func (k8sManifest) Truth() skylark.Bool {
 	return true
 }
 
-func (k8sService) Hash() (uint32, error) {
-	return 0, errors.New("unhashable type: k8sService")
+func (k8sManifest) Hash() (uint32, error) {
+	return 0, errors.New("unhashable type: k8sManifest")
 }
 
 type mount struct {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -44,7 +44,7 @@ func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args sk
 	return &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint}, nil
 }
 
-func makeSkylarkK8Service(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func makeSkylarkK8Manifest(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var yaml skylark.String
 	var dockerImage *dockerImage
 	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "yaml", &yaml, "dockerImage", &dockerImage)
@@ -52,22 +52,22 @@ func makeSkylarkK8Service(thread *skylark.Thread, fn *skylark.Builtin, args skyl
 		return nil, err
 	}
 	// Name will be initialized later
-	return k8sService{yaml, *dockerImage, ""}, nil
+	return k8sManifest{yaml, *dockerImage, ""}, nil
 }
 
-func makeSkylarkCompositeService(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func makeSkylarkCompositeManifest(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 
-	var serviceFuncs skylark.Iterable
+	var manifestFuncs skylark.Iterable
 	err := skylark.UnpackArgs(fn.Name(), args, kwargs,
-		"services", &serviceFuncs)
+		"services", &manifestFuncs)
 	if err != nil {
 		return nil, err
 	}
 
-	var services []k8sService
+	var manifests []k8sManifest
 
 	var v skylark.Value
-	i := serviceFuncs.Iterate()
+	i := manifestFuncs.Iterate()
 	defer i.Done()
 	for i.Next(&v) {
 		switch v := v.(type) {
@@ -76,17 +76,17 @@ func makeSkylarkCompositeService(thread *skylark.Thread, fn *skylark.Builtin, ar
 			if err != nil {
 				return nil, err
 			}
-			s, ok := r.(k8sService)
+			s, ok := r.(k8sManifest)
 			if !ok {
 				return nil, fmt.Errorf("composite_service: function %v returned %v %T; expected k8s_service", v.Name(), r, r)
 			}
 			s.name = v.Name()
-			services = append(services, s)
+			manifests = append(manifests, s)
 		default:
 			return nil, fmt.Errorf("composite_service: unexpected input %v %T", v, v)
 		}
 	}
-	return compService{services}, nil
+	return compManifest{manifests}, nil
 }
 
 func makeSkylarkGitRepo(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
@@ -132,10 +132,10 @@ func Load(filename string, out io.Writer) (*Tiltfile, error) {
 
 	predeclared := skylark.StringDict{
 		"build_docker_image": skylark.NewBuiltin("build_docker_image", makeSkylarkDockerImage),
-		"k8s_service":        skylark.NewBuiltin("k8s_service", makeSkylarkK8Service),
+		"k8s_service":        skylark.NewBuiltin("k8s_service", makeSkylarkK8Manifest),
 		"local_git_repo":     skylark.NewBuiltin("local_git_repo", makeSkylarkGitRepo),
 		"local":              skylark.NewBuiltin("local", runLocalCmd),
-		"composite_service":  skylark.NewBuiltin("composite_service", makeSkylarkCompositeService),
+		"composite_service":  skylark.NewBuiltin("composite_service", makeSkylarkCompositeManifest),
 	}
 
 	globals, err := skylark.ExecFile(thread, filename, nil, predeclared)
@@ -146,34 +146,34 @@ func Load(filename string, out io.Writer) (*Tiltfile, error) {
 	return &Tiltfile{globals, filename, thread}, nil
 }
 
-func (tiltfile Tiltfile) GetServiceConfigs(serviceName string) ([]model.Manifest, error) {
-	f, ok := tiltfile.globals[serviceName]
+func (tiltfile Tiltfile) GetManifestConfigs(manifestName string) ([]model.Manifest, error) {
+	f, ok := tiltfile.globals[manifestName]
 
 	if !ok {
-		return nil, fmt.Errorf("%v does not define a global named '%v'", tiltfile.filename, serviceName)
+		return nil, fmt.Errorf("%v does not define a global named '%v'", tiltfile.filename, manifestName)
 	}
 
-	serviceFunction, ok := f.(*skylark.Function)
+	manifestFunction, ok := f.(*skylark.Function)
 
 	if !ok {
-		return nil, fmt.Errorf("'%v' is a '%v', not a function. service definitions must be functions", serviceName, f.Type())
+		return nil, fmt.Errorf("'%v' is a '%v', not a function. service definitions must be functions", manifestName, f.Type())
 	}
 
-	if serviceFunction.NumParams() != 0 {
-		return nil, fmt.Errorf("func '%v' is defined to take more than 0 arguments. service definitions must take 0 arguments", serviceName)
+	if manifestFunction.NumParams() != 0 {
+		return nil, fmt.Errorf("func '%v' is defined to take more than 0 arguments. service definitions must take 0 arguments", manifestName)
 	}
 
-	val, err := serviceFunction.Call(tiltfile.thread, nil, nil)
+	val, err := manifestFunction.Call(tiltfile.thread, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error running '%v': %v", serviceName, err.Error())
+		return nil, fmt.Errorf("error running '%v': %v", manifestName, err.Error())
 	}
 
-	switch service := val.(type) {
-	case compService:
+	switch manifest := val.(type) {
+	case compManifest:
 		var servs []model.Manifest
 
-		for _, cServ := range service.cService {
-			s, err := skylarkServiceToDomain(cServ)
+		for _, cServ := range manifest.cManifest {
+			s, err := skylarkManifestToDomain(cServ)
 			if err != nil {
 				return nil, err
 			}
@@ -181,38 +181,38 @@ func (tiltfile Tiltfile) GetServiceConfigs(serviceName string) ([]model.Manifest
 			servs = append(servs, s)
 		}
 		return servs, nil
-	case k8sService:
-		s, err := skylarkServiceToDomain(service)
+	case k8sManifest:
+		s, err := skylarkManifestToDomain(manifest)
 		if err != nil {
 			return nil, err
 		}
-		s.Name = model.ManifestName(serviceName)
+		s.Name = model.ManifestName(manifestName)
 		return []model.Manifest{s}, nil
 
 	default:
-		return nil, fmt.Errorf("'%v' returned a '%v', but it needs to return a k8s_service or composite_service", serviceName, val.Type())
+		return nil, fmt.Errorf("'%v' returned a '%v', but it needs to return a k8s_service or composite_service", manifestName, val.Type())
 	}
 }
 
-func skylarkServiceToDomain(service k8sService) (model.Manifest, error) {
-	k8sYaml, ok := skylark.AsString(service.k8sYaml)
+func skylarkManifestToDomain(manifest k8sManifest) (model.Manifest, error) {
+	k8sYaml, ok := skylark.AsString(manifest.k8sYaml)
 	if !ok {
-		return model.Manifest{}, fmt.Errorf("internal error: k8sService.k8sYaml was not a string in '%v'", service)
+		return model.Manifest{}, fmt.Errorf("internal error: k8sService.k8sYaml was not a string in '%v'", manifest)
 	}
 
-	dockerFileBytes, err := ioutil.ReadFile(service.dockerImage.fileName)
+	dockerFileBytes, err := ioutil.ReadFile(manifest.dockerImage.fileName)
 	if err != nil {
-		return model.Manifest{}, fmt.Errorf("failed to open dockerfile '%v': %v", service.dockerImage.fileName, err)
+		return model.Manifest{}, fmt.Errorf("failed to open dockerfile '%v': %v", manifest.dockerImage.fileName, err)
 	}
 
 	return model.Manifest{
 		K8sYaml:        k8sYaml,
 		DockerfileText: string(dockerFileBytes),
-		Mounts:         skylarkMountsToDomain(service.dockerImage.mounts),
-		Steps:          service.dockerImage.steps,
-		Entrypoint:     model.ToShellCmd(service.dockerImage.entrypoint),
-		DockerfileTag:  service.dockerImage.fileTag,
-		Name:           model.ManifestName(service.name),
+		Mounts:         skylarkMountsToDomain(manifest.dockerImage.mounts),
+		Steps:          manifest.dockerImage.steps,
+		Entrypoint:     model.ToShellCmd(manifest.dockerImage.entrypoint),
+		DockerfileTag:  manifest.dockerImage.fileTag,
+		Name:           model.ManifestName(manifest.name),
 	}, nil
 
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -51,7 +51,7 @@ hello()
 	assert.Equal(t, expected, s)
 }
 
-func TestGetServiceConfig(t *testing.T) {
+func TestGetManifestConfig(t *testing.T) {
 	dockerfile := tempFile("docker text")
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
@@ -70,9 +70,9 @@ func TestGetServiceConfig(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	serviceConfig, err := tiltconfig.GetServiceConfigs("blorgly")
+	manifestConfig, err := tiltconfig.GetManifestConfigs("blorgly")
 	if err != nil {
-		t.Fatal("getting service config:", err)
+		t.Fatal("getting manifest config:", err)
 	}
 
 	wd, err := os.Getwd()
@@ -80,17 +80,17 @@ func TestGetServiceConfig(t *testing.T) {
 		t.Fatal("couldn't get working directory:", err)
 	}
 
-	service := serviceConfig[0]
-	assert.Equal(t, "docker text", service.DockerfileText)
-	assert.Equal(t, "docker.io/library/docker-tag", service.DockerfileTag.String())
-	assert.Equal(t, "yaaaaaaaaml", service.K8sYaml)
-	assert.Equal(t, 1, len(service.Mounts), "number of mounts")
-	assert.Equal(t, "/mount_points/1", service.Mounts[0].ContainerPath)
-	assert.Equal(t, wd, service.Mounts[0].Repo.LocalPath, "repo path")
-	assert.Equal(t, 2, len(service.Steps), "number of steps")
-	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, service.Steps[0].Cmd.Argv, "first step")
-	assert.Equal(t, []string{"sh", "-c", "echo hi"}, service.Steps[1].Cmd.Argv, "second step")
-	assert.Equal(t, []string{"sh", "-c", "the entrypoint"}, service.Entrypoint.Argv)
+	manifest := manifestConfig[0]
+	assert.Equal(t, "docker text", manifest.DockerfileText)
+	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerfileTag.String())
+	assert.Equal(t, "yaaaaaaaaml", manifest.K8sYaml)
+	assert.Equal(t, 1, len(manifest.Mounts), "number of mounts")
+	assert.Equal(t, "/mount_points/1", manifest.Mounts[0].ContainerPath)
+	assert.Equal(t, wd, manifest.Mounts[0].Repo.LocalPath, "repo path")
+	assert.Equal(t, 2, len(manifest.Steps), "number of steps")
+	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, manifest.Steps[0].Cmd.Argv, "first step")
+	assert.Equal(t, []string{"sh", "-c", "echo hi"}, manifest.Steps[1].Cmd.Argv, "second step")
+	assert.Equal(t, []string{"sh", "-c", "the entrypoint"}, manifest.Entrypoint.Argv)
 }
 
 func TestOldMountSyntax(t *testing.T) {
@@ -112,9 +112,9 @@ func TestOldMountSyntax(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltconfig.GetServiceConfigs("blorgly")
+	_, err = tiltconfig.GetManifestConfigs("blorgly")
 	if err == nil {
-		t.Fatal("service config should have errored, but it didn't")
+		t.Fatal("manifest config should have errored, but it didn't")
 	}
 
 	if !strings.Contains(err.Error(), oldMountSyntaxError) {
@@ -123,7 +123,7 @@ func TestOldMountSyntax(t *testing.T) {
 
 }
 
-func TestGetServiceConfigMissingDockerFile(t *testing.T) {
+func TestGetManifestConfigMissingDockerFile(t *testing.T) {
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
   image = build_docker_image("asfaergiuhaeriguhaergiu", "docker-tag", "the entrypoint")
@@ -139,7 +139,7 @@ func TestGetServiceConfigMissingDockerFile(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltconfig.GetServiceConfigs("blorgly")
+	_, err = tiltconfig.GetManifestConfigs("blorgly")
 	if assert.NotNil(t, err, "expected error from missing dockerfile") {
 		for _, s := range []string{"asfaergiuhaeriguhaergiu", "no such file or directory"} {
 			assert.True(t, strings.Contains(err.Error(), s),
@@ -199,16 +199,16 @@ def blorgly_frontend():
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	serviceConfig, err := tiltConfig.GetServiceConfigs("blorgly")
+	manifestConfig, err := tiltConfig.GetManifestConfigs("blorgly")
 	if err != nil {
-		t.Fatal("getting service config:", err)
+		t.Fatal("getting manifest config:", err)
 	}
 
-	assert.Equal(t, "blorgly_backend", serviceConfig[0].Name.String())
-	assert.Equal(t, "blorgly_frontend", serviceConfig[1].Name.String())
+	assert.Equal(t, "blorgly_backend", manifestConfig[0].Name.String())
+	assert.Equal(t, "blorgly_frontend", manifestConfig[1].Name.String())
 }
 
-func TestGetServiceConfigUndefined(t *testing.T) {
+func TestGetManifestConfigUndefined(t *testing.T) {
 	file := tempFile(
 		`def blorgly():
   return "yaaaaaaaml"
@@ -220,9 +220,9 @@ func TestGetServiceConfigUndefined(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfigs("blorgly2")
+	_, err = tiltConfig.GetManifestConfigs("blorgly2")
 	if err == nil {
-		t.Fatal("expected error b/c of undefined service config:")
+		t.Fatal("expected error b/c of undefined manifest config:")
 	}
 
 	for _, s := range []string{"does not define", "blorgly2"} {
@@ -230,7 +230,7 @@ func TestGetServiceConfigUndefined(t *testing.T) {
 	}
 }
 
-func TestGetServiceConfigNonFunction(t *testing.T) {
+func TestGetManifestConfigNonFunction(t *testing.T) {
 	file := tempFile("blorgly2 = 3")
 	defer os.Remove(file)
 
@@ -239,15 +239,15 @@ func TestGetServiceConfigNonFunction(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfigs("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
+	_, err = tiltConfig.GetManifestConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetManifestConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "function", "int"} {
 			assert.True(t, strings.Contains(err.Error(), s))
 		}
 	}
 }
 
-func TestGetServiceConfigTakesArgs(t *testing.T) {
+func TestGetManifestConfigTakesArgs(t *testing.T) {
 	file := tempFile(
 		`def blorgly2(x):
 			return "foo"
@@ -259,15 +259,15 @@ func TestGetServiceConfigTakesArgs(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfigs("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
+	_, err = tiltConfig.GetManifestConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetManifestConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "0 arguments"} {
 			assert.True(t, strings.Contains(err.Error(), s))
 		}
 	}
 }
 
-func TestGetServiceConfigRaisesError(t *testing.T) {
+func TestGetManifestConfigRaisesError(t *testing.T) {
 	file := tempFile(
 		`def blorgly2():
 			"foo"[10]`) // index out of range
@@ -278,15 +278,15 @@ func TestGetServiceConfigRaisesError(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfigs("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
+	_, err = tiltConfig.GetManifestConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetManifestConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "string index", "out of range"} {
 			assert.True(t, strings.Contains(err.Error(), s), "error message '%V' did not contain '%V'", err.Error(), s)
 		}
 	}
 }
 
-func TestGetServiceConfigReturnsWrongType(t *testing.T) {
+func TestGetManifestConfigReturnsWrongType(t *testing.T) {
 	file := tempFile(
 		`def blorgly2():
 			return "foo"`) // index out of range
@@ -297,15 +297,15 @@ func TestGetServiceConfigReturnsWrongType(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfigs("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
+	_, err = tiltConfig.GetManifestConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetManifestConfigs did not return an error") {
 		for _, s := range []string{"blorgly2", "string", "k8s_service"} {
 			assert.True(t, strings.Contains(err.Error(), s), "error message '%V' did not contain '%V'", err.Error(), s)
 		}
 	}
 }
 
-func TestGetServiceConfigLocalReturnsNon0(t *testing.T) {
+func TestGetManifestConfigLocalReturnsNon0(t *testing.T) {
 	file := tempFile(
 		`def blorgly2():
 			local('echo "foo" "bar" && echo "baz" "quu" >&2 && exit 1')`) // index out of range
@@ -316,8 +316,8 @@ func TestGetServiceConfigLocalReturnsNon0(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltConfig.GetServiceConfigs("blorgly2")
-	if assert.NotNil(t, err, "GetServiceConfigs did not return an error") {
+	_, err = tiltConfig.GetManifestConfigs("blorgly2")
+	if assert.NotNil(t, err, "GetManifestConfigs did not return an error") {
 		// "foo bar" and "baz quu" are separated above so that the match below only matches the strings in the output,
 		// not in the command
 		for _, s := range []string{"blorgly2", "exit status 1", "foo bar", "baz quu"} {
@@ -326,7 +326,7 @@ func TestGetServiceConfigLocalReturnsNon0(t *testing.T) {
 	}
 }
 
-func TestGetServiceConfigWithLocalCmd(t *testing.T) {
+func TestGetManifestConfigWithLocalCmd(t *testing.T) {
 	dockerfile := tempFile("docker text")
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
@@ -345,19 +345,19 @@ func TestGetServiceConfigWithLocalCmd(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	serviceConfig, err := tiltconfig.GetServiceConfigs("blorgly")
+	manifestConfig, err := tiltconfig.GetManifestConfigs("blorgly")
 	if err != nil {
-		t.Fatal("getting service config:", err)
+		t.Fatal("getting manifest config:", err)
 	}
 
-	service := serviceConfig[0]
-	assert.Equal(t, "docker text", service.DockerfileText)
-	assert.Equal(t, "docker.io/library/docker-tag", service.DockerfileTag.String())
-	assert.Equal(t, "yaaaaaaaaml\n", service.K8sYaml)
-	assert.Equal(t, 2, len(service.Steps))
-	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, service.Steps[0].Cmd.Argv)
-	assert.Equal(t, []string{"sh", "-c", "echo hi"}, service.Steps[1].Cmd.Argv)
-	assert.Equal(t, []string{"sh", "-c", "the entrypoint"}, service.Entrypoint.Argv)
+	manifest := manifestConfig[0]
+	assert.Equal(t, "docker text", manifest.DockerfileText)
+	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerfileTag.String())
+	assert.Equal(t, "yaaaaaaaaml\n", manifest.K8sYaml)
+	assert.Equal(t, 2, len(manifest.Steps))
+	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, manifest.Steps[0].Cmd.Argv)
+	assert.Equal(t, []string{"sh", "-c", "echo hi"}, manifest.Steps[1].Cmd.Argv)
+	assert.Equal(t, []string{"sh", "-c", "the entrypoint"}, manifest.Entrypoint.Argv)
 }
 
 func TestRunTrigger(t *testing.T) {
@@ -390,16 +390,16 @@ func TestRunTrigger(t *testing.T) {
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	services, err := tiltconfig.GetServiceConfigs("yarnly")
+	manifests, err := tiltconfig.GetManifestConfigs("yarnly")
 	if err != nil {
-		t.Fatal("getting service config:", err)
+		t.Fatal("getting manifest config:", err)
 	}
 
-	assert.Equal(t, len(services), 1)
+	assert.Equal(t, len(manifests), 1)
 
-	step0 := services[0].Steps[0]
-	step1 := services[0].Steps[1]
-	step2 := services[0].Steps[2]
+	step0 := manifests[0].Steps[0]
+	step1 := manifests[0].Steps[1]
+	step2 := manifests[0].Steps[2]
 	assert.Equal(
 		t,
 		step0.Cmd,
@@ -454,7 +454,7 @@ func TestInvalidDockerTag(t *testing.T) {
 	if err != nil {
 		t.Fatal("loading tiltconfig:", err)
 	}
-	_, err = tiltconfig.GetServiceConfigs("blorgly")
+	_, err = tiltconfig.GetManifestConfigs("blorgly")
 	msg := "invalid reference format"
 	if err == nil || !strings.Contains(err.Error(), msg) {
 		t.Errorf("Expected error message to contain %v, got %v", msg, err)
@@ -475,11 +475,11 @@ ENTRYPOINT echo hi`)
 	if err != nil {
 		t.Fatal("loading tiltconfig:", err)
 	}
-	services, err := tiltconfig.GetServiceConfigs("blorgly")
+	manifests, err := tiltconfig.GetManifestConfigs("blorgly")
 	if err != nil {
 		t.Fatal(err)
 	}
-	service := services[0]
+	manifest := manifests[0]
 	// TODO(dmiller) is this right?
-	assert.Equal(t, []string{"sh", "-c", ""}, service.Entrypoint.Argv)
+	assert.Equal(t, []string{"sh", "-c", ""}, manifest.Entrypoint.Argv)
 }


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch55/service:

5fdd655762d5d64f2ba456b3fa87dd4483abf7d2 (2018-09-13 16:32:08 -0400)
tiltfile: partial rename service -> manifest without changing syntax