### PR TITLE
synclet BaD: open tunnel/make synclet client asap so user doesn't have to wait

### DIFF
--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -272,5 +272,11 @@ func (sbd *SyncletBuildAndDeployer) populateDeployInfo(ctx context.Context, imag
 	info.containerID = cID
 	info.nodeID = nodeID
 
+	// preemptively set up the tunnel + client
+	_, err = sbd.ssm.ClientForPod(ctx, pID)
+	if err != nil {
+		return errors.Wrapf(err, "creating synclet client for pod '%s'", pID)
+	}
+
 	return nil
 }

--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -51,7 +51,7 @@ func WaitForContainerReady(ctx context.Context, client Client, pod *v1.Pod, ref 
 			}
 		}
 	}
-	panic("WaitForContainerReady")
+	panic("WaitForContainerReady") // should never reach this state
 }
 
 func waitForContainerReadyHelper(pod *v1.Pod, ref reference.Named) (ContainerID, error) {


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/prime-tunnel:

d223f891f3efc6a2b82b595dc30b89cbbd73c1b3 (2018-09-28 15:06:26 -0400)
synclet BaD: open tunnel/make synclet client asap so user doesn't have to wait

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics