### PR TITLE
engine: pull deploy discovery into a separate object, so i can use it for port-forwarding

### DIFF
--- a/internal/build/container_resolver.go
+++ b/internal/build/container_resolver.go
@@ -15,10 +15,6 @@ import (
 	"github.com/windmilleng/tilt/internal/logger"
 )
 
-// A magic constant. If the docker client returns this constant, we always match
-// even if the container doesn't have the correct image name.
-const MagicTestContainerID = "tilt-testcontainer"
-
 const containerUpTimeout = 10 * time.Second
 
 type ContainerResolver struct {
@@ -80,7 +76,7 @@ func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName
 	}
 
 	for _, c := range containers {
-		if c.ID == MagicTestContainerID {
+		if c.ID == k8s.MagicTestContainerID {
 			return k8s.ContainerID(c.ID), nil
 		}
 

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -32,19 +32,19 @@ func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model
 	}
 	portForwarder := k8s.ProvidePortForwarder()
 	k8sClient := k8s.NewK8sClient(ctx, env, coreV1Interface, config, portForwarder)
+	deployDiscovery := engine.NewDeployDiscovery(k8sClient)
 	syncletManager := engine.NewSyncletManager(k8sClient)
-	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(k8sClient, syncletManager)
+	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(deployDiscovery, syncletManager)
 	dockerCli, err := docker.DefaultDockerClient(ctx, env)
 	if err != nil {
 		return nil, err
 	}
 	containerUpdater := build.NewContainerUpdater(dockerCli)
-	containerResolver := build.NewContainerResolver(dockerCli)
 	analytics, err := provideAnalytics()
 	if err != nil {
 		return nil, err
 	}
-	localContainerBuildAndDeployer := engine.NewLocalContainerBuildAndDeployer(containerUpdater, containerResolver, env, k8sClient, analytics)
+	localContainerBuildAndDeployer := engine.NewLocalContainerBuildAndDeployer(containerUpdater, analytics, deployDiscovery)
 	console := build.DefaultConsole()
 	writer := build.DefaultOut()
 	labels := _wireLabelsValue

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -472,7 +472,7 @@ func newBDFixtureHelper(t *testing.T, env k8s.Env, fallbackFn FallbackTester) *b
 	docker.ContainerListOutput = map[string][]types.Container{
 		"pod": []types.Container{
 			types.Container{
-				ID: build.MagicTestContainerID,
+				ID: k8s.MagicTestContainerID,
 			},
 		},
 	}
@@ -506,7 +506,7 @@ func (f *bdFixture) assertContainerRestarts(count int) {
 	// restarts, and that it saw the right number of restarts.
 	expected := map[string]int{}
 	if count != 0 {
-		expected[string(build.MagicTestContainerID)] = count
+		expected[string(k8s.MagicTestContainerID)] = count
 	}
 	assert.Equal(f.T(), expected, f.docker.RestartsByContainer)
 }

--- a/internal/engine/deploy.go
+++ b/internal/engine/deploy.go
@@ -1,0 +1,148 @@
+package engine
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/docker/distribution/reference"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/logger"
+)
+
+// Looks up containers after they've been deployed.
+type DeployDiscovery struct {
+	kCli       k8s.Client
+	deployInfo map[docker.ImgNameAndTag]*DeployInfo
+	mu         sync.Mutex
+}
+
+func NewDeployDiscovery(kCli k8s.Client) *DeployDiscovery {
+	return &DeployDiscovery{
+		kCli:       kCli,
+		deployInfo: make(map[docker.ImgNameAndTag]*DeployInfo),
+	}
+}
+
+func (d *DeployDiscovery) DeployInfoForImage(img reference.NamedTagged) (*DeployInfo, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	deployInfo, ok := d.deployInfo[docker.ToImgNameAndTag(img)]
+	return deployInfo, ok
+}
+
+func (d *DeployDiscovery) EnsureDeployInfoFetchStarted(ctx context.Context, img reference.NamedTagged, ns k8s.Namespace) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, ok := d.deployInfo[docker.ToImgNameAndTag(img)]
+	if !ok {
+		deployInfo := newEmptyDeployInfo()
+		d.deployInfo[docker.ToImgNameAndTag(img)] = deployInfo
+
+		go func() {
+			err := d.populateDeployInfo(ctx, img, ns, deployInfo)
+			if err != nil {
+				// There's a variety of reasons why we might not be able to get the deploy info.
+				// The cluster could be in a transient bad state, or the pod
+				// could be in a crash loop because the user wrote some code that
+				// segfaults. Don't worry too much about it, we'll fall back to an image build.
+				logger.Get(ctx).Debugf("failed to get deployInfo: %v", err)
+			}
+		}()
+	}
+}
+
+func (d *DeployDiscovery) DeployInfoForImageBlocking(ctx context.Context, img reference.NamedTagged) (*DeployInfo, bool) {
+	deployInfo, ok := d.DeployInfoForImage(img)
+	if deployInfo != nil {
+		deployInfo.waitUntilReady(ctx)
+	}
+	return deployInfo, ok
+}
+
+// Returns the deploy info that was forgotten, if any.
+func (d *DeployDiscovery) ForgetImage(img reference.NamedTagged) (*DeployInfo, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	key := docker.ToImgNameAndTag(img)
+	deployInfo, ok := d.deployInfo[key]
+	delete(d.deployInfo, key)
+	return deployInfo, ok
+}
+
+func (d *DeployDiscovery) populateDeployInfo(ctx context.Context, image reference.NamedTagged, ns k8s.Namespace, info *DeployInfo) (err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "DeployDiscovery-populateDeployInfo")
+	defer span.Finish()
+
+	defer func() {
+		info.err = err
+		info.markReady()
+	}()
+
+	// get pod running the image we just deployed.
+	//
+	// We fetch the pod by the NamedTagged, to ensure we get a pod
+	// in the most recent Deployment, and not the pods in the process
+	// of being terminated from previous Deployments.
+	pods, err := d.kCli.PollForPodsWithImage(
+		ctx, image, ns,
+		[]k8s.LabelPair{TiltRunLabel()}, podPollTimeoutSynclet)
+	if err != nil {
+		return errors.Wrapf(err, "PodsWithImage (img = %s)", image)
+	}
+
+	// If there's more than one pod, two possible things could be happening:
+	// 1) K8s is in a transitiion state.
+	// 2) The user is running a configuration where they want multiple replicas
+	//    of the same pod (e.g., a cockroach developer testing primary/replica).
+	// If this happens, don't bother populating the deployInfo.
+	// We want to fallback to image builds rather than managing the complexity
+	// of multiple replicas.
+	if len(pods) != 1 {
+		logger.Get(ctx).Debugf("Found too many pods (%d), skipping container updates: %s", len(pods), image)
+		return nil
+	}
+
+	pod := &(pods[0])
+	pID := k8s.PodIDFromPod(pod)
+	nodeID := k8s.NodeIDFromPod(pod)
+
+	// Make sure that the deployed image is ready and not crashlooping.
+	cID, err := k8s.WaitForContainerReady(ctx, d.kCli, pod, image)
+	if err != nil {
+		return errors.Wrapf(err, "WaitForContainerReady (pod = %s)", pID)
+	}
+
+	logger.Get(ctx).Verbosef("talking to synclet client for pod %s", pID.String())
+
+	info.podID = pID
+	info.containerID = cID
+	info.nodeID = nodeID
+
+	return nil
+}
+
+type DeployInfo struct {
+	podID       k8s.PodID
+	containerID k8s.ContainerID
+	nodeID      k8s.NodeID
+
+	ready chan struct{} // Close this channel when the DeployInfo is populated
+	err   error         // error encountered when populating (if any)
+}
+
+func (di *DeployInfo) markReady() { close(di.ready) }
+func (di *DeployInfo) waitUntilReady(ctx context.Context) {
+	select {
+	case <-di.ready:
+	case <-ctx.Done():
+	}
+}
+
+func newEmptyDeployInfo() *DeployInfo {
+	return &DeployInfo{ready: make(chan struct{})}
+}

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -3,15 +3,11 @@ package engine
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
-	"github.com/docker/distribution/reference"
 	"github.com/opentracing/opentracing-go"
 	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/ignore"
-	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/wmclient/pkg/analytics"
@@ -23,39 +19,17 @@ const podPollTimeoutLocal = time.Second * 3
 
 type LocalContainerBuildAndDeployer struct {
 	cu        *build.ContainerUpdater
-	cr        *build.ContainerResolver
-	env       k8s.Env
-	k8sClient k8s.Client
 	analytics analytics.Analytics
-
-	deployInfo   map[docker.ImgNameAndTag]k8s.ContainerID
-	deployInfoMu sync.Mutex
+	dd        *DeployDiscovery
 }
 
-func NewLocalContainerBuildAndDeployer(cu *build.ContainerUpdater, cr *build.ContainerResolver,
-	env k8s.Env, kCli k8s.Client, analytics analytics.Analytics) *LocalContainerBuildAndDeployer {
+func NewLocalContainerBuildAndDeployer(cu *build.ContainerUpdater,
+	analytics analytics.Analytics, dd *DeployDiscovery) *LocalContainerBuildAndDeployer {
 	return &LocalContainerBuildAndDeployer{
-		cu:         cu,
-		cr:         cr,
-		env:        env,
-		k8sClient:  kCli,
-		analytics:  analytics,
-		deployInfo: make(map[docker.ImgNameAndTag]k8s.ContainerID),
+		cu:        cu,
+		analytics: analytics,
+		dd:        dd,
 	}
-}
-
-func (cbd *LocalContainerBuildAndDeployer) getContainerIDForImage(img reference.NamedTagged) (k8s.ContainerID, bool) {
-	cbd.deployInfoMu.Lock()
-	cID, ok := cbd.deployInfo[docker.ToImgNameAndTag(img)]
-	cbd.deployInfoMu.Unlock()
-	return cID, ok
-}
-
-func (cbd *LocalContainerBuildAndDeployer) setContainerIDForImage(img reference.NamedTagged, cID k8s.ContainerID) {
-	cbd.deployInfoMu.Lock()
-	key := docker.ToImgNameAndTag(img)
-	cbd.deployInfo[key] = cID
-	cbd.deployInfoMu.Unlock()
 }
 
 func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, state BuildState) (result BuildResult, err error) {
@@ -87,11 +61,12 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 	}
 
 	// Otherwise, manifest has already been deployed; try to update in the running container
-	cID, ok := cbd.getContainerIDForImage(state.LastResult.Image)
-
-	// (Unless we don't know what container it's running in, in which case we can't.)
-	if !ok {
-		return BuildResult{}, fmt.Errorf("no container info for this manifest")
+	deployInfo, ok := cbd.dd.DeployInfoForImageBlocking(ctx, state.LastResult.Image)
+	if !ok || deployInfo == nil {
+		// We theoretically already checked this condition :(
+		return BuildResult{}, fmt.Errorf("no container ID found for %s (image: %s) "+
+			"(should have checked this upstream, something is wrong)",
+			manifest.Name, state.LastResult.Image.String())
 	}
 
 	cf, err := build.FilesToPathMappings(state.FilesChanged(), manifest.Mounts)
@@ -104,7 +79,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 		return BuildResult{}, err
 	}
 
-	err = cbd.cu.UpdateInContainer(ctx, cID, cf, ignore.CreateFilter(manifest), boiledSteps)
+	err = cbd.cu.UpdateInContainer(ctx, deployInfo.containerID, cf, ignore.CreateFilter(manifest), boiledSteps)
 	if err != nil {
 		return BuildResult{}, err
 	}
@@ -118,65 +93,14 @@ func (cbd *LocalContainerBuildAndDeployer) PostProcessBuild(ctx context.Context,
 	span.SetTag("image", result.Image.String())
 	defer span.Finish()
 
+	if previousResult.HasImage() && (!result.HasImage() || result.Image != previousResult.Image) {
+		_, _ = cbd.dd.ForgetImage(previousResult.Image)
+	}
+
 	if !result.HasImage() {
 		// This is normal condition if the previous build failed.
 		return
 	}
 
-	if _, ok := cbd.getContainerIDForImage(result.Image); !ok {
-		cID, err := cbd.getContainerForBuild(ctx, result)
-		if err != nil {
-			// There's a variety of reasons why we might not be able to get a
-			// container.  The cluster could be in a transient bad state, or the pod
-			// could be in a crash loop because the user wrote some code that
-			// segfaults. Don't worry too much about it, we'll fall back to an image build.
-			logger.Get(ctx).Debugf("couldn't get container for img %s: %v", result.Image.String(), err)
-			return
-		}
-
-		if cID == "" {
-			return
-		}
-
-		cbd.setContainerIDForImage(result.Image, cID)
-	}
-}
-
-func (cbd *LocalContainerBuildAndDeployer) getContainerForBuild(ctx context.Context, build BuildResult) (k8s.ContainerID, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocalContainerBuildAndDeployer-getContainerForBuild")
-	defer span.Finish()
-
-	// get pod running the image we just deployed
-	//
-	// We fetch the pod by the NamedTagged, to ensure we get a pod
-	// in the most recent Deployment, and not the pods in the process
-	// of being terminated from previous Deployments.
-	pods, err := cbd.k8sClient.PollForPodsWithImage(
-		ctx, build.Image, build.Namespace,
-		[]k8s.LabelPair{TiltRunLabel()}, podPollTimeoutLocal)
-	if err != nil {
-		return "", fmt.Errorf("PodsWithImage (img = %s): %v", build.Image, err)
-	}
-
-	// If there's more than one pod, two possible things could be happening:
-	// 1) K8s is in a transitiion state.
-	// 2) The user is running a configuration where they want multiple replicas
-	//    of the same pod (e.g., a cockroach developer testing primary/replica).
-	// If this happens, don't bother populating the deployInfo.
-	// We want to fallback to image builds rather than managing the complexity
-	// of multiple replicas.
-	if len(pods) != 1 {
-		logger.Get(ctx).Debugf("Found too many pods (%d), skipping container updates: %s", len(pods), build.Image)
-		return "", nil
-	}
-
-	// get container that's running the app for the pod we found
-	pod := &(pods[0])
-	podID := k8s.PodIDFromPod(pod)
-	cID, err := cbd.cr.ContainerIDForPod(ctx, podID, build.Image)
-	if err != nil {
-		return "", fmt.Errorf("ContainerIDForPod (pod = %s): %v", podID, err)
-	}
-
-	return cID, nil
+	cbd.dd.EnsureDeployInfoFetchStarted(ctx, result.Image, result.Namespace)
 }

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -31,6 +31,7 @@ var DeployerBaseWireSet = wire.NewSet(
 	NewSyncletBuildAndDeployer,
 	NewLocalContainerBuildAndDeployer,
 	DefaultBuildOrder,
+	NewDeployDiscovery,
 
 	wire.Bind(new(BuildAndDeployer), new(CompositeBuildAndDeployer)),
 	NewCompositeBuildAndDeployer,

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -11,6 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+// A magic constant. If the docker client returns this constant, we always match
+// even if the container doesn't have the correct image name.
+const MagicTestContainerID = "tilt-testcontainer"
+
 var _ Client = &FakeK8sClient{}
 
 type FakeK8sClient struct {
@@ -69,7 +73,7 @@ func (c *FakeK8sClient) PodsWithImage(ctx context.Context, image reference.Named
 	status := v1.PodStatus{
 		ContainerStatuses: []v1.ContainerStatus{
 			{
-				ContainerID: "docker://tilt-testcontainer",
+				ContainerID: "docker://" + MagicTestContainerID,
 				Image:       image.String(),
 				Ready:       true,
 			},


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/deploy:

11424495ee6af0382727f3d794e2afcb6f30f460 (2018-10-10 11:29:03 -0400)
engine: pull deploy discovery into a separate object, so i can use it for port-forwarding