### PR TITLE
tiltfile: read gitignore, associate with docker image, use on backend

### DIFF
--- a/internal/dockerignore/ignore.go
+++ b/internal/dockerignore/ignore.go
@@ -79,16 +79,3 @@ func readDockerignorePatterns(repoRoot string) ([]string, error) {
 
 	return dockerignore.ReadAll(f)
 }
-
-func NewMultiRepoDockerIgnoreTester(repoRoots []string) (model.PathMatcher, error) {
-	var testers []model.PathMatcher
-	for _, repoRoot := range repoRoots {
-		t, err := NewDockerIgnoreTester(repoRoot)
-		if err != nil {
-			return nil, err
-		}
-		testers = append(testers, t)
-	}
-
-	return model.NewCompositeMatcher(testers), nil
-}

--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -21,13 +21,13 @@ import (
 // 4. does not take index into account
 
 // an IgnoreTester that ignores nothing
-type falseIgnoreTester struct{}
+type FalseIgnoreTester struct{}
 
-func (falseIgnoreTester) Matches(f string, isDir bool) (bool, error) {
+func (FalseIgnoreTester) Matches(f string, isDir bool) (bool, error) {
 	return false, nil
 }
 
-var _ model.PathMatcher = falseIgnoreTester{}
+var _ model.PathMatcher = FalseIgnoreTester{}
 
 // ignores files specified in .gitignore
 type gitIgnoreTester struct {
@@ -59,11 +59,11 @@ func NewGitIgnoreTester(ctx context.Context, repoRoot string) (model.PathMatcher
 
 		pathError, ok := err.(*os.PathError)
 		//if the error is that file isn't there (ENOENT), then we don't need a warning, since that's a normal case
-		//if it's any other error, log a warning and pretend the file doesn't exist (matching git's behavior)
+		//if it's any other error, log and pretend the file doesn't exist (matching git's behavior)
 		if ok && pathError.Err != syscall.ENOENT {
-			logger.Get(ctx).Infof("warning: failed to open %v: %v", p, err)
+			logger.Get(ctx).Verbosef("failed to open gitignore %v: %v", p, err)
 		}
-		return &falseIgnoreTester{}, nil
+		return &FalseIgnoreTester{}, nil
 	}
 	return &gitIgnoreTester{absRoot, i}, nil
 }

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -76,12 +76,12 @@ type mount struct {
 }
 
 type dockerImage struct {
-	fileName   string
-	fileTag    reference.Named
-	mounts     []mount
-	steps      []model.Step
-	entrypoint string
-	repo       gitRepo
+	fileName     string
+	fileTag      reference.Named
+	mounts       []mount
+	steps        []model.Step
+	entrypoint   string
+	pathMatchers []model.PathMatcher
 }
 
 var _ skylark.Value = &dockerImage{}
@@ -171,7 +171,7 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 	}
 
 	image.mounts = append(image.mounts, mount{lp, mountPoint})
-	image.repo = lp.repo
+	image.pathMatchers = append(image.pathMatchers, lp.repo.pathMatcher)
 
 	return skylark.None, nil
 }

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -81,6 +81,7 @@ type dockerImage struct {
 	mounts     []mount
 	steps      []model.Step
 	entrypoint string
+	repo       gitRepo
 }
 
 var _ skylark.Value = &dockerImage{}
@@ -164,12 +165,13 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 	case localPath:
 		lp = p
 	case gitRepo:
-		lp = localPath{path: p.basePath}
+		lp = localPath{p.basePath, p}
 	default:
 		return nil, fmt.Errorf(oldMountSyntaxError)
 	}
 
 	image.mounts = append(image.mounts, mount{lp, mountPoint})
+	image.repo = lp.repo
 
 	return skylark.None, nil
 }
@@ -213,7 +215,8 @@ func (*dockerImage) AttrNames() []string {
 }
 
 type gitRepo struct {
-	basePath string
+	basePath    string
+	pathMatcher model.PathMatcher
 }
 
 var _ skylark.Value = gitRepo{}
@@ -257,11 +260,12 @@ func (gr gitRepo) path(thread *skylark.Thread, fn *skylark.Builtin, args skylark
 		return nil, err
 	}
 
-	return localPath{path: filepath.Join(gr.basePath, path)}, nil
+	return localPath{filepath.Join(gr.basePath, path), gr}, nil
 }
 
 type localPath struct {
 	path string
+	repo gitRepo
 }
 
 var _ skylark.Value = localPath{}

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -76,12 +76,12 @@ type mount struct {
 }
 
 type dockerImage struct {
-	fileName     string
-	fileTag      reference.Named
-	mounts       []mount
-	steps        []model.Step
-	entrypoint   string
-	pathMatchers []model.PathMatcher
+	fileName   string
+	fileTag    reference.Named
+	mounts     []mount
+	steps      []model.Step
+	entrypoint string
+	filters    []model.PathMatcher
 }
 
 var _ skylark.Value = &dockerImage{}
@@ -171,7 +171,7 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 	}
 
 	image.mounts = append(image.mounts, mount{lp, mountPoint})
-	image.pathMatchers = append(image.pathMatchers, lp.repo.pathMatcher)
+	image.filters = append(image.filters, lp.repo.pathMatcher)
 
 	return skylark.None, nil
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -111,6 +111,10 @@ func makeSkylarkGitRepo(thread *skylark.Thread, fn *skylark.Builtin, args skylar
 		return nil, fmt.Errorf("Reading path %s: %v", path, err)
 	}
 
+	if _, err := os.Stat(filepath.Join(absPath, ".git")); os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s isn't a valid git repo: it doesn't have a .git/ directory", absPath)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	t1, err := git.NewGitIgnoreTester(ctx, absPath)

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -46,7 +46,7 @@ func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args sk
 		return nil, fmt.Errorf("Parsing %q: %v", dockerfileTag, err)
 	}
 
-	return &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint, gitRepo{}}, nil
+	return &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint, []model.PathMatcher{git.FalseIgnoreTester{}}}, nil
 }
 
 func makeSkylarkK8Manifest(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
@@ -253,7 +253,7 @@ func skylarkManifestToDomain(manifest k8sManifest) (model.Manifest, error) {
 		Entrypoint:     model.ToShellCmd(manifest.dockerImage.entrypoint),
 		DockerfileTag:  manifest.dockerImage.fileTag,
 		Name:           model.ManifestName(manifest.name),
-		FileFilter:     manifest.dockerImage.repo.pathMatcher,
+		FileFilter:     model.NewCompositeMatcher(manifest.dockerImage.pathMatchers),
 	}, nil
 
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -1,6 +1,7 @@
 package tiltfile
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -8,10 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/docker/distribution/reference"
 	"github.com/google/skylark"
 	"github.com/google/skylark/resolve"
+	"github.com/windmilleng/tilt/internal/dockerignore"
+	"github.com/windmilleng/tilt/internal/git"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -42,13 +46,14 @@ func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args sk
 		return nil, fmt.Errorf("Parsing %q: %v", dockerfileTag, err)
 	}
 
-	return &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint}, nil
+	return &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint, gitRepo{}}, nil
 }
 
 func makeSkylarkK8Manifest(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var yaml skylark.String
 	var dockerImage *dockerImage
-	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "yaml", &yaml, "dockerImage", &dockerImage)
+	var repo gitRepo
+	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "yaml", &yaml, "dockerImage", &dockerImage, "repo?", &repo)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +112,20 @@ func makeSkylarkGitRepo(thread *skylark.Thread, fn *skylark.Builtin, args skylar
 		return nil, fmt.Errorf("Reading path %s: %v", path, err)
 	}
 
-	return gitRepo{absPath}, nil
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	t1, err := git.NewGitIgnoreTester(ctx, absPath)
+	if err != nil {
+		return nil, err
+	}
+	t2, err := dockerignore.NewDockerIgnoreTester(absPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ct := model.NewCompositeMatcher([]model.PathMatcher{t1, t2})
+
+	return gitRepo{absPath, ct}, nil
 }
 
 func runLocalCmd(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
@@ -235,6 +253,7 @@ func skylarkManifestToDomain(manifest k8sManifest) (model.Manifest, error) {
 		Entrypoint:     model.ToShellCmd(manifest.dockerImage.entrypoint),
 		DockerfileTag:  manifest.dockerImage.fileTag,
 		Name:           model.ManifestName(manifest.name),
+		FileFilter:     manifest.dockerImage.repo.pathMatcher,
 	}, nil
 
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -52,8 +52,7 @@ func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args sk
 func makeSkylarkK8Manifest(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var yaml skylark.String
 	var dockerImage *dockerImage
-	var repo gitRepo
-	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "yaml", &yaml, "dockerImage", &dockerImage, "repo?", &repo)
+	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "yaml", &yaml, "dockerImage", &dockerImage)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +252,7 @@ func skylarkManifestToDomain(manifest k8sManifest) (model.Manifest, error) {
 		Entrypoint:     model.ToShellCmd(manifest.dockerImage.entrypoint),
 		DockerfileTag:  manifest.dockerImage.fileTag,
 		Name:           model.ManifestName(manifest.name),
-		FileFilter:     model.NewCompositeMatcher(manifest.dockerImage.pathMatchers),
+		FileFilter:     model.NewCompositeMatcher(manifest.dockerImage.filters),
 	}, nil
 
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -28,6 +28,26 @@ func tempFile(content string) string {
 	return f.Name()
 }
 
+func gitRepoFixture(t *testing.T) (func() error, *tempdir.TempDirFixture) {
+	td := tempdir.NewTempDirFixture(t)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Chdir(td.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Mkdir(".git", os.FileMode(0777))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func() error {
+		td.TearDown()
+		return os.Chdir(oldWD)
+	}, td
+}
+
 func TestSyntax(t *testing.T) {
 	file := tempFile(`
 def hello():
@@ -361,8 +381,8 @@ func TestGetManifestConfigWithLocalCmd(t *testing.T) {
 }
 
 func TestRunTrigger(t *testing.T) {
-	td := tempdir.NewTempDirFixture(t)
-	defer td.TearDown()
+	gitTeardown, td := gitRepoFixture(t)
+	defer gitTeardown()
 	oldWD, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -594,4 +614,39 @@ func TestAddOneFileByPath(t *testing.T) {
 	manifest := manifestConfig[0]
 	assert.Equal(t, manifest.Mounts[0].LocalPath, filepath.Join(wd, "package.json"))
 	assert.Equal(t, manifest.Mounts[0].ContainerPath, "/app/package.json")
+}
+
+func TestFailsIfNotGitRepo(t *testing.T) {
+	td := tempdir.NewTempDirFixture(t)
+	defer td.TearDown()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWD)
+	err = os.Chdir(td.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dockerfile := tempFile("docker text")
+	file := tempFile(
+		fmt.Sprintf(`def blorgly():
+  image = build_docker_image("%v", "docker-tag", "the entrypoint")
+  image.add(local_git_repo('.'), '/mount_points/1')
+  image.run("go install github.com/windmilleng/blorgly-frontend/server/...")
+  image.run("echo hi")
+  return k8s_service("yaaaaaaaaml", image)
+`, dockerfile))
+	defer os.Remove(file)
+	defer os.Remove(dockerfile)
+	tiltconfig, err := Load(file, os.Stdout)
+	if err != nil {
+		t.Fatal("loading tiltconfig:", err)
+	}
+	_, err = tiltconfig.GetManifestConfigs("blorgly")
+	if err == nil {
+		t.Error("Expected error")
+	} else if !strings.Contains(err.Error(), "isn't a valid git repo") {
+		t.Errorf("Expected error to be an invalid git repo error, got %s", err.Error())
+	}
 }


### PR DESCRIPTION
This does three things:

1) Read `.gitignore` and `.Dockerignore`, if present, upon invocation of `local_git_repo`. Store the path matcher on the `gitRepo` object
2) Associate the `gitRepo` to the `dockerImage` so that when we return the manifests we can assign a path matcher to the manifest
3) Use that path matcher in the up_watch code, rather than reading + parsing the ignore files there

Plus various cleanup.