### PR TITLE
buildAndDeploy: store deployInfo on BuildAndDeployer (rather than on build state)

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -151,7 +151,7 @@ func TestFallBackToImageDeploy(t *testing.T) {
 }
 
 func TestNoFallbackForCertainErrors(t *testing.T) {
-	f := newBDFixture(t, k8s.EnvDockerDesktop, false)
+	f := newBDFixture(t, k8s.EnvDockerDesktop, true)
 	defer f.TearDown()
 	ctx := output.CtxForTest()
 	f.docker.ExecErrorToThrow = errors.New(dontFallBackErrStr)

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -22,14 +22,17 @@ type LocalContainerBuildAndDeployer struct {
 	env       k8s.Env
 	k8sClient k8s.Client
 	analytics analytics.Analytics
+
+	deployInfo map[model.ManifestName]k8s.ContainerID
 }
 
 func NewLocalContainerBuildAndDeployer(cu *build.ContainerUpdater, env k8s.Env, kCli k8s.Client, analytics analytics.Analytics) *LocalContainerBuildAndDeployer {
 	return &LocalContainerBuildAndDeployer{
-		cu:        cu,
-		env:       env,
-		k8sClient: kCli,
-		analytics: analytics,
+		cu:         cu,
+		env:        env,
+		k8sClient:  kCli,
+		analytics:  analytics,
+		deployInfo: make(map[model.ManifestName]k8s.ContainerID),
 	}
 }
 
@@ -59,12 +62,11 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 
 	// Otherwise, manifest has already been deployed; try to update in the running container
 
+	cID, ok := cbd.deployInfo[manifest.Name]
 	// (Unless we don't know what container it's running in, in which case we can't.)
-	if !state.LastResult.HasContainer() {
-		return BuildResult{}, fmt.Errorf("prev. build state has no container")
+	if !ok {
+		return BuildResult{}, fmt.Errorf("no container info for this manifest")
 	}
-
-	cID := state.LastResult.Container
 	cf, err := build.FilesToPathMappings(state.FilesChanged(), manifest.Mounts)
 	if err != nil {
 		return BuildResult{}, err
@@ -82,8 +84,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 	logger.Get(ctx).Infof("  → Container updated!")
 
 	return BuildResult{
-		Entities:  state.LastResult.Entities,
-		Container: cID,
+		Entities: state.LastResult.Entities,
 	}, nil
 }
 
@@ -95,20 +96,23 @@ func (cbd *LocalContainerBuildAndDeployer) PostProcessBuilds(ctx context.Context
 	// TODO(maia): replace this with polling/smart waiting
 	logger.Get(ctx).Infof("Post-processing %d builds...", len(states))
 
-	for serv, state := range states {
-		if !state.LastResult.HasImage() {
-			logger.Get(ctx).Infof("can't get container for for '%s': BuildResult has no image", serv)
-			continue
+	for name, state := range states {
+		cbd.postProcessBuild(ctx, name, state)
+	}
+}
+
+func (cbd *LocalContainerBuildAndDeployer) postProcessBuild(ctx context.Context, name model.ManifestName, state BuildState) {
+	if !state.LastResult.HasImage() {
+		logger.Get(ctx).Infof("can't get container for for '%s': BuildResult has no image", name)
+		return
+	}
+	if _, ok := cbd.deployInfo[name]; !ok {
+		cID, err := cbd.getContainerForBuild(ctx, state.LastResult)
+		if err != nil {
+			logger.Get(ctx).Infof("couldn't get container for %s: %v", name, err)
+			return
 		}
-		if !state.LastResult.HasContainer() {
-			cID, err := cbd.getContainerForBuild(ctx, state.LastResult)
-			if err != nil {
-				logger.Get(ctx).Infof("couldn't get container for %s: %v", serv, err)
-				continue
-			}
-			state.LastResult.Container = cID
-			states[serv] = state
-		}
+		cbd.deployInfo[name] = cID
 	}
 }
 
@@ -119,7 +123,7 @@ func (cbd *LocalContainerBuildAndDeployer) getContainerForBuild(ctx context.Cont
 	// get pod running the image we just deployed
 	// TODO(maia): parallelize this polling (inefficient b/c first we deploy all manifests in series,
 	// then we poll for pods for all of them (again in series)
-	pID, err := cbd.k8sClient.PollForPodWithImage(ctx, build.Image, time.Second*3)
+	pID, err := cbd.k8sClient.PollForPodWithImage(ctx, build.Image, podPollTimeoutLocal)
 	if err != nil {
 		return "", fmt.Errorf("PodWithImage (img = %s): %v", build.Image, err)
 	}

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -103,7 +103,7 @@ func (cbd *LocalContainerBuildAndDeployer) PostProcessBuilds(ctx context.Context
 
 func (cbd *LocalContainerBuildAndDeployer) postProcessBuild(ctx context.Context, name model.ManifestName, state BuildState) {
 	if !state.LastResult.HasImage() {
-		logger.Get(ctx).Infof("can't get container for for '%s': BuildResult has no image", name)
+		logger.Get(ctx).Infof("can't get container for %q: BuildResult has no image", name)
 		return
 	}
 	if _, ok := cbd.deployInfo[name]; !ok {

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -11,21 +11,16 @@ import (
 
 // The results of a successful build.
 type BuildResult struct {
-	Image     reference.NamedTagged
-	Entities  []k8s.K8sEntity
-	Container k8s.ContainerID
+	Image    reference.NamedTagged
+	Entities []k8s.K8sEntity
 }
 
 func (b BuildResult) IsEmpty() bool {
-	return b.Image == nil && b.Container == ""
+	return b.Image == nil
 }
 
 func (b BuildResult) HasImage() bool {
 	return b.Image != nil
-}
-
-func (b BuildResult) HasContainer() bool {
-	return b.Container != ""
 }
 
 // The state of the system since the last successful build.

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -169,7 +169,7 @@ func (sbd *SyncletBuildAndDeployer) PostProcessBuilds(ctx context.Context, state
 
 func (sbd *SyncletBuildAndDeployer) postProcessBuild(ctx context.Context, name model.ManifestName, state BuildState) {
 	if !state.LastResult.HasImage() {
-		logger.Get(ctx).Infof("can't get container for for '%s': BuildResult has no image", name)
+		logger.Get(ctx).Infof("can't get container for %q: BuildResult has no image", name)
 		return
 	}
 	if _, ok := sbd.deployInfo[name]; !ok {

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -25,6 +25,8 @@ type SyncletBuildAndDeployer struct {
 	sCli synclet.SyncletClient
 
 	kCli k8s.Client
+
+	deployInfo map[model.ManifestName]k8s.ContainerID
 }
 
 func DefaultSyncletClient(env k8s.Env) (synclet.SyncletClient, error) {
@@ -42,8 +44,9 @@ func DefaultSyncletClient(env k8s.Env) (synclet.SyncletClient, error) {
 
 func NewSyncletBuildAndDeployer(sCli synclet.SyncletClient, kCli k8s.Client) *SyncletBuildAndDeployer {
 	return &SyncletBuildAndDeployer{
-		sCli: sCli,
-		kCli: kCli,
+		sCli:       sCli,
+		kCli:       kCli,
+		deployInfo: make(map[model.ManifestName]k8s.ContainerID),
 	}
 }
 
@@ -78,8 +81,8 @@ func (sbd *SyncletBuildAndDeployer) canSyncletBuild(ctx context.Context,
 	}
 
 	// Can't do container update if we don't know what container manifest is running in.
-	if !state.LastResult.HasContainer() {
-		return fmt.Errorf("prev. build state has no container")
+	if _, ok := sbd.deployInfo[manifest.Name]; !ok {
+		return fmt.Errorf("no container info for this manifest")
 	}
 
 	return nil
@@ -114,7 +117,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 	// TODO(maia): can refactor MissingLocalPaths to just return ContainerPaths?
 	containerPathsToRm := build.PathMappingsToContainerPaths(toRemove)
 
-	cID := state.LastResult.Container
+	cID := sbd.deployInfo[manifest.Name]
 
 	cmds, err := build.BoilSteps(manifest.Steps, paths)
 	if err != nil {
@@ -126,8 +129,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 	}
 
 	return BuildResult{
-		Entities:  state.LastResult.Entities,
-		Container: cID,
+		Entities: state.LastResult.Entities,
 	}, nil
 }
 
@@ -158,21 +160,24 @@ func (sbd *SyncletBuildAndDeployer) PostProcessBuilds(ctx context.Context, state
 
 	logger.Get(ctx).Infof("Post-processing %d builds...", len(states))
 
-	for serv, state := range states {
-		if !state.LastResult.HasImage() {
-			logger.Get(ctx).Infof("can't get container for for '%s': BuildResult has no image", serv)
-			continue
-		}
-		if !state.LastResult.HasContainer() {
-			cID, err := sbd.getContainerForBuild(ctx, state.LastResult)
-			if err != nil {
-				logger.Get(ctx).Infof("couldn't get container for %s: %v", serv, err)
-				continue
-			}
-			state.LastResult.Container = cID
-			states[serv] = state
-		}
+	for name, state := range states {
+		sbd.postProcessBuild(ctx, name, state)
 	}
 
 	return
+}
+
+func (sbd *SyncletBuildAndDeployer) postProcessBuild(ctx context.Context, name model.ManifestName, state BuildState) {
+	if !state.LastResult.HasImage() {
+		logger.Get(ctx).Infof("can't get container for for '%s': BuildResult has no image", name)
+		return
+	}
+	if _, ok := sbd.deployInfo[name]; !ok {
+		cID, err := sbd.getContainerForBuild(ctx, state.LastResult)
+		if err != nil {
+			logger.Get(ctx).Infof("couldn't get container for %s: %v", name, err)
+			return
+		}
+		sbd.deployInfo[name] = cID
+	}
 }


### PR DESCRIPTION
in preparation for rewiring PostProcessBuilds to be concurrent [ch209]