### PR TITLE
tests: add a cleaner function for asserting multiple files in a tarball

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -2,11 +2,9 @@ package engine
 
 import (
 	"archive/tar"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -335,25 +333,23 @@ func TestIncrementalBuildTwiceDeadPod(t *testing.T) {
 	}
 
 	// Make sure the right files were pushed to docker.
-	tarBB := bytes.NewBuffer(nil)
-	io.Copy(tarBB, f.docker.BuildOptions.Context)
-	tarBytes := tarBB.Bytes()
-
-	// TODO(nick): This is super-janky. Add a function that can assert multiple files in a tarball
-	testutils.AssertFileInTar(t, tar.NewReader(bytes.NewBuffer(tarBytes)), testutils.ExpectedFile{
-		Path: "Dockerfile",
-		Contents: `FROM gcr.io/some-project-162817/sancho:deadbeef
+	tr := tar.NewReader(f.docker.BuildOptions.Context)
+	testutils.AssertFilesInTar(t, tr, []expectedFile{
+		expectedFile{
+			Path: "Dockerfile",
+			Contents: `FROM gcr.io/some-project-162817/sancho:deadbeef
 LABEL "tilt.buildMode"="existing"
 ADD . /
 RUN ["go", "install", "github.com/windmilleng/sancho"]`,
-	})
-	testutils.AssertFileInTar(t, tar.NewReader(bytes.NewBuffer(tarBytes)), testutils.ExpectedFile{
-		Path:     "go/src/github.com/windmilleng/sancho/a.txt",
-		Contents: "a",
-	})
-	testutils.AssertFileInTar(t, tar.NewReader(bytes.NewBuffer(tarBytes)), testutils.ExpectedFile{
-		Path:     "go/src/github.com/windmilleng/sancho/b.txt",
-		Contents: "b",
+		},
+		expectedFile{
+			Path:     "go/src/github.com/windmilleng/sancho/a.txt",
+			Contents: "a",
+		},
+		expectedFile{
+			Path:     "go/src/github.com/windmilleng/sancho/b.txt",
+			Contents: "b",
+		},
 	})
 }
 

--- a/internal/testutils/tar.go
+++ b/internal/testutils/tar.go
@@ -11,44 +11,67 @@ type ExpectedFile struct {
 	Path     string
 	Contents string
 
-	// If true, we will assert that the file is not in the container.
+	// If true, we will assert that the file is not in the tarball.
 	Missing bool
 }
 
+// Asserts whether or not this file is in the tar.
 func AssertFileInTar(t testing.TB, tr *tar.Reader, expected ExpectedFile) {
+	AssertFilesInTar(t, tr, []ExpectedFile{expected})
+}
+
+// Asserts whether or not these files are in the tar, but not that they are the only
+// files in the tarball.
+func AssertFilesInTar(t testing.TB, tr *tar.Reader, expectedFiles []ExpectedFile) {
+	burndownMap := make(map[string]ExpectedFile, len(expectedFiles))
+	for _, f := range expectedFiles {
+		burndownMap[f.Path] = f
+	}
+
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
-			if expected.Missing {
-				return
-			}
-			t.Fatalf("File not found in container: %s", expected.Path)
+			break
 		} else if err != nil {
 			t.Fatalf("Error reading tar file: %v", err)
 		}
 
-		if expected.Path == header.Name {
-			if expected.Missing {
-				t.Errorf("Path %q was not expected in the tarball", expected.Path)
-				return
-			}
+		expected, ok := burndownMap[header.Name]
+		if !ok {
+			continue
+		}
 
-			if header.Typeflag != tar.TypeReg {
-				t.Errorf("Path %q exists but is not a regular file", expected.Path)
-				return
-			}
+		// we found it!
+		delete(burndownMap, expected.Path)
 
-			contents := bytes.NewBuffer(nil)
-			_, err = io.Copy(contents, tr)
-			if err != nil {
-				t.Fatalf("Error reading tar file: %v", err)
-			}
+		if expected.Missing {
+			t.Errorf("Path %q was not expected in the tarball", expected.Path)
+			continue
+		}
 
-			if contents.String() != expected.Contents {
-				t.Errorf("Wrong contents in %q. Expected: %q. Actual: %q",
-					expected.Path, expected.Contents, contents.String())
-			}
-			return // we found it!
+		if header.Typeflag != tar.TypeReg {
+			t.Errorf("Path %q exists but is not a regular file", expected.Path)
+			continue
+		}
+
+		contents := bytes.NewBuffer(nil)
+		_, err = io.Copy(contents, tr)
+		if err != nil {
+			t.Fatalf("Error reading tar file: %v", err)
+		}
+
+		if contents.String() != expected.Contents {
+			t.Errorf("Wrong contents in %q. Expected: %q. Actual: %q",
+				expected.Path, expected.Contents, contents.String())
+			continue
+		}
+
+		continue
+	}
+
+	for _, f := range burndownMap {
+		if !f.Missing {
+			t.Errorf("File not found in container: %s", f.Path)
 		}
 	}
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/tar:

7fa989c74181d4211e69d17f9830c45b7d025be7 (2018-09-18 11:58:25 -0400)
tests: add a cleaner function for asserting multiple files in a tarball