### PR TITLE
engine: refactor into a reactive builder, so we can build in response to things like pod restarts, etc

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -38,6 +38,7 @@ var BaseWireSet = wire.NewSet(
 	engine.ProvideServiceWatcherMaker,
 	engine.NewPodLogManager,
 	engine.NewPortForwardController,
+	engine.NewBuildController,
 
 	hud.NewDefaultHeadsUpDisplay,
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -1,0 +1,103 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/windmilleng/tilt/internal/logger"
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/ospath"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+type BuildController struct {
+	b                       BuildAndDeployer
+	lastCompletedBuildCount int
+}
+
+type buildEntry struct {
+	ctx        context.Context
+	manifest   model.Manifest
+	buildState store.BuildState
+	firstBuild bool
+}
+
+func NewBuildController(b BuildAndDeployer) *BuildController {
+	return &BuildController{
+		b: b,
+		lastCompletedBuildCount: -1,
+	}
+}
+
+func (c *BuildController) needsBuild(ctx context.Context, st *store.Store) (buildEntry, bool) {
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	if state.CurrentlyBuilding == "" {
+		return buildEntry{}, false
+	}
+
+	if c.lastCompletedBuildCount == state.CompletedBuildCount {
+		return buildEntry{}, false
+	}
+
+	c.lastCompletedBuildCount = state.CompletedBuildCount
+	ms := state.ManifestStates[state.CurrentlyBuilding]
+	manifest := ms.Manifest
+	firstBuild := !ms.HasBeenBuilt
+	buildState := store.NewBuildState(ms.LastBuild, ms.CurrentlyBuildingFileChanges)
+
+	// TODO(nick): This is...not great, because it modifies the build log in place.
+	// A better solution would dispatch actions (like PodLogManager does) so that
+	// they go thru the state loop and immediately update in the UX.
+	ctx = logger.CtxWithForkedOutput(ctx, ms.CurrentBuildLog)
+
+	return buildEntry{
+		ctx:        ctx,
+		manifest:   manifest,
+		firstBuild: firstBuild,
+		buildState: buildState,
+	}, true
+}
+
+func (c *BuildController) OnChange(ctx context.Context, st *store.Store) {
+	entry, ok := c.needsBuild(ctx, st)
+	if !ok {
+		return
+	}
+
+	go func() {
+		c.logBuildEntry(entry.ctx, entry)
+		result, err := c.b.BuildAndDeploy(entry.ctx, entry.manifest, entry.buildState)
+		st.Dispatch(NewBuildCompleteAction(result, err))
+	}()
+}
+
+func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry) {
+	firstBuild := entry.firstBuild
+	manifest := entry.manifest
+	buildState := entry.buildState
+
+	l := logger.Get(ctx)
+	if firstBuild {
+		p := logger.Blue(l).Sprintf("──┤ Building: ")
+		s := logger.Blue(l).Sprintf(" ├──────────────────────────────────────────────")
+		l.Infof("%s%s%s", p, manifest.Name, s)
+	} else {
+		changedFiles := buildState.FilesChanged()
+		var changedPathsToPrint []string
+		if len(changedFiles) > maxChangedFilesToPrint {
+			changedPathsToPrint = append(changedPathsToPrint, changedFiles[:maxChangedFilesToPrint]...)
+			changedPathsToPrint = append(changedPathsToPrint, "...")
+		} else {
+			changedPathsToPrint = changedFiles
+		}
+
+		p := logger.Green(l).Sprintf("\n%d changed: ", len(changedFiles))
+		l.Infof("%s%v\n", p, ospath.TryAsCwdChildren(changedPathsToPrint))
+		rp := logger.Blue(l).Sprintf("──┤ Rebuilding: ")
+		rs := logger.Blue(l).Sprintf(" ├────────────────────────────────────────────")
+		l.Infof("%s%s%s", rp, manifest.Name, rs)
+	}
+}
+
+var _ store.Subscriber = &BuildController{}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1387,13 +1387,14 @@ func newTestFixture(t *testing.T) *testFixture {
 	st := store.NewStore()
 
 	plm := NewPodLogManager(k8s)
+	bc := NewBuildController(b)
 
 	_ = os.Chdir(f.Path())
 	_ = os.Mkdir(f.JoinPath(".git"), os.FileMode(0777))
 
 	pfc := NewPortForwardController(k8s)
 
-	upper := NewUpper(ctx, b, k8s, reaper, hud, fakePodWatcherMaker, fakeServiceWatcherMaker, st, plm, pfc)
+	upper := NewUpper(ctx, k8s, reaper, hud, fakePodWatcherMaker, fakeServiceWatcherMaker, st, plm, pfc, bc)
 	upper.timerMaker = timerMaker.maker()
 	upper.hudErrorCh = make(chan error)
 	upper.fsWatcherMaker = fsWatcherMaker


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/reactive:

796185c3234d118064b9ae07667627215373f99c (2018-10-19 19:27:51 -0400)
engine: refactor into a reactive builder, so we can build in response to things like pod restarts, etc