### PR TITLE
cli: tilt watch-mode should be the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Click below to see a video of Tilt in action:
 Run `go get -u github.com/windmilleng/tilt`
 
 ## Using Tilt
-`tilt up <service_name>` starts a service once; `tilt up --watch <service_name>` starts it and watches for changes.
+
+`tilt up <service_name>` starts a service and watches for changes.
+
+`tilt up --watch=false <service_name>` starts the service once.
 
 Tilt reads from a Tiltfile. A simple Tiltfile is below:
 

--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -120,7 +120,7 @@ func (f *fixture) tiltCmd(tiltArgs []string, outWriter io.Writer) *exec.Cmd {
 
 func (f *fixture) TiltUp(name string) {
 	out := bytes.NewBuffer(nil)
-	cmd := f.tiltCmd([]string{"up", name, "--debug", "--image-tag-prefix=" + imageTagPrefix}, out)
+	cmd := f.tiltCmd([]string{"up", name, "--watch=false", "--debug", "--image-tag-prefix=" + imageTagPrefix}, out)
 	err := cmd.Run()
 	if err != nil {
 		f.t.Fatalf("Failed to up service: %v. Logs:\n%s", err, out.String())
@@ -128,7 +128,7 @@ func (f *fixture) TiltUp(name string) {
 }
 
 func (f *fixture) TiltWatch(name string) {
-	cmd := f.tiltCmd([]string{"up", name, "--debug", "--watch"}, os.Stdout)
+	cmd := f.tiltCmd([]string{"up", name, "--debug"}, os.Stdout)
 	err := cmd.Start()
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -36,7 +36,7 @@ func (c *upCmd) register() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 	}
 
-	cmd.Flags().BoolVar(&c.watch, "watch", false, "any started manifests will be automatically rebuilt and redeployed when files in their repos change")
+	cmd.Flags().BoolVar(&c.watch, "watch", true, "If true, services will be automatically rebuilt and redeployed when files change. Otherwise, each service will be started once.")
 	cmd.Flags().StringVar(&c.browserMode, "browser", "", "deprecated. TODO(nick): remove this flag")
 	cmd.Flags().StringVar(&updateModeFlag, "update-mode", string(engine.UpdateModeAuto),
 		fmt.Sprintf("Control the strategy Tilt uses for updating instances. Possible values: %v", engine.AllUpdateModes))


### PR DESCRIPTION
Hello @dbentley,

Please review the following commits I made in branch nicks/watch:

5da328023a9935bfac840d61b7bd1b396aea3768 (2018-10-24 18:20:21 -0400)
cli: tilt watch-mode should be the default