### PR TITLE
tilt: put LB URLs in EngineState and HUD

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -35,6 +35,7 @@ func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model
 		engine.DeployerWireSet,
 		engine.DefaultShouldFallBack,
 		engine.ProvidePodWatcherMaker,
+		engine.ProvideServiceWatcherMaker,
 		engine.NewPodLogManager,
 
 		hud.NewDefaultHeadsUpDisplay,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -66,9 +66,10 @@ func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model
 		return nil, err
 	}
 	podWatcherMaker := engine.ProvidePodWatcherMaker(k8sClient)
+	serviceWatcherMaker := engine.ProvideServiceWatcherMaker(k8sClient)
 	storeStore := store.NewStore()
 	podLogManager := engine.NewPodLogManager(k8sClient, deployDiscovery)
-	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, k8sClient, browser, imageReaper, headsUpDisplay, podWatcherMaker, storeStore, podLogManager)
+	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, k8sClient, browser, imageReaper, headsUpDisplay, podWatcherMaker, serviceWatcherMaker, storeStore, podLogManager)
 	return upper, nil
 }
 

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -26,6 +26,16 @@ func NewPodChangeAction(pod *v1.Pod) PodChangeAction {
 	return PodChangeAction{Pod: pod}
 }
 
+type ServiceChangeAction struct {
+	Service *v1.Service
+}
+
+func (ServiceChangeAction) Action() {}
+
+func NewServiceChangeAction(service *v1.Service) ServiceChangeAction {
+	return ServiceChangeAction{Service: service}
+}
+
 type BuildCompleteAction struct {
 	Result store.BuildResult
 	Error  error

--- a/internal/engine/service_watch.go
+++ b/internal/engine/service_watch.go
@@ -1,0 +1,27 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/windmilleng/tilt/internal/store"
+
+	"github.com/windmilleng/tilt/internal/k8s"
+	"k8s.io/api/core/v1"
+)
+
+func makeServiceWatcher(ctx context.Context, kCli k8s.Client, st *store.Store) error {
+	ch, err := kCli.WatchServices(ctx, []k8s.LabelPair{TiltRunLabel()})
+	if err != nil {
+		return err
+	}
+
+	go dispatchServiceChangesLoop(ch, st)
+
+	return nil
+}
+
+func dispatchServiceChangesLoop(ch <-chan *v1.Service, st *store.Store) {
+	for service := range ch {
+		st.Dispatch(NewServiceChangeAction(service))
+	}
+}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -881,6 +881,7 @@ func TestUpper_ServiceEvent(t *testing.T) {
 
 	f.Start([]model.Manifest{manifest}, true)
 
+	<-f.hud.Updates
 	<-f.b.calls
 	<-f.hud.Updates
 	f.upper.store.Dispatch(NewServiceChangeAction(testService("myservice", "foobar", "1.2.3.4", 8080)))
@@ -900,6 +901,7 @@ func TestUpper_ServiceEvent(t *testing.T) {
 	assert.Equal(t, "http://1.2.3.4:8080/", url.String())
 
 	f.assertAllBuildsConsumed()
+	f.assertAllHUDUpdatesConsumed()
 }
 
 type fakeTimerMaker struct {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -849,6 +849,59 @@ func TestUpper_ReplayBuildLogNonExistentResource(t *testing.T) {
 	f.assertAllHUDUpdatesConsumed()
 }
 
+func testService(serviceName string, manifestName string, ip string, port int) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   serviceName,
+			Labels: map[string]string{ManifestNameLabel: manifestName},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Port: int32(port),
+			}},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: ip,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestUpper_ServiceEvent(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	mount := model.Mount{LocalPath: "/go", ContainerPath: "/go"}
+	manifest := f.newManifest("foobar", []model.Mount{mount})
+
+	f.Start([]model.Manifest{manifest}, true)
+
+	<-f.b.calls
+	<-f.hud.Updates
+	f.upper.store.Dispatch(NewServiceChangeAction(testService("myservice", "foobar", "1.2.3.4", 8080)))
+
+	<-f.hud.Updates
+	err := f.Stop()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	ms := f.upper.store.State().ManifestStates[manifest.Name]
+	assert.Equal(t, 1, len(ms.LBs))
+	url, ok := ms.LBs["myservice"]
+	if !ok {
+		t.Fatalf("%v did not contain key 'myservice'", ms.LBs)
+	}
+	assert.Equal(t, "http://1.2.3.4:8080/", url.String())
+
+	f.assertAllBuildsConsumed()
+}
+
 type fakeTimerMaker struct {
 	restTimerLock *sync.Mutex
 	maxTimerLock  *sync.Mutex
@@ -900,6 +953,13 @@ func makeFakePodWatcherMaker(ch chan *v1.Pod) func(context.Context, *store.Store
 	}
 }
 
+func makeFakeServiceWatcherMaker(ch chan *v1.Service) func(context.Context, *store.Store) error {
+	return func(ctx context.Context, st *store.Store) error {
+		go dispatchServiceChangesLoop(ch, st)
+		return nil
+	}
+}
+
 type testFixture struct {
 	*tempdir.TempDirFixture
 	ctx                   context.Context
@@ -911,6 +971,7 @@ type testFixture struct {
 	docker                *docker.FakeDockerClient
 	hud                   *hud.FakeHud
 	podEvents             chan *v1.Pod
+	serviceEvents         chan *v1.Service
 	createManifestsResult chan error
 	log                   *bufsync.ThreadSafeBuffer
 }
@@ -923,6 +984,9 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	podEvents := make(chan *v1.Pod)
 	fakePodWatcherMaker := makeFakePodWatcherMaker(podEvents)
+
+	serviceEvents := make(chan *v1.Service)
+	fakeServiceWatcherMaker := makeFakeServiceWatcherMaker(serviceEvents)
 
 	timerMaker := makeFakeTimerMaker(t)
 	docker := docker.NewFakeDockerClient()
@@ -939,16 +1003,17 @@ func newTestFixture(t *testing.T) *testFixture {
 	plm := NewPodLogManager(k8s, dd)
 
 	upper := Upper{
-		b:               b,
-		fsWatcherMaker:  fsWatcherMaker,
-		timerMaker:      timerMaker.maker(),
-		podWatcherMaker: fakePodWatcherMaker,
-		k8s:             k8s,
-		browserMode:     BrowserAuto,
-		reaper:          reaper,
-		hud:             hud,
-		store:           store.NewStore(),
-		plm:             plm,
+		b:                   b,
+		fsWatcherMaker:      fsWatcherMaker,
+		timerMaker:          timerMaker.maker(),
+		podWatcherMaker:     fakePodWatcherMaker,
+		serviceWatcherMaker: fakeServiceWatcherMaker,
+		k8s:                 k8s,
+		browserMode:         BrowserOff,
+		reaper:              reaper,
+		hud:                 hud,
+		store:               store.NewStore(),
+		plm:                 plm,
 	}
 
 	return &testFixture{
@@ -962,6 +1027,7 @@ func newTestFixture(t *testing.T) *testFixture {
 		docker:         docker,
 		hud:            hud,
 		podEvents:      podEvents,
+		serviceEvents:  serviceEvents,
 		log:            log,
 	}
 }

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -143,8 +143,9 @@ func renderResource(p *pen, r view.Resource) {
 	if r.PodStatus != "" {
 		p.putlnf("  K8s:   Pod %s - %s ago • Status: %s", r.PodName, formatDuration(time.Since(r.PodCreationTime)), r.PodStatus)
 	}
-	if r.Endpoint != "" {
-		p.putlnf("         %s", r.Endpoint)
+
+	if len(r.Endpoints) != 0 {
+		p.putlnf("         %s", strings.Join(r.Endpoints, " "))
 	}
 
 }

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -21,7 +21,7 @@ type Resource struct {
 	PodName         string
 	PodCreationTime time.Time
 	PodStatus       string
-	Endpoint        string
+	Endpoints       []string
 }
 
 type View struct {

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -33,6 +33,10 @@ type FakeK8sClient struct {
 	PodLogs string
 }
 
+func (c *FakeK8sClient) WatchServices(ctx context.Context, lps []LabelPair) (<-chan *v1.Service, error) {
+	return nil, nil
+}
+
 func (c *FakeK8sClient) WatchPods(ctx context.Context, lps []LabelPair) (<-chan *v1.Pod, error) {
 	return nil, nil
 }

--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -51,3 +51,47 @@ func (kCli K8sClient) WatchPods(ctx context.Context, lps []LabelPair) (<-chan *v
 
 	return ch, nil
 }
+
+func (kCli K8sClient) WatchServices(ctx context.Context, lps []LabelPair) (<-chan *v1.Service, error) {
+	ch := make(chan *v1.Service)
+
+	ls := labels.Set{}
+	for _, lp := range lps {
+		ls[lp.Key] = lp.Value
+	}
+
+	// passing "" gets us all namespaces
+	watcher, err := kCli.core.Services("").Watch(metav1.ListOptions{LabelSelector: ls.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					close(ch)
+					return
+				}
+
+				if event.Object == nil {
+					continue
+				}
+
+				service, ok := event.Object.(*v1.Service)
+				if !ok {
+					continue
+				}
+
+				ch <- service
+			case <-ctx.Done():
+				watcher.Stop()
+				close(ch)
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}


### PR DESCRIPTION
1. subscribe to k8s service changes (most of the code in this diff is copying the pod-watching code for service watching.
2. when we get an LB, save its URL into EngineState
3. render those URLs in the HUD