### PR TITLE
tiltfile: read relative to tiltfile dir instead of working dir

### DIFF
--- a/internal/tiltfile/thread_local.go
+++ b/internal/tiltfile/thread_local.go
@@ -2,7 +2,6 @@ package tiltfile
 
 import (
 	"errors"
-	"path/filepath"
 
 	"github.com/google/skylark"
 )
@@ -47,16 +46,12 @@ func getReadFiles(t *skylark.Thread) ([]string, error) {
 	return readFiles, nil
 }
 
-func recordReadFile(t *skylark.Thread, path string) error {
-	path, err := filepath.Abs(path)
+func (t *Tiltfile) recordReadFile(thread *skylark.Thread, path string) error {
+	path = t.absPath(path)
+	readFiles, err := getReadFiles(thread)
 	if err != nil {
 		return err
 	}
-
-	readFiles, err := getReadFiles(t)
-	if err != nil {
-		return err
-	}
-	t.SetLocal(readFilesKey, append(readFiles, path))
+	thread.SetLocal(readFilesKey, append(readFiles, path))
 	return nil
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/rel:

9c7473d76e94154269be992404ef1fece87885e9 (2018-10-17 17:35:32 -0400)
tiltfile: read relative to tiltfile dir instead of working dir
We expect that the Tilt demo will have an arbitrary workdir