### PR TITLE
engine: organize watch loop to use reactive programming conventions

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -1,0 +1,23 @@
+package engine
+
+import "k8s.io/api/core/v1"
+
+type ErrorAction struct {
+	Error error
+}
+
+func (ErrorAction) Action() {}
+
+func NewErrorAction(err error) ErrorAction {
+	return ErrorAction{Error: err}
+}
+
+type PodChangeAction struct {
+	Pod *v1.Pod
+}
+
+func (PodChangeAction) Action() {}
+
+func NewPodChangeAction(pod *v1.Pod) PodChangeAction {
+	return PodChangeAction{Pod: pod}
+}

--- a/internal/engine/store.go
+++ b/internal/engine/store.go
@@ -1,0 +1,74 @@
+package engine
+
+import "sync"
+
+// A central state store, modeled after the Reactive programming UX pattern.
+// Terminology is borrowed liberally from Redux. These docs in particular are helpful:
+// https://redux.js.org/introduction/threeprinciples
+// https://redux.js.org/basics
+type Store struct {
+	state       *engineState
+	actionQueue *actionQueue
+	actionCh    chan Action
+	mu          sync.Mutex
+
+	// TODO(nick): Define Subscribers and Reducers.
+	// The actionChan is an intermediate representation to make the transition easiser.
+}
+
+func NewStore(state *engineState) *Store {
+	return &Store{
+		state:       state,
+		actionQueue: &actionQueue{},
+		actionCh:    make(chan Action),
+	}
+}
+
+// TODO(nick): Clone the state to ensure it's not mutated.
+func (s *Store) State() engineState {
+	return *(s.state)
+}
+
+func (s *Store) Actions() <-chan Action {
+	return s.actionCh
+}
+
+func (s *Store) Dispatch(action Action) {
+	s.actionQueue.add(action)
+	go s.drainActions()
+}
+
+func (s *Store) drainActions() {
+	// The mutex here ensures that the actions appear on the channel in-order.
+	// It will also be necessary once we have reducers.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	actions := s.actionQueue.drain()
+	for _, action := range actions {
+		s.actionCh <- action
+	}
+}
+
+type Action interface {
+	Action()
+}
+
+type actionQueue struct {
+	actions []Action
+	mu      sync.Mutex
+}
+
+func (q *actionQueue) add(action Action) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.actions = append(q.actions, action)
+}
+
+func (q *actionQueue) drain() []Action {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	result := append([]Action{}, q.actions...)
+	q.actions = nil
+	return result
+}

--- a/internal/engine/up_watch.go
+++ b/internal/engine/up_watch.go
@@ -10,32 +10,26 @@ import (
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
-type manifestFilesChangedEvent struct {
+type manifestFilesChangedAction struct {
 	manifestName model.ManifestName
 	files        []string
 }
 
-type manifestWatcher struct {
-	events <-chan manifestFilesChangedEvent
-	errs   <-chan error
-}
-
-func newDummyManifestWatcher() *manifestWatcher {
-	return &manifestWatcher{}
-}
+func (manifestFilesChangedAction) Action() {}
 
 // returns a manifestWatcher that tells its reader when a manifest's file dependencies have changed
 func makeManifestWatcher(
 	ctx context.Context,
+	store *Store,
 	watcherMaker fsWatcherMaker,
 	timerMaker timerMaker,
-	manifests []model.Manifest) (*manifestWatcher, error) {
+	manifests []model.Manifest) error {
 
 	var sns []manifestNotifyPair
 	for _, manifest := range manifests {
 		watcher, err := watcherMaker()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		localPaths := manifest.LocalPaths()
@@ -47,14 +41,14 @@ func makeManifestWatcher(
 		for _, localPath := range localPaths {
 			err = watcher.Add(localPath)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 
 		for _, cf := range manifest.ConfigFiles {
 			err = watcher.Add(cf)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 
@@ -62,15 +56,10 @@ func makeManifestWatcher(
 	}
 
 	if len(sns) == 0 {
-		return nil, errors.New("--watch used when no manifests define mounts - nothing to watch")
+		return errors.New("--watch used when no manifests define mounts - nothing to watch")
 	}
 
-	ret, err := snsToManifestWatcher(ctx, timerMaker, sns)
-	if err != nil {
-		return nil, err
-	}
-
-	return ret, nil
+	return snsToManifestWatcher(ctx, store, timerMaker, sns)
 }
 
 //makes an attempt to read some events from `eventChan` so that multiple file changes that happen at the same time
@@ -130,10 +119,7 @@ type manifestNotifyPair struct {
 }
 
 // turns a list of (manifest, chan fsevent) pairs into a single chan (manifest, fsevent)
-func snsToManifestWatcher(ctx context.Context, timerMaker timerMaker, sns []manifestNotifyPair) (*manifestWatcher, error) {
-	events := make(chan manifestFilesChangedEvent)
-	errs := make(chan error)
-
+func snsToManifestWatcher(ctx context.Context, store *Store, timerMaker timerMaker, sns []manifestNotifyPair) error {
 	for _, sn := range sns {
 		coalescedEvents := coalesceEvents(timerMaker, sn.notify.Events())
 
@@ -149,32 +135,35 @@ func snsToManifestWatcher(ctx context.Context, timerMaker timerMaker, sns []mani
 					if !ok {
 						return
 					}
-					errs <- err
+					store.Dispatch(NewErrorAction(err))
+
 				case fsEvents, ok := <-coalescedEvents:
 					if !ok {
 						return
 					}
-					watchEvent := manifestFilesChangedEvent{manifestName: manifest.Name}
+					watchEvent := manifestFilesChangedAction{manifestName: manifest.Name}
 					for _, fe := range fsEvents {
 						path, err := filepath.Abs(fe.Path)
 						if err != nil {
-							errs <- err
+							store.Dispatch(NewErrorAction(err))
+							continue
 						}
 						isIgnored, err := filter.Matches(path, false)
 						if err != nil {
-							errs <- err
+							store.Dispatch(NewErrorAction(err))
+							continue
 						}
 						if !isIgnored {
 							watchEvent.files = append(watchEvent.files, path)
 						}
 					}
 					if len(watchEvent.files) > 0 {
-						events <- watchEvent
+						store.Dispatch(watchEvent)
 					}
 				}
 			}
 		}(sn.manifest, sn.notify)
 	}
 
-	return &manifestWatcher{events, errs}, nil
+	return nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -842,9 +842,10 @@ func makeFakeFsWatcherMaker(fn *fakeNotify) fsWatcherMaker {
 	}
 }
 
-func makeFakePodWatcherMaker(ch chan *v1.Pod) func(context.Context) (*podWatcher, error) {
-	return func(context.Context) (*podWatcher, error) {
-		return &podWatcher{ch}, nil
+func makeFakePodWatcherMaker(ch chan *v1.Pod) func(context.Context, *Store) error {
+	return func(ctx context.Context, store *Store) error {
+		go dispatchPodChangesLoop(ch, store)
+		return nil
 	}
 }
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/actions:

6fe0c1d87cae5248332f883f0261050cda8f0bde (2018-10-10 15:47:01 -0400)
engine: organize watch loop to use reactive programming conventions