### PR TITLE
tiltfile: don't parse ignore files at runtime

### DIFF
--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -1,10 +1,11 @@
-package dockerignore
+package dockerignore_test
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/dockerignore"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
@@ -78,7 +79,7 @@ func newTestFixture(t *testing.T, dockerignores ...string) *testFixture {
 		tempDir.WriteFile(".dockerignore", ignoreText.String())
 	}
 
-	tester, err := NewDockerIgnoreTester(tempDir.Path())
+	tester, err := dockerignore.NewDockerIgnoreTester(tempDir.Path())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -404,7 +404,7 @@ func TestIgnoredFiles(t *testing.T) {
 	manifest := NewSanchoManifest()
 	manifest.Mounts[0].LocalPath = f.Path()
 
-	gitFilter, _ := git.NewRepoIgnoreTester(ctx, f.Path())
+	gitFilter, _ := git.NewRepoIgnoreTester(ctx, f.Path(), "")
 	tiltfileFilter, _ := model.NewSimpleFileMatcher(filepath.Join(f.Path(), "Tiltfile"))
 	manifest.FileFilter = model.NewCompositeMatcher([]model.PathMatcher{gitFilter, tiltfileFilter})
 

--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -2,15 +2,10 @@ package git
 
 import (
 	"context"
-	"os"
-	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/monochromegane/go-gitignore"
-	"github.com/windmilleng/tilt/internal/logger"
-	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/ospath"
 )
 
@@ -26,9 +21,7 @@ type gitIgnoreTester struct {
 	ignoreMatcher gitignore.IgnoreMatcher
 }
 
-var _ model.PathMatcher = gitIgnoreTester{}
-
-func (i gitIgnoreTester) Matches(f string, isDir bool) (bool, error) {
+func (i *gitIgnoreTester) Matches(f string, isDir bool) (bool, error) {
 	_, isChild := ospath.Child(i.repoRoot, f)
 	if !isChild {
 		return false, nil
@@ -37,35 +30,22 @@ func (i gitIgnoreTester) Matches(f string, isDir bool) (bool, error) {
 	return i.ignoreMatcher.Match(f, isDir), nil
 }
 
-func NewGitIgnoreTester(ctx context.Context, repoRoot string) (model.PathMatcher, error) {
+func NewGitIgnoreTesterFromContents(ctx context.Context, repoRoot string, gitignoreContents string) (*gitIgnoreTester, error) {
 	absRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	p := path.Join(absRoot, ".gitignore")
-	i, err := gitignore.NewGitIgnore(p)
-	if err != nil {
-		_, err = os.Open(path.Join(absRoot, ".gitignore"))
+	i := gitignore.NewGitIgnoreFromReader(repoRoot, strings.NewReader(gitignoreContents))
 
-		pathError, ok := err.(*os.PathError)
-		//if the error is that file isn't there (ENOENT), then we don't need a warning, since that's a normal case
-		//if it's any other error, log and pretend the file doesn't exist (matching git's behavior)
-		if ok && pathError.Err != syscall.ENOENT {
-			logger.Get(ctx).Verbosef("failed to open gitignore %v: %v", p, err)
-		}
-		return model.EmptyMatcher, nil
-	}
 	return &gitIgnoreTester{absRoot, i}, nil
 }
 
 // ignores files specified in .gitignore plus any files in $ROOT/.git/
 type repoIgnoreTester struct {
 	repoRoot        string
-	gitIgnoreTester model.PathMatcher
+	gitIgnoreTester *gitIgnoreTester
 }
-
-var _ model.PathMatcher = repoIgnoreTester{}
 
 func (r repoIgnoreTester) Matches(f string, isDir bool) (bool, error) {
 	// TODO(matt) what do we want to do with symlinks?
@@ -81,10 +61,16 @@ func (r repoIgnoreTester) Matches(f string, isDir bool) (bool, error) {
 	return r.gitIgnoreTester.Matches(f, isDir)
 }
 
-func NewRepoIgnoreTester(ctx context.Context, repoRoot string) (model.PathMatcher, error) {
-	g, err := NewGitIgnoreTester(ctx, repoRoot)
+func NewRepoIgnoreTester(ctx context.Context, repoRoot string, gitignoreContents string) (*repoIgnoreTester, error) {
+	g, err := NewGitIgnoreTesterFromContents(ctx, repoRoot, gitignoreContents)
 	if err != nil {
 		return nil, err
 	}
 	return &repoIgnoreTester{repoRoot, g}, nil
+}
+
+type nothingMatcher struct{}
+
+func (nothingMatcher) Matches(f string, isDir bool) (bool, error) {
+	return false, nil
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -53,7 +53,10 @@ func (m Manifest) IsStaticBuild() bool {
 }
 
 func (m Manifest) Filter() PathMatcher {
-	matchers := []PathMatcher{m.FileFilter}
+	matchers := []PathMatcher{}
+	if m.FileFilter != nil {
+		matchers = append(matchers, m.FileFilter)
+	}
 
 	for _, r := range m.Repos {
 		gim, err := git.NewRepoIgnoreTester(context.Background(), r.LocalPath, r.GitignoreContents)

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -73,6 +73,9 @@ func NewCompositeMatcher(matchers []PathMatcher) PathMatcher {
 
 func (c CompositePathMatcher) Matches(f string, isDir bool) (bool, error) {
 	for _, t := range c.Matchers {
+		if t == nil {
+			continue
+		}
 		ret, err := t.Matches(f, isDir)
 		if err != nil {
 			return false, err

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -56,6 +56,9 @@ type CompositePathMatcher struct {
 }
 
 func NewCompositeMatcher(matchers []PathMatcher) PathMatcher {
+	if len(matchers) == 0 {
+		return EmptyMatcher
+	}
 	cMatcher := CompositePathMatcher{Matchers: matchers}
 	pMatchers := make([]PatternMatcher, len(matchers))
 	for i, m := range matchers {
@@ -73,9 +76,6 @@ func NewCompositeMatcher(matchers []PathMatcher) PathMatcher {
 
 func (c CompositePathMatcher) Matches(f string, isDir bool) (bool, error) {
 	for _, t := range c.Matchers {
-		if t == nil {
-			continue
-		}
 		ret, err := t.Matches(f, isDir)
 		if err != nil {
 			return false, err

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -184,7 +184,6 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 	}
 
 	buildContext.mounts = append(buildContext.mounts, mount{lp, mountPoint})
-	buildContext.filters = append(buildContext.filters, lp.repo.pathMatcher)
 
 	return skylark.None, nil
 }
@@ -232,8 +231,9 @@ func (*dockerImage) AttrNames() []string {
 }
 
 type gitRepo struct {
-	basePath    string
-	pathMatcher model.PathMatcher
+	basePath             string
+	gitignoreContents    string
+	dockerignoreContents string
 }
 
 var _ skylark.Value = gitRepo{}

--- a/internal/tiltfile/thread_local.go
+++ b/internal/tiltfile/thread_local.go
@@ -9,6 +9,7 @@ import (
 
 const buildContextKey = "buildContext"
 const readFilesKey = "readFiles"
+const reposKey = "repos"
 
 func getAndClearBuildContext(t *skylark.Thread) (*dockerImage, error) {
 	obj := t.Local(buildContextKey)
@@ -57,5 +58,29 @@ func recordReadFile(t *skylark.Thread, path string) error {
 		return err
 	}
 	t.SetLocal(readFilesKey, append(readFiles, path))
+	return nil
+}
+
+func getRepos(t *skylark.Thread) ([]gitRepo, error) {
+	obj := t.Local(reposKey)
+	if obj == nil {
+		return []gitRepo{}, nil
+	}
+
+	repos, ok := obj.([]gitRepo)
+	if !ok {
+		return nil, errors.New("internal error: repos thread local was not of type []gitRepo")
+	}
+
+	return repos, nil
+}
+
+func addRepo(t *skylark.Thread, repo gitRepo) error {
+	repos, err := getRepos(t)
+	if err != nil {
+		return err
+	}
+
+	t.SetLocal(reposKey, append(repos, repo))
 	return nil
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -197,11 +197,10 @@ func makeSkylarkGitRepo(thread *skylark.Thread, fn *skylark.Builtin, args skylar
 	}
 
 	gitignoreContents, err := ioutil.ReadFile(filepath.Join(absPath, ".gitignore"))
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
 	}
+
 	dockerignoreContents, err := ioutil.ReadFile(filepath.Join(absPath, ".dockerignore"))
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -703,11 +703,11 @@ func TestReadsIgnoreFiles(t *testing.T) {
 `)
 
 	manifest := f.LoadManifest("blorgly")
-	assert.True(t, f.FiltersPath(manifest, "Tiltfile", true))
-	assert.True(t, f.FiltersPath(manifest, "cmd.exe", false))
-	assert.True(t, f.FiltersPath(manifest, "node_modules", true))
-	assert.True(t, f.FiltersPath(manifest, ".git", true))
-	assert.False(t, f.FiltersPath(manifest, "a.txt", false))
+	assert.Truef(t, f.FiltersPath(manifest, "Tiltfile", true), "Expected to filter Tiltfile")
+	assert.True(t, f.FiltersPath(manifest, "cmd.exe", false), "Expected to filter cmd.exe")
+	assert.True(t, f.FiltersPath(manifest, ".git", true), "Expected to filter .git")
+	assert.True(t, f.FiltersPath(manifest, "node_modules", true), "Expected to filter node_modules")
+	assert.False(t, f.FiltersPath(manifest, "a.txt", false), "Expected to filter a.txt")
 }
 
 func TestReadsIgnoreFilesMultipleGitRepos(t *testing.T) {
@@ -751,14 +751,14 @@ func TestReadsIgnoreFilesMultipleGitRepos(t *testing.T) {
 
 	manifest := manifests[0]
 
-	assert.True(t, f1.FiltersPath(manifest, "cmd.exe", false))
-	assert.True(t, f1.FiltersPath(manifest, "node_modules", true))
-	assert.True(t, f1.FiltersPath(manifest, ".git", true))
-	assert.False(t, f1.FiltersPath(manifest, "a.txt", false))
-	assert.False(t, f2.FiltersPath(manifest, "cmd.exe", false))
-	assert.False(t, f2.FiltersPath(manifest, "node_modules", true))
-	assert.True(t, f2.FiltersPath(manifest, ".git", true))
-	assert.True(t, f2.FiltersPath(manifest, "a.txt", false))
+	assert.Truef(t, f1.FiltersPath(manifest, "cmd.exe", false), "Expected to match cmd.exe")
+	assert.Truef(t, f1.FiltersPath(manifest, "node_modules", true), "Expected to match node_modules")
+	assert.Truef(t, f1.FiltersPath(manifest, ".git", true), "Expected to match .git")
+	assert.Falsef(t, f1.FiltersPath(manifest, "a.txt", false), "Expected to not match a.txt")
+	assert.Falsef(t, f2.FiltersPath(manifest, "cmd.exe", false), "Expected to not much cmd.exe")
+	assert.Falsef(t, f2.FiltersPath(manifest, "node_modules", true), "Expected to not match node_modules")
+	assert.Truef(t, f2.FiltersPath(manifest, ".git", true), "Expected to match .git")
+	assert.Truef(t, f2.FiltersPath(manifest, "a.txt", false), "Expected to match a.txt")
 }
 
 func TestBuildContextAddError(t *testing.T) {


### PR DESCRIPTION
Instead just pass the contents of the ignore files along so they can be
parsed later. This is important so that we can end up with a manifest
that consists entirely of comparable fields.