### PR TITLE
build: fmt.Printf interrupts TTY / HUD. everything needs to go thru logger

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -312,7 +312,7 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, df Dockerfile, pat
 	defer span.Finish()
 
 	// TODO(Han): Extend output to print without newline
-	fmt.Printf("  → Tarring context…")
+	output.Get(ctx).StartBuildStep("Tarring context…")
 
 	archive, err := tarContextAndUpdateDf(ctx, df, paths, filter)
 	if err != nil {
@@ -320,7 +320,8 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, df Dockerfile, pat
 	}
 
 	// TODO(Han): Extend output to print without newline
-	fmt.Printf(" (size: %s)\n", humanize.Bytes(uint64(archive.Len())))
+	output.Get(ctx).Printf("Created tarball (size: %s)",
+		humanize.Bytes(uint64(archive.Len())))
 
 	output.Get(ctx).StartBuildStep("Building image")
 	spanBuild, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuild")


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/output:

7b5b823c90383e74e1f7a5e371b6db95c4688468 (2018-10-17 20:00:32 -0400)
build: fmt.Printf interrupts TTY / HUD. everything needs to go thru logger