### PR TITLE
engine: store more state about the changed container in the BuildResult, to more accurately trigger builds

### DIFF
--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -81,10 +81,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 	}
 	logger.Get(ctx).Infof("  → Container updated!")
 
-	return BuildResult{
-		Entities:  state.LastResult.Entities,
-		Container: cID,
-	}, nil
+	return state.LastResult.ShallowCloneForContainerUpdate(cID, state.filesChangedSet), nil
 }
 
 func (cbd *LocalContainerBuildAndDeployer) PostProcessBuilds(ctx context.Context, states BuildStatesByName) {

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -125,10 +125,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 		return BuildResult{}, err
 	}
 
-	return BuildResult{
-		Entities:  state.LastResult.Entities,
-		Container: cID,
-	}, nil
+	return state.LastResult.ShallowCloneForContainerUpdate(cID, state.filesChangedSet), nil
 }
 
 func (sbd *SyncletBuildAndDeployer) getContainerForBuild(ctx context.Context, build BuildResult) (k8s.ContainerID, error) {

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -46,7 +46,7 @@ var SanchoManifest = model.Manifest{
 	DockerfileText: SanchoDockerfile,
 	Mounts: []model.Mount{
 		model.Mount{
-			Repo:          model.LocalGithubRepo{LocalPath: "sancho"},
+			Repo:          model.LocalGithubRepo{LocalPath: "/src/sancho"},
 			ContainerPath: "/go/src/github.com/windmilleng/sancho",
 		},
 	},


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch264/token:

1ccb91c32fd627131f0ccbfe0852a4498094f2ed (2018-09-17 13:53:56 -0400)
engine: store more state about the changed container in the BuildResult, to more accurately trigger builds