### PR TITLE
engine: disable the refresh timer in testing

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -128,6 +128,8 @@ func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest, 
 		u.maybeStartBuild(ctx, u.store)
 		u.maybeUpdateHUD(ctx, u.store)
 
+		timer := u.timerMaker(refreshInterval)
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -140,7 +142,10 @@ func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest, 
 				state.PermanentError = err
 			}
 			u.store.UnlockMutableState()
-		case <-time.After(refreshInterval):
+
+			// TODO(nick): This should be internal to the HUD
+			// once we have a way to do the locking properly.
+		case <-timer:
 			break
 		}
 	}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/timer:

bc6590fdeb11d5c514db72d2ce52c5b2a1757292 (2018-10-12 17:54:48 -0400)
engine: disable the refresh timer in testing