### PR TITLE
engine: inject and select labels to reduce the risk of collisions, and recognize that their might be more than one pod

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -134,7 +134,7 @@ func TestIncrementalBuildWaitsForPostProcess(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	f.k8s.SetPollForPodWithImageDelay(time.Second * 1)
+	f.k8s.SetPollForPodsWithImageDelay(time.Second * 1)
 
 	res, err := f.bd.BuildAndDeploy(f.ctx, SanchoManifest, BuildStateClean)
 	if err != nil {
@@ -360,7 +360,7 @@ func TestBaDForgetsImages(t *testing.T) {
 	// make sBaD return an error so that we fall back to iBaD and get a new image id
 	f.sCli.UpdateContainerErrorToReturn = errors.New("blah")
 
-	f.k8s.SetPodWithImageResp(pod1)
+	f.k8s.SetPodsWithImageResp(pod1)
 
 	_, err := f.bd.BuildAndDeploy(f.ctx, SanchoManifest, NewBuildState(alreadyBuilt))
 	if err != nil {

--- a/internal/engine/local_container_build_and_deployer_test.go
+++ b/internal/engine/local_container_build_and_deployer_test.go
@@ -33,7 +33,7 @@ func TestPostProcessBuild(t *testing.T) {
 	f := newContainerBadFixture()
 
 	f.dCli.SetContainerListOutput(containerListOutput)
-	f.kCli.SetPodWithImageResp(pod1)
+	f.kCli.SetPodsWithImageResp(pod1)
 
 	res := BuildResult{Image: image1}
 	f.cbad.PostProcessBuild(f.ctx, res, res)
@@ -47,7 +47,7 @@ func TestPostProcessBuildNoopIfAlreadyHaveInfo(t *testing.T) {
 	f := newContainerBadFixture()
 
 	f.dCli.SetContainerListOutput(containerListOutput)
-	f.kCli.SetPodWithImageResp(pod1)
+	f.kCli.SetPodsWithImageResp(pod1)
 
 	f.cbad.deployInfo[docker.ToImgNameAndTag(image1)] = k8s.ContainerID("ohai")
 

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -2,8 +2,16 @@ package engine
 
 import (
 	"github.com/google/uuid"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
 )
 
 const TiltRunIDLabel = "tilt-runid"
 
 var TiltRunID = uuid.New().String()
+
+func TiltRunLabel() k8s.LabelPair {
+	return k8s.LabelPair{
+		Key:   TiltRunIDLabel,
+		Value: TiltRunID,
+	}
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -55,8 +55,13 @@ type Client interface {
 	Apply(ctx context.Context, entities []K8sEntity) error
 	Delete(ctx context.Context, entities []K8sEntity) error
 
-	PodWithImage(ctx context.Context, image reference.NamedTagged, n Namespace) (*v1.Pod, error)
-	PollForPodWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, timeout time.Duration) (*v1.Pod, error)
+	// Find all the pods that match the given image, namespace, and labels.
+	PodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, labels []LabelPair) ([]v1.Pod, error)
+
+	// Find all the pods matching the given parameters, stopping on timeout or
+	// when we have at least one pod.
+	PollForPodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, labels []LabelPair, timeout time.Duration) ([]v1.Pod, error)
+
 	PodByID(ctx context.Context, podID PodID, n Namespace) (*v1.Pod, error)
 
 	// Creates a channel where all changes to the pod are brodcast.

--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -26,7 +26,7 @@ func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	}
 	f.addObject(&podData)
 
-	pod, err := f.client.PodWithImage(f.ctx, nt, DefaultNamespace)
+	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -34,6 +34,7 @@ func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	ctx, cancel := context.WithTimeout(f.ctx, time.Second)
 	defer cancel()
 
+	pod := &(pods[0])
 	cID, err := WaitForContainerReady(ctx, f.client, pod, nt)
 	if err != nil {
 		t.Fatal(err)
@@ -47,10 +48,12 @@ func TestWaitForContainerSuccess(t *testing.T) {
 	f.addObject(&fakePodList)
 
 	nt := MustParseNamedTagged(blorgDevImgStr)
-	pod, err := f.client.PodWithImage(f.ctx, nt, DefaultNamespace)
+	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)
 	}
+
+	pod := &(pods[0])
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Second)
 	defer cancel()
@@ -85,10 +88,12 @@ func TestWaitForContainerFailure(t *testing.T) {
 	f.addObject(&fakePodList)
 
 	nt := MustParseNamedTagged(blorgDevImgStr)
-	pod, err := f.client.PodWithImage(f.ctx, nt, DefaultNamespace)
+	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)
 	}
+
+	pod := &(pods[0])
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Second)
 	defer cancel()
@@ -126,10 +131,12 @@ func TestWaitForContainerUnschedulable(t *testing.T) {
 	f.addObject(&fakePodList)
 
 	nt := MustParseNamedTagged(blorgDevImgStr)
-	pod, err := f.client.PodWithImage(f.ctx, nt, DefaultNamespace)
+	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)
 	}
+
+	pod := &(pods[0])
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Second)
 	defer cancel()

--- a/internal/k8s/label.go
+++ b/internal/k8s/label.go
@@ -9,13 +9,16 @@ type LabelPair struct {
 	Value string
 }
 
-func makeLabelString(lps []LabelPair) string {
+func makeLabelSet(lps []LabelPair) labels.Set {
 	ls := labels.Set{}
 	for _, lp := range lps {
 		ls[lp.Key] = lp.Value
 	}
+	return ls
+}
 
-	return labels.SelectorFromSet(ls).String()
+func makeLabelSelector(lps []LabelPair) string {
+	return labels.SelectorFromSet(makeLabelSet(lps)).String()
 }
 
 func InjectLabels(entity K8sEntity, labels []LabelPair) (K8sEntity, error) {


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch436/labels:

45886270bb1a0b3c0f05861f3cc954e93d6fa68a (2018-10-02 20:01:23 -0400)
engine: inject and select labels to reduce the risk of collisions, and recognize that their might be more than one pod

57e0110c610c00d3b2305d52a63feb4204cef0ba (2018-10-02 19:50:59 -0400)
k8s: break out methods for applying labels
this is part of a larger change to do a better job selecting the right pods, but
labelling everything tilt deploys seems generally useful for auditing purposes