### PR TITLE
engine: re-execute Tiltfile when config files for manifest change

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -136,6 +136,7 @@ func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest, 
 				return ctx.Err()
 			case event := <-sw.events:
 				if eventContainsConfigFiles(event) {
+					fmt.Println("Event contains config files")
 					newManifest, err := getNewManifestFromTiltfile(ctx, event.manifest.Name)
 					if err != nil {
 						logger.Get(ctx).Infof("getting new manifest error: %v", err)

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -187,12 +187,13 @@ func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest, 
 }
 
 func eventContainsConfigFiles(e manifestFilesChangedEvent) bool {
-	if e.manifest.ConfigMatcher == nil {
+	matcher, err := e.manifest.ConfigMatcher()
+	if err != nil {
 		return false
 	}
 
 	for _, f := range e.files {
-		matches, err := e.manifest.ConfigMatcher.Matches(f, false)
+		matches, err := matcher.Matches(f, false)
 		if matches && err == nil {
 			return true
 		}

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -20,7 +20,9 @@ type Manifest struct {
 	DockerRef  reference.Named
 
 	// Local files read while reading the Tilt configuration.
+	ConfigFiles []string
 	// If these files are changed, we should reload the manifest.
+	// TODO(dmiller) make this a function on the manifest model
 	ConfigMatcher PathMatcher
 
 	// Properties for fast_build (builds that support

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -20,10 +20,8 @@ type Manifest struct {
 	DockerRef  reference.Named
 
 	// Local files read while reading the Tilt configuration.
-	ConfigFiles []string
 	// If these files are changed, we should reload the manifest.
-	// TODO(dmiller) make this a function on the manifest model
-	ConfigMatcher PathMatcher
+	ConfigFiles []string
 
 	// Properties for fast_build (builds that support
 	// iteration based on past artifacts)
@@ -36,6 +34,14 @@ type Manifest struct {
 	// we do not expect the iterative build fields to be populated.
 	StaticDockerfile string
 	StaticBuildPath  string // the absolute path to the files
+}
+
+func (m Manifest) ConfigMatcher() (PathMatcher, error) {
+	configMatcher, err := NewSimpleFileMatcher(m.ConfigFiles...)
+	if err != nil {
+		return nil, err
+	}
+	return configMatcher, nil
 }
 
 func (m Manifest) IsStaticBuild() bool {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -386,11 +386,6 @@ func skylarkManifestToDomain(manifest k8sManifest) (model.Manifest, error) {
 		}
 	}
 
-	configMatcher, err := model.NewSimpleFileMatcher(manifest.configFiles...)
-	if err != nil {
-		return model.Manifest{}, errors.Wrap(err, "skylarkManifestToDomain")
-	}
-
 	return model.Manifest{
 		K8sYaml:        k8sYaml,
 		BaseDockerfile: string(baseDockerfileBytes),
@@ -400,7 +395,6 @@ func skylarkManifestToDomain(manifest k8sManifest) (model.Manifest, error) {
 		DockerRef:      image.ref,
 		Name:           model.ManifestName(manifest.name),
 		FileFilter:     model.NewCompositeMatcher(image.filters),
-		ConfigMatcher:  configMatcher,
 		ConfigFiles:    manifest.configFiles,
 
 		StaticDockerfile: string(staticDockerfileBytes),

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -536,56 +536,6 @@ func TestReadFile(t *testing.T) {
 	assert.Equal(t, manifest.K8sYaml, "hello world")
 }
 
-func TestConfigMatcherWithFastBuild(t *testing.T) {
-	f := newGitRepoFixture(t)
-	defer f.TearDown()
-
-	f.WriteFile("Dockerfile.base", "docker text")
-	f.WriteFile("a.txt", "a")
-	f.WriteFile("b.txt", "b")
-	f.WriteFile("Tiltfile", `def blorgly():
-  yaml = read_file("a.txt")
-  start_fast_build("Dockerfile.base", "docker-tag", "the entrypoint")
-  image = stop_build()
-  return k8s_service(yaml, image)
-`)
-
-	manifest := f.LoadManifest("blorgly")
-	matches := func(p string) bool {
-		ok, err := manifest.ConfigMatcher.Matches(p, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return ok
-	}
-	assert.True(t, matches(f.JoinPath("Dockerfile.base")))
-	assert.True(t, matches(f.JoinPath("Tiltfile")))
-	assert.True(t, matches(f.JoinPath("a.txt")))
-	assert.False(t, matches(f.JoinPath("b.txt")))
-}
-
-func TestConfigMatcherWithStaticBuild(t *testing.T) {
-	f := newGitRepoFixture(t)
-	defer f.TearDown()
-
-	f.WriteFile("Dockerfile", "dockerfile text")
-	f.WriteFile("Tiltfile", `def blorgly():
-  yaml = local('echo yaaaaaaaaml')
-  return k8s_service(yaml, static_build("Dockerfile", "docker-tag"))`)
-
-	manifest := f.LoadManifest("blorgly")
-	matches := func(p string) bool {
-		ok, err := manifest.ConfigMatcher.Matches(p, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return ok
-	}
-	assert.True(t, matches(f.JoinPath("Dockerfile")))
-	assert.True(t, matches(f.JoinPath("Tiltfile")))
-	assert.False(t, matches(f.JoinPath("b.txt")))
-}
-
 func TestRepoPath(t *testing.T) {
 	f := newGitRepoFixture(t)
 	defer f.TearDown()

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -536,6 +536,59 @@ func TestReadFile(t *testing.T) {
 	assert.Equal(t, manifest.K8sYaml, "hello world")
 }
 
+func TestConfigMatcherWithFastBuild(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+	f.WriteFile("Dockerfile.base", "docker text")
+	f.WriteFile("a.txt", "a")
+	f.WriteFile("b.txt", "b")
+	f.WriteFile("Tiltfile", `def blorgly():
+  yaml = read_file("a.txt")
+  start_fast_build("Dockerfile.base", "docker-tag", "the entrypoint")
+  image = stop_build()
+  return k8s_service(yaml, image)
+`)
+	manifest := f.LoadManifest("blorgly")
+	matches := func(p string) bool {
+		matcher, err := manifest.ConfigMatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ok, err := matcher.Matches(p, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ok
+	}
+	assert.True(t, matches(f.JoinPath("Dockerfile.base")))
+	assert.True(t, matches(f.JoinPath("Tiltfile")))
+	assert.True(t, matches(f.JoinPath("a.txt")))
+	assert.False(t, matches(f.JoinPath("b.txt")))
+}
+func TestConfigMatcherWithStaticBuild(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+	f.WriteFile("Dockerfile", "dockerfile text")
+	f.WriteFile("Tiltfile", `def blorgly():
+  yaml = local('echo yaaaaaaaaml')
+  return k8s_service(yaml, static_build("Dockerfile", "docker-tag"))`)
+	manifest := f.LoadManifest("blorgly")
+	matches := func(p string) bool {
+		matcher, err := manifest.ConfigMatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ok, err := matcher.Matches(p, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ok
+	}
+	assert.True(t, matches(f.JoinPath("Dockerfile")))
+	assert.True(t, matches(f.JoinPath("Tiltfile")))
+	assert.False(t, matches(f.JoinPath("b.txt")))
+}
+
 func TestRepoPath(t *testing.T) {
 	f := newGitRepoFixture(t)
 	defer f.TearDown()
@@ -805,57 +858,4 @@ def blorgly():
 	assert.Equal(t, "dockerfile text", manifest.StaticDockerfile)
 	assert.Equal(t, f.Path(), manifest.StaticBuildPath)
 	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerRef.String())
-}
-
-func TestConfigMatcherWithFastBuild(t *testing.T) {
-	f := newGitRepoFixture(t)
-	defer f.TearDown()
-	f.WriteFile("Dockerfile.base", "docker text")
-	f.WriteFile("a.txt", "a")
-	f.WriteFile("b.txt", "b")
-	f.WriteFile("Tiltfile", `def blorgly():
-  yaml = read_file("a.txt")
-  start_fast_build("Dockerfile.base", "docker-tag", "the entrypoint")
-  image = stop_build()
-  return k8s_service(yaml, image)
-`)
-	manifest := f.LoadManifest("blorgly")
-	matches := func(p string) bool {
-		matcher, err := manifest.ConfigMatcher()
-		if err != nil {
-			t.Fatal(err)
-		}
-		ok, err := matcher.Matches(p, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return ok
-	}
-	assert.True(t, matches(f.JoinPath("Dockerfile.base")))
-	assert.True(t, matches(f.JoinPath("Tiltfile")))
-	assert.True(t, matches(f.JoinPath("a.txt")))
-	assert.False(t, matches(f.JoinPath("b.txt")))
-}
-func TestConfigMatcherWithStaticBuild(t *testing.T) {
-	f := newGitRepoFixture(t)
-	defer f.TearDown()
-	f.WriteFile("Dockerfile", "dockerfile text")
-	f.WriteFile("Tiltfile", `def blorgly():
-  yaml = local('echo yaaaaaaaaml')
-  return k8s_service(yaml, static_build("Dockerfile", "docker-tag"))`)
-	manifest := f.LoadManifest("blorgly")
-	matches := func(p string) bool {
-		matcher, err := manifest.ConfigMatcher()
-		if err != nil {
-			t.Fatal(err)
-		}
-		ok, err := matcher.Matches(p, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return ok
-	}
-	assert.True(t, matches(f.JoinPath("Dockerfile")))
-	assert.True(t, matches(f.JoinPath("Tiltfile")))
-	assert.False(t, matches(f.JoinPath("b.txt")))
 }


### PR DESCRIPTION
Same deal as last time: there are a couple outstanding TODOs and no tests but I wanted to validate the approach.

One question that's not in the code: It seems to me that we don't want to filter out any file events based off of information in the Tiltfile. Does that seem right? We certainly don't want to filter out file events for the dockerfile and tiltfile anymore and I couldn't think of any other situations.