### PR TITLE
integration: fix a race condition: port-forwarding has to wait until all pods are up

### DIFF
--- a/integration/oneup_test.go
+++ b/integration/oneup_test.go
@@ -13,9 +13,17 @@ func TestOneUp(t *testing.T) {
 	defer f.TearDown()
 
 	f.TiltUp("oneup")
+
+	// ForwardPort will fail if all the pods are not ready.
+	// TODO(nick): We should make port-forwarding a primitive in the
+	// Tiltfile since this seems generally useful, then get rid of this code.
+	ctx, cancel := context.WithTimeout(f.ctx, 20*time.Second)
+	defer cancel()
+	f.WaitForAllPodsReady(ctx, "app=oneup")
+
 	f.ForwardPort("deployment/oneup", "31234:8000")
 
-	ctx, cancel := context.WithTimeout(f.ctx, 20*time.Second)
+	ctx, cancel = context.WithTimeout(f.ctx, 20*time.Second)
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "🍄 One-Up! 🍄")
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/race:

71e5785a79d27d4225e3f4056b2e79ac7cffa615 (2018-10-04 15:14:33 -0400)
integration: fix a race condition: port-forwarding has to wait until all pods are up