### PR TITLE
tiltfile: validate that the path exists

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -99,6 +100,11 @@ func makeSkylarkGitRepo(thread *skylark.Thread, fn *skylark.Builtin, args skylar
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("filepath.Abs: %v", err)
+	}
+
+	_, err = os.Stat(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("Reading path %s: %v", path, err)
 	}
 
 	return gitRepo{absPath}, nil


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/tiltfile:

582a58507f988f50cf290cca38d1780f2d818cd7 (2018-09-14 17:24:04 -0400)
tiltfile: validate that the path exists