### PR TITLE
demo: add a script

### DIFF
--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -3,9 +3,14 @@ package demo
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/client"
@@ -13,7 +18,9 @@ import (
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/output"
 	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/tiltfile"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/api/core/v1"
 )
 
 // Runs the demo script
@@ -23,40 +30,84 @@ type Script struct {
 	store *store.Store
 	env   k8s.Env
 
-	ready chan bool
+	readTiltfileCh chan string
+	podMonitor     *podMonitor
 }
 
 func NewScript(upper engine.Upper, hud hud.HeadsUpDisplay, env k8s.Env, st *store.Store) Script {
 	s := Script{
-		upper: upper,
-		hud:   hud,
-		env:   env,
-		ready: make(chan bool),
-		store: st,
+		upper:          upper,
+		hud:            hud,
+		env:            env,
+		readTiltfileCh: make(chan string),
+		podMonitor:     &podMonitor{podsReadyCh: make(chan bool)},
+		store:          st,
 	}
-	st.AddSubscriber(s)
+	st.AddSubscriber(s.podMonitor)
 	return s
 }
 
-func (s Script) OnChange(ctx context.Context, store *store.Store) {
+type podMonitor struct {
+	podsReady   bool
+	podsReadyCh chan bool
+}
+
+func (m *podMonitor) arePodsReady(store *store.Store) bool {
+	state := store.RLockState()
+	defer store.RUnlockState()
+	hasPods := false
+	allPodsReady := true
+	for _, ms := range state.ManifestStates {
+		if ms.Pod.PodID != "" {
+			hasPods = true
+		}
+
+		if ms.Pod.Phase != v1.PodRunning {
+			allPodsReady = false
+		}
+	}
+	return hasPods && allPodsReady
+}
+
+func (m *podMonitor) OnChange(ctx context.Context, store *store.Store) {
+	podsReady := m.arePodsReady(store)
+	if podsReady != m.podsReady {
+		m.podsReady = podsReady
+		m.podsReadyCh <- podsReady
+	}
+}
+
+func (m *podMonitor) waitUntilPodsReady(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ready := <-m.podsReadyCh:
+			if ready {
+				return nil
+			}
+		}
+	}
 }
 
 func (s Script) Run(ctx context.Context) error {
 	if !s.env.IsLocalCluster() {
-		_, _ = fmt.Fprintf(os.Stderr, "tilt demo mode only supports docker-for-desktop or Minikube\n")
+		_, _ = fmt.Fprintf(os.Stderr, "tilt demo mode only supports Docker For Mac or Minikube\n")
 		_, _ = fmt.Fprintf(os.Stderr, "check your current cluster with:\n")
 		_, _ = fmt.Fprintf(os.Stderr, "\nkubectl config get-contexts\n\n")
 		return nil
 	}
 
-	// Discard all the logs
-	l := logger.NewLogger(logger.DebugLvl, ioutil.Discard)
+	// Discard all the logs. Uncomment the line below to make debugging easier.
+	out := ioutil.Discard
+	//out, _ = os.OpenFile("log.txt", os.O_WRONLY|os.O_TRUNC|os.O_CREATE, os.FileMode(0644))
+
+	l := logger.NewLogger(logger.DebugLvl, out)
 	ctx = output.WithOutputter(
 		logger.WithLogger(ctx, l),
 		output.NewOutputter(l))
 	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
-	s.hud.SetNarrationMessage(ctx, "\t🚀  Launching demo... ")
 
 	g.Go(func() error {
 		defer cancel()
@@ -68,5 +119,69 @@ func (s Script) Run(ctx context.Context) error {
 		return client.ConnectHud(ctx)
 	})
 
+	g.Go(func() error {
+		defer cancel()
+		return s.runSteps(ctx, out)
+	})
+
+	g.Go(func() error {
+		defer cancel()
+		var dir string
+		select {
+		case dir = <-s.readTiltfileCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		file := filepath.Join(dir, tiltfile.FileName)
+		tf, err := tiltfile.Load(file, out)
+		if err != nil {
+			return err
+		}
+
+		manifests, err := tf.GetManifestConfigs("tiltdemo")
+		if err != nil {
+			return err
+		}
+
+		return s.upper.CreateManifests(ctx, manifests, true)
+	})
+
 	return g.Wait()
+}
+
+func (s Script) runSteps(ctx context.Context, out io.Writer) error {
+	tmpDir, err := ioutil.TempDir("", "tiltdemo")
+	if err != nil {
+		return errors.Wrap(err, "demo.runSteps")
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	for _, step := range steps {
+		s.hud.SetNarrationMessage(ctx, step.Narration)
+
+		if step.Command != "" {
+			cmd := exec.CommandContext(ctx, "sh", "-c", step.Command)
+			cmd.Stdout = out
+			cmd.Stderr = out
+			cmd.Dir = tmpDir
+			err := cmd.Run()
+			if err != nil {
+				return errors.Wrap(err, "demo.runSteps")
+			}
+		} else if step.CreateManifests {
+			s.readTiltfileCh <- tmpDir
+			_ = s.podMonitor.waitUntilPodsReady(ctx)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(Pause):
+		}
+	}
+
+	return nil
 }

--- a/internal/demo/step.go
+++ b/internal/demo/step.go
@@ -1,0 +1,28 @@
+package demo
+
+import "time"
+
+const Pause = 3 * time.Second
+
+type Step struct {
+	Narration       string
+	Command         string
+	CreateManifests bool
+}
+
+var steps = []Step{
+	Step{
+		Narration: "\t🚀  Launching demo... ",
+	},
+	Step{
+		Narration: "\t📚  git clone https://github.com/windmilleng/tiltdemo",
+		Command:   "git clone https://github.com/windmilleng/tiltdemo $(pwd)",
+	},
+	Step{
+		Narration:       "\t🎂  Building and deploying demo server",
+		CreateManifests: true,
+	},
+	Step{
+		Narration: "\t🎉  Deployment success!",
+	},
+}


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch nicks/ch586/checkout:

554877407d5f6c60ec101d57508e86e5436da17e (2018-10-17 20:04:12 -0400)
demo: add a script

ee3ddef9e82ac192a07dd686d72bdd424fc1e3f8 (2018-10-17 20:04:00 -0400)
demo: make the demo connect to the hud directly

6ab36f26c6af4a2c657f8c5353f2f870055681e1 (2018-10-17 20:04:00 -0400)
tiltfile: read relative to tiltfile dir instead of working dir
We expect that the Tilt demo will have an arbitrary workdir

7b5b823c90383e74e1f7a5e371b6db95c4688468 (2018-10-17 20:00:32 -0400)
build: fmt.Printf interrupts TTY / HUD. everything needs to go thru logger