### PR TITLE
tilt: don't show pod logs from old crashes

### DIFF
--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -80,6 +80,9 @@ type Pod struct {
 	Status    string
 	Phase     v1.PodPhase
 
+	// The log for the previously active pod, if any
+	PreRestartLog []byte
+	// The log for the currently active pod, if any
 	Log []byte
 
 	// Corresponds to the deployed container.


### PR DESCRIPTION
Problem: when a pod gets into a crash loop, log replay pretty quickly starts showing 20 panics
Solution: don't show logs from pods preceding the last one or two

My first pass at the tests for this were pretty ugly, so I also added some new helper methods and converted some existing tests to use them, which ended up being a lot of the diff.