### PR TITLE
engine: change podwatcher and servicewatcher to use the subscriber interface

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -34,11 +34,11 @@ var BaseWireSet = wire.NewSet(
 
 	engine.DeployerWireSet,
 	engine.DefaultShouldFallBack,
-	engine.ProvidePodWatcherMaker,
-	engine.ProvideServiceWatcherMaker,
 	engine.NewPodLogManager,
 	engine.NewPortForwardController,
 	engine.NewBuildController,
+	engine.NewPodWatcher,
+	engine.NewServiceWatcher,
 
 	hud.NewDefaultHeadsUpDisplay,
 

--- a/internal/engine/service_watch.go
+++ b/internal/engine/service_watch.go
@@ -9,15 +9,36 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-func makeServiceWatcher(ctx context.Context, kCli k8s.Client, st *store.Store) error {
-	ch, err := kCli.WatchServices(ctx, []k8s.LabelPair{TiltRunLabel()})
+type ServiceWatcher struct {
+	kCli     k8s.Client
+	watching bool
+}
+
+func NewServiceWatcher(kCli k8s.Client) *ServiceWatcher {
+	return &ServiceWatcher{
+		kCli: kCli,
+	}
+}
+
+func (w *ServiceWatcher) needsWatch(st *store.Store) bool {
+	state := st.RLockState()
+	defer st.RUnlockState()
+	return state.WatchMounts && !w.watching
+}
+
+func (w *ServiceWatcher) OnChange(ctx context.Context, st *store.Store) {
+	if !w.needsWatch(st) {
+		return
+	}
+	w.watching = true
+
+	ch, err := w.kCli.WatchServices(ctx, []k8s.LabelPair{TiltRunLabel()})
 	if err != nil {
-		return err
+		st.Dispatch(NewErrorAction(err))
+		return
 	}
 
 	go dispatchServiceChangesLoop(ctx, ch, st)
-
-	return nil
 }
 
 func dispatchServiceChangesLoop(ctx context.Context, ch <-chan *v1.Service, st *store.Store) {

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -6,22 +6,22 @@
 package engine
 
 import (
-	context "context"
-	wire "github.com/google/go-cloud/wire"
-	build "github.com/windmilleng/tilt/internal/build"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
-	store "github.com/windmilleng/tilt/internal/store"
-	synclet "github.com/windmilleng/tilt/internal/synclet"
-	analytics "github.com/windmilleng/wmclient/pkg/analytics"
-	dirs "github.com/windmilleng/wmclient/pkg/dirs"
+	"context"
+	"github.com/google/go-cloud/wire"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/synclet"
+	"github.com/windmilleng/wmclient/pkg/analytics"
+	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 // Injectors from wire.go:
 
 func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode UpdateModeFlag, sCli synclet.SyncletClient, shouldFallBackToImgBuild FallbackTester) (BuildAndDeployer, error) {
-	store2 := store.NewStore()
-	deployDiscovery := NewDeployDiscovery(k8s2, store2)
+	storeStore := store.NewStore()
+	deployDiscovery := NewDeployDiscovery(k8s2, storeStore)
 	syncletManager := NewSyncletManagerForTests(k8s2, sCli)
 	syncletBuildAndDeployer := NewSyncletBuildAndDeployer(deployDiscovery, syncletManager)
 	containerUpdater := build.NewContainerUpdater(docker2)
@@ -32,12 +32,12 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(docker2, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
-	updateMode2, err := ProvideUpdateMode(updateMode, env)
+	engineUpdateMode, err := ProvideUpdateMode(updateMode, env)
 	if err != nil {
 		return nil, err
 	}
-	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, k8s2, env, memoryAnalytics, updateMode2)
-	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode2)
+	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, k8s2, env, memoryAnalytics, engineUpdateMode)
+	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, engineUpdateMode)
 	compositeBuildAndDeployer := NewCompositeBuildAndDeployer(buildOrder, shouldFallBackToImgBuild)
 	return compositeBuildAndDeployer, nil
 }

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -6,10 +6,10 @@
 package synclet
 
 import (
-	context "context"
-	build "github.com/windmilleng/tilt/internal/build"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
+	"context"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/k8s"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/watcher:

b7e645fe9e6b89850e580cafa79b3886dd6faf6f (2018-10-23 16:59:29 -0400)
engine: change podwatcher and servicewatcher to use the subscriber interface