### PR TITLE
tiltfile: track read files so that we can reload the manifest

### DIFF
--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -19,6 +19,10 @@ type Manifest struct {
 	FileFilter PathMatcher
 	DockerRef  reference.Named
 
+	// Local files read while reading the Tilt configuration.
+	// If these files are changed, we should reload the manifest.
+	ConfigMatcher PathMatcher
+
 	// Properties for fast_build (builds that support
 	// iteration based on past artifacts)
 	BaseDockerfile string

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -18,23 +18,27 @@ func (m emptyMatcher) Matches(f string, isDir bool) (bool, error) {
 
 var EmptyMatcher PathMatcher = emptyMatcher{}
 
-// A matcher that matches one file.
+// A matcher that matches against a set of files.
 type fileMatcher struct {
-	path string
+	paths map[string]bool
 }
 
 func (m fileMatcher) Matches(f string, isDir bool) (bool, error) {
-	return f == m.path, nil
+	return m.paths[f], nil
 }
 
-func NewSimpleFileMatcher(f string) (fileMatcher, error) {
-	// Get the absolute path of the file, because PathMatchers expect to always
-	// work with absolute paths.
-	f, err := filepath.Abs(f)
-	if err != nil {
-		return fileMatcher{}, fmt.Errorf("NewSimpleFileMatcher: %v", err)
+func NewSimpleFileMatcher(paths ...string) (fileMatcher, error) {
+	pathMap := make(map[string]bool, len(paths))
+	for _, path := range paths {
+		// Get the absolute path of the path, because PathMatchers expect to always
+		// work with absolute paths.
+		path, err := filepath.Abs(path)
+		if err != nil {
+			return fileMatcher{}, fmt.Errorf("NewSimplePathMatcher: %v", err)
+		}
+		pathMap[path] = true
 	}
-	return fileMatcher{path: f}, nil
+	return fileMatcher{paths: pathMap}, nil
 }
 
 type PatternMatcher interface {

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -14,6 +14,7 @@ import (
 )
 
 const oldMountSyntaxError = "The syntax for `add` has changed. Before it was `add(dest: string, src: string)`. Now it is `add(src: localPath, dest: string)`."
+const noActiveBuildError = "No active build"
 
 type compManifest struct {
 	cManifest []k8sManifest
@@ -40,6 +41,7 @@ type k8sManifest struct {
 	k8sYaml     skylark.String
 	dockerImage dockerImage
 	name        string
+	configFiles []string
 }
 
 var _ skylark.Value = k8sManifest{}

--- a/internal/tiltfile/thread_local.go
+++ b/internal/tiltfile/thread_local.go
@@ -1,0 +1,61 @@
+package tiltfile
+
+import (
+	"errors"
+	"path/filepath"
+
+	"github.com/google/skylark"
+)
+
+const buildContextKey = "buildContext"
+const readFilesKey = "readFiles"
+
+func getAndClearBuildContext(t *skylark.Thread) (*dockerImage, error) {
+	obj := t.Local(buildContextKey)
+	if obj == nil {
+		return nil, nil
+	}
+
+	buildContext, ok := obj.(*dockerImage)
+	if !ok {
+		return nil, errors.New("internal error: buildContext thread local was not of type *dockerImage")
+	}
+	t.SetLocal(buildContextKey, nil)
+	return buildContext, nil
+}
+
+func getAndClearReadFiles(t *skylark.Thread) ([]string, error) {
+	readFiles, err := getReadFiles(t)
+	t.SetLocal(readFilesKey, nil)
+	if err != nil {
+		return nil, err
+	}
+	return readFiles, nil
+}
+
+func getReadFiles(t *skylark.Thread) ([]string, error) {
+	obj := t.Local(readFilesKey)
+	if obj == nil {
+		return nil, nil
+	}
+
+	readFiles, ok := obj.([]string)
+	if !ok {
+		return nil, errors.New("internal error: readFiles thread local was not of type []string")
+	}
+	return readFiles, nil
+}
+
+func recordReadFile(t *skylark.Thread, path string) error {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	readFiles, err := getReadFiles(t)
+	if err != nil {
+		return err
+	}
+	t.SetLocal(readFilesKey, append(readFiles, path))
+	return nil
+}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch353/files:

4f8d2e2288a81d1594d3b92e1882ec70dc74cda0 (2018-09-28 13:33:05 -0400)
tiltfile: track read files so that we can reload the manifest