### PR TITLE
model: new type of manifest that is only YAML

### DIFF
--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -46,10 +46,15 @@ func CreateBuildContextFilter(m model.Manifest) model.PathMatcher {
 	return model.NewCompositeMatcher(matchers)
 }
 
+type IgnorableManifest interface {
+	ConfigMatcher() (model.PathMatcher, error)
+	LocalRepos() []model.LocalGithubRepo
+}
+
 // Filter out files that should not trigger new builds.
-func CreateFileChangeFilter(m model.Manifest) (model.PathMatcher, error) {
+func CreateFileChangeFilter(m IgnorableManifest) (model.PathMatcher, error) {
 	matchers := []model.PathMatcher{}
-	for _, r := range m.Repos {
+	for _, r := range m.LocalRepos() {
 		gim, err := git.NewRepoIgnoreTester(context.Background(), r.LocalPath, r.GitignoreContents)
 		if err == nil {
 			matchers = append(matchers, gim)

--- a/internal/model/globalyaml.go
+++ b/internal/model/globalyaml.go
@@ -1,0 +1,29 @@
+package model
+
+type YAMLManifest struct {
+	name    ManifestName
+	k8sYaml string
+
+	configFiles []string
+}
+
+func (y YAMLManifest) Dependencies() []string {
+	return y.configFiles
+}
+
+func (y YAMLManifest) ManifestName() ManifestName {
+	return y.name
+}
+
+func (y YAMLManifest) ConfigMatcher() (PathMatcher, error) {
+	configMatcher, err := NewSimpleFileMatcher(y.configFiles...)
+	if err != nil {
+		return nil, err
+	}
+
+	return configMatcher, nil
+}
+
+func (YAMLManifest) LocalRepos() []LocalGithubRepo {
+	return []LocalGithubRepo{}
+}

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -199,6 +199,28 @@ func (m1 Manifest) stepsEqual(s2 []Step) bool {
 	return true
 }
 
+func (m Manifest) ManifestName() ManifestName {
+	return m.Name
+}
+
+func (m Manifest) Dependencies() []string {
+	// TODO(dmiller) we can know the length of this slice
+	deps := []string{}
+
+	for _, p := range m.LocalPaths() {
+		deps = append(deps, p)
+	}
+	for _, f := range m.ConfigFiles {
+		deps = append(deps, f)
+	}
+
+	return deps
+}
+
+func (m Manifest) LocalRepos() []LocalGithubRepo {
+	return m.Repos
+}
+
 type Mount struct {
 	LocalPath     string
 	ContainerPath string

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -39,6 +39,11 @@ type EngineState struct {
 	BuildControllerActionCount int
 
 	PermanentError error
+
+	// GlobalYAML is a special manifest that has no images, but has dependencies
+	// and a bunch of YAML that is deployed when those dependencies change.
+	// TODO(dmiller) in the future we may have many of these manifsts, but for now it's a special case.
+	GlobalYAML model.YAMLManifest
 }
 
 type ManifestState struct {


### PR DESCRIPTION
Unified in the appropriate places with the new `WatchableManifest`
interface, that both `model.Manifest` and `model.GlobalYAMLManifest`
implement.