### PR TITLE
synclet: wait for container up

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -73,7 +73,7 @@ type Client interface {
 	ResolveLoadBalancer(ctx context.Context, lb LoadBalancerSpec) (LoadBalancer, error)
 
 	// Opens a tunnel to the specified pod+port. Returns the tunnel's local port and a function that closes the tunnel
-	ForwardPort(ctx context.Context, namespace string, podID PodID, remotePort int) (localPort int, closer func(), err error)
+	ForwardPort(ctx context.Context, namespace Namespace, podID PodID, remotePort int) (localPort int, closer func(), err error)
 }
 
 type K8sClient struct {

--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -10,27 +11,29 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-func WaitForContainerReady(ctx context.Context, client Client, pod *v1.Pod, ref reference.Named) error {
-	ready, err := waitForContainerReadyHelper(pod, ref)
+const containerIDPrefix = "docker://"
+
+func WaitForContainerReady(ctx context.Context, client Client, pod *v1.Pod, ref reference.Named) (ContainerID, error) {
+	cID, err := waitForContainerReadyHelper(pod, ref)
 	if err != nil {
-		return err
-	} else if ready {
-		return nil
+		return "", err
+	} else if cID != "" {
+		return cID, nil
 	}
 
 	watch, err := client.WatchPod(ctx, pod)
 	if err != nil {
-		return errors.Wrap(err, "WaitForContainerReady")
+		return "", errors.Wrap(err, "WaitForContainerReady")
 	}
 	defer watch.Stop()
 
 	for true {
 		select {
 		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "WaitForContainerReady")
+			return "", errors.Wrap(ctx.Err(), "WaitForContainerReady")
 		case event, ok := <-watch.ResultChan():
 			if !ok {
-				return fmt.Errorf("Container watch closed: %s", ref)
+				return "", fmt.Errorf("Container watch closed: %s", ref)
 			}
 
 			obj := event.Object
@@ -40,32 +43,32 @@ func WaitForContainerReady(ctx context.Context, client Client, pod *v1.Pod, ref 
 				continue
 			}
 
-			ready, err := waitForContainerReadyHelper(pod, ref)
+			cID, err := waitForContainerReadyHelper(pod, ref)
 			if err != nil {
-				return err
-			} else if ready {
-				return nil
+				return "", err
+			} else if cID != "" {
+				return cID, nil
 			}
 		}
 	}
-	return nil
+	panic("WaitForContainerReady")
 }
 
-func waitForContainerReadyHelper(pod *v1.Pod, ref reference.Named) (bool, error) {
+func waitForContainerReadyHelper(pod *v1.Pod, ref reference.Named) (ContainerID, error) {
 	cStatus, err := ContainerMatching(pod, ref)
 	if err != nil {
-		return false, errors.Wrap(err, "WaitForContainerReady")
+		return "", errors.Wrap(err, "WaitForContainerReadyHelper")
 	}
 
 	if IsContainerExited(pod.Status, cStatus) {
-		return false, fmt.Errorf("Container will never be ready: %s", ref)
+		return "", fmt.Errorf("Container will never be ready: %s", ref)
 	}
 
 	if cStatus.Ready {
-		return true, nil
+		return ContainerIDFromContainerStatus(cStatus)
 	}
 
-	return false, nil
+	return "", nil
 }
 
 // If true, this means the container is gone and will never recover.
@@ -93,4 +96,12 @@ func ContainerMatching(pod *v1.Pod, ref reference.Named) (v1.ContainerStatus, er
 		}
 	}
 	return v1.ContainerStatus{}, nil
+}
+
+func ContainerIDFromContainerStatus(status v1.ContainerStatus) (ContainerID, error) {
+	id := status.ContainerID
+	if !strings.HasPrefix(id, containerIDPrefix) {
+		return "", fmt.Errorf("Malformed container ID: %s", id)
+	}
+	return ContainerID(id[len(containerIDPrefix):]), nil
 }

--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 )
 
@@ -17,8 +18,9 @@ func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	podData.Status = v1.PodStatus{
 		ContainerStatuses: []v1.ContainerStatus{
 			{
-				Image: nt.String(),
-				Ready: true,
+				ContainerID: "docker://container-id",
+				Image:       nt.String(),
+				Ready:       true,
 			},
 		},
 	}
@@ -32,10 +34,12 @@ func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	ctx, cancel := context.WithTimeout(f.ctx, time.Second)
 	defer cancel()
 
-	err = WaitForContainerReady(ctx, f.client, pod, nt)
+	cID, err := WaitForContainerReady(ctx, f.client, pod, nt)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	assert.Equal(t, "container-id", cID.String())
 }
 
 func TestWaitForContainerSuccess(t *testing.T) {
@@ -53,7 +57,7 @@ func TestWaitForContainerSuccess(t *testing.T) {
 
 	result := make(chan error)
 	go func() {
-		err := WaitForContainerReady(ctx, f.client, pod, nt)
+		_, err := WaitForContainerReady(ctx, f.client, pod, nt)
 		result <- err
 	}()
 
@@ -61,8 +65,9 @@ func TestWaitForContainerSuccess(t *testing.T) {
 	newPod.Status = v1.PodStatus{
 		ContainerStatuses: []v1.ContainerStatus{
 			{
-				Image: nt.String(),
-				Ready: true,
+				ContainerID: "docker://container-id",
+				Image:       nt.String(),
+				Ready:       true,
 			},
 		},
 	}
@@ -90,7 +95,7 @@ func TestWaitForContainerFailure(t *testing.T) {
 
 	result := make(chan error)
 	go func() {
-		err := WaitForContainerReady(ctx, f.client, pod, nt)
+		_, err := WaitForContainerReady(ctx, f.client, pod, nt)
 		result <- err
 	}()
 

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -103,3 +103,11 @@ func MustParseNamedTagged(s string) reference.NamedTagged {
 	}
 	return nt
 }
+
+func MustParseNamed(s string) reference.Named {
+	n, err := reference.ParseNamed(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (k K8sClient) ForwardPort(ctx context.Context, namespace string, podID PodID, remotePort int) (localPort int, closer func(), err error) {
+func (k K8sClient) ForwardPort(ctx context.Context, namespace Namespace, podID PodID, remotePort int) (localPort int, closer func(), err error) {
 	// preferably, we'd set the localport to 0, and let the underlying function pick a port for us,
 	// to avoid the race condition potential of something else grabbing this port between
 	// the call to `getAvailablePort` and whenever `portForwarder` actually binds the port.
@@ -30,7 +30,7 @@ func (k K8sClient) ForwardPort(ctx context.Context, namespace string, podID PodI
 		return 0, nil, errors.Wrap(err, "failed to find an available local port")
 	}
 
-	closer, err = k.portForwarder(ctx, k.restConfig, k.core, namespace, podID, localPort, remotePort)
+	closer, err = k.portForwarder(ctx, k.restConfig, k.core, namespace.String(), podID, localPort, remotePort)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/internal/synclet/sidecar/sidecar.go
+++ b/internal/synclet/sidecar/sidecar.go
@@ -3,6 +3,7 @@ package sidecar
 import (
 	"fmt"
 
+	"github.com/windmilleng/tilt/internal/k8s"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"k8s.io/api/core/v1"
@@ -17,6 +18,8 @@ func syncletPrivileged() *bool {
 var SyncletTag = "latest"
 
 const SyncletImageName = "gcr.io/windmill-public-containers/tilt-synclet"
+
+var SyncletImageRef = k8s.MustParseNamed(SyncletImageName)
 
 var SyncletContainer = v1.Container{
 	Name:            "tilt-synclet",


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch393/wait:

b5b16534fab7a2ea2ceb6081b2375c95594183d1 (2018-09-27 18:25:07 -0400)
synclet: wait for container up
in theory, this should failover more gracefully if the synclet or pod is
crashlooping or not coming up for some reason