### PR TITLE
integration: add a flag to namespace container tags, so that integration tests don't step on each other

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ test:
 	./hide_tbd_warning go test -timeout 60s ./...
 
 integration:
-	integration/purge-test-images.sh
 	./hide_tbd_warning go test -tags 'integration' -timeout 300s ./integration
 
 ensure:

--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 var packageDir string
+var imageTagPrefix string
 
 const namespaceFlag = "-n=tilt-integration"
 
@@ -29,6 +30,7 @@ func init() {
 	}
 
 	packageDir = pkg.Dir
+	imageTagPrefix = fmt.Sprintf("tilt-T-%x-", time.Now().Unix())
 }
 
 type fixture struct {
@@ -109,7 +111,7 @@ func (f *fixture) tiltCmd(tiltArgs []string, outWriter io.Writer) *exec.Cmd {
 
 func (f *fixture) TiltUp(name string) {
 	out := bytes.NewBuffer(nil)
-	cmd := f.tiltCmd([]string{"up", name, "--debug"}, out)
+	cmd := f.tiltCmd([]string{"up", name, "--debug", "--image-tag-prefix=" + imageTagPrefix}, out)
 	err := cmd.Run()
 	if err != nil {
 		f.t.Fatalf("Failed to up service: %v. Logs:\n%s", err, out.String())

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -508,23 +508,21 @@ func getDigestFromAux(aux json.RawMessage) (digest.Digest, error) {
 	return digest.Digest(id), nil
 }
 
-const tagPrefix = "tilt-"
-
 func digestAsTag(d digest.Digest) (string, error) {
 	str := d.Encoded()
 	if len(str) < 16 {
 		return "", fmt.Errorf("Digest too short: %s", str)
 	}
-	return fmt.Sprintf("%s%s", tagPrefix, str[:16]), nil
+	return fmt.Sprintf("%s%s", ImageTagPrefix, str[:16]), nil
 }
 
 func digestMatchesRef(ref reference.NamedTagged, digest digest.Digest) bool {
 	digestHash := digest.Encoded()
 	tag := ref.Tag()
-	if len(tag) <= len(tagPrefix) {
+	if len(tag) <= len(ImageTagPrefix) {
 		return false
 	}
 
-	tagHash := tag[len(tagPrefix):]
+	tagHash := tag[len(ImageTagPrefix):]
 	return strings.HasPrefix(digestHash, tagHash)
 }

--- a/internal/build/tag.go
+++ b/internal/build/tag.go
@@ -1,0 +1,8 @@
+package build
+
+// The image tag prefix can be customized.
+//
+// This allows our integration tests to customize
+// the prefix so that they can write to a public
+// registry without interfering with each other.
+var ImageTagPrefix = "tilt-"

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/logger"
 
 	"github.com/fatih/color"
@@ -40,6 +41,12 @@ func (c *upCmd) register() *cobra.Command {
 	cmd.Flags().StringVar(&updateModeFlag, "update-mode", string(engine.UpdateModeAuto),
 		fmt.Sprintf("Control the strategy Tilt uses for updating instances. Possible values: %v", engine.AllUpdateModes))
 	cmd.Flags().StringVar(&c.traceTags, "traceTags", "", "tags to add to spans for easy querying, of the form: key1=val1,key2=val2")
+	cmd.Flags().StringVar(&build.ImageTagPrefix, "image-tag-prefix", build.ImageTagPrefix,
+		"For integration tests. Customize the image tag prefix so tests can write to a public registry")
+	err := cmd.Flags().MarkHidden("image-tag-prefix")
+	if err != nil {
+		panic(err)
+	}
 
 	return cmd
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/images2:

b14563f439d8d23710aece02e5d32e146dde0ab8 (2018-10-05 10:46:34 -0400)
integration: add a flag to namespace container tags, so that integration tests don't step on each other