### PR TITLE
tilt: reset terminal on hud exit

### DIFF
--- a/internal/cli/hud.go
+++ b/internal/cli/hud.go
@@ -49,6 +49,18 @@ func (c *hudCmd) run(ctx context.Context, args []string) error {
 
 	logOutput(fmt.Sprintf("Starting the HUD (built %s)…\n", buildDateStamp()))
 
+	// TODO(matt) figure out why tcell's Fini isn't working for us here
+	// this is a crummy workaround
+	defer func() {
+		cmd := exec.Command("reset")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("error restoring terminal settings: %v", err)
+		}
+	}()
+
 	return connectHud(ctx)
 }
 


### PR DESCRIPTION
Problem:
For some reason, tcell's `Fini` is not working in the `hud` process, whether called from the `hud` process itself, or on the hud's tty from the `up` process. When the hud exits, we're left with a terminal that doesn't echo input, show the cursor, or reset to column 0 on `\n` (among probably others).

Solution:
Call `reset` from the hud before we exit. This ain't great because it clears the screen.
I also tried saving off the termios before and restoring it after. That mostly worked, and did not clear the screen, but still left me with an invisible cursor for reasons I did not manage to understand in 20 minutes.