### PR TITLE
engine: correctly handle the case when the container id hasn't materialized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 *.generated.yaml
 
 .synclet-dev-image-tag
+.#*

--- a/internal/engine/deploy.go
+++ b/internal/engine/deploy.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -127,6 +128,8 @@ func (d *DeployDiscovery) populateDeployInfo(ctx context.Context, image referenc
 	cID, err := k8s.ContainerIDFromContainerStatus(cStatus)
 	if err != nil {
 		return errors.Wrapf(err, "populateDeployInfo")
+	} else if cID == "" {
+		return fmt.Errorf("Missing container ID: %+v", cStatus)
 	}
 
 	cName := k8s.ContainerNameFromContainerStatus(cStatus)

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -462,6 +462,8 @@ func handlePodEvent(ctx context.Context, state *store.EngineState, pod *v1.Pod) 
 	if err != nil {
 		logger.Get(ctx).Debugf("Error matching container: %v", err)
 		return
+	} else if cStatus.Name == "" {
+		return
 	}
 	populateContainerStatus(ctx, ms, pod, cStatus)
 }

--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -115,6 +115,10 @@ func ContainerMatching(pod *v1.Pod, ref reference.Named) (v1.ContainerStatus, er
 
 func ContainerIDFromContainerStatus(status v1.ContainerStatus) (ContainerID, error) {
 	id := status.ContainerID
+	if id == "" {
+		return "", nil
+	}
+
 	if !strings.HasPrefix(id, containerIDPrefix) {
 		return "", fmt.Errorf("Malformed container ID: %s", id)
 	}


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/cid:

9dbd65f3303d9617f753b53579f523e043bc8f8d (2018-10-16 15:19:17 -0400)
engine: correctly handle the case when the container id hasn't materialized