### PR TITLE
build: move assertFileInTar into a helper package so i can use it elsewhere

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -35,8 +35,8 @@ func TestMount(t *testing.T) {
 	}
 
 	pcs := []expectedFile{
-		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
-		expectedFile{path: "/src/sup", contents: "my name is dan"},
+		expectedFile{Path: "/src/hi/hello", Contents: "hi hello"},
+		expectedFile{Path: "/src/sup", Contents: "my name is dan"},
 	}
 	f.assertFilesInImage(ref, pcs)
 }
@@ -64,8 +64,8 @@ func TestMultipleMounts(t *testing.T) {
 	}
 
 	pcs := []expectedFile{
-		expectedFile{path: "/hello_there/hello", contents: "hi hello"},
-		expectedFile{path: "/goodbye_there/ciao/goodbye", contents: "bye laterz"},
+		expectedFile{Path: "/hello_there/hello", Contents: "hi hello"},
+		expectedFile{Path: "/goodbye_there/ciao/goodbye", Contents: "bye laterz"},
 	}
 	f.assertFilesInImage(ref, pcs)
 }
@@ -95,7 +95,7 @@ func TestMountCollisions(t *testing.T) {
 	}
 
 	pcs := []expectedFile{
-		expectedFile{path: "/hello_there/hello", contents: "bye laterz"},
+		expectedFile{Path: "/hello_there/hello", Contents: "bye laterz"},
 	}
 	f.assertFilesInImage(ref, pcs)
 }
@@ -131,8 +131,8 @@ func TestPush(t *testing.T) {
 	}
 
 	pcs := []expectedFile{
-		expectedFile{path: "/src/hi/hello", contents: "hi hello"},
-		expectedFile{path: "/src/sup", contents: "my name is dan"},
+		expectedFile{Path: "/src/hi/hello", Contents: "hi hello"},
+		expectedFile{Path: "/src/sup", Contents: "my name is dan"},
 	}
 
 	f.assertFilesInImage(namedTagged, pcs)
@@ -175,7 +175,7 @@ func TestBuildOneStep(t *testing.T) {
 	}
 
 	expected := []expectedFile{
-		expectedFile{path: "hi", contents: "hello"},
+		expectedFile{Path: "hi", Contents: "hello"},
 	}
 	f.assertFilesInImage(ref, expected)
 }
@@ -195,8 +195,8 @@ func TestBuildMultipleSteps(t *testing.T) {
 	}
 
 	expected := []expectedFile{
-		expectedFile{path: "hi", contents: "hello"},
-		expectedFile{path: "hi2", contents: "sup"},
+		expectedFile{Path: "hi", Contents: "hello"},
+		expectedFile{Path: "hi2", Contents: "sup"},
 	}
 	f.assertFilesInImage(ref, expected)
 }
@@ -217,8 +217,8 @@ func TestBuildMultipleStepsRemoveFiles(t *testing.T) {
 	}
 
 	expected := []expectedFile{
-		expectedFile{path: "hi2", contents: "sup"},
-		expectedFile{path: "hi", missing: true},
+		expectedFile{Path: "hi2", Contents: "sup"},
+		expectedFile{Path: "hi", Missing: true},
 	}
 	f.assertFilesInImage(ref, expected)
 }
@@ -255,7 +255,7 @@ func TestEntrypoint(t *testing.T) {
 	}
 
 	expected := []expectedFile{
-		expectedFile{path: "hi", contents: "hello"},
+		expectedFile{Path: "hi", Contents: "hello"},
 	}
 
 	// Start container WITHOUT overriding entrypoint (which assertFilesInImage... does)
@@ -314,10 +314,10 @@ func TestSelectiveAddFilesToExisting(t *testing.T) {
 	}
 
 	pcs := []expectedFile{
-		expectedFile{path: "/src/hi/hello", contents: "hello world"},
-		expectedFile{path: "/src/sup", missing: true},
-		expectedFile{path: "/src/nested/sup", missing: true}, // should have deleted whole directory
-		expectedFile{path: "/src/unchanged", contents: "should be unchanged"},
+		expectedFile{Path: "/src/hi/hello", Contents: "hello world"},
+		expectedFile{Path: "/src/sup", Missing: true},
+		expectedFile{Path: "/src/nested/sup", Missing: true}, // should have deleted whole directory
+		expectedFile{Path: "/src/unchanged", Contents: "should be unchanged"},
 	}
 	f.assertFilesInImage(ref, pcs)
 }
@@ -346,8 +346,8 @@ func TestExecStepsOnExisting(t *testing.T) {
 	}
 
 	pcs := []expectedFile{
-		expectedFile{path: "/src/foo", contents: "hello world"},
-		expectedFile{path: "/src/bar", contents: "foo contains: hello world"},
+		expectedFile{Path: "/src/foo", Contents: "hello world"},
+		expectedFile{Path: "/src/bar", Contents: "foo contains: hello world"},
 	}
 	f.assertFilesInImage(ref, pcs)
 }
@@ -378,8 +378,8 @@ func TestBuildImageFromExistingPreservesEntrypoint(t *testing.T) {
 	}
 
 	expected := []expectedFile{
-		expectedFile{path: "/src/foo", contents: "a whole new world"},
-		expectedFile{path: "/src/bar", contents: "foo contains: a whole new world"},
+		expectedFile{Path: "/src/foo", Contents: "a whole new world"},
+		expectedFile{Path: "/src/bar", Contents: "foo contains: a whole new world"},
 	}
 
 	// Start container WITHOUT overriding entrypoint (which assertFilesInImage... does)
@@ -415,9 +415,9 @@ func TestBuildDockerWithStepsFromExistingPreservesEntrypoint(t *testing.T) {
 	}
 
 	expected := []expectedFile{
-		expectedFile{path: "/src/foo", contents: "a whole new world"},
-		expectedFile{path: "/src/bar", contents: "foo contains: a whole new world"},
-		expectedFile{path: "/src/baz", contents: "hellohello"},
+		expectedFile{Path: "/src/foo", Contents: "a whole new world"},
+		expectedFile{Path: "/src/bar", Contents: "foo contains: a whole new world"},
+		expectedFile{Path: "/src/baz", Contents: "hellohello"},
 	}
 
 	// Start container WITHOUT overriding entrypoint (which assertFilesInImage... does)
@@ -467,10 +467,10 @@ func TestUpdateInContainerE2E(t *testing.T) {
 	}
 
 	expected := []expectedFile{
-		expectedFile{path: "/src/delete_me", missing: true},
-		expectedFile{path: "/src/foo", contents: "hello world"},
-		expectedFile{path: "/src/bar", contents: ""},         // from cmd
-		expectedFile{path: "/src/startcount", contents: "2"}, // from entrypoint (confirm container restarted)
+		expectedFile{Path: "/src/delete_me", Missing: true},
+		expectedFile{Path: "/src/foo", Contents: "hello world"},
+		expectedFile{Path: "/src/bar", Contents: ""},         // from cmd
+		expectedFile{Path: "/src/startcount", Contents: "2"}, // from entrypoint (confirm container restarted)
 	}
 
 	f.assertFilesInContainer(f.ctx, cID, expected)
@@ -534,10 +534,10 @@ func TestConditionalRunInRealDocker(t *testing.T) {
 	}
 
 	pcs := []expectedFile{
-		expectedFile{path: "/src/a.txt", contents: "a"},
-		expectedFile{path: "/src/b.txt", contents: "b"},
-		expectedFile{path: "/src/c.txt", contents: "a"},
-		expectedFile{path: "/src/d.txt", contents: "b"},
+		expectedFile{Path: "/src/a.txt", Contents: "a"},
+		expectedFile{Path: "/src/b.txt", Contents: "b"},
+		expectedFile{Path: "/src/c.txt", Contents: "a"},
+		expectedFile{Path: "/src/d.txt", Contents: "b"},
 	}
 	f.assertFilesInImage(ref, pcs)
 }

--- a/internal/build/docker_benchmark_test.go
+++ b/internal/build/docker_benchmark_test.go
@@ -27,7 +27,7 @@ func BenchmarkBuildTenSteps(b *testing.B) {
 		}
 
 		expected := []expectedFile{
-			expectedFile{path: "hi", contents: "9"},
+			expectedFile{Path: "hi", Contents: "9"},
 		}
 		f.assertFilesInImage(ref, expected)
 	}
@@ -55,7 +55,7 @@ func BenchmarkBuildTenStepsInOne(b *testing.B) {
 		}
 
 		expected := []expectedFile{
-			expectedFile{path: "hi", contents: "9"},
+			expectedFile{Path: "hi", Contents: "9"},
 		}
 		f.assertFilesInImage(ref, expected)
 	}

--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -145,7 +145,7 @@ func (a *ArchiveBuilder) tarPath(ctx context.Context, source, dest string) error
 
 			_, err = io.CopyN(a.tw, file, info.Size())
 			if err != nil && err != io.EOF {
-				return fmt.Errorf("%s: copying contents: %v", path, err)
+				return fmt.Errorf("%s: copying Contents: %v", path, err)
 			}
 		}
 		return nil

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -2,11 +2,10 @@ package build
 
 import (
 	"archive/tar"
-	"bytes"
 	"context"
-	"io"
 	"testing"
 
+	"github.com/windmilleng/tilt/internal/testutils"
 	"github.com/windmilleng/tilt/internal/testutils/output"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
@@ -27,8 +26,8 @@ func TestArchiveDf(t *testing.T) {
 	actual := tar.NewReader(ab.buf)
 
 	f.assertFileInTar(actual, expectedFile{
-		path:     "Dockerfile",
-		contents: dfText,
+		Path:     "Dockerfile",
+		Contents: dfText,
 	})
 }
 
@@ -56,8 +55,8 @@ func TestArchivePathsIfExists(t *testing.T) {
 		f.t.Fatal(err)
 	}
 	actual := tar.NewReader(ab.buf)
-	f.assertFileInTar(actual, expectedFile{path: "a", contents: "a"})
-	f.assertFileInTar(actual, expectedFile{path: "b", missing: true})
+	f.assertFileInTar(actual, expectedFile{Path: "a", Contents: "a"})
+	f.assertFileInTar(actual, expectedFile{Path: "b", Missing: true})
 }
 
 func TestLen(t *testing.T) {
@@ -95,47 +94,9 @@ func newFixture(t *testing.T) *fixture {
 }
 
 func (f *fixture) assertFileInTar(tr *tar.Reader, expected expectedFile) {
-	assertFileInTar(f.t, tr, expected)
+	testutils.AssertFileInTar(f.t, tr, expected)
 }
 
 func (f *fixture) tearDown() {
 	f.TempDirFixture.TearDown()
-}
-
-func assertFileInTar(t testing.TB, tr *tar.Reader, expected expectedFile) {
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			if expected.missing {
-				return
-			}
-			t.Fatalf("File not found in container: %s", expected.path)
-		} else if err != nil {
-			t.Fatalf("Error reading tar file: %v", err)
-		}
-
-		if expected.path == header.Name {
-			if expected.missing {
-				t.Errorf("Path %q was not expected in the tarball", expected.path)
-				return
-			}
-
-			if header.Typeflag != tar.TypeReg {
-				t.Errorf("Path %q exists but is not a regular file", expected.path)
-				return
-			}
-
-			contents := bytes.NewBuffer(nil)
-			_, err = io.Copy(contents, tr)
-			if err != nil {
-				t.Fatalf("Error reading tar file: %v", err)
-			}
-
-			if contents.String() != expected.contents {
-				t.Errorf("Wrong contents in %q. Expected: %q. Actual: %q",
-					expected.path, expected.contents, contents.String())
-			}
-			return // we found it!
-		}
-	}
 }

--- a/internal/testutils/tar.go
+++ b/internal/testutils/tar.go
@@ -1,0 +1,54 @@
+package testutils
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"testing"
+)
+
+type ExpectedFile struct {
+	Path     string
+	Contents string
+
+	// If true, we will assert that the file is not in the container.
+	Missing bool
+}
+
+func AssertFileInTar(t testing.TB, tr *tar.Reader, expected ExpectedFile) {
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			if expected.Missing {
+				return
+			}
+			t.Fatalf("File not found in container: %s", expected.Path)
+		} else if err != nil {
+			t.Fatalf("Error reading tar file: %v", err)
+		}
+
+		if expected.Path == header.Name {
+			if expected.Missing {
+				t.Errorf("Path %q was not expected in the tarball", expected.Path)
+				return
+			}
+
+			if header.Typeflag != tar.TypeReg {
+				t.Errorf("Path %q exists but is not a regular file", expected.Path)
+				return
+			}
+
+			contents := bytes.NewBuffer(nil)
+			_, err = io.Copy(contents, tr)
+			if err != nil {
+				t.Fatalf("Error reading tar file: %v", err)
+			}
+
+			if contents.String() != expected.Contents {
+				t.Errorf("Wrong contents in %q. Expected: %q. Actual: %q",
+					expected.Path, expected.Contents, contents.String())
+			}
+			return // we found it!
+		}
+	}
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch264/tar:

11fa162335818b68f85d686cf1f020f765d5c51c (2018-09-17 15:56:11 -0400)
build: move assertFileInTar into a helper package so i can use it elsewhere