### PR TITLE
tilt: close portforwards on error

### DIFF
--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -75,6 +75,7 @@ func portForwarder(ctx context.Context, restConfig *rest.Config, core v1.CoreV1I
 	go func() {
 		errChan <- pf.ForwardPorts()
 		err := <-errChan
+		pf.Close()
 		// logging isn't really sufficient, since we're in a goroutine and who knows where the caller
 		// has moved on to by this point, but other options are much more expensive (e.g., monitoring the state
 		// of the port forward from the caller and/or automatically reconnecting port forwards)
@@ -83,6 +84,7 @@ func portForwarder(ctx context.Context, restConfig *rest.Config, core v1.CoreV1I
 
 	select {
 	case err = <-errChan:
+		pf.Close()
 		return nil, errors.Wrap(err, "error forwarding port")
 	case <-pf.Ready:
 		closer = func() {


### PR DESCRIPTION
This should reduce the flood of tunnel errors.

1) I haven't yet seen an error for which we *don't* want to kill the portforward (i.e., a situation in which it might recover on its own)
2) we need to solve reconnects at a higher level anyway, so it shouldn't matter if we close the tunnel at this level