### PR TITLE
tilt: move initial builds into event loop

### DIFF
--- a/internal/engine/engine_state.go
+++ b/internal/engine/engine_state.go
@@ -17,7 +17,10 @@ type engineState struct {
 	currentlyBuilding model.ManifestName
 	completedBuilds   chan completedBuild
 
-	initialBuildCount   int
+	// How many builds were queued on startup (i.e., how many manifests there were)
+	initialBuildCount int
+
+	// How many builds have been completed (pass or fail) since starting tilt
 	completedBuildCount int
 
 	openBrowserOnNextLB bool

--- a/internal/engine/up_watch.go
+++ b/internal/engine/up_watch.go
@@ -19,6 +19,10 @@ type manifestWatcher struct {
 	errs   <-chan error
 }
 
+func newDummyManifestWatcher() *manifestWatcher {
+	return &manifestWatcher{}
+}
+
 // returns a manifestWatcher that tells its reader when a manifest's file dependencies have changed
 func makeManifestWatcher(
 	ctx context.Context,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -151,18 +151,10 @@ func TestUpper_UpWatchError(t *testing.T) {
 		f.watcher.errors <- errors.New("bazquu")
 	}()
 	err := f.upper.CreateManifests(output.CtxForTest(), []model.Manifest{manifest}, true)
-	close(f.b.calls)
 
 	if assert.NotNil(t, err) {
 		assert.Equal(t, "bazquu", err.Error())
 	}
-
-	var startedManifests []model.Manifest
-	for call := range f.b.calls {
-		startedManifests = append(startedManifests, call.manifest)
-	}
-
-	assert.Equal(t, []model.Manifest{manifest}, startedManifests)
 }
 
 // we can't have a test for a file change w/o error because Up doesn't return unless there's an error


### PR DESCRIPTION
This makes it so that we update the engine state and HUD while the initial round of builds is executing.

It also slightly reduces duplicated code (we now only handle BaD in one place).

I don't have a good mental model about what the LB stuff is doing and am not sure I've made the right change. It's working on my machine, but I don't know if that's just because there are already LBs deployed or something.