### PR TITLE
tilt: support build log replay

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -75,15 +75,6 @@ func NewUpper(ctx context.Context, b BuildAndDeployer, k8s k8s.Client, browserMo
 		return watch.NewWatcher()
 	}
 
-	// Run the HUD in the background
-	go func() {
-		err := hud.Run(ctx)
-		if err != nil {
-			//TODO(matt) this might not be the best thing to do with an error - seems easy to miss
-			logger.Get(ctx).Infof("error in hud: %v", err)
-		}
-	}()
-
 	return Upper{
 		b:               b,
 		fsWatcherMaker:  fsWatcherMaker,
@@ -105,6 +96,15 @@ func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest, 
 		WatchMounts: watchMounts,
 		Manifests:   manifests,
 	})
+
+	// Run the HUD in the background
+	go func() {
+		err := u.hud.Run(ctx, u.store)
+		if err != nil {
+			//TODO(matt) this might not be the best thing to do with an error - seems easy to miss
+			logger.Get(ctx).Infof("error in hud: %v", err)
+		}
+	}()
 
 	for {
 		if len(u.store.State().ManifestStates) > 0 {
@@ -143,7 +143,8 @@ func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest, 
 				if !u.store.State().WatchMounts && len(u.store.State().ManifestsToBuild) == 0 {
 					return nil
 				}
-
+			case hud.ReplayBuildLogAction:
+				replayBuildLog(ctx, u.store.State(), action.ResourceNumber)
 			default:
 				return fmt.Errorf("Unrecognized action: %T", action)
 
@@ -495,6 +496,24 @@ func (u Upper) reapOldWatchBuilds(ctx context.Context, manifests []model.Manifes
 	}
 
 	return nil
+}
+
+func replayBuildLog(ctx context.Context, state store.EngineState, resourceNumber int) {
+	if resourceNumber > len(state.ManifestDefinitionOrder) {
+		logger.Get(ctx).Infof("Resource %d does not exist, so no log to print", resourceNumber)
+		return
+	}
+
+	mn := state.ManifestDefinitionOrder[resourceNumber-1]
+
+	ms := state.ManifestStates[mn]
+	if ms.LastBuildFinishTime.Equal(time.Time{}) {
+		logger.Get(ctx).Infof("Resource %d has no previous build, so no log to print", resourceNumber)
+		return
+	}
+
+	logger.Get(ctx).Infof("Reprinting last build log for %s:", mn)
+	logger.Get(ctx).Infof("%s", ms.LastBuildLog.String())
 }
 
 var _ model.ManifestCreator = Upper{}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -11,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/windmilleng/tilt/internal/testutils/bufsync"
 
 	"github.com/docker/distribution/reference"
 	"github.com/stretchr/testify/assert"
@@ -901,7 +902,7 @@ type testFixture struct {
 	hud                   *hud.FakeHud
 	podEvents             chan *v1.Pod
 	createManifestsResult chan error
-	log                   *bytes.Buffer
+	log                   *bufsync.ThreadSafeBuffer
 }
 
 func newTestFixture(t *testing.T) *testFixture {
@@ -921,7 +922,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	hud := hud.NewFakeHud()
 
-	log := new(bytes.Buffer)
+	log := new(bufsync.ThreadSafeBuffer)
 	ctx, cancel := context.WithCancel(testoutput.ForkedCtxForTest(log))
 
 	upper := Upper{

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -922,7 +922,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	hud := hud.NewFakeHud()
 
-	log := new(bufsync.ThreadSafeBuffer)
+	log := bufsync.NewThreadSafeBuffer()
 	ctx, cancel := context.WithCancel(testoutput.ForkedCtxForTest(log))
 
 	upper := Upper{

--- a/internal/hud/actions.go
+++ b/internal/hud/actions.go
@@ -1,0 +1,12 @@
+package hud
+
+type ReplayBuildLogAction struct {
+	// 1-based index of resource whose log should be printed
+	ResourceNumber int
+}
+
+func (ReplayBuildLogAction) Action() {}
+
+func NewReplayBuildLogAction(resourceNumber int) ReplayBuildLogAction {
+	return ReplayBuildLogAction{resourceNumber}
+}

--- a/internal/hud/fake_hud.go
+++ b/internal/hud/fake_hud.go
@@ -3,6 +3,8 @@ package hud
 import (
 	"context"
 
+	"github.com/windmilleng/tilt/internal/store"
+
 	"github.com/windmilleng/tilt/internal/hud/view"
 )
 
@@ -19,7 +21,7 @@ func NewFakeHud() *FakeHud {
 	}
 }
 
-func (h *FakeHud) Run(ctx context.Context) error { return nil }
+func (h *FakeHud) Run(ctx context.Context, st *store.Store) error { return nil }
 
 func (h *FakeHud) Update(v view.View) error {
 	h.LastView = v

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -6,10 +6,11 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/windmilleng/tilt/internal/hud/view"
+	"github.com/windmilleng/tilt/internal/store"
 )
 
 type HeadsUpDisplay interface {
-	Run(ctx context.Context) error
+	Run(ctx context.Context, st *store.Store) error
 	Update(v view.View) error
 }
 
@@ -32,13 +33,13 @@ func NewDefaultHeadsUpDisplay() (HeadsUpDisplay, error) {
 	}, nil
 }
 
-func (h *Hud) Run(ctx context.Context) error {
+func (h *Hud) Run(ctx context.Context, st *store.Store) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case ready := <-h.a.readyCh:
-			err := h.r.SetUp(ready)
+			err := h.r.SetUp(ready, st)
 			if err != nil {
 				return err
 			}

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/windmilleng/tcell"
 	"github.com/windmilleng/tilt/internal/hud/view"
+	"github.com/windmilleng/tilt/internal/store"
 )
 
 type Renderer struct {
@@ -148,7 +149,7 @@ func renderResource(p *pen, r view.Resource) {
 
 }
 
-func (r *Renderer) SetUp(event ReadyEvent) error {
+func (r *Renderer) SetUp(event ReadyEvent, st *store.Store) error {
 	r.screenMu.Lock()
 	defer r.screenMu.Unlock()
 
@@ -171,6 +172,11 @@ func (r *Renderer) SetUp(event ReadyEvent) error {
 				case tcell.KeyEscape, tcell.KeyEnter:
 					// TODO: tell `tilt hud` to exit
 					screen.Fini()
+				case tcell.KeyRune:
+					switch r := ev.Rune(); {
+					case r >= '1' && r <= '9':
+						st.Dispatch(NewReplayBuildLogAction(int(r - '0')))
+					}
 				}
 			}
 		}

--- a/internal/testutils/output/context.go
+++ b/internal/testutils/output/context.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"io"
 	"os"
 
 	"github.com/windmilleng/tilt/internal/logger"
@@ -14,5 +15,15 @@ func CtxForTest() context.Context {
 	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
 	ctx := logger.WithLogger(context.Background(), l)
 	ctx = output.WithOutputter(ctx, output.NewOutputter(l))
+	return ctx
+}
+
+// CtxForTest returns a context.Context suitable for use in tests (i.e. with
+// logger, outputter, etc. attached), and with all output being copied to `w`
+func ForkedCtxForTest(w io.Writer) context.Context {
+	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
+	ctx := logger.WithLogger(context.Background(), l)
+	ctx = output.WithOutputter(ctx, output.NewOutputter(l))
+	ctx = output.CtxWithForkedOutput(ctx, w)
 	return ctx
 }


### PR DESCRIPTION
The 1-9 keys will now replay the last build log for that resource (in display order).

This is not the interface we intend to ship with the alpha, but is a cheap way to get us basic usability while we mature the UI code.