### PR TITLE
k8s: break out methods for applying labels

### DIFF
--- a/internal/k8s/extract.go
+++ b/internal/k8s/extract.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ExtractPods(obj interface{}) ([]*v1.PodSpec, error) {
@@ -18,6 +19,23 @@ func ExtractPods(obj interface{}) ([]*v1.PodSpec, error) {
 		c, ok := e.(*v1.PodSpec)
 		if !ok {
 			return nil, fmt.Errorf("extractPods: expected Pod, actual %T", e)
+		}
+		result[i] = c
+	}
+	return result, nil
+}
+
+func extractObjectMetas(obj interface{}) ([]*metav1.ObjectMeta, error) {
+	extracted, err := extractPointersOf(obj, reflect.TypeOf(metav1.ObjectMeta{}))
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*metav1.ObjectMeta, len(extracted))
+	for i, e := range extracted {
+		c, ok := e.(*metav1.ObjectMeta)
+		if !ok {
+			return nil, fmt.Errorf("ExtractObjectMetas: expected ObjectMeta, actual %T", e)
 		}
 		result[i] = c
 	}

--- a/internal/k8s/label.go
+++ b/internal/k8s/label.go
@@ -1,0 +1,37 @@
+package k8s
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type LabelPair struct {
+	Key   string
+	Value string
+}
+
+func makeLabelString(lps []LabelPair) string {
+	ls := labels.Set{}
+	for _, lp := range lps {
+		ls[lp.Key] = lp.Value
+	}
+
+	return labels.SelectorFromSet(ls).String()
+}
+
+func InjectLabels(entity K8sEntity, labels []LabelPair) (K8sEntity, error) {
+	entity = entity.DeepCopy()
+	metas, err := extractObjectMetas(&entity)
+	if err != nil {
+		return K8sEntity{}, err
+	}
+
+	for _, meta := range metas {
+		for _, label := range labels {
+			if meta.Labels == nil {
+				meta.Labels = make(map[string]string, 1)
+			}
+			meta.Labels[label.Key] = label.Value
+		}
+	}
+	return entity, nil
+}

--- a/internal/k8s/label_test.go
+++ b/internal/k8s/label_test.go
@@ -1,0 +1,76 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+)
+
+func TestInjectLabelPod(t *testing.T) {
+	entities, err := ParseYAMLFromString(testyaml.LonelyPodYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entities) != 1 {
+		t.Fatalf("Unexpected entities: %+v", entities)
+	}
+
+	entity := entities[0]
+	newEntity, err := InjectLabels(entity, []LabelPair{
+		{
+			Key:   "tier",
+			Value: "test",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := SerializeYAML([]K8sEntity{newEntity})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, fmt.Sprintf("tier: test")) {
+		t.Errorf("labels did not appear in serialized yaml: %s", result)
+	}
+}
+
+func TestInjectLabelDeployment(t *testing.T) {
+	entities, err := ParseYAMLFromString(testyaml.SanchoYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entities) != 1 {
+		t.Fatalf("Unexpected entities: %+v", entities)
+	}
+
+	entity := entities[0]
+	newEntity, err := InjectLabels(entity, []LabelPair{
+		{
+			Key:   "tier",
+			Value: "test",
+		},
+		{
+			Key:   "owner",
+			Value: "me",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := SerializeYAML([]K8sEntity{newEntity})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We expect both the Deployment and the PodTemplate to get the labels.
+	assert.Equal(t, 2, strings.Count(result, fmt.Sprintf("tier: test")))
+	assert.Equal(t, 2, strings.Count(result, fmt.Sprintf("owner: me")))
+}

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -243,3 +243,19 @@ spec:
           hostPath:
             path: /var/run/docker.sock
 `
+
+// We deliberately create a pod without any labels, to
+// ensure code works without them.
+const LonelyPodYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lonely-pod
+spec:
+  containers:
+  - name: lonely-pod
+    image: gcr.io/windmill-public-containers/lonely-pod
+    command: ["/go/bin/lonely-pod"]
+    ports:
+    - containerPort: 8001
+`


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/labels:

b466fd3598197ad9b981d991393d1b8250c57807 (2018-10-02 18:16:26 -0400)
k8s: break out methods for applying labels
this is part of a larger change to do a better job selecting the right pods, but
labelling everything tilt deploys seems generally useful for auditing purposes