### PR TITLE
tilt: fix pod unknown/pending status color

### DIFF
--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -90,6 +90,7 @@ var cPending = tcell.ColorYellow
 var podStatusColors = map[string]tcell.Color{
 	"Running":           cGood,
 	"ContainerCreating": cPending,
+	"Pending":           cPending,
 	"Error":             cBad,
 	"CrashLoopBackOff":  cBad,
 }
@@ -211,7 +212,7 @@ func renderResource(r view.Resource) rty.Component {
 	if r.PodStatus != "" {
 		podStatusColor, ok := podStatusColors[r.PodStatus]
 		if !ok {
-			podStatusColor = tcell.ColorBlack
+			podStatusColor = tcell.ColorDefault
 		}
 
 		l := rty.NewLine()


### PR DESCRIPTION
1. when a pod has a status with no defined color, we are printing black on black, which ain't great
2. we could probably give the "pending" status the color for pending!