### PR TITLE
engine: if a config file changes, re-execute the tiltfile

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -95,6 +95,9 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 
 func getChangedConfigFiles(changedFiles []string, m model.Manifest) []string {
 	crf := []string{}
+	if m.ConfigMatcher == nil {
+		return crf
+	}
 	for _, f := range changedFiles {
 		matches, err := m.ConfigMatcher.Matches(f, false)
 		if err != nil {

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -153,6 +153,22 @@ func (b BuildState) OnlySpuriousChanges() (bool, error) {
 	return true, nil
 }
 
+func (b BuildState) NewStateWithConfigFilesRemoved(matcher model.PathMatcher) BuildState {
+	result := NewBuildState(b.LastResult)
+	newCF := map[string]bool{}
+	for f, v := range b.filesChangedSet {
+		matches, err := matcher.Matches(f, false)
+		if matches || err != nil {
+			continue
+		}
+		newCF[f] = v
+	}
+
+	result.filesChangedSet = newCF
+
+	return result
+}
+
 // A build state is empty if there are no previous results.
 func (b BuildState) IsEmpty() bool {
 	return b.LastResult.IsEmpty()

--- a/internal/engine/up_watch.go
+++ b/internal/engine/up_watch.go
@@ -39,12 +39,21 @@ func makeManifestWatcher(
 			continue
 		}
 
+		// TODO(dmiller) also watch readFiles, or something?
 		for _, localPath := range localPaths {
 			err = watcher.Add(localPath)
 			if err != nil {
 				return nil, err
 			}
 		}
+
+		for _, localPath := range manifest.ConfigFiles {
+			err = watcher.Add(localPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		sns = append(sns, manifestNotifyPair{manifest, watcher})
 	}
 

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -20,6 +20,7 @@ type Manifest struct {
 	DockerRef  reference.Named
 
 	// Local files read while reading the Tilt configuration.
+	ConfigFiles []string
 	// If these files are changed, we should reload the manifest.
 	ConfigMatcher PathMatcher
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -396,6 +396,7 @@ func skylarkManifestToDomain(manifest k8sManifest) (model.Manifest, error) {
 		Name:           model.ManifestName(manifest.name),
 		FileFilter:     model.NewCompositeMatcher(image.filters),
 		ConfigMatcher:  configMatcher,
+		ConfigFiles:    manifest.configFiles,
 
 		StaticDockerfile: string(staticDockerfileBytes),
 		StaticBuildPath:  string(image.staticBuildPath),


### PR DESCRIPTION
…and do an image build with new manifest

requires #449 