### PR TITLE
engine: pass config files as changed files iff they belong to a mount

### DIFF
--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -119,6 +119,11 @@ func fileToPathMapping(file string, mounts []model.Mount) (pathMapping, *PathMap
 	return pathMapping{}, pathMappingErrf("file %s matches no mounts", file)
 }
 
+func FileBelongsToMount(file string, mounts []model.Mount) bool {
+	_, err := fileToPathMapping(file, mounts)
+	return err == nil
+}
+
 func MountsToPathMappings(mounts []model.Mount) []pathMapping {
 	pms := make([]pathMapping, len(mounts))
 	for i, m := range mounts {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -222,15 +222,15 @@ func (u Upper) maybeStartBuild(ctx context.Context, st *store.Store) {
 				ms.LastError = nil
 			}
 
-			changedFilesWithoutConfigFiles, err := ms.PendingFileChangesWithoutConfigFiles(ctx)
+			mountedChangedFiles, err := ms.PendingFileChangesWithoutUnmountedConfigFiles(ctx)
 			if err != nil {
 				logger.Get(ctx).Infof(err.Error())
 				return
 			}
-			ms.PendingFileChanges = changedFilesWithoutConfigFiles
+			ms.PendingFileChanges = mountedChangedFiles
 
 			if len(ms.PendingFileChanges) == 0 {
-				// No non-config files changed, no need to build.
+				// No mounted files changed, no need to build.
 				ms.ConfigIsDirty = false
 				return
 			}

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -61,6 +61,14 @@ func (f *TempDirFixture) WriteFile(path string, contents string) {
 	}
 }
 
+func (f *TempDirFixture) MkdirAll(path string) {
+	fullPath := filepath.Join(f.Path(), path)
+	err := os.MkdirAll(fullPath, os.FileMode(0777))
+	if err != nil {
+		f.t.Fatal(err)
+	}
+}
+
 func (f *TempDirFixture) TouchFiles(paths []string) {
 	for _, p := range paths {
 		f.WriteFile(p, "")


### PR DESCRIPTION
Addresses [ch621](https://app.clubhouse.io/windmill/story/621/configfiles-not-copied-to-container).

If a config file changes but this doesn't result in a change to the manifest, we incremental build (since a bug fixed in #561) -- but incremental build runs individual changed files through `FilesToPathMapping` (unlike image build, which just makes a mapping per mount).

So when we change e.g. a Tiltfile and it DOESN'T change the manifest and results in an incremental build, we try to make a path mapping of Tiltfile and get an error b/c Tiltfile doesn't belong to any of our mounts.

The solution in this PR is to filter out non-mounted config files from the changed files set before continuing with the build process.

We should probably do this for the changed manifest case as well to be consistent? Maybe? It kind of doesn't matter.