### PR TITLE
tilt: don't request cpu for synclet sidecar

### DIFF
--- a/internal/synclet/sidecar/sidecar.go
+++ b/internal/synclet/sidecar/sidecar.go
@@ -3,6 +3,8 @@ package sidecar
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"k8s.io/api/core/v1"
 )
 
@@ -20,6 +22,7 @@ var SyncletContainer = v1.Container{
 	Name:            "tilt-synclet",
 	Image:           fmt.Sprintf("%s:%s", SyncletImageName, SyncletTag),
 	ImagePullPolicy: v1.PullIfNotPresent,
+	Resources:       v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("0Mi")}},
 	VolumeMounts: []v1.VolumeMount{
 		v1.VolumeMount{
 			Name:      "tilt-dockersock",


### PR DESCRIPTION
I was hitting cpu quota limits when trying to work on servantes. The default CPU allocation for containers is 100 mCPU, so we're paying 2x that per service (service + synclet). We should probably not consume CPU quota with the synclet.

The CPU request for the service itself is owned by the user, so not addressing that in tilt.