### PR TITLE
tilt: FindAppByNode: parameterize namespace + username

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -429,7 +429,7 @@ func (c *FakeK8sClient) applyWasCalled() bool {
 	return c.yaml != ""
 }
 
-func (c *FakeK8sClient) FindAppByNode(ctx context.Context, appName string, nodeID k8s.NodeID) (k8s.PodID, error) {
+func (c *FakeK8sClient) FindAppByNode(ctx context.Context, nodeID k8s.NodeID, appName string, options k8s.FindAppByNodeOptions) (k8s.PodID, error) {
 	return k8s.PodID("pod2"), nil
 }
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -47,7 +47,7 @@ type Client interface {
 	GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error)
 
 	// Finds the PodID for the instance of appName running on the same node as podID
-	FindAppByNode(ctx context.Context, appName string, nodeID NodeID) (PodID, error)
+	FindAppByNode(ctx context.Context, nodeID NodeID, appName string, options FindAppByNodeOptions) (PodID, error)
 
 	// Waits for the LoadBalancer to get a publicly available URL,
 	// then opens that URL in a web browser.

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -25,7 +25,7 @@ type fakeKubectlRunner struct {
 	calls []call
 }
 
-func (f fakeKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin io.Reader) (stdout string, stderr string, err error) {
+func (f *fakeKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin io.Reader) (stdout string, stderr string, err error) {
 	b, err := ioutil.ReadAll(stdin)
 	if err != nil {
 		return "", "", fmt.Errorf("reading stdin: %v", err)
@@ -34,12 +34,12 @@ func (f fakeKubectlRunner) execWithStdin(ctx context.Context, args []string, std
 	return f.stdout, f.stderr, f.err
 }
 
-func (f fakeKubectlRunner) exec(ctx context.Context, args []string) (stdout string, stderr string, err error) {
+func (f *fakeKubectlRunner) exec(ctx context.Context, args []string) (stdout string, stderr string, err error) {
 	f.calls = append(f.calls, call{argv: args})
 	return f.stdout, f.stderr, f.err
 }
 
-var _ kubectlRunner = fakeKubectlRunner{}
+var _ kubectlRunner = &fakeKubectlRunner{}
 
 type clientTestFixture struct {
 	t      *testing.T

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -158,10 +158,10 @@ func TestFindAppByNodeKubectlError(t *testing.T) {
 	}
 }
 
-func TestFindAppByNodeWithUsername(t *testing.T) {
+func TestFindAppByNodeWithOwner(t *testing.T) {
 	f := newClientTestFixture(t)
-	_, _ = f.FindAppByNodeWithOptions(FindAppByNodeOptions{Username: "bob"})
-	f.AssertCallExistsWithArg("-luser=bob")
+	_, _ = f.FindAppByNodeWithOptions(FindAppByNodeOptions{Owner: "bob"})
+	f.AssertCallExistsWithArg("-lowner=bob")
 }
 
 func TestFindAppByNodeWithNamespace(t *testing.T) {


### PR DESCRIPTION
This is motivated by needing to filter by username when getting the synclet (e.g., knowing whether to use maia's or dan's or my synclet), and while I was at it, I figured it wasn't pretty to hardcode the namespace into a k8s client function.