### PR TITLE
fix kubectl -l args

### DIFF
--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -161,7 +161,7 @@ func TestFindAppByNodeKubectlError(t *testing.T) {
 func TestFindAppByNodeWithOwner(t *testing.T) {
 	f := newClientTestFixture(t)
 	_, _ = f.FindAppByNodeWithOptions(FindAppByNodeOptions{Owner: "bob"})
-	f.AssertCallExistsWithArg("-lowner=bob")
+	f.AssertCallExistsWithArg("-lapp=synclet,owner=bob")
 }
 
 func TestFindAppByNodeWithNamespace(t *testing.T) {


### PR DESCRIPTION
I noticed when debugging today that `kubectl get pods -lowner=matt -lapp=synclet` was returning all the synclets, not just mine. It turns out that kubectl just keeps the last `-l` and silently drops any preceding ones, and the correct way to filter by multiple labels is to separate by commas. The code is working in practice as-is because we don't have any other pods with the 'owner' label.