### PR TITLE
cli: add an update-mode flag to control update strategy

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -35,6 +35,7 @@ func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model
 		engine.NewUpper,
 		wire.Bind(new(model.ManifestCreator), engine.Upper{}),
 		provideAnalytics,
+		provideUpdateModeFlag,
 	)
 	return nil, nil
 }

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -49,8 +49,13 @@ func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
-	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, k8sClient, env, analytics)
-	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env)
+	updateModeFlag2 := provideUpdateModeFlag()
+	updateMode, err := engine.ProvideUpdateMode(updateModeFlag2, env)
+	if err != nil {
+		return nil, err
+	}
+	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, k8sClient, env, analytics, updateMode)
+	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode)
 	fallbackTester := engine.DefaultShouldFallBack()
 	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder, fallbackTester)
 	imageReaper := build.NewImageReaper(dockerCli)

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -451,7 +451,8 @@ func newBDFixtureHelper(t *testing.T, env k8s.Env, fallbackFn FallbackTester) *b
 	ctx := output.CtxForTest()
 	k8s := k8s.NewFakeK8sClient()
 	sCli := synclet.NewFakeSyncletClient()
-	bd, err := provideBuildAndDeployer(output.CtxForTest(), docker, k8s, dir, env, sCli, fallbackFn)
+	mode := UpdateModeFlag(UpdateModeAuto)
+	bd, err := provideBuildAndDeployer(output.CtxForTest(), docker, k8s, dir, env, mode, sCli, fallbackFn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/mode.go
+++ b/internal/engine/mode.go
@@ -1,0 +1,58 @@
+package engine
+
+import (
+	"fmt"
+
+	k8s "github.com/windmilleng/tilt/internal/k8s"
+)
+
+type UpdateMode string
+
+// A type to bind to flag values that need validation.
+type UpdateModeFlag UpdateMode
+
+var (
+	// Auto-pick the build mode based on
+	UpdateModeAuto UpdateMode = "auto"
+
+	// Only do image builds
+	UpdateModeImage UpdateMode = "image"
+
+	// Only do image builds from scratch
+	UpdateModeNaive UpdateMode = "naive"
+
+	// Deploy a synclet to make container updates faster
+	UpdateModeSynclet UpdateMode = "synclet"
+
+	// Update containers in-place. This mode only works with DockerForDesktop and Minikube.
+	// If you try to use this mode with a different K8s cluster type, we will return an error
+	UpdateModeContainer UpdateMode = "container"
+)
+
+var AllUpdateModes = []UpdateMode{
+	UpdateModeAuto,
+	UpdateModeImage,
+	UpdateModeNaive,
+	UpdateModeSynclet,
+	UpdateModeContainer,
+}
+
+func ProvideUpdateMode(flag UpdateModeFlag, env k8s.Env) (UpdateMode, error) {
+	valid := false
+	for _, mode := range AllUpdateModes {
+		if mode == UpdateMode(flag) {
+			valid = true
+		}
+	}
+
+	if !valid {
+		return "", fmt.Errorf("Unknown update mode %q. Valid Values: %v", flag, AllUpdateModes)
+	}
+
+	mode := UpdateMode(flag)
+	if mode == UpdateModeContainer && !env.IsLocalCluster() {
+		return "", fmt.Errorf("Update mode %q is only valid with local clusters like Minikube or DockerForDesktop", flag)
+	}
+
+	return mode, nil
+}

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -34,6 +34,7 @@ var DeployerBaseWireSet = wire.NewSet(
 
 	wire.Bind(new(BuildAndDeployer), new(CompositeBuildAndDeployer)),
 	NewCompositeBuildAndDeployer,
+	ProvideUpdateMode,
 )
 
 var DeployerWireSetTest = wire.NewSet(
@@ -52,6 +53,7 @@ func provideBuildAndDeployer(
 	k8s k8s.Client,
 	dir *dirs.WindmillDir,
 	env k8s.Env,
+	updateMode UpdateModeFlag,
 	sCli synclet.SyncletClient,
 	shouldFallBackToImgBuild FallbackTester) (BuildAndDeployer, error) {
 	wire.Build(

--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -15,6 +15,10 @@ const (
 	EnvDockerDesktop     = "docker-for-desktop"
 )
 
+func (e Env) IsLocalCluster() bool {
+	return e == EnvMinikube || e == EnvDockerDesktop
+}
+
 func DetectEnv() (Env, error) {
 	cmd := exec.Command("kubectl", "config", "current-context")
 	outputBytes, err := cmd.Output()


### PR DESCRIPTION
Hello @dbentley,

Please review the following commits I made in branch nicks/ch470/mode:

00da6ad6692b1e579ead5e448f5de31354b2b5ba (2018-10-03 12:15:06 -0400)
cli: add an update-mode flag to control update strategy
This flag is intended for people trying out Tilt for the first time
and want to better control what it's doing, and for testing.