### PR TITLE
k8s/buildAndDeploy: PollForPodWithImage (and invoke from PostProcessBuilds) [ch134]

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -229,6 +230,10 @@ func (c *FakeK8sClient) PodWithImage(ctx context.Context, image reference.NamedT
 	}
 
 	return k8s.PodID("pod"), nil
+}
+
+func (c *FakeK8sClient) PollForPodWithImage(ctx context.Context, image reference.NamedTagged, timeout time.Duration) (k8s.PodID, error) {
+	return c.PodWithImage(ctx, image)
 }
 
 func (c *FakeK8sClient) applyWasCalled() bool {

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -117,6 +117,8 @@ func (cbd *LocalContainerBuildAndDeployer) getContainerForBuild(ctx context.Cont
 	defer span.Finish()
 
 	// get pod running the image we just deployed
+	// TODO(maia): parallelize this polling (inefficient b/c first we deploy all manifests in series,
+	// then we poll for pods for all of them (again in series)
 	pID, err := cbd.k8sClient.PollForPodWithImage(ctx, build.Image, time.Second*3)
 	if err != nil {
 		return "", fmt.Errorf("PodWithImage (img = %s): %v", build.Image, err)

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const podPollTimeoutSynclet = time.Second * 30
+
 var _ BuildAndDeployer = &SyncletBuildAndDeployer{}
 
 type SyncletBuildAndDeployer struct {

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -136,7 +136,9 @@ func (sbd *SyncletBuildAndDeployer) getContainerForBuild(ctx context.Context, bu
 	defer span.Finish()
 
 	// get pod running the image we just deployed
-	pID, err := sbd.kCli.PodWithImage(ctx, build.Image)
+	// TODO(maia): parallelize this polling (inefficient b/c first we deploy all manifests in series,
+	// then we poll for pods for all of them (again in series)
+	pID, err := sbd.kCli.PollForPodWithImage(ctx, build.Image, time.Second*45)
 	if err != nil {
 		return "", fmt.Errorf("PodWithImage (img = %s): %v", build.Image, err)
 	}
@@ -154,17 +156,7 @@ func (sbd *SyncletBuildAndDeployer) PostProcessBuilds(ctx context.Context, state
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncletBuildAndDeployer-PostProcessBuilds")
 	defer span.Finish()
 
-	// HACK(maia): give the pod(s) we just deployed a bit to come up (takes longer on gke, sigh)
-	// TODO(maia): replace this with polling/smart waiting
 	logger.Get(ctx).Infof("Post-processing %d builds...", len(states))
-	fmt.Printf("SLEEPING")
-	for i := 0; i < 30; i++ {
-		if ctx.Err() != nil {
-			return
-		}
-		fmt.Printf(".")
-		time.Sleep(time.Second)
-	}
 
 	for serv, state := range states {
 		if !state.LastResult.HasImage() {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
-//represents a single call to `BuildAndDeploy`
+// represents a single call to `BuildAndDeploy`
 type buildAndDeployCall struct {
 	manifest model.Manifest
 	state    BuildState

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/docker/distribution/reference"
 	"github.com/opentracing/opentracing-go"
@@ -19,6 +20,7 @@ type ContainerID string
 type NodeID string
 
 func (pID PodID) String() string { return string(pID) }
+func (pID PodID) Empty() bool    { return pID.String() == "" }
 
 func (cID ContainerID) String() string { return string(cID) }
 func (cID ContainerID) ShortStr() string {
@@ -35,6 +37,7 @@ type Client interface {
 	Delete(ctx context.Context, entities []K8sEntity) error
 
 	PodWithImage(ctx context.Context, image reference.NamedTagged) (PodID, error)
+	PollForPodWithImage(ctx context.Context, image reference.NamedTagged, timeout time.Duration) (PodID, error)
 
 	// Gets the ID for the Node on which the specified Pod is running
 	GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error)

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
+
+	"github.com/windmilleng/tilt/internal/testutils/output"
 )
 
 type call struct {
@@ -39,6 +41,7 @@ var _ kubectlRunner = fakeKubectlRunner{}
 
 type clientTestFixture struct {
 	t      *testing.T
+	ctx    context.Context
 	client KubectlClient
 	runner *fakeKubectlRunner
 }
@@ -46,6 +49,7 @@ type clientTestFixture struct {
 func newClientTestFixture(t *testing.T) *clientTestFixture {
 	ret := &clientTestFixture{}
 	ret.t = t
+	ret.ctx = output.CtxForTest()
 	ret.runner = &fakeKubectlRunner{}
 	ret.client = KubectlClient{EnvUnknown, ret.runner}
 	return ret

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -163,3 +163,11 @@ func ParseNamedTagged(s string) (reference.NamedTagged, error) {
 	}
 	return nt, nil
 }
+
+func MustParseNamedTagged(s string) reference.NamedTagged {
+	nt, err := ParseNamedTagged(s)
+	if err != nil {
+		panic(err)
+	}
+	return nt
+}

--- a/internal/k8s/kubectl_runner.go
+++ b/internal/k8s/kubectl_runner.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"io"
 	"os/exec"
-
-	"github.com/windmilleng/tilt/internal/output"
 )
 
 type kubectlRunner interface {
@@ -21,28 +19,24 @@ var _ kubectlRunner = realKubectlRunner{}
 func (k realKubectlRunner) exec(ctx context.Context, args []string) (stdout string, stderr string, err error) {
 	c := exec.CommandContext(ctx, "kubectl", args...)
 
-	writer := output.Get(ctx).Writer()
-
 	stdoutBuf := &bytes.Buffer{}
-	c.Stdout = io.MultiWriter(stdoutBuf, writer)
-
 	stderrBuf := &bytes.Buffer{}
-	c.Stderr = io.MultiWriter(stderrBuf, writer)
+	c.Stdout = stdoutBuf
+	c.Stderr = stderrBuf
 
-	return stdoutBuf.String(), stderrBuf.String(), c.Run()
+	err = c.Run()
+	return stdoutBuf.String(), stderrBuf.String(), err
 }
 
 func (k realKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin io.Reader) (stdout string, stderr string, err error) {
 	c := exec.CommandContext(ctx, "kubectl", args...)
 	c.Stdin = stdin
 
-	writer := output.Get(ctx).Writer()
-
 	stdoutBuf := &bytes.Buffer{}
-	c.Stdout = io.MultiWriter(stdoutBuf, writer)
-
 	stderrBuf := &bytes.Buffer{}
-	c.Stderr = io.MultiWriter(stderrBuf, writer)
+	c.Stdout = stdoutBuf
+	c.Stderr = stderrBuf
 
-	return stdoutBuf.String(), stderrBuf.String(), c.Run()
+	err = c.Run()
+	return stdoutBuf.String(), stderrBuf.String(), err
 }

--- a/internal/testutils/output/context.go
+++ b/internal/testutils/output/context.go
@@ -8,8 +8,8 @@ import (
 	"github.com/windmilleng/tilt/internal/output"
 )
 
-// CtxForTest returns a context.Context suitable for use in tests.
-// Currently, this means that it has a Logger attached.
+// CtxForTest returns a context.Context suitable for use in tests (i.e. with
+// logger, outputter, etc. attached).
 func CtxForTest() context.Context {
 	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
 	ctx := logger.WithLogger(context.Background(), l)


### PR DESCRIPTION
this keeps us from having to `sleep` for an arbitrary amount of time before trying to talk to pods