### PR TITLE
engine: make configIsDirty tests better

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -609,8 +609,10 @@ func TestRebuildDockerfileFailed(t *testing.T) {
 	f.fsWatcher.events <- watch.FileEvent{Path: f.JoinPath("Dockerfile")}
 	call = <-f.b.calls
 	assert.Equal(t, "FROM iron/go:dev2", call.manifest.BaseDockerfile)
-	// TODO(maia): any way to assert that manifestState.LastError got cleared?
 	assert.False(t, call.state.HasImage()) // we cleared the previous build state to force an image build
+	f.WaitUntilManifest("LastError was cleared", "foobar", func(state store.ManifestState) bool {
+		return state.LastError == nil
+	})
 
 	err := f.Stop()
 	assert.Nil(t, err)
@@ -655,7 +657,10 @@ func TestBreakAndUnbreakManifestWithNoChange(t *testing.T) {
 		t.Errorf("Expected build to not get called, but it did: %+v", call)
 	case <-time.After(100 * time.Millisecond):
 	}
-	// TODO(maia): any way to assert that manifestState.LastError got cleared?
+
+	f.WaitUntilManifest("LastError was cleared", "foobar", func(state store.ManifestState) bool {
+		return state.LastError == nil
+	})
 }
 
 func TestFilterOutNonMountedConfigFiles(t *testing.T) {


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/configDirty-tests:

bda6c1609c2805709bbc2ed9980b1b8db74eef28 (2018-10-25 11:50:24 -0400)
engine: make configIsDirty tests better

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics