### PR TITLE
circleci: spin up a test k8s cluster and run tests against it

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -1,0 +1,56 @@
+FROM golang:1.10
+
+# Install docker
+# Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
+RUN set -ex \
+  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+  && echo Docker URL: $DOCKER_URL \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+  && ls -lha /tmp/docker.tgz \
+  && tar -xz -C /tmp -f /tmp/docker.tgz \
+  && mv /tmp/docker/* /usr/bin \
+  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && which docker \
+  && (docker version || true)
+  
+# Install kubectl client
+RUN apt update && apt install -y apt-transport-https \
+  && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+  && touch /etc/apt/sources.list.d/kubernetes.list \
+  && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \
+  && apt update && apt install -y kubectl
+
+# Install gcloud.
+# Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/Dockerfile
+ENV CLOUD_SDK_VERSION=219.0.1
+RUN apt-get -qqy update && apt-get install -qqy \
+        curl \
+        gcc \
+        python-dev \
+        python-setuptools \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        git \
+        gnupg \
+    && easy_install -U pip && \
+    pip install -U crcmod   && \
+    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
+    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    apt-get update && \
+    apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
+
+# Install cluster script, which downloads the necessary containers.
+# The dind-based kubernetes cluster uses socat to do port-forwarding
+ADD https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.11.sh ./dind-cluster.sh
+ADD https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/build/portforward.sh .
+RUN apt install -y curl ca-certificates git liblz4-tool rsync socat tzdata \
+  && chmod a+x /go/dind-cluster.sh \
+  && chmod a+x /go/portforward.sh
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,34 @@ jobs:
       - setup_remote_docker
       - run: docker pull registry:2
       - run: make all
+      
+  build-integration:
+    docker:
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci
+    working_directory: /go/src/github.com/windmilleng/tilt
+    steps:
+      - checkout
+      - run: echo 'export PATH=~/go/bin:$PATH' >> $BASH_ENV
+      - setup_remote_docker
+      - run: echo ${GCLOUD_SERVICE_KEY} > ${HOME}/gcloud-service-key.json
+      # NOTE(nick): Integration tests currently push images to windmill-test-containers,
+      # so we need to use a gcloud service account.
+      # I'm not super happy with this solution. I'd prefer we ran a local registry.
+      # But this is hard to coordinate effectively.
+      - run: |
+          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+          gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+          gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+          gcloud auth configure-docker
+      # Cleaning is helpful when running with the local circleci toolchain
+      - run: /go/dind-cluster.sh clean
+      - run: docker kill portforward || exit 0
+      - run: docker rm portforward || exit 0
+      - run: /go/portforward.sh start
+      - run: DIND_PORT_FORWARDER_WAIT=1 DIND_PORT_FORWARDER="/go/portforward.sh" NUM_NODES=1 /go/dind-cluster.sh up
+      - run: /go/portforward.sh -wait $(/go/dind-cluster.sh apiserver-port) && 
+             kubectl get nodes &&
+             make integration
 
   build-macos:
     macos:
@@ -38,5 +66,8 @@ workflows:
     jobs:
       - build-linux
       - build-macos:
+          requires:
+            - build-linux
+      - build-integration:
           requires:
             - build-linux

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ ci-container:
 	docker build -t gcr.io/windmill-public-containers/tilt-ci -f .circleci/Dockerfile .circleci
 	docker push gcr.io/windmill-public-containers/tilt-ci
 
+ci-integration-container:
+	docker build -t gcr.io/windmill-public-containers/tilt-integration-ci -f .circleci/Dockerfile.integration .circleci
+	docker push gcr.io/windmill-public-containers/tilt-integration-ci
+
 clean:
 	go clean -cache -testcache -r -i ./...
 	docker rmi synclet-cache

--- a/integration/README.md
+++ b/integration/README.md
@@ -10,12 +10,11 @@ What This Framework Does: Compiles the Tilt binary, deploys servers to the
 Each subdirectory is a test case driven by the file of the same name
 (e.g., `oneup_.go` drives the test driven by the data in `oneup`).
 Each Tiltfile should deploy small services to gcr.io/windmill-test-containers.
-Add new images to purge-test-images.sh so that they get purged between runs.
+Add new images to purge-test-images.sh so that they get purged periodically.
 
 Run the tests with
 
 ```
-integration/purge-test-images.sh
 go test -tags 'integration' -timeout 300s ./integration
 ```
 
@@ -26,3 +25,8 @@ make integration
 ```
 
 These tests will not run with the normal `make test`.
+
+On CircleCI, we run these tests against a clean Kubernetes cluster.
+Follow these instructions if you want to run the same cluster locally.
+
+https://github.com/kubernetes-sigs/kubeadm-dind-cluster

--- a/integration/oneup_test.go
+++ b/integration/oneup_test.go
@@ -17,13 +17,13 @@ func TestOneUp(t *testing.T) {
 	// ForwardPort will fail if all the pods are not ready.
 	// TODO(nick): We should make port-forwarding a primitive in the
 	// Tiltfile since this seems generally useful, then get rid of this code.
-	ctx, cancel := context.WithTimeout(f.ctx, 20*time.Second)
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.WaitForAllPodsReady(ctx, "app=oneup")
 
 	f.ForwardPort("deployment/oneup", "31234:8000")
 
-	ctx, cancel = context.WithTimeout(f.ctx, 20*time.Second)
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "🍄 One-Up! 🍄")
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch456/circle:

c9bc063eeeaa8e489f3d0d3bc3440d34c2c0b9aa (2018-10-05 12:15:44 -0400)
circleci: spin up a test k8s cluster and run tests against it

fe7d8a57630469afc39df862248521dc4da11258 (2018-10-05 12:05:47 -0400)
integration: add a flag to namespace container tags, so that integration tests don't step on each other