### PR TITLE
tilt: fix esc key, make resources scrollable

### DIFF
--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -34,6 +34,7 @@ type Resource struct {
 type ViewState struct {
 	ShowNarration    bool
 	NarrationMessage string
+	SelectedResource int
 }
 
 type View struct {

--- a/internal/rty/components.go
+++ b/internal/rty/components.go
@@ -22,6 +22,7 @@ type RTY interface {
 type ElementScroller interface {
 	UpElement()
 	DownElement()
+	GetSelectedIndex() int
 }
 
 type TextScroller interface {

--- a/internal/rty/scroll.go
+++ b/internal/rty/scroll.go
@@ -240,6 +240,10 @@ func adjustElementScroll(prevInt interface{}, newChildren []string) (*ElementScr
 	return next, ""
 }
 
+func (s *ElementScrollController) GetSelectedIndex() int {
+	return s.state.elementIdx
+}
+
 func (s *ElementScrollController) GetSelectedChild() string {
 	if len(s.state.children) == 0 {
 		return ""


### PR DESCRIPTION
The scrolling has a couple flaws at the moment:
1. The selected resource is always at the top, so if you have 3 resources and you hit down to select the second resource, now you can only see 2 resources.
2. There is no indication of which resource is selected (mostly because while (1) is the case, I'd kinda prefer to hide the fact that scrolling exists).