### PR TITLE
docker: fix bug where fake client build/push were one-use-only

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -128,7 +128,7 @@ func (d *dockerImageBuilder) BuildImageFromExisting(ctx context.Context, existin
 	// already handled by the watch loop.
 	df, err := d.addMounts(ctx, df, paths)
 	if err != nil {
-		return nil, fmt.Errorf("BuildImageFromScratch: %v", err)
+		return nil, fmt.Errorf("BuildImageFromExisting: %v", err)
 	}
 
 	df = d.addRemainingSteps(df, steps)

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -63,11 +63,11 @@ type FakeDockerClient struct {
 	PushCount   int
 	PushImage   string
 	PushOptions types.ImagePushOptions
-	PushOutput  io.ReadCloser
+	PushOutput  string
 
 	BuildCount   int
 	BuildOptions types.ImageBuildOptions
-	BuildOutput  io.ReadCloser
+	BuildOutput  string
 
 	TagCount  int
 	TagSource string
@@ -88,8 +88,8 @@ type FakeDockerClient struct {
 
 func NewFakeDockerClient() *FakeDockerClient {
 	return &FakeDockerClient{
-		PushOutput:          NewFakeDockerResponse(ExamplePushOutput1),
-		BuildOutput:         NewFakeDockerResponse(ExampleBuildOutput1),
+		PushOutput:          ExamplePushOutput1,
+		BuildOutput:         ExampleBuildOutput1,
 		ContainerListOutput: make(map[string][]types.Container),
 		RestartsByContainer: make(map[string]int),
 	}
@@ -149,13 +149,13 @@ func (c *FakeDockerClient) ImagePush(ctx context.Context, image string, options 
 	c.PushCount++
 	c.PushImage = image
 	c.PushOptions = options
-	return c.PushOutput, nil
+	return NewFakeDockerResponse(c.PushOutput), nil
 }
 
 func (c *FakeDockerClient) ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
 	c.BuildCount++
 	c.BuildOptions = options
-	return types.ImageBuildResponse{Body: c.BuildOutput}, nil
+	return types.ImageBuildResponse{Body: NewFakeDockerResponse(c.BuildOutput)}, nil
 }
 
 func (c *FakeDockerClient) ImageTag(ctx context.Context, source, target string) error {


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/reusable-fake-docker-responses:

943bb4622cd458a0cc4fcaf8692bfd089b3ebf9f (2018-09-26 17:59:18 -0400)
docker: fix bug where fake client build/push were one-use-only

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics