### PR TITLE
internal: mounts have multiple paths

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -25,7 +25,7 @@ func TestMount(t *testing.T) {
 	f.WriteFile("sup", "my name is dan")
 
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 
@@ -50,11 +50,11 @@ func TestMultipleMounts(t *testing.T) {
 	f.WriteFile("bye/ciao/goodbye", "bye laterz")
 
 	m1 := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.JoinPath("hi")},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.JoinPath("hi")}},
 		ContainerPath: "/hello_there",
 	}
 	m2 := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.JoinPath("bye")},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.JoinPath("bye")}},
 		ContainerPath: "goodbye_there",
 	}
 
@@ -81,11 +81,11 @@ func TestMountCollisions(t *testing.T) {
 	// Mounting two files to the same place in the container -- expect the second mount
 	// to take precedence (file should contain "bye laterz")
 	m1 := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.JoinPath("hi")},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.JoinPath("hi")}},
 		ContainerPath: "/hello_there",
 	}
 	m2 := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.JoinPath("bye")},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.JoinPath("bye")}},
 		ContainerPath: "/hello_there",
 	}
 
@@ -111,7 +111,7 @@ func TestPush(t *testing.T) {
 	f.WriteFile("sup", "my name is dan")
 
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 
@@ -143,7 +143,7 @@ func TestPushInvalid(t *testing.T) {
 	defer f.teardown()
 
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 	name, err := reference.WithName("localhost:5005/myimage")
@@ -289,7 +289,7 @@ func TestSelectiveAddFilesToExisting(t *testing.T) {
 	f.WriteFile("unchanged", "should be unchanged")
 	mounts := []model.Mount{
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+			Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 			ContainerPath: "/src",
 		},
 	}
@@ -328,7 +328,7 @@ func TestExecStepsOnExisting(t *testing.T) {
 
 	f.WriteFile("foo", "hello world")
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 
@@ -358,7 +358,7 @@ func TestBuildImageFromExistingPreservesEntrypoint(t *testing.T) {
 
 	f.WriteFile("foo", "hello world")
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 	entrypoint := model.ToShellCmd("echo -n foo contains: $(cat /src/foo) >> /src/bar")
@@ -393,7 +393,7 @@ func TestBuildDockerWithStepsFromExistingPreservesEntrypoint(t *testing.T) {
 
 	f.WriteFile("foo", "hello world")
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 	step := model.ToShellCmd("echo -n hello >> /src/baz")
@@ -433,7 +433,7 @@ func TestUpdateInContainerE2E(t *testing.T) {
 
 	f.WriteFile("delete_me", "will be deleted")
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 
@@ -481,7 +481,7 @@ func TestReapOneImage(t *testing.T) {
 	defer f.teardown()
 
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 
@@ -516,7 +516,7 @@ func TestConditionalRunInRealDocker(t *testing.T) {
 	f.WriteFile("b.txt", "b")
 
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 	inputs, _ := dockerignore.NewDockerPatternMatcher(f.Path(), []string{"a.txt"})

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -88,7 +88,7 @@ func TestConditionalRunInFakeDocker(t *testing.T) {
 	f.WriteFile("b.txt", "b")
 
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 	inputs, _ := dockerignore.NewDockerPatternMatcher(f.Path(), []string{"a.txt"})
@@ -126,7 +126,7 @@ func TestAllConditionalRunsInFakeDocker(t *testing.T) {
 	f.WriteFile("b.txt", "b")
 
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: f.Path()},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{f.Path()}},
 		ContainerPath: "/src",
 	}
 	inputs, _ := dockerignore.NewDockerPatternMatcher(f.Path(), []string{"a.txt"})

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -30,11 +30,11 @@ func TestFilesToPathMappings(t *testing.T) {
 
 	mounts := []model.Mount{
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: f.JoinPath("mount1")},
+			Repo:          model.LocalGithubRepo{LocalPaths: []string{f.JoinPath("mount1")}},
 			ContainerPath: "/dest1",
 		},
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: f.JoinPath("mount2")},
+			Repo:          model.LocalGithubRepo{LocalPaths: []string{f.JoinPath("mount2")}},
 			ContainerPath: "/nested/dest2",
 		},
 	}
@@ -69,7 +69,7 @@ func TestRelativeRepoPathsThrowError(t *testing.T) {
 	files := []string{"/foo/bar.baz"}
 	mounts := []model.Mount{
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: "./hello"},
+			Repo:          model.LocalGithubRepo{LocalPaths: []string{"./hello"}},
 			ContainerPath: "/src",
 		},
 	}
@@ -88,7 +88,7 @@ func TestFileNotInMountThrowsErr(t *testing.T) {
 
 	mounts := []model.Mount{
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: f.JoinPath("mount1")},
+			Repo:          model.LocalGithubRepo{LocalPaths: []string{f.JoinPath("mount1")}},
 			ContainerPath: "/dest1",
 		},
 	}

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -27,7 +27,7 @@ var dontFallBackErrStr = "don't fall back"
 
 func TestShouldImageBuild(t *testing.T) {
 	m := model.Mount{
-		Repo:          model.LocalGithubRepo{LocalPath: "asdf"},
+		Repo:          model.LocalGithubRepo{LocalPaths: []string{"asdf"}},
 		ContainerPath: "blah",
 	}
 	_, pathMapErr := build.FilesToPathMappings([]string{"a"}, []model.Mount{m})

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -46,7 +46,7 @@ var SanchoManifest = model.Manifest{
 	DockerfileText: SanchoDockerfile,
 	Mounts: []model.Mount{
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: "sancho"},
+			Repo:          model.LocalGithubRepo{LocalPaths: []string{"sancho"}},
 			ContainerPath: "/go/src/github.com/windmilleng/sancho",
 		},
 	},

--- a/internal/engine/up_watch.go
+++ b/internal/engine/up_watch.go
@@ -41,9 +41,11 @@ func makeManifestWatcher(
 		}
 
 		for _, mount := range manifest.Mounts {
-			err = watcher.Add(mount.Repo.LocalPath)
-			if err != nil {
-				return nil, err
+			for _, p := range mount.Repo.LocalPaths {
+				err = watcher.Add(p)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		sns = append(sns, manifestNotifyPair{manifest, watcher})
@@ -146,7 +148,9 @@ func makeFilter(ctx context.Context, manifest model.Manifest) (model.PathMatcher
 	var repoRoots []string
 
 	for _, mount := range manifest.Mounts {
-		repoRoots = append(repoRoots, mount.Repo.LocalPath)
+		for _, p := range mount.Repo.LocalPaths {
+			repoRoots = append(repoRoots, p)
+		}
 	}
 
 	mrt, err := git.NewMultiRepoIgnoreTester(ctx, repoRoots)

--- a/internal/engine/up_watch_test.go
+++ b/internal/engine/up_watch_test.go
@@ -79,7 +79,7 @@ func makeManifestWatcherTestFixture(t *testing.T, manifestCount int) *manifestWa
 		manifests = append(manifests,
 			model.Manifest{
 				Name:   model.ManifestName(fmt.Sprintf("manifest%v", i)),
-				Mounts: []model.Mount{{Repo: model.LocalGithubRepo{LocalPath: tempDir.Path()}, ContainerPath: ""}}})
+				Mounts: []model.Mount{{Repo: model.LocalGithubRepo{LocalPaths: []string{tempDir.Path()}}, ContainerPath: ""}}})
 
 		tempDirs = append(tempDirs, tempDir)
 		watcher := newFakeNotify()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -132,7 +132,7 @@ func TestUpper_UpWatchZeroRepos(t *testing.T) {
 func TestUpper_UpWatchError(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	go func() {
 		f.watcher.errors <- errors.New("bazquu")
@@ -156,7 +156,7 @@ func TestUpper_UpWatchError(t *testing.T) {
 func TestUpper_UpWatchFileChangeThenError(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	go func() {
 		f.timerMaker.maxTimerLock.Lock()
@@ -187,7 +187,7 @@ func TestUpper_UpWatchFileChangeThenError(t *testing.T) {
 func TestUpper_UpWatchCoalescedFileChanges(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	go func() {
 		f.timerMaker.maxTimerLock.Lock()
@@ -227,7 +227,7 @@ func TestUpper_UpWatchCoalescedFileChanges(t *testing.T) {
 func TestUpper_UpWatchCoalescedFileChangesHitMaxTimeout(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	go func() {
 		call := <-f.b.calls
@@ -267,7 +267,7 @@ func TestUpper_UpWatchCoalescedFileChangesHitMaxTimeout(t *testing.T) {
 func TestFirstBuildFailsWhileWatching(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	endToken := errors.New("my-err-token")
 	f.b.nextBuildFailure = errors.New("Build failed")
@@ -290,7 +290,7 @@ func TestFirstBuildFailsWhileWatching(t *testing.T) {
 func TestFirstBuildFailsWhileNotWatching(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	buildFailedToken := errors.New("doesn't compile")
 	f.b.nextBuildFailure = buildFailedToken
@@ -303,7 +303,7 @@ func TestFirstBuildFailsWhileNotWatching(t *testing.T) {
 func TestRebuildWithChangedFiles(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	endToken := errors.New("my-err-token")
 	go func() {
@@ -336,7 +336,7 @@ func TestRebuildWithChangedFiles(t *testing.T) {
 func TestRebuildWithSpuriousChangedFiles(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 	endToken := errors.New("my-err-token")
 	go func() {
@@ -371,7 +371,7 @@ func TestRebuildWithSpuriousChangedFiles(t *testing.T) {
 func TestReapOldBuilds(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPath: "/go"}, ContainerPath: "/go"}
+	mount := model.Mount{Repo: model.LocalGithubRepo{LocalPaths: []string{"/go"}}, ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 
 	f.docker.BuildCount++

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -66,7 +66,7 @@ type Repo interface {
 }
 
 type LocalGithubRepo struct {
-	LocalPath string
+	LocalPaths []string
 }
 
 func (LocalGithubRepo) IsRepo() {}

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -14,7 +14,7 @@ type Summary struct {
 
 type Service struct {
 	Name    string
-	Path    string
+	Paths   []string
 	k8sData k8sData
 }
 
@@ -37,14 +37,16 @@ func (s *Summary) Gather(services []model.Manifest) error {
 
 	for _, svc := range services {
 		// Assume that, in practice, there is only one mount
-		path := ""
+		paths := []string{}
 		if len(svc.Mounts) > 0 {
-			path = svc.Mounts[0].Repo.LocalPath
+			for _, p := range svc.Mounts[0].Repo.LocalPaths {
+				paths = append(paths, p)
+			}
 		}
 
 		svcSummary := &Service{
-			Name: string(svc.Name),
-			Path: path,
+			Name:  string(svc.Name),
+			Paths: paths,
 		}
 
 		entities, err := k8s.ParseYAMLFromString(svc.K8sYaml)
@@ -74,7 +76,9 @@ func (s *Summary) Output() string {
 
 	for _, svc := range s.Services {
 		ret += fmt.Sprintf("    SERVICE NAME: %s\n", svc.Name)
-		ret += fmt.Sprintf("    WATCHING: %s\n", svc.Path)
+		for _, p := range svc.Paths {
+			ret += fmt.Sprintf("    WATCHING: %s\n", p)
+		}
 
 		k := svc.k8sData
 

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -70,8 +70,8 @@ func (k8sManifest) Hash() (uint32, error) {
 }
 
 type mount struct {
-	mountPoint string
-	repo       gitRepo
+	containerPath string
+	repoPaths     []string
 }
 
 type dockerImage struct {
@@ -158,7 +158,7 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 		return nil, errors.New("internal error: add_docker_image_cmd called on non-dockerImage")
 	}
 
-	image.mounts = append(image.mounts, mount{mountPoint, gitRepo})
+	image.mounts = append(image.mounts, mount{mountPoint, []string{gitRepo.path}})
 
 	return skylark.None, nil
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -221,8 +221,8 @@ func skylarkMountsToDomain(sMounts []mount) []model.Mount {
 	dMounts := make([]model.Mount, len(sMounts))
 	for i, m := range sMounts {
 		dMounts[i] = model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: m.repo.path},
-			ContainerPath: m.mountPoint,
+			Repo:          model.LocalGithubRepo{LocalPaths: m.repoPaths},
+			ContainerPath: m.containerPath,
 		}
 	}
 	return dMounts

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -86,7 +86,7 @@ func TestGetManifestConfig(t *testing.T) {
 	assert.Equal(t, "yaaaaaaaaml", manifest.K8sYaml)
 	assert.Equal(t, 1, len(manifest.Mounts), "number of mounts")
 	assert.Equal(t, "/mount_points/1", manifest.Mounts[0].ContainerPath)
-	assert.Equal(t, wd, manifest.Mounts[0].Repo.LocalPath, "repo path")
+	assert.Equal(t, wd, manifest.Mounts[0].Repo.LocalPaths[0], "repo path")
 	assert.Equal(t, 2, len(manifest.Steps), "number of steps")
 	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, manifest.Steps[0].Cmd.Argv, "first step")
 	assert.Equal(t, []string{"sh", "-c", "echo hi"}, manifest.Steps[1].Cmd.Argv, "second step")


### PR DESCRIPTION
This is step 1 towards being able to selectively mount individual files. I'm implementing the syntax that @nicks  outlined [here](https://app.clubhouse.io/windmill/story/110/selectively-mounting-files-in-a-container#activity-111). I realized that on the backend we'll need to be able to handle multiple local files being mapped in to the same container mount point. I decided to make that change first.

This PR should not affect the functionality of tilt in any way, it's just to lay the groundwork.