### PR TITLE
tilt: don't print hud context canceled errors

### DIFF
--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -39,7 +39,12 @@ func (h *Hud) Run(ctx context.Context, st *store.Store) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			err := ctx.Err()
+			if err != context.Canceled {
+				return err
+			} else {
+				return nil
+			}
 		case ready := <-h.a.readyCh:
 			err := h.r.SetUp(ready, st)
 			if err != nil {


### PR DESCRIPTION
we've been printing this when quitting `tilt up` with a hud attached:
`^Cerror in hud: context canceled`

no more!