### PR TITLE
gofmt 1.10 vs 1.11 is different

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -23,7 +23,7 @@ type buildEntry struct {
 
 func NewBuildController(b BuildAndDeployer) *BuildController {
 	return &BuildController{
-		b:                       b,
+		b: b,
 		lastCompletedBuildCount: -1,
 	}
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/gofmt:

d69c3cb08187c13a37cf4bbf37b7fb01b7ed7748 (2018-10-22 17:21:10 -0400)
gofmt 1.10 vs 1.11 is different