### PR TITLE
engine: move more logic into BuildController, take tiltfile reloading out of the write lock

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"time"
+
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
@@ -66,3 +68,19 @@ type InitAction struct {
 }
 
 func (InitAction) Action() {}
+
+type ManifestReloadedAction struct {
+	OldManifest model.Manifest
+	NewManifest model.Manifest
+	Error       *manifestErr
+}
+
+func (ManifestReloadedAction) Action() {}
+
+type BuildStartedAction struct {
+	Manifest     model.Manifest
+	StartTime    time.Time
+	FilesChanged []string
+}
+
+func (BuildStartedAction) Action() {}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -809,6 +809,7 @@ func TestPodEvent(t *testing.T) {
 		f.podEvents <- f.testPod("my pod", "foobar", "CrashLoopBackOff", time.Now())
 
 		<-f.hud.Updates
+		<-f.hud.Updates
 		rv := f.hud.LastView.Resources[0]
 		assert.Equal(t, "my pod", rv.PodName)
 		assert.Equal(t, "CrashLoopBackOff", rv.PodStatus)
@@ -868,6 +869,7 @@ func TestPodEventUpdateByTimestamp(t *testing.T) {
 
 		call := <-f.b.calls
 		assert.True(t, call.state.IsEmpty())
+		<-f.hud.Updates
 		<-f.hud.Updates
 
 		firstCreationTime := time.Now()

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -32,16 +32,26 @@ type EngineState struct {
 	// How many builds have been completed (pass or fail) since starting tilt
 	CompletedBuildCount int
 
+	// For synchronizing BuildController so that it's only
+	// doing one action at a time. In the future, we might
+	// want to allow it to parallelize builds better, but that
+	// would require better tools for triaging output to different streams.
+	BuildControllerActionCount int
+
 	PermanentError error
 }
 
 type ManifestState struct {
-	LastBuild                    BuildResult
-	Manifest                     model.Manifest
-	Pod                          Pod
-	LBs                          map[k8s.ServiceName]*url.URL
-	HasBeenBuilt                 bool
-	PendingFileChanges           map[string]bool
+	LastBuild    BuildResult
+	Manifest     model.Manifest
+	Pod          Pod
+	LBs          map[k8s.ServiceName]*url.URL
+	HasBeenBuilt bool
+
+	// TODO(nick): Maybe we should keep timestamps for the most
+	// recent change to each file?
+	PendingFileChanges map[string]bool
+
 	CurrentlyBuildingFileChanges []string
 
 	CurrentBuildStartTime     time.Time


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/reactive:

bb3a36120ed02c9b25feeacca72f966e60785a14 (2018-10-22 17:33:40 -0400)
engine: move more logic into BuildController, take tiltfile reloading out of the write lock