### PR TITLE
tiltfile: use an implicit build context for the docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Run `go get -u github.com/windmilleng/tilt`
 Tilt reads from a Tiltfile. A simple Tiltfile is below:
 ```python
 def backend():
-  img = start_fast_build('Dockerfile', 'companyname/backend', '/go/bin/server')
+  start_fast_build('Dockerfile', 'companyname/backend', '/go/bin/server')
   repo = local_git_repo('.')
-  img.add(repo, '/go/src/github.com/companyname/backend')
-  img.run('go install github.com/companyname/backend/server')
+  add(repo, '/go/src/github.com/companyname/backend')
+  run('go install github.com/companyname/backend/server')
+  img = stop_build()
+
   return k8s_service(read_file('backend.yaml'), img)
 ```
 
@@ -32,8 +34,8 @@ Creates a `repo` with the content at `path`.
     * `path`: **str**
 * Returns: **Repo**
 
-#### Repo.add(path)
-Gets the absolute to the file specified at `path` in the repo
+#### Repo.path(path)
+Gets the absolute to the file specified at `path` in the repo. Must be a relative path.
 
 * Args:
   * `path`: **str**
@@ -48,17 +50,17 @@ Builds a docker image.
   * `entrypoint?`: **str**
 * Returns: **Image**
 
-#### Image.add(src, dest)
-Adds the content from `src` into the image at path `dest`.
+#### add(src, dest)
+Adds the content from `src` into the image at path `dest`. Paths must be relative.
 
 * Args:
   * `src`: **localPath|gitRepo**
   * `dest`: **str**
 * Returns: nothing
 
-#### Image.run(cmd, trigger?)
+#### run(cmd, trigger?)
 Runs `cmd` as a build step in the image.
-If the `trigger` file is specified, the build step is only run if the file is changed.
+If the `trigger` file is specified, the build step is only run if the file is changed. Path must be relative.
 
 * Args:
   * `cmd`: **str**
@@ -93,6 +95,11 @@ Reads file and returns its contents.
 * Args:
   * `file_path`: **str**
 * Returns: **str**
+
+#### stop_build(file_path)
+Closes the currently active build and returns a container Image that has all of the adds and runs applied.
+
+* Returns: **Image**
 
 ## Developing
 See DEVELOPING.md

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -93,8 +93,12 @@ func runDockerImageCmd(thread *skylark.Thread, fn *skylark.Builtin, args skylark
 	if err != nil {
 		return nil, err
 	}
+	buildContext, ok := thread.Local("buildContext").(*dockerImage)
 	if buildContext == nil {
 		return nil, errors.New("run called without a build context")
+	}
+	if !ok {
+		return nil, errors.New("internal error: buildContext thread local was not of type *dockerImage")
 	}
 
 	cmd, ok := skylark.AsString(skylarkCmd)
@@ -144,8 +148,12 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 	var src interface{}
 	var mountPoint string
 
+	buildContext, ok := thread.Local("buildContext").(*dockerImage)
 	if buildContext == nil {
 		return nil, errors.New("add called without a build context")
+	}
+	if !ok {
+		return nil, errors.New("internal error: buildContext thread local was not of type *dockerImage")
 	}
 
 	if len(buildContext.steps) > 0 {

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -13,7 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 )
 
-const oldMountSyntaxError = "The syntax for `add` has changed. Before it was `.add(dest: string, src: string)`. Now it is `.add(src: localPath, dest: string)`."
+const oldMountSyntaxError = "The syntax for `add` has changed. Before it was `add(dest: string, src: string)`. Now it is `add(src: localPath, dest: string)`."
 
 type compManifest struct {
 	cManifest []k8sManifest
@@ -93,9 +93,8 @@ func runDockerImageCmd(thread *skylark.Thread, fn *skylark.Builtin, args skylark
 	if err != nil {
 		return nil, err
 	}
-	image, ok := fn.Receiver().(*dockerImage)
-	if !ok {
-		return nil, errors.New("internal error: add_docker_image_cmd called on non-dockerImage")
+	if buildContext == nil {
+		return nil, errors.New("run called without a build context")
 	}
 
 	cmd, ok := skylark.AsString(skylarkCmd)
@@ -137,14 +136,19 @@ func runDockerImageCmd(thread *skylark.Thread, fn *skylark.Builtin, args skylark
 		step.Trigger = pm
 	}
 
-	image.steps = append(image.steps, step)
+	buildContext.steps = append(buildContext.steps, step)
 	return skylark.None, nil
 }
 
 func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var src interface{}
 	var mountPoint string
-	if len(fn.Receiver().(*dockerImage).steps) > 0 {
+
+	if buildContext == nil {
+		return nil, errors.New("add called without a build context")
+	}
+
+	if len(buildContext.steps) > 0 {
 		return nil, errors.New("add mount before run command")
 	}
 	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "src", &src, "dest", &mountPoint)
@@ -153,11 +157,6 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 			return nil, fmt.Errorf(oldMountSyntaxError)
 		}
 		return nil, err
-	}
-
-	image, ok := fn.Receiver().(*dockerImage)
-	if !ok {
-		return nil, errors.New("internal error: add_docker_image_cmd called on non-dockerImage")
 	}
 
 	var lp localPath
@@ -170,8 +169,8 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 		return nil, fmt.Errorf(oldMountSyntaxError)
 	}
 
-	image.mounts = append(image.mounts, mount{lp, mountPoint})
-	image.filters = append(image.filters, lp.repo.pathMatcher)
+	buildContext.mounts = append(buildContext.mounts, mount{lp, mountPoint})
+	buildContext.filters = append(buildContext.filters, lp.repo.pathMatcher)
 
 	return skylark.None, nil
 }
@@ -201,10 +200,6 @@ func (d *dockerImage) Attr(name string) (skylark.Value, error) {
 		return skylark.String(d.fileName), nil
 	case "file_tag":
 		return skylark.String(d.fileTag.String()), nil
-	case "run":
-		return skylark.NewBuiltin(name, runDockerImageCmd).BindReceiver(d), nil
-	case "add":
-		return skylark.NewBuiltin(name, addMount).BindReceiver(d), nil
 	default:
 		return nil, nil
 	}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -48,6 +48,12 @@ func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args sk
 		return nil, fmt.Errorf("Parsing %q: %v", dockerfileTag, err)
 	}
 
+	existingBC := thread.Local("buildContext")
+
+	if existingBC != nil {
+		return skylark.None, errors.New("tried to start a build context while another build context was already open")
+	}
+
 	buildContext := &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint, []model.PathMatcher{git.FalseIgnoreTester{}}}
 	thread.SetLocal("buildContext", buildContext)
 	return skylark.None, nil

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -707,11 +707,8 @@ func TestReadsIgnoreFiles(t *testing.T) {
 }
 
 func TestBuildContextAddError(t *testing.T) {
-	gitTeardown, td := gitRepoFixture(t)
+	gitTeardown, _ := gitRepoFixture(t)
 	defer gitTeardown()
-	td.WriteFile(".gitignore", "*.exe")
-	td.WriteFile(".dockerignore", "node_modules")
-
 	dockerfile := tempFile("docker text")
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
@@ -723,8 +720,6 @@ func TestBuildContextAddError(t *testing.T) {
   add(local_git_repo('.'), '/mount_points/2')
   return k8s_service("yaaaaaaaaml", image)
 `, dockerfile))
-	defer os.Remove(file)
-	defer os.Remove(dockerfile)
 	tiltconfig, err := Load(file, os.Stdout)
 	if err != nil {
 		t.Fatal("loading tiltconfig:", err)
@@ -740,11 +735,8 @@ func TestBuildContextAddError(t *testing.T) {
 }
 
 func TestBuildContextRunError(t *testing.T) {
-	gitTeardown, td := gitRepoFixture(t)
+	gitTeardown, _ := gitRepoFixture(t)
 	defer gitTeardown()
-	td.WriteFile(".gitignore", "*.exe")
-	td.WriteFile(".dockerignore", "node_modules")
-
 	dockerfile := tempFile("docker text")
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
@@ -756,8 +748,6 @@ func TestBuildContextRunError(t *testing.T) {
   run("echo hi2")
   return k8s_service("yaaaaaaaaml", image)
 `, dockerfile))
-	defer os.Remove(file)
-	defer os.Remove(dockerfile)
 	tiltconfig, err := Load(file, os.Stdout)
 	if err != nil {
 		t.Fatal("loading tiltconfig:", err)


### PR DESCRIPTION
Rather than passing around the image explicitly.