### PR TITLE
hud: hud exit works, so no more need for hack where we reset the terminal

### DIFF
--- a/internal/hud/client/client.go
+++ b/internal/hud/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -82,18 +81,6 @@ func ConnectHud(ctx context.Context) error {
 		}); err != nil {
 		return errors.Wrap(err, "error sending to hud server")
 	}
-
-	// TODO(matt) figure out why tcell's Fini isn't working for us here
-	// this is a crummy workaround
-	defer func() {
-		cmd := exec.Command("reset")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err := cmd.Run()
-		if err != nil {
-			fmt.Printf("error restoring terminal settings: %v", err)
-		}
-	}()
 
 	// Wait for the stream to close
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Hello @landism, @yuindustries,

Please review the following commits I made in branch maiamcc/no-reset-on-hud-quit:

7075194c2fe2a6ea841c69181a1e8aae20d220ac (2018-10-18 14:45:57 -0400)
hud: hud exit works, so no more need for hack where we reset the terminal

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics