### PR TITLE
tiltfile: realpath the tiltfile. fixes the demo on macos b/c its temp files use symlinks

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/skylark/resolve"
 	"github.com/windmilleng/tilt/internal/kustomize"
 	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/ospath"
 )
 
 const FileName = "Tiltfile"
@@ -314,7 +315,7 @@ func Load(filename string, out io.Writer) (*Tiltfile, error) {
 		},
 	}
 
-	filename, err := filepath.Abs(filename)
+	filename, err := ospath.RealAbs(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/symlinks:

6941f1ac0e541359d7dcdad1e0cfde28ef78e9d1 (2018-10-18 22:13:53 -0400)
tiltfile: realpath the tiltfile. fixes the demo on macos b/c its temp files use symlinks