### PR TITLE
tilt: fix a couple minor hud layout issues

### DIFF
--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -196,7 +196,7 @@ func renderResource(r view.Resource, selected bool) rty.Component {
 	if !r.LastDeployTime.Equal(time.Time{}) {
 		if len(r.LastDeployEdits) > 0 {
 			sb := rty.NewStringBuilder()
-			sb.Fg(cLightText).Text(" Last Deployed Edits: ").Fg(tcell.ColorDefault)
+			sb.Fg(cLightText).Text("  Last Deployed Edits: ").Fg(tcell.ColorDefault)
 			sb.Text(formatFileList(r.LastDeployEdits))
 			layout.Add(sb.Build())
 		}
@@ -289,6 +289,12 @@ func renderResource(r view.Resource, selected bool) rty.Component {
 
 		layout.Add(sb.Build())
 
+		if len(r.Endpoints) != 0 {
+			sb := rty.NewStringBuilder()
+			sb.Textf("         %s", strings.Join(r.Endpoints, " "))
+			layout.Add(sb.Build())
+		}
+
 		if r.PodRestarts > 0 {
 			logLines := abbreviateLog(r.PodLog)
 			if len(logLines) > 0 {
@@ -298,12 +304,6 @@ func renderResource(r view.Resource, selected bool) rty.Component {
 				}
 			}
 		}
-	}
-
-	if len(r.Endpoints) != 0 {
-		sb := rty.NewStringBuilder()
-		sb.Textf("         %s", strings.Join(r.Endpoints, " "))
-		layout.Add(sb.Build())
 	}
 
 	layout.Add(rty.NewLine())


### PR DESCRIPTION
1. we were showing k8s LB below the log:
```
  BUILD: Last build (done in 1s) ended <1m ago — OK
    K8S: Pod [matt-fe-b5558bcc6-jk699] • <1m ago — Error [2 restart(s)]
    LOG: panic: hellllooooo

         goroutine 1 :
         main.main()
          /go/src/github.com/windmilleng/servantes/fe/main.go:39 +0x39
         http://localhost:8080/
```

move it above:
```
  BUILD: Last build (done in 1s) ended <1m ago — OK
    K8S: Pod [matt-fe-b5558bcc6-jk699] • <1m ago — Error [2 restart(s)]
    LOG: panic: hellllooooo

         goroutine 1 :
         main.main()
          /go/src/github.com/windmilleng/servantes/fe/main.go:39 +0x39
         http://localhost:8080/
```

2. we were missing a space on Last deployed edits