### PR TITLE
container: move container-related stuff out of k8s cuz they don't really belong there

### DIFF
--- a/internal/build/container_resolver.go
+++ b/internal/build/container_resolver.go
@@ -27,7 +27,7 @@ func NewContainerResolver(dcli docker.DockerClient) *ContainerResolver {
 }
 
 // containerIdForPod looks for the container ID associated with the pod and image ID
-func (r *ContainerResolver) ContainerIDForPod(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (container.ContainerID, error) {
+func (r *ContainerResolver) ContainerIDForPod(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (container.ID, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContainerResolver-containerIdForPod")
 	defer span.Finish()
 
@@ -59,7 +59,7 @@ func (r *ContainerResolver) ContainerIDForPod(ctx context.Context, podName k8s.P
 	return "", ctx.Err()
 }
 
-func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (container.ContainerID, error) {
+func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (container.ID, error) {
 
 	a := filters.NewArgs()
 	a.Add("name", string(podName))
@@ -78,7 +78,7 @@ func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName
 
 	for _, c := range containers {
 		if c.ID == k8s.MagicTestContainerID {
-			return container.ContainerID(c.ID), nil
+			return container.ID(c.ID), nil
 		}
 
 		dig, err := digest.Parse(c.ImageID)
@@ -87,7 +87,7 @@ func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName
 			continue
 		}
 		if digestMatchesRef(image, dig) {
-			return container.ContainerID(c.ID), nil
+			return container.ID(c.ID), nil
 		}
 	}
 

--- a/internal/build/container_resolver.go
+++ b/internal/build/container_resolver.go
@@ -9,7 +9,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/opencontainers/go-digest"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
@@ -26,7 +27,7 @@ func NewContainerResolver(dcli docker.DockerClient) *ContainerResolver {
 }
 
 // containerIdForPod looks for the container ID associated with the pod and image ID
-func (r *ContainerResolver) ContainerIDForPod(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (k8s.ContainerID, error) {
+func (r *ContainerResolver) ContainerIDForPod(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (container.ContainerID, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContainerResolver-containerIdForPod")
 	defer span.Finish()
 
@@ -58,7 +59,7 @@ func (r *ContainerResolver) ContainerIDForPod(ctx context.Context, podName k8s.P
 	return "", ctx.Err()
 }
 
-func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (k8s.ContainerID, error) {
+func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName k8s.PodID, image reference.NamedTagged) (container.ContainerID, error) {
 
 	a := filters.NewArgs()
 	a.Add("name", string(podName))
@@ -77,7 +78,7 @@ func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName
 
 	for _, c := range containers {
 		if c.ID == k8s.MagicTestContainerID {
-			return k8s.ContainerID(c.ID), nil
+			return container.ContainerID(c.ID), nil
 		}
 
 		dig, err := digest.Parse(c.ImageID)
@@ -86,7 +87,7 @@ func (r *ContainerResolver) containerIDForPodHelper(ctx context.Context, podName
 			continue
 		}
 		if digestMatchesRef(image, dig) {
-			return k8s.ContainerID(c.ID), nil
+			return container.ContainerID(c.ID), nil
 		}
 	}
 

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -7,8 +7,8 @@ import (
 	"io"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 )
@@ -21,7 +21,7 @@ func NewContainerUpdater(dcli docker.DockerClient) *ContainerUpdater {
 	return &ContainerUpdater{dcli: dcli}
 }
 
-func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID k8s.ContainerID, paths []pathMapping, filter model.PathMatcher, steps []model.Cmd, w io.Writer) error {
+func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.ContainerID, paths []pathMapping, filter model.PathMatcher, steps []model.Cmd, w io.Writer) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-UpdateInContainer")
 	defer span.Finish()
 
@@ -76,7 +76,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID k8s.Contai
 	return nil
 }
 
-func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID k8s.ContainerID, paths []pathMapping) error {
+func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID container.ContainerID, paths []pathMapping) error {
 	if len(paths) == 0 {
 		return nil
 	}

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -21,7 +21,7 @@ func NewContainerUpdater(dcli docker.DockerClient) *ContainerUpdater {
 	return &ContainerUpdater{dcli: dcli}
 }
 
-func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.ContainerID, paths []pathMapping, filter model.PathMatcher, steps []model.Cmd, w io.Writer) error {
+func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.ID, paths []pathMapping, filter model.PathMatcher, steps []model.Cmd, w io.Writer) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-UpdateInContainer")
 	defer span.Finish()
 
@@ -76,7 +76,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 	return nil
 }
 
-func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID container.ContainerID, paths []pathMapping) error {
+func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID container.ID, paths []pathMapping) error {
 	if len(paths) == 0 {
 		return nil
 	}

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/testutils"
 )
@@ -36,7 +36,7 @@ func TestDigestMatchesRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ref, _ := k8s.ParseNamedTagged("windmill.build/image:" + tag)
+	ref, _ := container.ParseNamedTagged("windmill.build/image:" + tag)
 	if !digestMatchesRef(ref, dig) {
 		t.Errorf("Expected digest %s to match ref %s", dig, ref)
 	}
@@ -44,7 +44,7 @@ func TestDigestMatchesRef(t *testing.T) {
 
 func TestDigestNotMatchesRef(t *testing.T) {
 	dig := digest.Digest("sha256:cc5f4c463f81c55183d8d737ba2f0d30b3e6f3670dbe2da68f0aac168e93fbb1")
-	ref, _ := k8s.ParseNamedTagged("windmill.build/image:tilt-deadbeef")
+	ref, _ := container.ParseNamedTagged("windmill.build/image:tilt-deadbeef")
 	if digestMatchesRef(ref, dig) {
 		t.Errorf("Expected digest %s to not match ref %s", dig, ref)
 	}

--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	container2 "github.com/windmilleng/tilt/internal/container"
+	wmcontainer "github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
@@ -35,7 +35,7 @@ type dockerBuildFixture struct {
 	b            *dockerImageBuilder
 	registry     *exec.Cmd
 	reaper       ImageReaper
-	containerIDs []container2.ContainerID
+	containerIDs []wmcontainer.ID
 	ps           *PipelineState
 }
 
@@ -161,7 +161,7 @@ func (f *dockerBuildFixture) assertFilesInImage(ref reference.NamedTagged, expec
 }
 
 func (f *dockerBuildFixture) assertFilesInContainer(
-	ctx context.Context, cID container2.ContainerID, expectedFiles []expectedFile) {
+	ctx context.Context, cID wmcontainer.ID, expectedFiles []expectedFile) {
 	for _, expectedFile := range expectedFiles {
 		reader, _, err := f.dcli.CopyFromContainer(ctx, cID.String(), expectedFile.Path)
 		if expectedFile.Missing {
@@ -187,7 +187,7 @@ func (f *dockerBuildFixture) assertFilesInContainer(
 }
 
 // startContainer starts a container from the given config
-func (f *dockerBuildFixture) startContainer(ctx context.Context, config *container.Config) container2.ContainerID {
+func (f *dockerBuildFixture) startContainer(ctx context.Context, config *container.Config) wmcontainer.ID {
 	resp, err := f.dcli.ContainerCreate(ctx, config, nil, nil, "")
 	if err != nil {
 		f.t.Fatalf("startContainer: %v", err)
@@ -199,7 +199,7 @@ func (f *dockerBuildFixture) startContainer(ctx context.Context, config *contain
 		f.t.Fatalf("startContainer: %v", err)
 	}
 
-	result := container2.ContainerID(cID)
+	result := wmcontainer.ID(cID)
 	f.containerIDs = append(f.containerIDs, result)
 	return result
 }

--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	container2 "github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
@@ -34,7 +35,7 @@ type dockerBuildFixture struct {
 	b            *dockerImageBuilder
 	registry     *exec.Cmd
 	reaper       ImageReaper
-	containerIDs []k8s.ContainerID
+	containerIDs []container2.ContainerID
 	ps           *PipelineState
 }
 
@@ -160,7 +161,7 @@ func (f *dockerBuildFixture) assertFilesInImage(ref reference.NamedTagged, expec
 }
 
 func (f *dockerBuildFixture) assertFilesInContainer(
-	ctx context.Context, cID k8s.ContainerID, expectedFiles []expectedFile) {
+	ctx context.Context, cID container2.ContainerID, expectedFiles []expectedFile) {
 	for _, expectedFile := range expectedFiles {
 		reader, _, err := f.dcli.CopyFromContainer(ctx, cID.String(), expectedFile.Path)
 		if expectedFile.Missing {
@@ -186,7 +187,7 @@ func (f *dockerBuildFixture) assertFilesInContainer(
 }
 
 // startContainer starts a container from the given config
-func (f *dockerBuildFixture) startContainer(ctx context.Context, config *container.Config) k8s.ContainerID {
+func (f *dockerBuildFixture) startContainer(ctx context.Context, config *container.Config) container2.ContainerID {
 	resp, err := f.dcli.ContainerCreate(ctx, config, nil, nil, "")
 	if err != nil {
 		f.t.Fatalf("startContainer: %v", err)
@@ -198,7 +199,7 @@ func (f *dockerBuildFixture) startContainer(ctx context.Context, config *contain
 		f.t.Fatalf("startContainer: %v", err)
 	}
 
-	result := k8s.ContainerID(cID)
+	result := container2.ContainerID(cID)
 	f.containerIDs = append(f.containerIDs, result)
 	return result
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -6,19 +6,19 @@ import (
 	"github.com/docker/distribution/reference"
 )
 
-type ContainerID string
-type ContainerName string
+type ID string
+type Name string
 
-func (cID ContainerID) Empty() bool    { return cID.String() == "" }
-func (cID ContainerID) String() string { return string(cID) }
-func (cID ContainerID) ShortStr() string {
-	if len(string(cID)) > 10 {
-		return string(cID)[:10]
+func (id ID) Empty() bool    { return id.String() == "" }
+func (id ID) String() string { return string(id) }
+func (id ID) ShortStr() string {
+	if len(string(id)) > 10 {
+		return string(id)[:10]
 	}
-	return string(cID)
+	return string(id)
 }
 
-func (n ContainerName) String() string { return string(n) }
+func (n Name) String() string { return string(n) }
 
 func ParseNamedTagged(s string) (reference.NamedTagged, error) {
 	ref, err := reference.Parse(s)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1,0 +1,50 @@
+package container
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+)
+
+type ContainerID string
+type ContainerName string
+
+func (cID ContainerID) Empty() bool    { return cID.String() == "" }
+func (cID ContainerID) String() string { return string(cID) }
+func (cID ContainerID) ShortStr() string {
+	if len(string(cID)) > 10 {
+		return string(cID)[:10]
+	}
+	return string(cID)
+}
+
+func (n ContainerName) String() string { return string(n) }
+
+func ParseNamedTagged(s string) (reference.NamedTagged, error) {
+	ref, err := reference.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %v", s, err)
+	}
+
+	nt, ok := ref.(reference.NamedTagged)
+	if !ok {
+		return nil, fmt.Errorf("could not parse ref %s as NamedTagged", ref)
+	}
+	return nt, nil
+}
+
+func MustParseNamedTagged(s string) reference.NamedTagged {
+	nt, err := ParseNamedTagged(s)
+	if err != nil {
+		panic(err)
+	}
+	return nt
+}
+
+func MustParseNamed(s string) reference.Named {
+	n, err := reference.ParseNamed(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -35,7 +35,7 @@ type DockerClient interface {
 
 	// Execute a command in a container, streaming the command output to `out`.
 	// Returns an ExitError if the command exits with a non-zero exit code.
-	ExecInContainer(ctx context.Context, cID container.ContainerID, cmd model.Cmd, out io.Writer) error
+	ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error
 
 	ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error)
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
@@ -158,7 +158,7 @@ func (d *DockerCli) ContainerRestartNoWait(ctx context.Context, containerID stri
 	return d.ContainerRestart(ctx, containerID, &dur)
 }
 
-func (d *DockerCli) ExecInContainer(ctx context.Context, cID container.ContainerID, cmd model.Cmd, out io.Writer) error {
+func (d *DockerCli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "dockerCli-ExecInContainer")
 	span.SetTag("cmd", strings.Join(cmd.Argv, " "))
 	defer span.Finish()

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/opentracing/opentracing-go"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/minikube"
 	"github.com/windmilleng/tilt/internal/model"
@@ -34,7 +35,7 @@ type DockerClient interface {
 
 	// Execute a command in a container, streaming the command output to `out`.
 	// Returns an ExitError if the command exits with a non-zero exit code.
-	ExecInContainer(ctx context.Context, cID k8s.ContainerID, cmd model.Cmd, out io.Writer) error
+	ExecInContainer(ctx context.Context, cID container.ContainerID, cmd model.Cmd, out io.Writer) error
 
 	ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error)
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
@@ -157,7 +158,7 @@ func (d *DockerCli) ContainerRestartNoWait(ctx context.Context, containerID stri
 	return d.ContainerRestart(ctx, containerID, &dur)
 }
 
-func (d *DockerCli) ExecInContainer(ctx context.Context, cID k8s.ContainerID, cmd model.Cmd, out io.Writer) error {
+func (d *DockerCli) ExecInContainer(ctx context.Context, cID container.ContainerID, cmd model.Cmd, out io.Writer) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "dockerCli-ExecInContainer")
 	span.SetTag("cmd", strings.Join(cmd.Argv, " "))
 	defer span.Finish()

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -125,7 +125,7 @@ func (c *FakeDockerClient) ContainerRestartNoWait(ctx context.Context, container
 	return nil
 }
 
-func (c *FakeDockerClient) ExecInContainer(ctx context.Context, cID k8s.ContainerID, cmd model.Cmd, out io.Writer) error {
+func (c *FakeDockerClient) ExecInContainer(ctx context.Context, cID container.ContainerID, cmd model.Cmd, out io.Writer) error {
 	execCall := ExecCall{
 		Container: cID.String(),
 		Cmd:       cmd,

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -125,7 +125,7 @@ func (c *FakeDockerClient) ContainerRestartNoWait(ctx context.Context, container
 	return nil
 }
 
-func (c *FakeDockerClient) ExecInContainer(ctx context.Context, cID container.ContainerID, cmd model.Cmd, out io.Writer) error {
+func (c *FakeDockerClient) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error {
 	execCall := ExecCall{
 		Container: cID.String(),
 		Cmd:       cmd,

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/store"
 
 	"github.com/docker/docker/api/types"
@@ -26,7 +27,7 @@ import (
 	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
-var imageID = k8s.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef")
+var imageID = container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef")
 var alreadyBuilt = store.BuildResult{Image: imageID}
 
 type expectedFile = testutils.ExpectedFile

--- a/internal/engine/deploy.go
+++ b/internal/engine/deploy.go
@@ -104,7 +104,7 @@ func (d *DeployDiscovery) populateDeployInfo(ctx context.Context, image referenc
 	return nil
 }
 
-func podInfoForImage(ctx context.Context, kCli k8s.Client, image reference.NamedTagged, ns k8s.Namespace) (k8s.NodeID, k8s.PodID, container.ContainerID, container.ContainerName, error) {
+func podInfoForImage(ctx context.Context, kCli k8s.Client, image reference.NamedTagged, ns k8s.Namespace) (k8s.NodeID, k8s.PodID, container.ID, container.Name, error) {
 	// get pod running the image we just deployed.
 	//
 	// We fetch the pod by the NamedTagged, to ensure we get a pod
@@ -154,8 +154,8 @@ func podInfoForImage(ctx context.Context, kCli k8s.Client, image reference.Named
 type DeployInfo struct {
 	nodeID        k8s.NodeID
 	podID         k8s.PodID
-	containerID   container.ContainerID
-	containerName container.ContainerName
+	containerID   container.ID
+	containerName container.Name
 }
 
 func (d DeployInfo) Empty() bool {

--- a/internal/engine/deploy.go
+++ b/internal/engine/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
@@ -103,7 +104,7 @@ func (d *DeployDiscovery) populateDeployInfo(ctx context.Context, image referenc
 	return nil
 }
 
-func podInfoForImage(ctx context.Context, kCli k8s.Client, image reference.NamedTagged, ns k8s.Namespace) (k8s.NodeID, k8s.PodID, k8s.ContainerID, k8s.ContainerName, error) {
+func podInfoForImage(ctx context.Context, kCli k8s.Client, image reference.NamedTagged, ns k8s.Namespace) (k8s.NodeID, k8s.PodID, container.ContainerID, container.ContainerName, error) {
 	// get pod running the image we just deployed.
 	//
 	// We fetch the pod by the NamedTagged, to ensure we get a pod
@@ -153,8 +154,8 @@ func podInfoForImage(ctx context.Context, kCli k8s.Client, image reference.Named
 type DeployInfo struct {
 	nodeID        k8s.NodeID
 	podID         k8s.PodID
-	containerID   k8s.ContainerID
-	containerName k8s.ContainerName
+	containerID   container.ContainerID
+	containerName container.ContainerName
 }
 
 func (d DeployInfo) Empty() bool {

--- a/internal/engine/local_container_build_and_deployer_test.go
+++ b/internal/engine/local_container_build_and_deployer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/store"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ import (
 
 const pod1 = k8s.PodID("pod1")
 
-var image1 = k8s.MustParseNamedTagged("re.po/project/myapp:tilt-936a185caaa266bb")
+var image1 = container.MustParseNamedTagged("re.po/project/myapp:tilt-936a185caaa266bb")
 
 const digest1 = "sha256:936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af"
 
@@ -39,7 +40,7 @@ func TestPostProcessBuildNoopIfAlreadyHaveInfo(t *testing.T) {
 	f.kCli.SetPodsWithImageResp(pod1)
 
 	entry := newDeployInfoEntry()
-	entry.containerID = k8s.ContainerID("ohai")
+	entry.containerID = container.ContainerID("ohai")
 	entry.markReady()
 	f.cbad.dd.deployInfo[docker.ToImgNameAndTag(image1)] = entry
 
@@ -48,7 +49,7 @@ func TestPostProcessBuildNoopIfAlreadyHaveInfo(t *testing.T) {
 
 	info, err := f.cbad.dd.DeployInfoForImageBlocking(f.ctx, image1)
 	assert.Nil(t, err)
-	assert.Equal(t, k8s.ContainerID("ohai"), info.containerID,
+	assert.Equal(t, container.ContainerID("ohai"), info.containerID,
 		"Getting info again for same image -- contents should not have changed")
 }
 

--- a/internal/engine/local_container_build_and_deployer_test.go
+++ b/internal/engine/local_container_build_and_deployer_test.go
@@ -40,7 +40,7 @@ func TestPostProcessBuildNoopIfAlreadyHaveInfo(t *testing.T) {
 	f.kCli.SetPodsWithImageResp(pod1)
 
 	entry := newDeployInfoEntry()
-	entry.containerID = container.ContainerID("ohai")
+	entry.containerID = container.ID("ohai")
 	entry.markReady()
 	f.cbad.dd.deployInfo[docker.ToImgNameAndTag(image1)] = entry
 
@@ -49,7 +49,7 @@ func TestPostProcessBuildNoopIfAlreadyHaveInfo(t *testing.T) {
 
 	info, err := f.cbad.dd.DeployInfoForImageBlocking(f.ctx, image1)
 	assert.Nil(t, err)
-	assert.Equal(t, container.ContainerID("ohai"), info.containerID,
+	assert.Equal(t, container.ID("ohai"), info.containerID,
 		"Getting info again for same image -- contents should not have changed")
 }
 

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -151,13 +151,13 @@ type PodLogWatch struct {
 	name      model.ManifestName
 	podID     k8s.PodID
 	namespace k8s.Namespace
-	cID       container.ContainerID
-	cName     container.ContainerName
+	cID       container.ID
+	cName     container.Name
 }
 
 type podLogKey struct {
 	podID k8s.PodID
-	cID   container.ContainerID
+	cID   container.ID
 }
 
 type PodLogActionWriter struct {

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
@@ -150,13 +151,13 @@ type PodLogWatch struct {
 	name      model.ManifestName
 	podID     k8s.PodID
 	namespace k8s.Namespace
-	cID       k8s.ContainerID
-	cName     k8s.ContainerName
+	cID       container.ContainerID
+	cName     container.ContainerName
 }
 
 type podLogKey struct {
 	podID k8s.PodID
-	cID   k8s.ContainerID
+	cID   container.ContainerID
 }
 
 type PodLogActionWriter struct {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -55,7 +55,7 @@ type fakeBuildAndDeployer struct {
 	buildCount int
 
 	// where we store container info for each manifest
-	deployInfo map[docker.ImgNameAndTag]container.ContainerID
+	deployInfo map[docker.ImgNameAndTag]container.ID
 
 	// Set this to simulate the build failing. Do not set this directly, use fixture.SetNextBuildFailure
 	nextBuildFailure error
@@ -94,7 +94,7 @@ func (b *fakeBuildAndDeployer) haveContainerForImage(img reference.NamedTagged) 
 
 func (b *fakeBuildAndDeployer) PostProcessBuild(ctx context.Context, result, previousResult store.BuildResult) {
 	if result.HasImage() && !b.haveContainerForImage(result.Image) {
-		b.deployInfo[docker.ToImgNameAndTag(result.Image)] = container.ContainerID("testcontainer")
+		b.deployInfo[docker.ToImgNameAndTag(result.Image)] = container.ID("testcontainer")
 	}
 }
 
@@ -102,7 +102,7 @@ func newFakeBuildAndDeployer(t *testing.T) *fakeBuildAndDeployer {
 	return &fakeBuildAndDeployer{
 		t:          t,
 		calls:      make(chan buildAndDeployCall, 5),
-		deployInfo: make(map[docker.ImgNameAndTag]container.ContainerID),
+		deployInfo: make(map[docker.ImgNameAndTag]container.ID),
 	}
 }
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -12,7 +12,8 @@ import (
 	"testing"
 	"time"
 
-	logger "github.com/windmilleng/tilt/internal/logger"
+	"github.com/windmilleng/tilt/internal/container"
+	"github.com/windmilleng/tilt/internal/logger"
 
 	"github.com/windmilleng/tilt/internal/testutils/bufsync"
 	"github.com/windmilleng/tilt/internal/tiltfile"
@@ -54,7 +55,7 @@ type fakeBuildAndDeployer struct {
 	buildCount int
 
 	// where we store container info for each manifest
-	deployInfo map[docker.ImgNameAndTag]k8s.ContainerID
+	deployInfo map[docker.ImgNameAndTag]container.ContainerID
 
 	// Set this to simulate the build failing. Do not set this directly, use fixture.SetNextBuildFailure
 	nextBuildFailure error
@@ -93,7 +94,7 @@ func (b *fakeBuildAndDeployer) haveContainerForImage(img reference.NamedTagged) 
 
 func (b *fakeBuildAndDeployer) PostProcessBuild(ctx context.Context, result, previousResult store.BuildResult) {
 	if result.HasImage() && !b.haveContainerForImage(result.Image) {
-		b.deployInfo[docker.ToImgNameAndTag(result.Image)] = k8s.ContainerID("testcontainer")
+		b.deployInfo[docker.ToImgNameAndTag(result.Image)] = container.ContainerID("testcontainer")
 	}
 }
 
@@ -101,7 +102,7 @@ func newFakeBuildAndDeployer(t *testing.T) *fakeBuildAndDeployer {
 	return &fakeBuildAndDeployer{
 		t:          t,
 		calls:      make(chan buildAndDeployCall, 5),
-		deployInfo: make(map[docker.ImgNameAndTag]k8s.ContainerID),
+		deployInfo: make(map[docker.ImgNameAndTag]container.ContainerID),
 	}
 }
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -69,7 +69,7 @@ type Client interface {
 	WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, error)
 
 	// Streams the container logs
-	ContainerLogs(ctx context.Context, podID PodID, cName container.ContainerName, n Namespace) (io.ReadCloser, error)
+	ContainerLogs(ctx context.Context, podID PodID, cName container.Name, n Namespace) (io.ReadCloser, error)
 
 	// Gets the ID for the Node on which the specified Pod is running
 	GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,8 +28,6 @@ import (
 
 type Namespace string
 type PodID string
-type ContainerID string
-type ContainerName string
 type NodeID string
 type ServiceName string
 
@@ -36,17 +35,6 @@ const DefaultNamespace = Namespace("default")
 
 func (pID PodID) Empty() bool    { return pID.String() == "" }
 func (pID PodID) String() string { return string(pID) }
-
-func (cID ContainerID) Empty() bool    { return cID.String() == "" }
-func (cID ContainerID) String() string { return string(cID) }
-func (cID ContainerID) ShortStr() string {
-	if len(string(cID)) > 10 {
-		return string(cID)[:10]
-	}
-	return string(cID)
-}
-
-func (n ContainerName) String() string { return string(n) }
 
 func (nID NodeID) String() string { return string(nID) }
 
@@ -81,7 +69,7 @@ type Client interface {
 	WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, error)
 
 	// Streams the container logs
-	ContainerLogs(ctx context.Context, podID PodID, cName ContainerName, n Namespace) (io.ReadCloser, error)
+	ContainerLogs(ctx context.Context, podID PodID, cName container.ContainerName, n Namespace) (io.ReadCloser, error)
 
 	// Gets the ID for the Node on which the specified Pod is running
 	GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error)

--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/logger"
 	"k8s.io/api/core/v1"
 )
@@ -113,7 +114,7 @@ func ContainerMatching(pod *v1.Pod, ref reference.Named) (v1.ContainerStatus, er
 	return v1.ContainerStatus{}, nil
 }
 
-func ContainerIDFromContainerStatus(status v1.ContainerStatus) (ContainerID, error) {
+func ContainerIDFromContainerStatus(status v1.ContainerStatus) (container.ContainerID, error) {
 	id := status.ContainerID
 	if id == "" {
 		return "", nil
@@ -122,11 +123,11 @@ func ContainerIDFromContainerStatus(status v1.ContainerStatus) (ContainerID, err
 	if !strings.HasPrefix(id, ContainerIDPrefix) {
 		return "", fmt.Errorf("Malformed container ID: %s", id)
 	}
-	return ContainerID(id[len(ContainerIDPrefix):]), nil
+	return container.ContainerID(id[len(ContainerIDPrefix):]), nil
 }
 
-func ContainerNameFromContainerStatus(status v1.ContainerStatus) ContainerName {
-	return ContainerName(status.Name)
+func ContainerNameFromContainerStatus(status v1.ContainerStatus) container.ContainerName {
+	return container.ContainerName(status.Name)
 }
 
 func ContainerSpecOf(pod *v1.Pod, status v1.ContainerStatus) v1.Container {

--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -114,7 +114,7 @@ func ContainerMatching(pod *v1.Pod, ref reference.Named) (v1.ContainerStatus, er
 	return v1.ContainerStatus{}, nil
 }
 
-func ContainerIDFromContainerStatus(status v1.ContainerStatus) (container.ContainerID, error) {
+func ContainerIDFromContainerStatus(status v1.ContainerStatus) (container.ID, error) {
 	id := status.ContainerID
 	if id == "" {
 		return "", nil
@@ -123,11 +123,11 @@ func ContainerIDFromContainerStatus(status v1.ContainerStatus) (container.Contai
 	if !strings.HasPrefix(id, ContainerIDPrefix) {
 		return "", fmt.Errorf("Malformed container ID: %s", id)
 	}
-	return container.ContainerID(id[len(ContainerIDPrefix):]), nil
+	return container.ID(id[len(ContainerIDPrefix):]), nil
 }
 
-func ContainerNameFromContainerStatus(status v1.ContainerStatus) container.ContainerName {
-	return container.ContainerName(status.Name)
+func ContainerNameFromContainerStatus(status v1.ContainerStatus) container.Name {
+	return container.Name(status.Name)
 }
 
 func ContainerSpecOf(pod *v1.Pod, status v1.ContainerStatus) v1.Container {

--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 )
 
 func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	f := newClientTestFixture(t)
 
-	nt := MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseNamedTagged(blorgDevImgStr)
 	podData := fakePod(expectedPod, blorgDevImgStr)
 	podData.Status = v1.PodStatus{
 		ContainerStatuses: []v1.ContainerStatus{
@@ -52,7 +53,7 @@ func TestWaitForContainerSuccess(t *testing.T) {
 	f := newClientTestFixture(t)
 	f.addObject(&fakePodList)
 
-	nt := MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseNamedTagged(blorgDevImgStr)
 	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)
@@ -92,7 +93,7 @@ func TestWaitForContainerFailure(t *testing.T) {
 	f := newClientTestFixture(t)
 	f.addObject(&fakePodList)
 
-	nt := MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseNamedTagged(blorgDevImgStr)
 	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)
@@ -135,7 +136,7 @@ func TestWaitForContainerUnschedulable(t *testing.T) {
 	f := newClientTestFixture(t)
 	f.addObject(&fakePodList)
 
-	nt := MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseNamedTagged(blorgDevImgStr)
 	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -81,7 +82,7 @@ func (c *FakeK8sClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interf
 	return watch.NewEmptyWatch(), nil
 }
 
-func (c *FakeK8sClient) ContainerLogs(ctx context.Context, pID PodID, cName ContainerName, n Namespace) (io.ReadCloser, error) {
+func (c *FakeK8sClient) ContainerLogs(ctx context.Context, pID PodID, cName container.ContainerName, n Namespace) (io.ReadCloser, error) {
 	if c.ContainerLogsError != nil {
 		return nil, c.ContainerLogsError
 	}

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -82,7 +82,7 @@ func (c *FakeK8sClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interf
 	return watch.NewEmptyWatch(), nil
 }
 
-func (c *FakeK8sClient) ContainerLogs(ctx context.Context, pID PodID, cName container.ContainerName, n Namespace) (io.ReadCloser, error) {
+func (c *FakeK8sClient) ContainerLogs(ctx context.Context, pID PodID, cName container.Name, n Namespace) (io.ReadCloser, error) {
 	if c.ContainerLogsError != nil {
 		return nil, c.ContainerLogsError
 	}

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -82,32 +82,3 @@ func PodContainsRef(pod *v1.PodSpec, ref reference.Named) (bool, error) {
 	}
 	return false, nil
 }
-
-func ParseNamedTagged(s string) (reference.NamedTagged, error) {
-	ref, err := reference.Parse(s)
-	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %v", s, err)
-	}
-
-	nt, ok := ref.(reference.NamedTagged)
-	if !ok {
-		return nil, fmt.Errorf("could not parse ref %s as NamedTagged", ref)
-	}
-	return nt, nil
-}
-
-func MustParseNamedTagged(s string) reference.NamedTagged {
-	nt, err := ParseNamedTagged(s)
-	if err != nil {
-		panic(err)
-	}
-	return nt
-}
-
-func MustParseNamed(s string) reference.Named {
-	n, err := reference.ParseNamed(s)
-	if err != nil {
-		panic(err)
-	}
-	return n
-}

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/reference"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 
 	"k8s.io/api/core/v1"
@@ -214,7 +215,7 @@ func TestInjectSyncletImage(t *testing.T) {
 	assert.Equal(t, 1, len(entities))
 	entity := entities[0]
 	name := "gcr.io/windmill-public-containers/synclet"
-	namedTagged, _ := ParseNamedTagged(fmt.Sprintf("%s:tilt-deadbeef", name))
+	namedTagged, _ := container.ParseNamedTagged(fmt.Sprintf("%s:tilt-deadbeef", name))
 	newEntity, replaced, err := InjectImageDigest(entity, namedTagged, v1.PullNever)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/opentracing/opentracing-go"
+	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -27,7 +28,7 @@ func (k K8sClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, 
 	return podAPI.Watch(watchOptions)
 }
 
-func (k K8sClient) ContainerLogs(ctx context.Context, pID PodID, cName ContainerName, n Namespace) (io.ReadCloser, error) {
+func (k K8sClient) ContainerLogs(ctx context.Context, pID PodID, cName container.ContainerName, n Namespace) (io.ReadCloser, error) {
 	options := &v1.PodLogOptions{
 		Container: cName.String(),
 		Follow:    true,

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -28,7 +28,7 @@ func (k K8sClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, 
 	return podAPI.Watch(watchOptions)
 }
 
-func (k K8sClient) ContainerLogs(ctx context.Context, pID PodID, cName container.ContainerName, n Namespace) (io.ReadCloser, error) {
+func (k K8sClient) ContainerLogs(ctx context.Context, pID PodID, cName container.Name, n Namespace) (io.ReadCloser, error) {
 	options := &v1.PodLogOptions{
 		Container: cName.String(),
 		Follow:    true,

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -83,7 +84,7 @@ func (c clientTestFixture) AssertCallExistsWithArg(expectedArg string) {
 func TestPodsWithImage(t *testing.T) {
 	f := newClientTestFixture(t)
 	f.addObject(&fakePodList)
-	nt := MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseNamedTagged(blorgDevImgStr)
 	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, nil)
 	if err != nil {
 		f.t.Fatal(err)
@@ -102,7 +103,7 @@ func TestPodsWithImageLabels(t *testing.T) {
 
 	f.addObject(&pod1)
 	f.addObject(&pod2)
-	nt := MustParseNamedTagged("cockroachdb/cockroach:v2.0.5")
+	nt := container.MustParseNamedTagged("cockroachdb/cockroach:v2.0.5")
 
 	pods, err := f.client.PodsWithImage(f.ctx, nt, DefaultNamespace, []LabelPair{{"type", "primary"}})
 	if err != nil {
@@ -130,7 +131,7 @@ func TestPollForPodsWithImage(t *testing.T) {
 		f.addObject(&fakePodList)
 	}()
 
-	nt := MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseNamedTagged(blorgDevImgStr)
 	pods, err := f.client.PollForPodsWithImage(f.ctx, nt, DefaultNamespace, nil, 2*time.Second)
 	if err != nil {
 		f.t.Fatal(err)
@@ -146,7 +147,7 @@ func TestPollForPodsWithImageTimesOut(t *testing.T) {
 		f.addObject(&fakePodList)
 	}()
 
-	nt := MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseNamedTagged(blorgDevImgStr)
 	_, err := f.client.PollForPodsWithImage(f.ctx, nt, DefaultNamespace, nil, 500*time.Millisecond)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "timed out polling for pod running image")

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/container"
 )
 
 var equalitytests = []struct {
@@ -269,7 +269,7 @@ func TestManifestValidateMountRelativePath(t *testing.T) {
 	manifest := Manifest{
 		Name:           "test",
 		K8sYaml:        "yamlll",
-		DockerRef:      k8s.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef"),
+		DockerRef:      container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef"),
 		BaseDockerfile: "FROM node",
 		Mounts:         mounts,
 	}

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -17,7 +17,7 @@ type BuildResult struct {
 	Image reference.NamedTagged
 
 	// If this build was a container build, containerID we built on top of
-	ContainerID container.ContainerID
+	ContainerID container.ID
 
 	// The namespace where the pod was deployed.
 	Namespace k8s.Namespace

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 )
 
@@ -16,7 +17,7 @@ type BuildResult struct {
 	Image reference.NamedTagged
 
 	// If this build was a container build, containerID we built on top of
-	ContainerID k8s.ContainerID
+	ContainerID container.ContainerID
 
 	// The namespace where the pod was deployed.
 	Namespace k8s.Namespace

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -66,7 +66,7 @@ type ManifestState struct {
 	QueueEntryTime            time.Time
 
 	// If the pod isn't running this container then it's possible we're running stale code
-	ExpectedContainerID container.ContainerID
+	ExpectedContainerID container.ID
 	// We detected stale code and are currently doing an image build
 	CrashRebuildInProg bool
 	// we've observed changes to config file(s) and need to reload the manifest next time we start a build
@@ -102,8 +102,8 @@ type Pod struct {
 	CurrentLog []byte
 
 	// Corresponds to the deployed container.
-	ContainerName  container.ContainerName
-	ContainerID    container.ContainerID
+	ContainerName  container.Name
+	ContainerID    container.ID
 	ContainerPorts []int32
 	ContainerReady bool
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
@@ -65,7 +66,7 @@ type ManifestState struct {
 	QueueEntryTime            time.Time
 
 	// If the pod isn't running this container then it's possible we're running stale code
-	ExpectedContainerID k8s.ContainerID
+	ExpectedContainerID container.ContainerID
 	// We detected stale code and are currently doing an image build
 	CrashRebuildInProg bool
 	// we've observed changes to config file(s) and need to reload the manifest next time we start a build
@@ -101,8 +102,8 @@ type Pod struct {
 	CurrentLog []byte
 
 	// Corresponds to the deployed container.
-	ContainerName  k8s.ContainerName
-	ContainerID    k8s.ContainerID
+	ContainerName  container.ContainerName
+	ContainerID    container.ContainerID
 	ContainerPorts []int32
 	ContainerReady bool
 

--- a/internal/synclet/fake_client.go
+++ b/internal/synclet/fake_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 )
@@ -24,7 +25,7 @@ func NewFakeSyncletClient() *FakeSyncletClient {
 	return &FakeSyncletClient{}
 }
 
-func (c *FakeSyncletClient) UpdateContainer(ctx context.Context, containerID k8s.ContainerID,
+func (c *FakeSyncletClient) UpdateContainer(ctx context.Context, containerID container.ContainerID,
 	tarArchive []byte, filesToDelete []string, commands []model.Cmd) error {
 	if c.UpdateContainerErrorToReturn != nil {
 		ret := c.UpdateContainerErrorToReturn
@@ -35,8 +36,8 @@ func (c *FakeSyncletClient) UpdateContainer(ctx context.Context, containerID k8s
 	return nil
 }
 
-func (c *FakeSyncletClient) ContainerIDForPod(ctx context.Context, podID k8s.PodID, imageID reference.NamedTagged) (k8s.ContainerID, error) {
-	return k8s.ContainerID("foobar"), nil
+func (c *FakeSyncletClient) ContainerIDForPod(ctx context.Context, podID k8s.PodID, imageID reference.NamedTagged) (container.ContainerID, error) {
+	return container.ContainerID("foobar"), nil
 }
 
 func (c *FakeSyncletClient) Close() error {

--- a/internal/synclet/fake_client.go
+++ b/internal/synclet/fake_client.go
@@ -25,7 +25,7 @@ func NewFakeSyncletClient() *FakeSyncletClient {
 	return &FakeSyncletClient{}
 }
 
-func (c *FakeSyncletClient) UpdateContainer(ctx context.Context, containerID container.ContainerID,
+func (c *FakeSyncletClient) UpdateContainer(ctx context.Context, containerID container.ID,
 	tarArchive []byte, filesToDelete []string, commands []model.Cmd) error {
 	if c.UpdateContainerErrorToReturn != nil {
 		ret := c.UpdateContainerErrorToReturn
@@ -36,8 +36,8 @@ func (c *FakeSyncletClient) UpdateContainer(ctx context.Context, containerID con
 	return nil
 }
 
-func (c *FakeSyncletClient) ContainerIDForPod(ctx context.Context, podID k8s.PodID, imageID reference.NamedTagged) (container.ContainerID, error) {
-	return container.ContainerID("foobar"), nil
+func (c *FakeSyncletClient) ContainerIDForPod(ctx context.Context, podID k8s.PodID, imageID reference.NamedTagged) (container.ID, error) {
+	return container.ID("foobar"), nil
 }
 
 func (c *FakeSyncletClient) Close() error {

--- a/internal/synclet/server_adapter.go
+++ b/internal/synclet/server_adapter.go
@@ -71,5 +71,5 @@ func (s *GRPCServer) UpdateContainer(req *proto.UpdateContainerRequest, server p
 		return err
 	}
 
-	return s.del.UpdateContainer(ctx, container.ContainerID(req.ContainerId), req.TarArchive, req.FilesToDelete, commands)
+	return s.del.UpdateContainer(ctx, container.ID(req.ContainerId), req.TarArchive, req.FilesToDelete, commands)
 }

--- a/internal/synclet/server_adapter.go
+++ b/internal/synclet/server_adapter.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 
 	"github.com/windmilleng/tilt/internal/model"
@@ -70,5 +71,5 @@ func (s *GRPCServer) UpdateContainer(req *proto.UpdateContainerRequest, server p
 		return err
 	}
 
-	return s.del.UpdateContainer(ctx, k8s.ContainerID(req.ContainerId), req.TarArchive, req.FilesToDelete, commands)
+	return s.del.UpdateContainer(ctx, container.ContainerID(req.ContainerId), req.TarArchive, req.FilesToDelete, commands)
 }

--- a/internal/synclet/sidecar/sidecar.go
+++ b/internal/synclet/sidecar/sidecar.go
@@ -3,7 +3,7 @@ package sidecar
 import (
 	"fmt"
 
-	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"k8s.io/api/core/v1"
@@ -20,7 +20,7 @@ var SyncletTag = "v20180928"
 const SyncletImageName = "gcr.io/windmill-public-containers/tilt-synclet"
 const SyncletContainerName = "tilt-synclet"
 
-var SyncletImageRef = k8s.MustParseNamed(SyncletImageName)
+var SyncletImageRef = container.MustParseNamed(SyncletImageName)
 
 var SyncletContainer = v1.Container{
 	Name:            SyncletContainerName,

--- a/internal/synclet/synclet.go
+++ b/internal/synclet/synclet.go
@@ -30,14 +30,14 @@ func NewSynclet(dcli docker.DockerClient, cr *build.ContainerResolver) *Synclet 
 	return &Synclet{dcli: dcli, cr: cr}
 }
 
-func (s Synclet) ContainerIDForPod(ctx context.Context, podID k8s.PodID, imageID reference.NamedTagged) (container.ContainerID, error) {
+func (s Synclet) ContainerIDForPod(ctx context.Context, podID k8s.PodID, imageID reference.NamedTagged) (container.ID, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Synclet-ContainerIDForPod")
 	defer span.Finish()
 
 	return s.cr.ContainerIDForPod(ctx, podID, imageID)
 }
 
-func (s Synclet) writeFiles(ctx context.Context, containerId container.ContainerID, tarArchive []byte) error {
+func (s Synclet) writeFiles(ctx context.Context, containerId container.ID, tarArchive []byte) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Synclet-writeFiles")
 	defer span.Finish()
 
@@ -48,7 +48,7 @@ func (s Synclet) writeFiles(ctx context.Context, containerId container.Container
 	return s.dcli.CopyToContainerRoot(ctx, containerId.String(), bytes.NewBuffer(tarArchive))
 }
 
-func (s Synclet) rmFiles(ctx context.Context, containerId container.ContainerID, filesToDelete []string) error {
+func (s Synclet) rmFiles(ctx context.Context, containerId container.ID, filesToDelete []string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Synclet-rmFiles")
 	defer span.Finish()
 
@@ -70,7 +70,7 @@ func (s Synclet) rmFiles(ctx context.Context, containerId container.ContainerID,
 	return nil
 }
 
-func (s Synclet) execCmds(ctx context.Context, containerId container.ContainerID, cmds []model.Cmd) error {
+func (s Synclet) execCmds(ctx context.Context, containerId container.ID, cmds []model.Cmd) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Synclet-execCommands")
 	defer span.Finish()
 
@@ -91,7 +91,7 @@ func (s Synclet) execCmds(ctx context.Context, containerId container.ContainerID
 	return nil
 }
 
-func (s Synclet) restartContainer(ctx context.Context, containerId container.ContainerID) error {
+func (s Synclet) restartContainer(ctx context.Context, containerId container.ID) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Synclet-restartContainer")
 	defer span.Finish()
 
@@ -100,7 +100,7 @@ func (s Synclet) restartContainer(ctx context.Context, containerId container.Con
 
 func (s Synclet) UpdateContainer(
 	ctx context.Context,
-	containerId container.ContainerID,
+	containerId container.ID,
 	tarArchive []byte,
 	filesToDelete []string,
 	commands []model.Cmd) error {


### PR DESCRIPTION
feel free to tell me that this PR isnt worth merging, but it's been
bugging me for a bit that we're keeping all this code in the k8s package
when it's not k8s specific at all. (It can't go straight into the `docker`
package however cuz we get import cycles.)