### PR TITLE
tiltfile: fix phantom entrypoints and apply labels later to help caching

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -105,13 +105,10 @@ func (d *dockerImageBuilder) BuildImageFromScratch(ctx context.Context, ref refe
 		return nil, err
 	}
 
-	// TODO(nick): should there be an error if hasEntrypoint is false?
-	// right now, Service#Validate will fail on this case, but many of our
-	// test cases don't have entrypoints.
 	hasEntrypoint := !entrypoint.Empty()
 
 	paths := MountsToPathMappings(mounts)
-	df := d.applyLabels(baseDockerfile, BuildModeScratch)
+	df := baseDockerfile
 	df, steps, err = d.addConditionalSteps(df, steps, paths)
 	if err != nil {
 		return nil, fmt.Errorf("BuildImageFromScratch: %v", err)
@@ -127,6 +124,7 @@ func (d *dockerImageBuilder) BuildImageFromScratch(ctx context.Context, ref refe
 		df = df.Entrypoint(entrypoint)
 	}
 
+	df = d.applyLabels(df, BuildModeScratch)
 	return d.buildFromDf(ctx, df, paths, filter, ref)
 }
 

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -117,12 +117,12 @@ func TestConditionalRunInFakeDocker(t *testing.T) {
 	expected := expectedFile{
 		Path: "Dockerfile",
 		Contents: `FROM alpine
-LABEL "tilt.buildMode"="scratch"
-LABEL "tilt.test"="1"
 COPY /src/a.txt /src/a.txt
 RUN cat /src/a.txt > /src/c.txt
 ADD . /
-RUN cat /src/b.txt > /src/d.txt`,
+RUN cat /src/b.txt > /src/d.txt
+LABEL "tilt.buildMode"="scratch"
+LABEL "tilt.test"="1"`,
 	}
 	testutils.AssertFileInTar(f.t, tar.NewReader(f.fakeDocker.BuildOptions.Context), expected)
 }
@@ -152,11 +152,11 @@ func TestAllConditionalRunsInFakeDocker(t *testing.T) {
 	expected := expectedFile{
 		Path: "Dockerfile",
 		Contents: `FROM alpine
-LABEL "tilt.buildMode"="scratch"
-LABEL "tilt.test"="1"
 COPY /src/a.txt /src/a.txt
 RUN cat /src/a.txt > /src/c.txt
-ADD . /`,
+ADD . /
+LABEL "tilt.buildMode"="scratch"
+LABEL "tilt.test"="1"`,
 	}
 	testutils.AssertFileInTar(f.t, tar.NewReader(f.fakeDocker.BuildOptions.Context), expected)
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -206,6 +206,9 @@ func (c Cmd) Empty() bool {
 }
 
 func ToShellCmd(cmd string) Cmd {
+	if cmd == "" {
+		return Cmd{}
+	}
 	return Cmd{Argv: []string{"sh", "-c", cmd}}
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -496,8 +496,8 @@ ENTRYPOINT echo hi`)
 `)
 
 	manifest := f.LoadManifest("blorgly")
-	// TODO(dmiller) is this right?
-	assert.Equal(t, []string{"sh", "-c", ""}, manifest.Entrypoint.Argv)
+	assert.Equal(t, []string(nil), manifest.Entrypoint.Argv)
+	assert.True(t, manifest.Entrypoint.Empty())
 }
 
 func TestAddMissingDir(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch517/entrypoint:

81b5e5957793e34731401670fea430c4157cbf6e (2018-10-08 18:01:59 -0400)
tiltfile: fix phantom entrypoints and apply labels later to help caching