### PR TITLE
model: config file equality is not order dependent

### DIFF
--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -118,29 +118,13 @@ func (m1 Manifest) configFilesEqual(c2 []string) bool {
 		return false
 	}
 
-	diff := make(map[string]int, len(m1.ConfigFiles))
-
-	for _, x := range m1.ConfigFiles {
-		diff[x]++
-	}
-
-	for _, y := range c2 {
-		// If the string is not in the things from x, bail
-		if _, ok := diff[y]; !ok {
+	for i := range c2 {
+		if m1.ConfigFiles[i] != c2[i] {
 			return false
 		}
-		diff[y] -= 1
-		if diff[y] == 0 {
-			delete(diff, y)
-		}
 	}
 
-	// If there's anything left then the slices are not equal
-	if len(diff) == 0 {
-		return true
-	}
-
-	return false
+	return true
 }
 
 func (m1 Manifest) mountsEqual(m2 []Mount) bool {

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -118,13 +118,29 @@ func (m1 Manifest) configFilesEqual(c2 []string) bool {
 		return false
 	}
 
-	for i := range c2 {
-		if m1.ConfigFiles[i] != c2[i] {
+	diff := make(map[string]int, len(m1.ConfigFiles))
+
+	for _, x := range m1.ConfigFiles {
+		diff[x]++
+	}
+
+	for _, y := range c2 {
+		// If the string is not in the things from x, bail
+		if _, ok := diff[y]; !ok {
 			return false
+		}
+		diff[y] -= 1
+		if diff[y] == 0 {
+			delete(diff, y)
 		}
 	}
 
-	return true
+	// If there's anything left then the slices are not equal
+	if len(diff) == 0 {
+		return true
+	}
+
+	return false
 }
 
 func (m1 Manifest) mountsEqual(m2 []Mount) bool {

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -136,7 +136,7 @@ var equalitytests = []struct {
 		Manifest{
 			ConfigFiles: []string{"hi", "hello", "my"},
 		},
-		true,
+		false,
 	},
 	{
 		Manifest{

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -120,6 +120,33 @@ var equalitytests = []struct {
 		},
 		true,
 	},
+	{
+		Manifest{
+			ConfigFiles: []string{"hi", "hello"},
+		},
+		Manifest{
+			ConfigFiles: []string{"hi", "hello", "my"},
+		},
+		false,
+	},
+	{
+		Manifest{
+			ConfigFiles: []string{"my", "hi", "hello"},
+		},
+		Manifest{
+			ConfigFiles: []string{"hi", "hello", "my"},
+		},
+		true,
+	},
+	{
+		Manifest{
+			ConfigFiles: []string{"hi", "hello", "my"},
+		},
+		Manifest{
+			ConfigFiles: []string{"hi", "hello", "my"},
+		},
+		true,
+	},
 }
 
 func TestManifestEquality(t *testing.T) {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 
 	"github.com/pkg/errors"
 
@@ -394,6 +395,13 @@ func skylarkManifestToDomain(manifest *k8sManifest) (model.Manifest, error) {
 		PortForwards: manifest.portForwards,
 	}, nil
 
+}
+
+func SkylarkConfigFilesToDomain(cf []string) []string {
+	ss := sort.StringSlice(cf)
+	ss.Sort()
+
+	return ss
 }
 
 func SkylarkReposToDomain(sMount []mount) []model.LocalGithubRepo {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -386,7 +386,7 @@ func skylarkManifestToDomain(manifest *k8sManifest) (model.Manifest, error) {
 		DockerRef:      image.ref,
 		Name:           model.ManifestName(manifest.name),
 		TiltFilename:   image.tiltFilename,
-		ConfigFiles:    manifest.configFiles,
+		ConfigFiles:    SkylarkConfigFilesToDomain(manifest.configFiles),
 
 		StaticDockerfile: string(staticDockerfileBytes),
 		StaticBuildPath:  string(image.staticBuildPath),


### PR DESCRIPTION
It's possible that other slices in the manifest will need to be treated the same, but I haven't observed any of the others being unstable yet. Cross that bridge when we get to it.