### PR TITLE
engine: separate out the DeployInfo data from deployInfo readiness

### DIFF
--- a/internal/engine/deploy_test.go
+++ b/internal/engine/deploy_test.go
@@ -1,0 +1,65 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+)
+
+func TestDeployEmpty(t *testing.T) {
+	f := newDeployFixture(t)
+	defer f.TearDown()
+
+	info, err := f.dd.DeployInfoForImageBlocking(f.ctx, image1)
+	assert.Nil(t, err)
+	assert.True(t, info.Empty())
+}
+
+func TestDeploy(t *testing.T) {
+	f := newDeployFixture(t)
+	defer f.TearDown()
+
+	f.kClient.SetPodsWithImageResp(pod1)
+	f.dd.EnsureDeployInfoFetchStarted(f.ctx, image1, k8s.DefaultNamespace)
+
+	info, err := f.dd.DeployInfoForImageBlocking(f.ctx, image1)
+	assert.Nil(t, err)
+	assert.Equal(t, string(k8s.MagicTestContainerID), string(info.containerID))
+}
+
+func TestDeployFail(t *testing.T) {
+	f := newDeployFixture(t)
+	defer f.TearDown()
+
+	fakeErr := fmt.Errorf("my-error")
+	f.kClient.PodsWithImageError = fakeErr
+	f.dd.EnsureDeployInfoFetchStarted(f.ctx, image1, k8s.DefaultNamespace)
+
+	info, err := f.dd.DeployInfoForImageBlocking(f.ctx, image1)
+	assert.Contains(t, err.Error(), fakeErr.Error())
+	assert.True(t, info.Empty())
+}
+
+type deployFixture struct {
+	*tempdir.TempDirFixture
+	ctx     context.Context
+	kClient *k8s.FakeK8sClient
+	dd      *DeployDiscovery
+}
+
+func newDeployFixture(t *testing.T) *deployFixture {
+	f := tempdir.NewTempDirFixture(t)
+	kClient := k8s.NewFakeK8sClient()
+	dd := NewDeployDiscovery(kClient)
+	return &deployFixture{
+		TempDirFixture: f,
+		ctx:            output.CtxForTest(),
+		kClient:        kClient,
+		dd:             dd,
+	}
+}

--- a/internal/engine/local_container_build_and_deployer_test.go
+++ b/internal/engine/local_container_build_and_deployer_test.go
@@ -28,8 +28,8 @@ func TestPostProcessBuild(t *testing.T) {
 	res := store.BuildResult{Image: image1}
 	f.cbad.PostProcessBuild(f.ctx, res, res)
 
-	info, ok := f.cbad.dd.DeployInfoForImageBlocking(f.ctx, image1)
-	assert.True(t, ok)
+	info, err := f.cbad.dd.DeployInfoForImageBlocking(f.ctx, image1)
+	assert.Nil(t, err)
 	assert.Equal(t, string(k8s.MagicTestContainerID), string(info.containerID))
 }
 
@@ -38,16 +38,16 @@ func TestPostProcessBuildNoopIfAlreadyHaveInfo(t *testing.T) {
 
 	f.kCli.SetPodsWithImageResp(pod1)
 
-	info := newEmptyDeployInfo()
-	info.containerID = k8s.ContainerID("ohai")
-	info.markReady()
-	f.cbad.dd.deployInfo[docker.ToImgNameAndTag(image1)] = info
+	entry := newDeployInfoEntry()
+	entry.containerID = k8s.ContainerID("ohai")
+	entry.markReady()
+	f.cbad.dd.deployInfo[docker.ToImgNameAndTag(image1)] = entry
 
 	res := store.BuildResult{Image: image1}
 	f.cbad.PostProcessBuild(f.ctx, res, res)
 
-	info, ok := f.cbad.dd.DeployInfoForImageBlocking(f.ctx, image1)
-	assert.True(t, ok)
+	info, err := f.cbad.dd.DeployInfoForImageBlocking(f.ctx, image1)
+	assert.Nil(t, err)
 	assert.Equal(t, k8s.ContainerID("ohai"), info.containerID,
 		"Getting info again for same image -- contents should not have changed")
 }

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -22,6 +22,7 @@ type FakeK8sClient struct {
 	Lb   LoadBalancerSpec
 
 	PodsWithImageResp         PodID
+	PodsWithImageError        error
 	PollForPodsWithImageDelay time.Duration
 
 	LastPodQueryNamespace Namespace
@@ -65,6 +66,10 @@ func (c *FakeK8sClient) PodByID(ctx context.Context, pID PodID, n Namespace) (*v
 func (c *FakeK8sClient) PodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, labels []LabelPair) ([]v1.Pod, error) {
 	c.LastPodQueryImage = image
 	c.LastPodQueryNamespace = n
+
+	if c.PodsWithImageError != nil {
+		return nil, c.PodsWithImageError
+	}
 
 	status := v1.PodStatus{
 		ContainerStatuses: []v1.ContainerStatus{


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/deployinfo:

f92aaaad732f38eb39cd15155d7e7472d68ed176 (2018-10-11 12:43:43 -0400)
engine: separate out the DeployInfo data from deployInfo readiness