### PR TITLE
tilt: use hashes in dev synclet tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 
 # Generated yaml (from synclet deploy)
 *.generated.yaml
+
+.synclet-dev-image-tag


### PR DESCRIPTION
constant tags lead to us using any old image that happens to have that tag