### PR TITLE
synclet: rename sidecar...client => ...client

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -6,12 +6,12 @@
 package cli
 
 import (
-	"context"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/engine"
-	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/model"
+	context "context"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	engine "github.com/windmilleng/tilt/internal/engine"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
+	model "github.com/windmilleng/tilt/internal/model"
 )
 
 // Injectors from wire.go:
@@ -31,8 +31,8 @@ func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model
 	}
 	portForwarder := k8s.ProvidePortForwarder()
 	k8sClient := k8s.NewK8sClient(ctx, env, coreV1Interface, config, portForwarder)
-	sidecarSyncletManager := engine.NewSidecarSyncletManager(k8sClient)
-	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(k8sClient, sidecarSyncletManager)
+	syncletManager := engine.NewSyncletManager(k8sClient)
+	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(k8sClient, syncletManager)
 	dockerCli, err := docker.DefaultDockerClient(ctx, env)
 	if err != nil {
 		return nil, err

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -38,12 +38,12 @@ var DeployerBaseWireSet = wire.NewSet(
 
 var DeployerWireSetTest = wire.NewSet(
 	DeployerBaseWireSet,
-	NewSidecarSyncletManagerForTests,
+	NewSyncletManagerForTests,
 )
 
 var DeployerWireSet = wire.NewSet(
 	DeployerBaseWireSet,
-	NewSidecarSyncletManager,
+	NewSyncletManager,
 )
 
 func provideBuildAndDeployer(

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -6,21 +6,21 @@
 package engine
 
 import (
-	"context"
-	"github.com/google/go-cloud/wire"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/synclet"
-	"github.com/windmilleng/wmclient/pkg/analytics"
-	"github.com/windmilleng/wmclient/pkg/dirs"
+	context "context"
+	wire "github.com/google/go-cloud/wire"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
+	synclet "github.com/windmilleng/tilt/internal/synclet"
+	analytics "github.com/windmilleng/wmclient/pkg/analytics"
+	dirs "github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 // Injectors from wire.go:
 
 func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, sCli synclet.SyncletClient, shouldFallBackToImgBuild FallbackTester) (BuildAndDeployer, error) {
-	sidecarSyncletManager := NewSidecarSyncletManagerForTests(k8s2, sCli)
-	syncletBuildAndDeployer := NewSyncletBuildAndDeployer(k8s2, sidecarSyncletManager)
+	syncletManager := NewSyncletManagerForTests(k8s2, sCli)
+	syncletBuildAndDeployer := NewSyncletBuildAndDeployer(k8s2, syncletManager)
 	containerUpdater := build.NewContainerUpdater(docker2)
 	containerResolver := build.NewContainerResolver(docker2)
 	memoryAnalytics := analytics.NewMemoryAnalytics()
@@ -49,10 +49,10 @@ var DeployerBaseWireSet = wire.NewSet(build.DefaultConsole, build.DefaultOut, wi
 
 var DeployerWireSetTest = wire.NewSet(
 	DeployerBaseWireSet,
-	NewSidecarSyncletManagerForTests,
+	NewSyncletManagerForTests,
 )
 
 var DeployerWireSet = wire.NewSet(
 	DeployerBaseWireSet,
-	NewSidecarSyncletManager,
+	NewSyncletManager,
 )

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -6,10 +6,10 @@
 package synclet
 
 import (
-	"context"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
+	context "context"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
now that we're exclusively running the synclet as a sidecar, don't need 'sidecar' in the name to differentiate from daemonset.

not a big deal, but thought i'd clean it up