### PR TITLE
tilt: make it easy to skip image tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 
 # skip some tests that are slow and not always relevant
 shorttest:
-	./hide_tbd_warning go test -short -timeout 60s ./...
+	./hide_tbd_warning go test -tags 'skipcontainertests' -timeout 60s ./...
 
 integration:
 	./hide_tbd_warning go test -tags 'integration' -timeout 300s ./integration

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ build:
 test:
 	./hide_tbd_warning go test -timeout 60s ./...
 
+# skip some tests that are slow and not always relevant
+shorttest:
+	./hide_tbd_warning go test -short -timeout 60s ./...
+
 integration:
 	./hide_tbd_warning go test -tags 'integration' -timeout 300s ./integration
 

--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -39,6 +39,10 @@ type dockerBuildFixture struct {
 }
 
 func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
+	if testing.Short() {
+		t.Skip("skipping test due to short mode")
+	}
+
 	ctx := output.CtxForTest()
 	dcli, err := docker.DefaultDockerClient(ctx, k8s.EnvGKE)
 	if err != nil {

--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -39,10 +39,6 @@ type dockerBuildFixture struct {
 }
 
 func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
-	if testing.Short() {
-		t.Skip("skipping test due to short mode")
-	}
-
 	ctx := output.CtxForTest()
 	dcli, err := docker.DefaultDockerClient(ctx, k8s.EnvGKE)
 	if err != nil {


### PR DESCRIPTION
The image tests are regularly making `make test` take 10x as long, and are generally not relevant to what I'm working on.