### PR TITLE
engine: clean up loops on cancel, so that there are fewer goroutines to sort thru in tests

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1093,14 +1093,14 @@ func makeFakeFsWatcherMaker(fn *fakeNotify) fsWatcherMaker {
 
 func makeFakePodWatcherMaker(ch chan *v1.Pod) func(context.Context, *store.Store) error {
 	return func(ctx context.Context, st *store.Store) error {
-		go dispatchPodChangesLoop(ch, st)
+		go dispatchPodChangesLoop(ctx, ch, st)
 		return nil
 	}
 }
 
 func makeFakeServiceWatcherMaker(ch chan *v1.Service) func(context.Context, *store.Store) error {
 	return func(ctx context.Context, st *store.Store) error {
-		go dispatchServiceChangesLoop(ch, st)
+		go dispatchServiceChangesLoop(ctx, ch, st)
 		return nil
 	}
 }
@@ -1242,6 +1242,8 @@ func (f *testFixture) LogLines() []string {
 func (f *testFixture) TearDown() {
 	f.TempDirFixture.TearDown()
 	f.cancel()
+	close(f.podEvents)
+	close(f.serviceEvents)
 }
 
 func (f *testFixture) newManifest(name string, mounts []model.Mount) model.Manifest {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/loops:

b58edd3209aacc91fdc67e149332fecac08d3602 (2018-10-12 17:26:09 -0400)
engine: clean up loops on cancel, so that there are fewer goroutines to sort thru in tests