### PR TITLE
tiltfile: associate repos to mounts iff they are used

### DIFF
--- a/internal/tiltfile/thread_local.go
+++ b/internal/tiltfile/thread_local.go
@@ -60,27 +60,3 @@ func recordReadFile(t *skylark.Thread, path string) error {
 	t.SetLocal(readFilesKey, append(readFiles, path))
 	return nil
 }
-
-func getRepos(t *skylark.Thread) ([]gitRepo, error) {
-	obj := t.Local(reposKey)
-	if obj == nil {
-		return []gitRepo{}, nil
-	}
-
-	repos, ok := obj.([]gitRepo)
-	if !ok {
-		return nil, errors.New("internal error: repos thread local was not of type []gitRepo")
-	}
-
-	return repos, nil
-}
-
-func addRepo(t *skylark.Thread, repo gitRepo) error {
-	repos, err := getRepos(t)
-	if err != nil {
-		return err
-	}
-
-	t.SetLocal(reposKey, append(repos, repo))
-	return nil
-}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -229,6 +229,8 @@ def blorgly_frontend():
 }
 
 func TestCompositeFunction(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
 	dockerfile := tempFile("docker text")
 	file := tempFile(
 		fmt.Sprintf(`def blorgly():
@@ -236,7 +238,7 @@ func TestCompositeFunction(t *testing.T) {
 
 def blorgly_backend():
   start_fast_build("%v", "docker-tag", "the entrypoint")
-  add(local_git_repo('.'), '/mount_points/1')
+  add(local_git_repo('%s'), '/mount_points/1')
   run("go install github.com/windmilleng/blorgly-frontend/server/...")
   run("echo hi")
   image = stop_build()
@@ -244,12 +246,12 @@ def blorgly_backend():
 
 def blorgly_frontend():
   start_fast_build("%v", "docker-tag", "the entrypoint")
-  add(local_git_repo('.'), '/mount_points/2')
+  add(local_git_repo('%s'), '/mount_points/2')
   run("go install github.com/windmilleng/blorgly-frontend/server/...")
   run("echo hi")
   image = stop_build()
   return k8s_service("yaaaaaaaaml", image)
-`, dockerfile, dockerfile))
+`, dockerfile, f.Path(), dockerfile, f.Path()))
 	defer os.Remove(file)
 	defer os.Remove(dockerfile)
 


### PR DESCRIPTION
Note that with this approach we only record a repo if it is used in a mount. This might be OK, but if you used a `repo.path` and interpolated in to like a `local` command and _never_ used it in a mount we wouldn't know that you used it