### PR TITLE
tiltfile: respect gitignore when adding subpaths. Fixes gitignore in servantes

### DIFF
--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -202,6 +202,7 @@ func addMount(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 	switch p := src.(type) {
 	case localPath:
 		m.src = p
+		m.repo = p.repo
 	case gitRepo:
 		m.src = localPath{p.basePath, p}
 		m.repo = p


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/gitignore:

4333eff7551d0cf83fbc385b52ee84e3ca02f3cb (2018-10-11 15:21:39 -0400)
tiltfile: respect gitignore when adding subpaths. Fixes gitignore in servantes