### PR TITLE
watch: use `sinceWhen` and `HistoryDone` to avoid spurious events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - homebrew_cache_v3
+            - homebrew_cache_v5
       - run: brew install go@1.10 kustomize # bump cache version when changing this
       - save_cache:
           paths:
             - /usr/local/Homebrew
-          key: homebrew_cache_v3
+          key: homebrew_cache_v5
       - run: echo 'export PATH="/usr/local/opt/go@1.10/bin:$PATH"' >> $BASH_ENV
       # We can't run the container tests on macos because nested
       # VMs don't work on circleci.

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -304,7 +303,7 @@ func TestWatchBrokenLink(t *testing.T) {
 	f.assertEvents(link)
 }
 
-func TestVimEdit(t *testing.T) {
+func TestMoveAndReplace(t *testing.T) {
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 
@@ -319,21 +318,23 @@ func TestVimEdit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = f.notify.Add(root.Path())
+	err = f.notify.Add(file)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// ex -s +'%s/hello/world/g' -cwq file
-	cmd := fmt.Sprintf("ex -s '+%%s/hello/world/g' %s", file)
-	fmt.Println(cmd)
-	out, err := exec.Command("sh", "-c", cmd).Output()
-	fmt.Println(out)
+	tmpFile := filepath.Join(root.Path(), ".myfile.swp")
+	err = ioutil.WriteFile(tmpFile, []byte("world"), 0777)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	f.assertEvents(file, filepath.Join(root.Path(), ".myfile.swpx"), filepath.Join(root.Path(), ".myfile.swp"))
+	err = os.Rename(tmpFile, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.assertEvents(file)
 }
 
 type notifyFixture struct {


### PR DESCRIPTION
TODO: I need to write a test for this new behavior, wanted to get this solution in front of y'all first.

Here's our new watch strategy on Darwin in a nutshell:

1. Create an fsevents stream for events "since" the last event ID that
we saw globally.
2. Add a path that we want to watch
3. Add that path to a map of paths that we're watching _directly_.
4. Restart the event stream to pick up the new path.
5. Ignore all events for all watches until we've seen a `HistoryDone`
event.
6. Ignore the first `ItemCreated` event for paths we're watching that
are also directories
7. Otherwise, forward along all events.