### PR TITLE
tilt: move tunnel errors to debug level

### DIFF
--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -65,7 +65,7 @@ func portForwarder(ctx context.Context, restConfig *rest.Config, core v1.CoreV1I
 		stopChan,
 		readyChan,
 		logger.Get(ctx).Writer(logger.DebugLvl),
-		logger.Get(ctx).Writer(logger.InfoLvl))
+		logger.Get(ctx).Writer(logger.DebugLvl))
 
 	if err != nil {
 		return nil, errors.Wrap(err, "error forwarding port")


### PR DESCRIPTION
right now, if I kill a pod with a tunnel open, this gets printed to the console:
```
ERROR: logging before flag.Parse: E0928 15:53:51.779339   55827 portforward.go:331] an error occurred forwarding 55975 -> 23551: error forwarding port 23551 to pod ed9ff17ea164f04a0c5861b3455fe767d74147ec2f5b782c89945051c4d45b7e, uid : container not running (ed9ff17ea164f04a0c5861b3455fe767d74147ec2f5b782c89945051c4d45b7e)
ERROR: logging before flag.Parse: E0928 15:53:52.782373   55827 portforward.go:331] an error occurred forwarding 55975 -> 23551: error forwarding port 23551 to pod ed9ff17ea164f04a0c5861b3455fe767d74147ec2f5b782c89945051c4d45b7e, uid : container not running (ed9ff17ea164f04a0c5861b3455fe767d74147ec2f5b782c89945051c4d45b7e)
ERROR: logging before flag.Parse: E0928 15:53:54.089961   55827 portforward.go:331] an error occurred forwarding 55975 -> 23551: error forwarding port 23551 to pod ed9ff17ea164f04a0c5861b3455fe767d74147ec2f5b782c89945051c4d45b7e, uid : container not running (ed9ff17ea164f04a0c5861b3455fe767d74147ec2f5b782c89945051c4d45b7e)
```
I think our layers on top of the tunnel are now generally robust enough that it's not worth confusing users with this ugliness.