### PR TITLE
tilt: fix duplicates in LastDeployedEdits

### DIFF
--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -92,7 +92,7 @@ func (m *podMonitor) OnChange(ctx context.Context, store *store.Store) {
 			m.healthy = false
 		}
 
-		if state.CurrentlyBuilding != "" || len(ms.PendingFileChanges) > 0 {
+		if state.CurrentlyBuilding != "" || len(ms.FileChangesSinceLastBuild) > 0 {
 			m.healthy = false
 		}
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -64,11 +64,7 @@ func (b *fakeBuildAndDeployer) nextBuildResult(ref reference.Named) store.BuildR
 }
 
 func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, state store.BuildState) (store.BuildResult, error) {
-	select {
-	case <-b.frozenCh:
-		//case <-time.After(time.Second):
-		//	b.t.Fatal("fakeBuildAndDeployer was frozen for more than a second")
-	}
+	<-b.frozenCh
 
 	select {
 	case b.calls <- buildAndDeployCall{manifest, state}:

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -23,9 +23,9 @@ func TestStateToViewMultipleMounts(t *testing.T) {
 	}
 	state := newState([]model.Manifest{m})
 	ms := state.ManifestStates[m.Name]
-	ms.CurrentlyBuildingFileChanges = []string{"/a/b/d", "/a/b/c/d/e"}
+	ms.NewFileChangesInCurrentBuild = []string{"/a/b/d", "/a/b/c/d/e"}
 	ms.LastSuccessfulDeployEdits = []string{"/a/b/d", "/a/b/c/d/e"}
-	ms.PendingFileChanges = map[string]bool{"/a/b/d": true, "/a/b/c/d/e": true}
+	ms.FileChangesSinceLastBuild = map[string]bool{"/a/b/d": true, "/a/b/c/d/e": true}
 	v := StateToView(*state)
 
 	if !assert.Equal(t, 1, len(v.Resources)) {


### PR DESCRIPTION
Problem:
After a failed build, changed files were showing up twice in "Last deployed edits"

This was supposed to be a one-line change, plus tests :(. `ManifestState` had three lists of files, and I figured we were just incorrectly populating one.

The three lists were:
1. `CurrentlyBuildingFileChanges`
2. `LastSuccessfulDeployEdits`
3. `PendingFileChanges`

It turns out (1) was both "file changes included in the current build", "files that have changed since the last image we pushed (i.e., changes since the last successful build)". We weren't clearing it after failed builds because we needed to ensure we copy those files on subsequent image builds, which meant the changes from those failed builds got listed as currently building changes and last deployed changes (and, if any of those files were changed again, they'd get listed twice).

One option is to just dedupe (1) and (2) above. This leaves us with a UI question: do we want to show new changes that we just tried to build for the first time, or do we want to show all changes that we had not successfully built?

If the user changes one file, gets a failure, changes another file, gets a success, it's probably fine to show both.

If I edit 10 files, causing failures all the way, and then tabs back to tilt when they're done, I *think* it'd be better to show only the more recent changes, since what I want to know is whether tilt has caught up to me, and the full list would just scroll of the screen (given current implementation) or wrap, either of which are ugly.

So what I've done here is turn these three into four lists of files, which are hopefully reasonably described [here](https://github.com/windmilleng/tilt/compare/mlandis/ch631/lastdeployededits-are-duplicated?expand=1#diff-37605622f8a4a7297256d94300e05717R45). I'm not in love with the names: they don't capture that we exclude unmounted config files and they are coupled to the current implementation that the last image content is identical to the content used for the last successful build, but those are problems with the previous names as well.

A good middle ground I hadn't considered until posting this is to dedupe and sort the changes in reverse chron, which would solve the "I'm most interested in confirming the changes I just made have been picked up" problem, but not the "long file lists are ugly" problem. I prefer the UI implemented in this PR.