### PR TITLE
tilt: log traceid on startup

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/logger"
+
 	"github.com/fatih/color"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
@@ -52,6 +54,14 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	}
 
 	logOutput(fmt.Sprintf("Starting Tilt (built %s)…\n", buildDateStamp()))
+
+	if trace {
+		traceID, err := tracer.TraceID(ctx)
+		if err != nil {
+			return err
+		}
+		logger.Get(ctx).Infof("TraceID: %s", traceID)
+	}
 
 	tf, err := tiltfile.Load(tiltfile.FileName, os.Stdout)
 	if err != nil {

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -47,6 +47,18 @@ func Init(ctx context.Context) (func() error, error) {
 
 }
 
+func TraceID(ctx context.Context) (string, error) {
+	spanContext := opentracing.SpanFromContext(ctx)
+	if spanContext == nil {
+		return "", errors.New("cannot get traceid - there is no span context")
+	}
+	zipkinSpanContext, ok := spanContext.Context().(zipkin.SpanContext)
+	if !ok {
+		return "", errors.New("cannot get traceid - span context was not a zipkin span context")
+	}
+	return zipkinSpanContext.TraceID.ToHex(), nil
+}
+
 // TagStrToMap converts a user-passed string of tags of the form `key1=val1,key2=val2` to a map.
 func TagStrToMap(tagStr string) map[string]string {
 	if tagStr == "" {


### PR DESCRIPTION
Ideally we'd be dropping the trace id into a URL that'd visualize the trace for you, but I haven't yet found any way to do that with honeycomb.