### PR TITLE
engine: auto-reconnect log streaming if the container crashes by making PodLogManager more reactive

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -68,7 +68,7 @@ func wireManifestCreator(ctx context.Context, browser engine.BrowserMode) (model
 	}
 	podWatcherMaker := engine.ProvidePodWatcherMaker(k8sClient)
 	serviceWatcherMaker := engine.ProvideServiceWatcherMaker(k8sClient)
-	podLogManager := engine.NewPodLogManager(k8sClient, deployDiscovery, storeStore)
+	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, k8sClient, browser, imageReaper, headsUpDisplay, podWatcherMaker, serviceWatcherMaker, storeStore, podLogManager, portForwardController)
 	return upper, nil

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -4,81 +4,108 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
 
-	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/output"
 	"github.com/windmilleng/tilt/internal/store"
+	"k8s.io/api/core/v1"
 )
 
 // Collects logs from deployed containers.
 type PodLogManager struct {
 	kClient k8s.Client
-	dd      *DeployDiscovery
-	store   *store.Store
 
-	// TODO(nick): This should really be part of a reactive state store.
-	watches map[docker.ImgNameAndTag]PodLogWatch
-	mu      sync.Mutex
+	watches map[podLogKey]PodLogWatch
 }
 
-func NewPodLogManager(kClient k8s.Client, dd *DeployDiscovery, store *store.Store) *PodLogManager {
+func NewPodLogManager(kClient k8s.Client) *PodLogManager {
 	return &PodLogManager{
 		kClient: kClient,
-		dd:      dd,
-		store:   store,
-		watches: make(map[docker.ImgNameAndTag]PodLogWatch),
+		watches: make(map[podLogKey]PodLogWatch),
 	}
 }
 
-func (m *PodLogManager) PostProcessBuild(ctx context.Context, name model.ManifestName, result, previousResult store.BuildResult) {
-	if previousResult.HasImage() && (!result.HasImage() || result.Image != previousResult.Image) {
-		m.tearDownWatcher(previousResult)
+// Diff the current watches against the state store of what
+// we're supposed to be watching, returning the changes
+// we need to make.
+func (m *PodLogManager) diff(ctx context.Context, st *store.Store) (setup []PodLogWatch, teardown []PodLogWatch) {
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	// If we're not watching the mounts, then don't bother watching logs.
+	if !state.WatchMounts {
+		return nil, nil
 	}
 
-	if !result.HasImage() {
-		// This is normal if the previous build failed.
-		return
+	stateWatches := make(map[podLogKey]bool, 0)
+	for _, ms := range state.ManifestStates {
+		pod := ms.Pod
+		if pod.PodID == "" || pod.ContainerName == "" || pod.ContainerID == "" {
+			continue
+		}
+
+		// Only fetch pod logs if the pod is running.
+		// Otherwise it will reject our connection.
+		if ms.Pod.Phase != v1.PodRunning {
+			continue
+		}
+
+		// Key the log watcher by the container id, so we auto-restart the
+		// watching if the container crashes.
+		key := podLogKey{
+			podID: pod.PodID,
+			cID:   pod.ContainerID,
+		}
+		stateWatches[key] = true
+
+		_, isActive := m.watches[key]
+		if isActive {
+			continue
+		}
+
+		ctx, cancel := context.WithCancel(ctx)
+		w := PodLogWatch{
+			ctx:       ctx,
+			cancel:    cancel,
+			name:      ms.Manifest.Name,
+			podID:     pod.PodID,
+			cID:       pod.ContainerID,
+			cName:     pod.ContainerName,
+			namespace: pod.Namespace,
+		}
+		m.watches[key] = w
+		setup = append(setup, w)
 	}
 
-	m.dd.EnsureDeployInfoFetchStarted(ctx, result.Image, result.Namespace)
-	m.setUpWatcher(ctx, name, result)
+	for key, value := range m.watches {
+		_, inState := stateWatches[key]
+		if !inState {
+			delete(m.watches, key)
+			teardown = append(teardown, value)
+		}
+	}
+
+	return setup, teardown
 }
 
-func (m *PodLogManager) setUpWatcher(ctx context.Context, name model.ManifestName, result store.BuildResult) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	key := docker.ToImgNameAndTag(result.Image)
-	w, ok := m.watches[key]
-	if ok {
-		return
+func (m *PodLogManager) OnChange(ctx context.Context, st *store.Store) {
+	setup, teardown := m.diff(ctx, st)
+	for _, watch := range teardown {
+		watch.cancel()
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	w = PodLogWatch{ctx: ctx, cancel: cancel}
-	m.watches[key] = w
-
-	go m.consumeLogs(name, result, w)
+	for _, watch := range setup {
+		go m.consumeLogs(watch, st)
+	}
 }
 
-func (m *PodLogManager) consumeLogs(name model.ManifestName, result store.BuildResult, watch PodLogWatch) {
-	defer m.tearDownWatcher(result)
-
-	deployInfo, err := m.dd.DeployInfoForImageBlocking(watch.ctx, result.Image)
-	if err != nil {
-		logger.Get(watch.ctx).Infof("Error streaming %s logs: %v", name, err)
-		return
-	} else if deployInfo.Empty() {
-		logger.Get(watch.ctx).Infof("Error streaming %s logs: pod not found", name)
-		return
-	}
-
-	pID := deployInfo.podID
-	containerName := deployInfo.containerName
-	ns := result.Namespace
+func (m *PodLogManager) consumeLogs(watch PodLogWatch, st *store.Store) {
+	name := watch.name
+	pID := watch.podID
+	containerName := watch.cName
+	ns := watch.namespace
 	readCloser, err := m.kClient.ContainerLogs(watch.ctx, pID, containerName, ns)
 	if err != nil {
 		logger.Get(watch.ctx).Infof("Error streaming %s logs: %v", name, err)
@@ -91,7 +118,7 @@ func (m *PodLogManager) consumeLogs(name model.ManifestName, result store.BuildR
 	logWriter := logger.Get(watch.ctx).Writer(logger.InfoLvl)
 	prefixLogWriter := output.NewPrefixedWriter(fmt.Sprintf("[%s] ", name), logWriter)
 	actionWriter := PodLogActionWriter{
-		store:        m.store,
+		store:        st,
 		manifestName: name,
 		podID:        pID,
 	}
@@ -104,20 +131,20 @@ func (m *PodLogManager) consumeLogs(name model.ManifestName, result store.BuildR
 	}
 }
 
-func (m *PodLogManager) tearDownWatcher(result store.BuildResult) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	key := docker.ToImgNameAndTag(result.Image)
-	w, ok := m.watches[key]
-	if ok {
-		w.cancel()
-	}
-	delete(m.watches, key)
-}
-
 type PodLogWatch struct {
 	ctx    context.Context
 	cancel func()
+
+	name      model.ManifestName
+	podID     k8s.PodID
+	namespace k8s.Namespace
+	cID       k8s.ContainerID
+	cName     k8s.ContainerName
+}
+
+type podLogKey struct {
+	podID k8s.PodID
+	cID   k8s.ContainerID
 }
 
 type PodLogActionWriter struct {
@@ -134,3 +161,5 @@ func (w PodLogActionWriter) Write(p []byte) (n int, err error) {
 	})
 	return len(p), nil
 }
+
+var _ store.Subscriber = &PodLogManager{}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -60,7 +60,6 @@ type Upper struct {
 	reaper              build.ImageReaper
 	hud                 hud.HeadsUpDisplay
 	store               *store.Store
-	plm                 *PodLogManager
 }
 
 type fsWatcherMaker func() (watch.Notify, error)
@@ -89,6 +88,7 @@ func NewUpper(ctx context.Context, b BuildAndDeployer, k8s k8s.Client, browserMo
 
 	st.AddSubscriber(hud)
 	st.AddSubscriber(pfc)
+	st.AddSubscriber(plm)
 
 	return Upper{
 		b:                   b,
@@ -101,7 +101,6 @@ func NewUpper(ctx context.Context, b BuildAndDeployer, k8s k8s.Client, browserMo
 		reaper:              reaper,
 		hud:                 hud,
 		store:               st,
-		plm:                 plm,
 	}
 }
 
@@ -315,15 +314,9 @@ func (u Upper) handleCompletedBuild(ctx context.Context, engineState *store.Engi
 		}
 	} else {
 		ms.LastSuccessfulDeployTime = time.Now()
-
-		prevBuild := ms.LastBuild
 		ms.LastBuild = store.NewBuildState(cb.Result)
 		ms.LastSuccessfulDeployEdits = ms.CurrentlyBuildingFileChanges
 		ms.CurrentlyBuildingFileChanges = nil
-
-		if engineState.WatchMounts {
-			u.plm.PostProcessBuild(ctx, ms.Manifest.Name, cb.Result, prevBuild.LastResult)
-		}
 	}
 
 	if engineState.WatchMounts {
@@ -428,6 +421,7 @@ func ensureManifestStateWithPod(state *store.EngineState, pod *v1.Pod) *store.Ma
 func populateContainerStatus(ctx context.Context, ms *store.ManifestState, pod *v1.Pod, cStatus v1.ContainerStatus) {
 	cName := k8s.ContainerNameFromContainerStatus(cStatus)
 	ms.Pod.ContainerName = cName
+	ms.Pod.ContainerReady = cStatus.Ready
 
 	cID, err := k8s.ContainerIDFromContainerStatus(cStatus)
 	if err != nil {
@@ -471,8 +465,6 @@ func handlePodEvent(ctx context.Context, state *store.EngineState, pod *v1.Pod) 
 	cStatus, err := k8s.ContainerMatching(pod, ms.Manifest.DockerRef)
 	if err != nil {
 		logger.Get(ctx).Debugf("Error matching container: %v", err)
-		return
-	} else if !cStatus.Ready {
 		return
 	}
 	populateContainerStatus(ctx, ms, pod, cStatus)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1240,8 +1240,9 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	st := store.NewStore()
 	st.AddSubscriber(hud)
-	dd := NewDeployDiscovery(k8s, st)
-	plm := NewPodLogManager(k8s, dd, st)
+
+	plm := NewPodLogManager(k8s)
+	st.AddSubscriber(plm)
 
 	upper := Upper{
 		b:                   b,
@@ -1254,7 +1255,6 @@ func newTestFixture(t *testing.T) *testFixture {
 		reaper:              reaper,
 		hud:                 hud,
 		store:               st,
-		plm:                 plm,
 	}
 
 	return &testFixture{

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -30,7 +30,8 @@ type FakeK8sClient struct {
 	LastPodQueryNamespace Namespace
 	LastPodQueryImage     reference.NamedTagged
 
-	PodLogs string
+	PodLogs            string
+	ContainerLogsError error
 
 	LastForwardPortPodID      PodID
 	LastForwardPortRemotePort int
@@ -71,6 +72,9 @@ func (c *FakeK8sClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interf
 }
 
 func (c *FakeK8sClient) ContainerLogs(ctx context.Context, pID PodID, cName ContainerName, n Namespace) (io.ReadCloser, error) {
+	if c.ContainerLogsError != nil {
+		return nil, c.ContainerLogsError
+	}
 	return BufferCloser{bytes.NewBufferString(c.PodLogs)}, nil
 }
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -85,6 +85,7 @@ type Pod struct {
 	ContainerName  k8s.ContainerName
 	ContainerID    k8s.ContainerID
 	ContainerPorts []int32
+	ContainerReady bool
 }
 
 func shortenFile(baseDirs []string, f string) string {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch551:

3cd7bafb6209d96950f66ba2e2ff6d95adf697c7 (2018-10-16 11:05:48 -0400)
engine: auto-reconnect log streaming if the container crashes by making PodLogManager more reactive