### PR TITLE
engine: don't image build if config file changes but doesn't result in manifest change

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/windmilleng/tilt/internal/testutils/bufsync"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/windmilleng/tilt/internal/testutils/bufsync"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 
@@ -547,10 +548,7 @@ func TestNoOpChangeToDockerfile(t *testing.T) {
 	// incremental build.
 	call = <-f.b.calls
 	assert.Equal(t, "foobar", string(call.manifest.Name))
-	assert.ElementsMatch(t, []string{
-		f.JoinPath("Dockerfile"),
-		f.JoinPath("random_file.go"),
-	}, call.state.FilesChanged())
+	assert.ElementsMatch(t, []string{f.JoinPath("random_file.go")}, call.state.FilesChanged())
 
 	f.WaitUntil("all builds complete", func(es store.EngineState) bool {
 		return es.CurrentlyBuilding == ""
@@ -560,7 +558,7 @@ func TestNoOpChangeToDockerfile(t *testing.T) {
 	assert.Nil(t, err)
 	f.assertAllBuildsConsumed()
 
-	assert.Contains(t, f.LogLines(), "Manifest foobar hasn't changed, not rebuilding")
+	assert.Contains(t, strings.Join(f.LogLines(), "\n"), "manifest foobar hasn't changed")
 }
 
 func TestRebuildDockerfileFailed(t *testing.T) {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -2,12 +2,15 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"net/url"
 	"sort"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/ospath"
 	"k8s.io/api/core/v1"
@@ -50,7 +53,7 @@ type ManifestState struct {
 	LastBuildLog              *bytes.Buffer
 	QueueEntryTime            time.Time
 
-	// we've observed changes to the config file and need to reload it the next time we start a build
+	// we've observed changes to config file(s) and need to reload the manifest next time we start a build
 	ConfigIsDirty bool
 }
 
@@ -116,6 +119,26 @@ func (s EngineState) Manifests() []model.Manifest {
 		result = append(result, ms.Manifest)
 	}
 	return result
+}
+
+// Returns a set of pending file changes, with all config files removed
+func (ms *ManifestState) PendingFileChangesWithoutConfigFiles(ctx context.Context) (map[string]bool, error) {
+	matcher, err := ms.Manifest.ConfigMatcher()
+	if err != nil {
+		return nil, errors.Wrap(err, "[PendingFileChangesWithoutConfigFiles] getting config matcher")
+	}
+
+	files := make(map[string]bool)
+	for f := range ms.PendingFileChanges {
+		matches, err := matcher.Matches(f, false)
+		if err != nil {
+			logger.Get(ctx).Infof("Error matches %s: %v", f, err)
+		}
+		if !matches {
+			files[f] = true
+		}
+	}
+	return files, nil
 }
 
 func StateToView(s EngineState) view.View {


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/break-unbreak:

0e4e0c70a5e510dec426d99ca34a0194afed8c81 (2018-10-17 16:52:51 -0400)
engine: don't image build if config file changes but doesn't result in manifest change

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics