### PR TITLE
tilt: have output.StartPipeline return a Context with a new Outputter

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -39,7 +39,7 @@ type dockerBuildFixture struct {
 }
 
 func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
-	ctx := output.CtxForTest()
+	ctx := output.CtxWithPipelineForTest()
 	dcli, err := docker.DefaultDockerClient(ctx, k8s.EnvGKE)
 	if err != nil {
 		t.Fatal(err)
@@ -59,7 +59,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 }
 
 func newFakeDockerBuildFixture(t testing.TB) *dockerBuildFixture {
-	ctx := output.CtxForTest()
+	ctx := output.CtxWithPipelineForTest()
 	dcli := docker.NewFakeDockerClient()
 	labels := Labels(map[Label]LabelValue{
 		TestImage: "1",

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -57,7 +57,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest m
 	}()
 
 	// TODO - currently hardcoded that we have 2 pipeline steps. This might end up being dynamic? drop it from the output?
-	ctx = output.Get(ctx).StartPipeline(ctx, 2)
+	ctx = output.Get(ctx).ContextWithNewPipeline(ctx, 2)
 	defer func() { output.Get(ctx).EndPipeline(err) }()
 
 	err = manifest.Validate()

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -57,7 +57,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest m
 	}()
 
 	// TODO - currently hardcoded that we have 2 pipeline steps. This might end up being dynamic? drop it from the output?
-	output.Get(ctx).StartPipeline(2)
+	ctx = output.Get(ctx).StartPipeline(ctx, 2)
 	defer func() { output.Get(ctx).EndPipeline(err) }()
 
 	err = manifest.Validate()

--- a/internal/output/outputter.go
+++ b/internal/output/outputter.go
@@ -61,12 +61,16 @@ func (o *Outputter) yellow() *color.Color { return o.color(color.FgYellow) }
 func (o *Outputter) green() *color.Color  { return o.color(color.FgGreen) }
 func (o *Outputter) Red() *color.Color    { return o.color(color.FgRed) }
 
-func (o *Outputter) StartPipeline(totalStepCount int) {
+func (o *Outputter) StartPipeline(ctx context.Context, totalStepCount int) context.Context {
 	o.logger.Infof("%s", o.blue().Sprint("──┤ Pipeline Starting… ├──────────────────────────────────────────────"))
-	o.curPipelineStep = 1
-	o.totalPipelineStepCount = totalStepCount
-	o.pipelineStepDurations = nil
-	o.curPipelineStart = time.Now()
+
+	newOutputter := NewOutputter(o.logger)
+	newOutputter.curPipelineStep = 1
+	newOutputter.totalPipelineStepCount = totalStepCount
+	newOutputter.pipelineStepDurations = nil
+	newOutputter.curPipelineStart = time.Now()
+
+	return WithOutputter(ctx, newOutputter)
 }
 
 // NOTE(maia): this func should always be deferred in a closure, so that the `err` arg

--- a/internal/output/outputter_test.go
+++ b/internal/output/outputter_test.go
@@ -46,7 +46,7 @@ func TestPipeline(t *testing.T) {
 	out := &bytes.Buffer{}
 	l := logger.NewLogger(logger.InfoLvl, out)
 	o := NewOutputter(l)
-	ctx := o.StartPipeline(context.Background(), 1)
+	ctx := o.ContextWithNewPipeline(context.Background(), 1)
 	o = *Get(ctx)
 	o.StartPipelineStep("%s %s", "hello", "world")
 	o.Printf("in ur step")
@@ -61,7 +61,7 @@ func TestErroredPipeline(t *testing.T) {
 	out := &bytes.Buffer{}
 	l := logger.NewLogger(logger.InfoLvl, out)
 	o := NewOutputter(l)
-	ctx := o.StartPipeline(context.Background(), 1)
+	ctx := o.ContextWithNewPipeline(context.Background(), 1)
 	o = *Get(ctx)
 	o.StartPipelineStep("%s %s", "hello", "world")
 	o.Printf("in ur step")
@@ -76,7 +76,7 @@ func TestMultilinePrintInPipeline(t *testing.T) {
 	out := &bytes.Buffer{}
 	l := logger.NewLogger(logger.InfoLvl, out)
 	o := NewOutputter(l)
-	ctx := o.StartPipeline(context.Background(), 1)
+	ctx := o.ContextWithNewPipeline(context.Background(), 1)
 	o = *Get(ctx)
 	o.StartPipelineStep("%s %s", "hello", "world")
 	o.Printf("line 1\nline 2\n")
@@ -91,7 +91,7 @@ func TestPipelineContext(t *testing.T) {
 	out := &bytes.Buffer{}
 	l := logger.NewLogger(logger.InfoLvl, out)
 	o := NewOutputter(l)
-	ctx := o.StartPipeline(context.Background(), 1)
+	ctx := o.ContextWithNewPipeline(context.Background(), 1)
 	o2 := *Get(ctx)
 	o2.StartPipelineStep("%s %s", "hello", "world")
 	o.Printf("line 1\nline 2\n")

--- a/internal/output/testdata/TestPipelineContext_master
+++ b/internal/output/testdata/TestPipelineContext_master
@@ -1,0 +1,10 @@
+──┤ Pipeline Starting… ├──────────────────────────────────────────────
+STEP 1/1 — hello world
+line 1
+line 2
+
+    (Done 0.000s)
+
+  │ Step 1 - 0.000s │
+──┤ Done in: 0.000s ︎├──
+

--- a/internal/testutils/output/context.go
+++ b/internal/testutils/output/context.go
@@ -16,3 +16,8 @@ func CtxForTest() context.Context {
 	ctx = output.WithOutputter(ctx, output.NewOutputter(l))
 	return ctx
 }
+
+func CtxWithPipelineForTest() context.Context {
+	ctx := CtxForTest()
+	return output.Get(ctx).ContextWithNewPipeline(ctx, 2)
+}


### PR DESCRIPTION
This means that once we have async builds, different threads writing to Outputter won't depend on the current pipeline state.