### PR TITLE
tilt: log more info in synclet when rm fails

### DIFF
--- a/internal/synclet/synclet.go
+++ b/internal/synclet/synclet.go
@@ -59,8 +59,9 @@ func (s Synclet) rmFiles(ctx context.Context, containerId k8s.ContainerID, files
 	out := bytes.NewBuffer(nil)
 	err := s.dcli.ExecInContainer(ctx, containerId, cmd, out)
 	if err != nil {
-		if docker.IsExitError(err) {
-			return fmt.Errorf("Error deleting files: %s", out.String())
+		dockerExitErr, ok := err.(docker.ExitError)
+		if ok {
+			return fmt.Errorf("Error deleting files. error '%v', exit code %d, output '%s'", err, dockerExitErr.ExitCode, out.String())
 		}
 		return fmt.Errorf("Error deleting files: %v", err)
 	}


### PR DESCRIPTION
So if we hit [this](https://app.clubhouse.io/windmill/story/380/error-removing-files-while-updating-container-on-temporary-idea-files) again, hopefully we can tell what's going on.