### PR TITLE
engine: add some logging when we find too many pods

### DIFF
--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -165,6 +165,7 @@ func (cbd *LocalContainerBuildAndDeployer) getContainerForBuild(ctx context.Cont
 	// We want to fallback to image builds rather than managing the complexity
 	// of multiple replicas.
 	if len(pods) != 1 {
+		logger.Get(ctx).Debugf("Found too many pods (%d), skipping container updates: %s", len(pods), build.Image)
 		return "", nil
 	}
 

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -273,6 +273,7 @@ func (sbd *SyncletBuildAndDeployer) populateDeployInfo(ctx context.Context, imag
 	// We want to fallback to image builds rather than managing the complexity
 	// of multiple replicas.
 	if len(pods) != 1 {
+		logger.Get(ctx).Debugf("Found too many pods (%d), skipping container updates: %s", len(pods), image)
 		return nil
 	}
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ch436/labels:

0c9b8207bfe3afc359ba39ec322896fa0311de35 (2018-10-03 11:30:01 -0400)
engine: add some logging when we find too many pods