### PR TITLE
tilt: fix make install-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ install:
 install-dev:
 	docker build -t $(SYNCLET_IMAGE):dirty -f synclet/Dockerfile .
 	$(eval HASH := $(shell docker inspect $(SYNCLET_IMAGE):dirty -f '{{.Id}}' | \
-                         sed -r 's/sha256:(.{20}).*/dirty-\1/'))
+                         sed -E 's/sha256:(.{20}).*/dirty-\1/'))
 	docker tag $(SYNCLET_IMAGE):dirty $(SYNCLET_IMAGE):$(HASH)
 	docker push $(SYNCLET_IMAGE):$(HASH)
-	./hide_tbd_warning go install -ldflags "-X './internal/synclet/sidecar.SyncletTag=$(HASH)'" ./...
+	./hide_tbd_warning go install -ldflags "-X 'github.com/windmilleng/tilt/internal/synclet/sidecar.SyncletTag=$(HASH)'" ./...
 
 lint:
 	go vet -all -printfuncs=Verbosef,Infof,Debugf,PrintColorf ./...

--- a/internal/synclet/sidecar/sidecar.go
+++ b/internal/synclet/sidecar/sidecar.go
@@ -14,7 +14,7 @@ func syncletPrivileged() *bool {
 }
 
 // When we deploy Tilt, we override this with LDFLAGS
-const SyncletTag = "latest"
+var SyncletTag = "latest"
 
 const SyncletImageName = "gcr.io/windmill-public-containers/tilt-synclet"
 


### PR DESCRIPTION
two issues:
1. `-X` doesn't work on consts
2. `-X` seems to require fully qualified names (at least, changing the path to match the output of `go tool nm` took this from red to green)