### PR TITLE
synclet: add polling/retries to synclet client creation, get container id [ch373]

### DIFF
--- a/internal/engine/sidecar_synclet_manager.go
+++ b/internal/engine/sidecar_synclet_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -14,6 +15,8 @@ import (
 	"github.com/windmilleng/tilt/internal/synclet"
 	"google.golang.org/grpc"
 )
+
+const newClientTimeout = time.Second * 10
 
 type newCliFn func(ctx context.Context, kCli k8s.Client, podID k8s.PodID) (synclet.SyncletClient, error)
 type SidecarSyncletManager struct {
@@ -54,7 +57,7 @@ func (ssm SidecarSyncletManager) ClientForPod(ctx context.Context, podID k8s.Pod
 		return client, nil
 	}
 
-	client, err := ssm.newClient(ctx, ssm.kCli, podID)
+	client, err := ssm.pollForNewClient(ctx, ssm.kCli, podID, newClientTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating synclet client")
 	}
@@ -63,7 +66,26 @@ func (ssm SidecarSyncletManager) ClientForPod(ctx context.Context, podID k8s.Pod
 	return client, nil
 }
 
+func (ssm SidecarSyncletManager) pollForNewClient(ctx context.Context, kCli k8s.Client, podID k8s.PodID, timeout time.Duration) (cli synclet.SyncletClient, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "SidecarSyncletManager-pollForNewClient")
+	defer span.Finish()
+
+	start := time.Now()
+	for time.Since(start) < timeout {
+		// TODO(maia): better distinction between errs meaning "couldn't connect yet"
+		// and "everything is borked, stop trying"
+		cli, err = ssm.newClient(ctx, kCli, podID)
+		if cli != nil {
+			return cli, nil
+		}
+	}
+	return nil, errors.Wrapf(err, "timed out trying to create new synclet client for pod %s (after %s) with err",
+		podID.String(), timeout)
+}
 func newSidecarSyncletClient(ctx context.Context, kCli k8s.Client, podID k8s.PodID) (synclet.SyncletClient, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "SidecarSyncletManager-newSidecarSyncletClient")
+	defer span.Finish()
+
 	// TODO(nick): We need a better way to kill the client when the pod dies.
 	tunneledPort, _, err := kCli.ForwardPort(ctx, "default", podID, synclet.Port)
 	if err != nil {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -28,9 +28,10 @@ type PodID string
 type ContainerID string
 type NodeID string
 
-func (pID PodID) String() string { return string(pID) }
 func (pID PodID) Empty() bool    { return pID.String() == "" }
+func (pID PodID) String() string { return string(pID) }
 
+func (cID ContainerID) Empty() bool    { return cID.String() == "" }
 func (cID ContainerID) String() string { return string(cID) }
 func (cID ContainerID) ShortStr() string {
 	if len(string(cID)) > 10 {


### PR DESCRIPTION
i'm not positive that the client_adaptor is the right place to put this polling code... but sometimes we are able to connect to the synclet but it's not yet up and running in such a way that it can actually accept calls to `ContainerIdForPod`.