### PR TITLE
tilt: enable log following for resource logs

### DIFF
--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -144,11 +144,15 @@ func (h *Hud) handleScreenEvent(ctx context.Context, st *store.Store, ev tcell.E
 		case tcell.KeyDown:
 			h.selectedScroller(h.r.rty).Down()
 			h.refresh(ctx)
+		case tcell.KeyHome:
+			h.selectedScroller(h.r.rty).Top()
+		case tcell.KeyEnd:
+			h.selectedScroller(h.r.rty).Bottom()
 		case tcell.KeyEnter:
 			if h.viewState.DisplayedLogNumber == 0 {
 				selectedIdx, _ := h.selectedResource()
 				h.viewState.DisplayedLogNumber = selectedIdx + 1
-				logModal(h.r.rty).Top()
+				logModal(h.r.rty).Bottom()
 			} else {
 				h.viewState.DisplayedLogNumber = 0
 			}
@@ -224,4 +228,6 @@ func (h *Hud) selectedScroller(rty rty.RTY) Scroller {
 type Scroller interface {
 	Up()
 	Down()
+	Top()
+	Bottom()
 }

--- a/internal/rty/components.go
+++ b/internal/rty/components.go
@@ -22,6 +22,8 @@ type RTY interface {
 type ElementScroller interface {
 	Up()
 	Down()
+	Top()
+	Bottom()
 	GetSelectedIndex() int
 }
 
@@ -29,12 +31,10 @@ type TextScroller interface {
 	Up()
 	Down()
 	Top()
-	// PgUp()
-	// PgDn()
-	// Home()
-	// End()
+	Bottom()
 
 	ToggleFollow()
+	SetFollow(following bool)
 }
 
 // Component renders onto a canvas

--- a/internal/rty/scroll.go
+++ b/internal/rty/scroll.go
@@ -156,13 +156,21 @@ type TextScrollController struct {
 
 func (s *TextScrollController) Top() {
 	st := s.state
+	if st.canvasIdx != 0 || st.lineIdx != 0 {
+		s.SetFollow(false)
+	}
 	st.canvasIdx = 0
 	st.lineIdx = 0
+}
+
+func (s *TextScrollController) Bottom() {
+	s.SetFollow(true)
 }
 
 func (s *TextScrollController) Up() {
 	st := s.state
 	if st.lineIdx != 0 {
+		s.SetFollow(false)
 		st.lineIdx--
 		return
 	}
@@ -170,6 +178,7 @@ func (s *TextScrollController) Up() {
 	if st.canvasIdx == 0 {
 		return
 	}
+	s.SetFollow(false)
 	st.canvasIdx--
 	st.lineIdx = st.canvasLengths[st.canvasIdx] - 1
 }
@@ -189,6 +198,7 @@ func (s *TextScrollController) Down() {
 	}
 	if st.canvasIdx == len(st.canvasLengths)-1 {
 		// we're at the end of the last canvas
+		s.SetFollow(true)
 		return
 	}
 	st.canvasIdx++
@@ -197,6 +207,10 @@ func (s *TextScrollController) Down() {
 
 func (s *TextScrollController) ToggleFollow() {
 	s.state.following = !s.state.following
+}
+
+func (s *TextScrollController) SetFollow(follow bool) {
+	s.state.following = follow
 }
 
 func NewScrollingWrappingTextArea(name string, text string) Component {
@@ -367,4 +381,12 @@ func (s *ElementScrollController) Down() {
 		return
 	}
 	s.state.elementIdx++
+}
+
+func (s *ElementScrollController) Top() {
+	s.state.elementIdx = 0
+}
+
+func (s *ElementScrollController) Bottom() {
+	s.state.elementIdx = len(s.state.children)
 }


### PR DESCRIPTION
1. Default to the bottom of the log when you open it
2. If you're at the bottom of the log, keep scrolling with new log output
3. Add support for home/end keys