### PR TITLE
buildAndDeploy: block on PostProcessBuild

### DIFF
--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -26,35 +26,85 @@ type SyncletBuildAndDeployer struct {
 
 	kCli k8s.Client
 
-	deployInfo   map[docker.ImgNameAndTag]DeployInfo
+	deployInfo   map[docker.ImgNameAndTag]*DeployInfo
 	deployInfoMu sync.Mutex
 }
 
 type DeployInfo struct {
 	containerID k8s.ContainerID
 	nodeID      k8s.NodeID
+	mu          *sync.Mutex // use this to block container builds while we're in the process of fetching deploy info
+}
+
+func newEmptyDeployInfo() *DeployInfo {
+	return &DeployInfo{mu: &sync.Mutex{}}
+}
+
+func (di *DeployInfo) complete() bool {
+	return !di.containerID.Empty() && !di.nodeID.Empty()
+}
+
+func (di *DeployInfo) lock() {
+	if di == nil {
+		// ~~~ is this right? or should this be an error case?
+		return
+	}
+	if di.mu == nil {
+		di.mu = &sync.Mutex{}
+	}
+	di.mu.Lock()
+}
+
+func (di *DeployInfo) unlock() {
+	if di == nil {
+		return
+	}
+	if di.mu == nil {
+		// ~~~ is this right? or should this be an error case?
+		di.mu = &sync.Mutex{}
+	}
+	di.mu.Unlock()
 }
 
 func NewSyncletBuildAndDeployer(kCli k8s.Client, scm SyncletClientManager) *SyncletBuildAndDeployer {
 	return &SyncletBuildAndDeployer{
 		kCli:                 kCli,
-		deployInfo:           make(map[docker.ImgNameAndTag]DeployInfo),
+		deployInfo:           make(map[docker.ImgNameAndTag]*DeployInfo),
 		syncletClientManager: scm,
 	}
 }
 
-func (sbd *SyncletBuildAndDeployer) getDeployInfoForImage(img reference.NamedTagged) (DeployInfo, bool) {
+func (sbd *SyncletBuildAndDeployer) deployInfoForImg(img reference.NamedTagged) (*DeployInfo, bool) {
 	sbd.deployInfoMu.Lock()
+	defer sbd.deployInfoMu.Unlock()
+
 	deployInfo, ok := sbd.deployInfo[docker.ToImgNameAndTag(img)]
-	sbd.deployInfoMu.Unlock()
 	return deployInfo, ok
 }
 
-func (sbd *SyncletBuildAndDeployer) setDeployInfoForImage(img reference.NamedTagged, deployInfo DeployInfo) {
-	sbd.deployInfoMu.Lock()
-	key := docker.ToImgNameAndTag(img)
-	sbd.deployInfo[key] = deployInfo
-	sbd.deployInfoMu.Unlock()
+func (sbd *SyncletBuildAndDeployer) deployInfoForImgOrCreate(img reference.NamedTagged) (*DeployInfo, bool) {
+	deployInfo, ok := sbd.deployInfo[docker.ToImgNameAndTag(img)]
+	if deployInfo == nil {
+		sbd.deployInfoMu.Lock()
+		defer sbd.deployInfoMu.Unlock()
+
+		deployInfo = newEmptyDeployInfo()
+		sbd.deployInfo[docker.ToImgNameAndTag(img)] = deployInfo
+	}
+	return deployInfo, ok
+}
+
+func (sbd *SyncletBuildAndDeployer) deployInfoForImgBlocking(img reference.NamedTagged) (*DeployInfo, bool) {
+	deployInfo, ok := sbd.deployInfoForImg(img)
+	if deployInfo != nil {
+		// ~~~ open Q: should i make a mutex if there isn't on here already?
+		if deployInfo.mu == nil {
+			deployInfo.mu = &sync.Mutex{}
+		}
+		deployInfo.mu.Lock() // ensures we can't return this if this deployInfo object is being populated elsewhere
+		defer deployInfo.mu.Unlock()
+	}
+	return deployInfo, ok
 }
 
 func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, state BuildState) (BuildResult, error) {
@@ -88,8 +138,14 @@ func (sbd *SyncletBuildAndDeployer) canSyncletBuild(ctx context.Context,
 	}
 
 	// Can't do container update if we don't know what container manifest is running in.
-	if _, ok := sbd.getDeployInfoForImage(state.LastResult.Image); !ok {
-		return fmt.Errorf("no container info for this manifest")
+	info, ok := sbd.deployInfoForImgBlocking(state.LastResult.Image)
+	if !ok {
+		return fmt.Errorf("have not populated container info for this manifest")
+	}
+
+	// If we attempted to fetch deploy info and failed, we DO expect an entry in the map, just with no useful info.
+	if !info.complete() {
+		return fmt.Errorf("no(t enough) deploy info for this manifest (have: %+v)", info)
 	}
 
 	return nil
@@ -125,7 +181,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 	// TODO(maia): can refactor MissingLocalPaths to just return ContainerPaths?
 	containerPathsToRm := build.PathMappingsToContainerPaths(toRemove)
 
-	deployInfo, ok := sbd.getDeployInfoForImage(state.LastResult.Image)
+	deployInfo, ok := sbd.deployInfoForImgBlocking(state.LastResult.Image)
 	if !ok {
 		// We theoretically already checked this condition :(
 		return BuildResult{}, fmt.Errorf("no container ID found for %s (image: %s)",
@@ -155,13 +211,17 @@ func (sbd *SyncletBuildAndDeployer) PostProcessBuild(ctx context.Context, result
 	span.SetTag("image", result.Image.String())
 	defer span.Finish()
 
+	info, haveInfo := sbd.deployInfoForImgOrCreate(result.Image)
+	info.lock()
+	defer info.unlock()
+
 	if !result.HasImage() {
 		// This is normal if the previous build failed.
 		return
 	}
 
-	if _, ok := sbd.getDeployInfoForImage(result.Image); !ok {
-		deployInfo, err := sbd.getDeployInfo(ctx, result.Image)
+	if !haveInfo {
+		err := sbd.populateDeployInfo(ctx, result.Image, info)
 		if err != nil {
 			// There's a variety of reasons why we might not be able to get the deploy info.
 			// The cluster could be in a transient bad state, or the pod
@@ -170,23 +230,27 @@ func (sbd *SyncletBuildAndDeployer) PostProcessBuild(ctx context.Context, result
 			logger.Get(ctx).Debugf("failed to get deployInfo: %v", err)
 			return
 		}
-		sbd.setDeployInfoForImage(result.Image, deployInfo)
 	}
 }
 
-func (sbd *SyncletBuildAndDeployer) getDeployInfo(ctx context.Context, image reference.NamedTagged) (DeployInfo, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncletBuildAndDeployer-getDeployInfo")
+func (sbd *SyncletBuildAndDeployer) populateDeployInfo(ctx context.Context, image reference.NamedTagged, info *DeployInfo) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncletBuildAndDeployer-populateDeployInfo")
 	defer span.Finish()
+
+	if info == nil {
+		info = newEmptyDeployInfo()
+		info.lock()
+	}
 
 	// get pod running the image we just deployed
 	pID, err := sbd.kCli.PollForPodWithImage(ctx, image, podPollTimeoutSynclet)
 	if err != nil {
-		return DeployInfo{}, errors.Wrapf(err, "PodWithImage (img = %s)", image)
+		return errors.Wrapf(err, "PodWithImage (img = %s)", image)
 	}
 
 	nodeID, err := sbd.kCli.GetNodeForPod(ctx, pID)
 	if err != nil {
-		return DeployInfo{}, errors.Wrapf(err, "couldn't get node for pod '%s'", pID.String())
+		return errors.Wrapf(err, "couldn't get node for pod '%s'", pID.String())
 	}
 
 	// note: this is here both to get sCli for the call to getContainerForBuild below
@@ -195,16 +259,16 @@ func (sbd *SyncletBuildAndDeployer) getDeployInfo(ctx context.Context, image ref
 	// sCli)
 	sCli, err := sbd.syncletClientManager.ClientForNode(ctx, nodeID)
 	if err != nil {
-		return DeployInfo{}, errors.Wrapf(err, "error getting synclet client for node '%s'", nodeID)
+		return errors.Wrapf(err, "error getting synclet client for node '%s'", nodeID)
 	}
 
 	// get container that's running the app for the pod we found
 	cID, err := sCli.ContainerIDForPod(ctx, pID, image)
 	if err != nil {
-		return DeployInfo{}, errors.Wrapf(err, "syncletClient.GetContainerIdForPod (pod = %s)", pID)
+		return errors.Wrapf(err, "syncletClient.GetContainerIdForPod (pod = %s)", pID)
 	}
 
-	logger.Get(ctx).Verbosef("talking to synclet client for node %s", nodeID.String())
-
-	return DeployInfo{cID, nodeID}, nil
+	info.nodeID = nodeID
+	info.containerID = cID
+	return nil
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -27,9 +27,10 @@ type PodID string
 type ContainerID string
 type NodeID string
 
-func (pID PodID) String() string { return string(pID) }
 func (pID PodID) Empty() bool    { return pID.String() == "" }
+func (pID PodID) String() string { return string(pID) }
 
+func (cID ContainerID) Empty() bool    { return cID.String() == "" }
 func (cID ContainerID) String() string { return string(cID) }
 func (cID ContainerID) ShortStr() string {
 	if len(string(cID)) > 10 {
@@ -38,6 +39,7 @@ func (cID ContainerID) ShortStr() string {
 	return string(cID)
 }
 
+func (nID NodeID) Empty() bool    { return nID.String() == "" }
 func (nID NodeID) String() string { return string(nID) }
 
 type Client interface {


### PR DESCRIPTION
container deploys block on PostProcessBuild [ch334] **WIP**

**WIP** still need tests and to do this for LocalContainerBuildAndDeployer but wanted to make sure I'm on the right track.

don't quite know my way around concurrency-land, left some Q's in comments inline (look for `~~~`).

In particular @nicks I now lock `sbd.deployInfoMu` when retrieving deploy info's off the struct, but the map value is a pointer, so i don't really write back to the map as much as just modify the value behind the pointer... (i lock a mutex on the `*DeployInfo` itself before I edit it but not before I read from it.) will this explode anything?