### PR TITLE
model: organize empty matcher a bit

### DIFF
--- a/internal/engine/up_watch.go
+++ b/internal/engine/up_watch.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"path/filepath"
 
-	"github.com/windmilleng/tilt/internal/git"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/watch"
 )
@@ -123,10 +122,7 @@ func snsToManifestWatcher(ctx context.Context, timerMaker timerMaker, sns []mani
 
 	for _, sn := range sns {
 		coalescedEvents := coalesceEvents(timerMaker, sn.notify.Events())
-		filter := sn.manifest.FileFilter
-		if filter == nil {
-			filter = git.FalseIgnoreTester{}
-		}
+		filter := sn.manifest.Filter()
 
 		go func(manifest model.Manifest, watcher watch.Notify) {
 			// TODO(matt) this will panic if we actually close channels. look at "merge" in https://blog.golang.org/pipelines

--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -20,15 +20,6 @@ import (
 // 3. does not use .git/info/exclude
 // 4. does not take index into account
 
-// an IgnoreTester that ignores nothing
-type FalseIgnoreTester struct{}
-
-func (FalseIgnoreTester) Matches(f string, isDir bool) (bool, error) {
-	return false, nil
-}
-
-var _ model.PathMatcher = FalseIgnoreTester{}
-
 // ignores files specified in .gitignore
 type gitIgnoreTester struct {
 	repoRoot      string
@@ -63,7 +54,7 @@ func NewGitIgnoreTester(ctx context.Context, repoRoot string) (model.PathMatcher
 		if ok && pathError.Err != syscall.ENOENT {
 			logger.Get(ctx).Verbosef("failed to open gitignore %v: %v", p, err)
 		}
-		return &FalseIgnoreTester{}, nil
+		return model.EmptyMatcher, nil
 	}
 	return &gitIgnoreTester{absRoot, i}, nil
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -23,6 +23,14 @@ type Manifest struct {
 	Name           ManifestName
 }
 
+func (m Manifest) Filter() PathMatcher {
+	f := m.FileFilter
+	if f == nil {
+		return EmptyMatcher
+	}
+	return f
+}
+
 func (m Manifest) Validate() error {
 	err := m.validate()
 	if err != nil {

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -4,6 +4,15 @@ type PathMatcher interface {
 	Matches(f string, isDir bool) (bool, error)
 }
 
+// A Matcher that matches nothing.
+type emptyMatcher struct{}
+
+func (m emptyMatcher) Matches(f string, isDir bool) (bool, error) {
+	return false, nil
+}
+
+var EmptyMatcher PathMatcher = emptyMatcher{}
+
 type PatternMatcher interface {
 	PathMatcher
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -55,7 +55,7 @@ func makeSkylarkDockerImage(thread *skylark.Thread, fn *skylark.Builtin, args sk
 		return skylark.None, errors.New("tried to start a build context while another build context was already open")
 	}
 
-	buildContext := &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint, []model.PathMatcher{git.FalseIgnoreTester{}}}
+	buildContext := &dockerImage{dockerfileName, tag, []mount{}, []model.Step{}, entrypoint, []model.PathMatcher{model.EmptyMatcher}}
 	thread.SetLocal(buildContextKey, buildContext)
 	return skylark.None, nil
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/matcher:

43bc633d8388f5ba29ec8f5eb36886f4cdd834ca (2018-09-26 15:33:49 -0400)
model: organize empty matcher a bit