### PR TITLE
engine: PostProcessDeploy should only pass control [ch381]

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -21,6 +21,7 @@ type BuildAndDeployer interface {
 
 	// PostProcessBuild gets any info about the build that we'll need for subsequent builds.
 	// In general, we'll store this info ON the BuildAndDeployer that needs it.
+	// Each implementation of PostProcessBuild is responsible for executing long-running steps async.
 	PostProcessBuild(ctx context.Context, result BuildResult)
 }
 
@@ -35,6 +36,8 @@ type CompositeBuildAndDeployer struct {
 	builders       BuildOrder
 	shouldFallBack FallbackTester
 }
+
+var _ BuildAndDeployer = &CompositeBuildAndDeployer{}
 
 func DefaultShouldFallBack() FallbackTester {
 	return FallbackTester(shouldImageBuild)
@@ -54,7 +57,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 		if err == nil {
 			// TODO(maia): maybe this only needs to be called after certain builds?
 			// I.e. should be called after image build but not after a successful container build?
-			go composite.PostProcessBuild(ctx, br)
+			composite.PostProcessBuild(ctx, br)
 			return br, err
 		}
 

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -134,25 +134,33 @@ func TestIncrementalBuildWaitsForPostProcess(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	f.k8s.SetPollForPodWithImageDelay(time.Second)
-	go f.bd.PostProcessBuild(f.ctx, alreadyBuilt) // will take 1s
-	time.Sleep(time.Millisecond * 100)            // let the PostProcessBuild call actually start
+	f.k8s.SetPollForPodWithImageDelay(time.Second * 1)
 
-	_, err := f.bd.BuildAndDeploy(f.ctx, SanchoManifest, NewBuildState(alreadyBuilt))
+	res, err := f.bd.BuildAndDeploy(f.ctx, SanchoManifest, BuildStateClean)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Rather than falling back to image build b/c of lack of deploy info, we should
-	// wait for the concurrent call to PostProcessBuild to finish and do a container build.
-	if f.docker.BuildCount != 0 {
-		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
+	// HACK: if we fail to container build here, the test has already failed. However,
+	// this test setup doesn't support incremental image build, and we'll get misleading
+	// errors, so just don't fall back.
+	dontFallBack := func(err error) bool { return false }
+	f.setBDFallbackTester(dontFallBack)
+
+	// Expected behavior: this build call waits on the PostProcess initiated at the end
+	// of the previous build, and when that info is available, does a container build
+	_, err = f.bd.BuildAndDeploy(f.ctx, SanchoManifest, NewBuildState(res))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if f.docker.PushCount != 0 {
-		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	if f.docker.BuildCount != 1 { // initial build
+		t.Errorf("Expected 1 docker build, actual: %d", f.docker.BuildCount)
 	}
-	if f.sCli.UpdateContainerCount != 1 {
-		t.Errorf("Expected 1 UpdateContaine count via synclet, actual: %d", f.sCli.UpdateContainerCount)
+	if f.docker.PushCount != 1 { // initial build
+		t.Errorf("Expected 1 push to docker, actual: %d", f.docker.PushCount)
+	}
+	if f.sCli.UpdateContainerCount != 1 { // second build via synclet
+		t.Errorf("Expected 1 UpdateContainer count via synclet, actual: %d", f.sCli.UpdateContainerCount)
 	}
 }
 
@@ -443,6 +451,14 @@ func newBDFixtureHelper(t *testing.T, env k8s.Env, fallbackFn FallbackTester) *b
 		sCli:           sCli,
 		bd:             bd,
 	}
+}
+
+func (f *bdFixture) setBDFallbackTester(tester FallbackTester) {
+	composite, ok := f.bd.(*CompositeBuildAndDeployer)
+	if !ok {
+		f.T().Fatal("bdFixture.bd is not a *CompositeBuildAndDeployer?? This should never happen.")
+	}
+	composite.shouldFallBack = tester
 }
 
 // Ensure that the BuildAndDeployer has container information attached for the given manifest.

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -141,12 +141,6 @@ func TestIncrementalBuildWaitsForPostProcess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// HACK: if we fail to container build here, the test has already failed. However,
-	// this test setup doesn't support incremental image build, and we'll get misleading
-	// errors, so just don't fall back.
-	dontFallBack := func(err error) bool { return false }
-	f.setBDFallbackTester(dontFallBack)
-
 	// Expected behavior: this build call waits on the PostProcess initiated at the end
 	// of the previous build, and when that info is available, does a container build
 	_, err = f.bd.BuildAndDeploy(f.ctx, SanchoManifest, NewBuildState(res))
@@ -451,14 +445,6 @@ func newBDFixtureHelper(t *testing.T, env k8s.Env, fallbackFn FallbackTester) *b
 		sCli:           sCli,
 		bd:             bd,
 	}
-}
-
-func (f *bdFixture) setBDFallbackTester(tester FallbackTester) {
-	composite, ok := f.bd.(*CompositeBuildAndDeployer)
-	if !ok {
-		f.T().Fatal("bdFixture.bd is not a *CompositeBuildAndDeployer?? This should never happen.")
-	}
-	composite.shouldFallBack = tester
 }
 
 // Ensure that the BuildAndDeployer has container information attached for the given manifest.

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -120,8 +120,8 @@ func (sbd *SyncletBuildAndDeployer) canSyncletBuild(ctx context.Context,
 	// Can't do container update if we don't know what container manifest is running in.
 	info, ok := sbd.deployInfoForImageBlocking(ctx, state.LastResult.Image)
 	if !ok {
-		// TODO(maia): or we could, yknow, actually fetch the deploy info here.
-		return fmt.Errorf("have not yet fetched deploy info for this manifest")
+		return fmt.Errorf("have not yet fetched deploy info for this manifest. " +
+			"This should NEVER HAPPEN b/c of the way PostProcessBuild blocks, something is wrong")
 	}
 
 	if info.err != nil {


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/better-async:

77efe492438f114c144c86ec071ceb889fb4f9cb (2018-09-26 17:27:03 -0400)
engine: PostProcessDeploy should only pass control back to main thread after it has taken out locks

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics