### PR TITLE
tiltfile: prelim refactor to support global yaml returned when we get manifests [ch682]

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -35,11 +35,12 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, err := tf.GetManifestConfigs(args...)
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYaml(args...)
 	if err != nil {
 		return err
 	}
 
+	// TODO(maia): k8s.delete entities from global yaml as well
 	entities, err := engine.ParseYAMLFromManifests(manifests...)
 	if err != nil {
 		return errors.Wrap(err, "Parsing YAML")

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -35,7 +35,7 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, _, err := tf.GetManifestConfigsAndGlobalYaml(args...)
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(args...)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -85,7 +85,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, _, err := tf.GetManifestConfigsAndGlobalYaml(args...)
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(args...)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -85,7 +85,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, err := tf.GetManifestConfigs(args...)
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYaml(args...)
 	if err != nil {
 		return err
 	}
@@ -104,6 +104,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		}
 	}()
 
+	// TODO(maia): send along globalYamlManifest (returned by GetManifest...Yaml above)
 	err = upper.CreateManifests(ctx, manifests, c.watch)
 	s, ok := status.FromError(err)
 	if ok && s.Code() == codes.Unknown {

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -181,7 +181,7 @@ func (s Script) Run(ctx context.Context) error {
 			return err
 		}
 
-		manifests, _, err := tf.GetManifestConfigsAndGlobalYaml("tiltdemo")
+		manifests, _, err := tf.GetManifestConfigsAndGlobalYAML("tiltdemo")
 		if err != nil {
 			return err
 		}

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -181,13 +181,14 @@ func (s Script) Run(ctx context.Context) error {
 			return err
 		}
 
-		manifests, err := tf.GetManifestConfigs("tiltdemo")
+		manifests, _, err := tf.GetManifestConfigsAndGlobalYaml("tiltdemo")
 		if err != nil {
 			return err
 		}
 
 		defer s.cleanUp(context.Background(), manifests)
 
+		// TODO(maia): send along globalYamlManifest (returned by GetManifest...Yaml above)
 		return s.upper.CreateManifests(ctx, manifests, true)
 	})
 

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -65,7 +65,7 @@ func NewBuildCompleteAction(result store.BuildResult, err error) BuildCompleteAc
 type InitAction struct {
 	WatchMounts        bool
 	Manifests          []model.Manifest
-	GlobalYamlManifest model.YAMLManifest
+	GlobalYAMLManifest model.YAMLManifest
 }
 
 func (InitAction) Action() {}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -63,8 +63,9 @@ func NewBuildCompleteAction(result store.BuildResult, err error) BuildCompleteAc
 }
 
 type InitAction struct {
-	WatchMounts bool
-	Manifests   []model.Manifest
+	WatchMounts        bool
+	Manifests          []model.Manifest
+	GlobalYamlManifest model.YAMLManifest
 }
 
 func (InitAction) Action() {}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -149,7 +149,7 @@ func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (m
 	if err != nil {
 		return model.Manifest{}, manifestErrf(err.Error())
 	}
-	newManifests, _, err := t.GetManifestConfigsAndGlobalYaml(string(name))
+	newManifests, _, err := t.GetManifestConfigsAndGlobalYAML(string(name))
 	if err != nil {
 		return model.Manifest{}, manifestErrf(err.Error())
 	}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -149,7 +149,7 @@ func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (m
 	if err != nil {
 		return model.Manifest{}, manifestErrf(err.Error())
 	}
-	newManifests, err := t.GetManifestConfigs(string(name))
+	newManifests, _, err := t.GetManifestConfigsAndGlobalYaml(string(name))
 	if err != nil {
 		return model.Manifest{}, manifestErrf(err.Error())
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -543,7 +543,7 @@ func (u Upper) handleInitAction(ctx context.Context, engineState *store.EngineSt
 	watchMounts := action.WatchMounts
 	manifests := action.Manifests
 
-	engineState.GlobalYAML = action.GlobalYamlManifest
+	engineState.GlobalYAML = action.GlobalYAMLManifest
 
 	for _, m := range manifests {
 		engineState.ManifestDefinitionOrder = append(engineState.ManifestDefinitionOrder, m.Name)

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -543,6 +543,8 @@ func (u Upper) handleInitAction(ctx context.Context, engineState *store.EngineSt
 	watchMounts := action.WatchMounts
 	manifests := action.Manifests
 
+	engineState.GlobalYAML = action.GlobalYamlManifest
+
 	for _, m := range manifests {
 		engineState.ManifestDefinitionOrder = append(engineState.ManifestDefinitionOrder, m.Name)
 		engineState.ManifestStates[m.Name] = store.NewManifestState(m)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1687,7 +1687,7 @@ func (f *testFixture) loadManifest(name string) model.Manifest {
 	if err != nil {
 		f.T().Fatal(err)
 	}
-	manifests, _, err := tf.GetManifestConfigsAndGlobalYaml("foobar")
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML("foobar")
 	if err != nil {
 		f.T().Fatal(err)
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1687,7 +1687,7 @@ func (f *testFixture) loadManifest(name string) model.Manifest {
 	if err != nil {
 		f.T().Fatal(err)
 	}
-	manifests, err := tf.GetManifestConfigs("foobar")
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYaml("foobar")
 	if err != nil {
 		f.T().Fatal(err)
 	}

--- a/internal/model/globalyaml.go
+++ b/internal/model/globalyaml.go
@@ -7,6 +7,13 @@ type YAMLManifest struct {
 	configFiles []string
 }
 
+func NewYAMLManifest(name ManifestName, k8sYaml string, configFiles []string) YAMLManifest {
+	return YAMLManifest{
+		name:        name,
+		k8sYaml:     k8sYaml,
+		configFiles: configFiles,
+	}
+}
 func (y YAMLManifest) Dependencies() []string {
 	return y.configFiles
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -43,7 +43,7 @@ type EngineState struct {
 
 	// GlobalYAML is a special manifest that has no images, but has dependencies
 	// and a bunch of YAML that is deployed when those dependencies change.
-	// TODO(dmiller) in the future we may have many of these manifsts, but for now it's a special case.
+	// TODO(dmiller) in the future we may have many of these manifests, but for now it's a special case.
 	GlobalYAML model.YAMLManifest
 }
 

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -336,14 +336,14 @@ type localPath struct {
 	repo gitRepo
 }
 
-func (tf *Tiltfile) localPathFromSkylarkValue(v skylark.Value) (localPath, error) {
+func (t *Tiltfile) localPathFromSkylarkValue(v skylark.Value) (localPath, error) {
 	switch v := v.(type) {
 	case localPath:
 		return v, nil
 	case gitRepo:
 		return v.makeLocalPath("."), nil
 	case skylark.String:
-		return tf.localPathFromString(string(v))
+		return t.localPathFromString(string(v))
 	default:
 		return localPath{}, fmt.Errorf(" Expected local path. Actual type: %T", v)
 	}
@@ -380,8 +380,8 @@ func (t *Tiltfile) localPathFromString(path string) (localPath, error) {
 
 var _ skylark.Value = localPath{}
 
-func (l localPath) String() string {
-	return l.path
+func (lp localPath) String() string {
+	return lp.path
 }
 
 func (localPath) Type() string {
@@ -394,8 +394,8 @@ func (localPath) Hash() (uint32, error) {
 	return 0, errors.New("unhashable type: localPath")
 }
 
-func (p localPath) Truth() skylark.Bool {
-	return p != localPath{}
+func (lp localPath) Truth() skylark.Bool {
+	return lp != localPath{}
 }
 
 func badTypeErr(b *skylark.Builtin, ex interface{}, v skylark.Value) error {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -28,6 +28,10 @@ type Tiltfile struct {
 
 	// The filename we're executing. Must be absolute.
 	filename string
+
+	// ** comment
+	globalYamlStr  string
+	globalYamlDeps []string
 }
 
 func init() {
@@ -310,6 +314,28 @@ func (t *Tiltfile) callKustomize(thread *skylark.Thread, fn *skylark.Builtin, ar
 	return skylark.String(yaml), nil
 }
 
+func (t *Tiltfile) globalYaml(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	if t.globalYamlStr != "" {
+		return nil, fmt.Errorf("`global_yaml` can be called only once per Tiltfile")
+	}
+
+	var yaml string
+	err := skylark.UnpackArgs(fn.Name(), args, kwargs, "yaml", &yaml)
+	if err != nil {
+		return nil, err
+	}
+
+	deps, err := getReadFiles(thread)
+	if err != nil {
+		return nil, err
+	}
+
+	t.globalYamlStr = yaml
+	t.globalYamlDeps = deps
+
+	return skylark.None, nil
+}
+
 func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 	thread := &skylark.Thread{
 		Print: func(_ *skylark.Thread, msg string) {
@@ -340,6 +366,7 @@ func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 		"add":               skylark.NewBuiltin("add", addMount),
 		"run":               skylark.NewBuiltin("run", tiltfile.runDockerImageCmd),
 		"kustomize":         skylark.NewBuiltin("kustomize", tiltfile.callKustomize),
+		"global_yaml":       skylark.NewBuiltin("global_yaml", tiltfile.globalYaml),
 	}
 
 	globals, err := skylark.ExecFile(thread, filename, nil, predeclared)
@@ -351,25 +378,28 @@ func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 	return tiltfile, nil
 }
 
-func (t Tiltfile) GetManifestConfigs(names ...string) ([]model.Manifest, error) {
+// GetManifestConfigsAndGlobalYaml executes the Tiltfile to create manifests for all resources and
+// a manifest representing the global yaml
+func (t Tiltfile) GetManifestConfigsAndGlobalYaml(names ...string) ([]model.Manifest, model.YAMLManifest, error) {
 	var manifests []model.Manifest
 	for _, manifestName := range names {
 		curManifests, err := t.getManifestConfigsHelper(manifestName)
 		if err != nil {
-			return manifests, err
+			return manifests, model.YAMLManifest{}, err
 		}
 
 		manifests = append(manifests, curManifests...)
 	}
 
-	return manifests, nil
+	// TODO(maia): return GlobalYaml here (be sure to put its deps onto all of the resource manifests)
+	return manifests, model.YAMLManifest{}, nil
 }
 
-func (tiltfile Tiltfile) getManifestConfigsHelper(manifestName string) ([]model.Manifest, error) {
-	f, ok := tiltfile.globals[manifestName]
+func (t Tiltfile) getManifestConfigsHelper(manifestName string) ([]model.Manifest, error) {
+	f, ok := t.globals[manifestName]
 
 	if !ok {
-		return nil, fmt.Errorf("%v does not define a global named '%v'", tiltfile.filename, manifestName)
+		return nil, fmt.Errorf("%v does not define a global named '%v'", t.filename, manifestName)
 	}
 
 	manifestFunction, ok := f.(*skylark.Function)
@@ -382,15 +412,15 @@ func (tiltfile Tiltfile) getManifestConfigsHelper(manifestName string) ([]model.
 		return nil, fmt.Errorf("func '%v' is defined to take more than 0 arguments. service definitions must take 0 arguments", manifestName)
 	}
 
-	thread := tiltfile.thread
+	thread := t.thread
 	thread.SetLocal(readFilesKey, []string{})
 
-	err := tiltfile.recordReadToTiltFile(thread)
+	err := t.recordReadToTiltFile(thread)
 	if err != nil {
 		return nil, err
 	}
 
-	val, err := manifestFunction.Call(tiltfile.thread, nil, nil)
+	val, err := manifestFunction.Call(t.thread, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error running '%v': %v", manifestName, err.Error())
 	}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -29,9 +29,8 @@ type Tiltfile struct {
 	// The filename we're executing. Must be absolute.
 	filename string
 
-	// ** comment
-	globalYamlStr  string
-	globalYamlDeps []string
+	globalYAMLStr  string
+	globalYAMLDeps []string
 }
 
 func init() {
@@ -315,7 +314,7 @@ func (t *Tiltfile) callKustomize(thread *skylark.Thread, fn *skylark.Builtin, ar
 }
 
 func (t *Tiltfile) globalYaml(thread *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
-	if t.globalYamlStr != "" {
+	if t.globalYAMLStr != "" {
 		return nil, fmt.Errorf("`global_yaml` can be called only once per Tiltfile")
 	}
 
@@ -330,8 +329,8 @@ func (t *Tiltfile) globalYaml(thread *skylark.Thread, fn *skylark.Builtin, args 
 		return nil, err
 	}
 
-	t.globalYamlStr = yaml
-	t.globalYamlDeps = deps
+	t.globalYAMLStr = yaml
+	t.globalYAMLDeps = deps
 
 	return skylark.None, nil
 }
@@ -378,9 +377,9 @@ func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 	return tiltfile, nil
 }
 
-// GetManifestConfigsAndGlobalYaml executes the Tiltfile to create manifests for all resources and
+// GetManifestConfigsAndGlobalYAML executes the Tiltfile to create manifests for all resources and
 // a manifest representing the global yaml
-func (t Tiltfile) GetManifestConfigsAndGlobalYaml(names ...string) ([]model.Manifest, model.YAMLManifest, error) {
+func (t Tiltfile) GetManifestConfigsAndGlobalYAML(names ...string) ([]model.Manifest, model.YAMLManifest, error) {
 	var manifests []model.Manifest
 	for _, manifestName := range names {
 		curManifests, err := t.getManifestConfigsHelper(manifestName)
@@ -391,7 +390,7 @@ func (t Tiltfile) GetManifestConfigsAndGlobalYaml(names ...string) ([]model.Mani
 		manifests = append(manifests, curManifests...)
 	}
 
-	// TODO(maia): return GlobalYaml here (be sure to put its deps onto all of the resource manifests)
+	// TODO(maia): return GlobalYAML here (be sure to put its deps onto all of the resource manifests)
 	return manifests, model.YAMLManifest{}, nil
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -72,7 +72,7 @@ func (f *gitRepoFixture) LoadManifests(names ...string) []model.Manifest {
 		f.T().Fatal("loading tiltconfig:", err)
 	}
 
-	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYaml(names...)
+	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYAML(names...)
 	if err != nil {
 		f.T().Fatal("getting manifest config:", err)
 	}
@@ -93,7 +93,7 @@ func (f *gitRepoFixture) LoadManifestForError(name string) error {
 		f.T().Fatal("loading tiltconfig:", err)
 	}
 
-	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYaml(name)
+	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYAML(name)
 	if err == nil {
 		f.T().Fatal("Expected manifest load error")
 	}
@@ -663,7 +663,7 @@ def blorgly():
 	if err != nil {
 		t.Fatal("loading tiltconfig:", err)
 	}
-	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYaml("blorgly")
+	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYAML("blorgly")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "isn't a valid git repo")
 	}
@@ -918,7 +918,7 @@ def blorgly():
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYaml("blorgly")
+	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYAML("blorgly")
 	if err != nil {
 		t.Fatal("getting manifest config:", err)
 	}
@@ -1023,7 +1023,7 @@ def blorgly():
 	assert.Equal(t, expected, manifest.ConfigFiles)
 }
 
-func TestGlobalYaml(t *testing.T) {
+func TestGlobalYAML(t *testing.T) {
 	f := newGitRepoFixture(t)
 	defer f.TearDown()
 
@@ -1035,11 +1035,11 @@ global_yaml(yaml)`)
 	if err != nil {
 		f.T().Fatal("loading tiltconfig:", err)
 	}
-	assert.Equal(t, tiltconfig.globalYamlStr, "this is the global yaml")
-	assert.Equal(t, tiltconfig.globalYamlDeps, []string{f.JoinPath("global.yaml")})
+	assert.Equal(t, tiltconfig.globalYAMLStr, "this is the global yaml")
+	assert.Equal(t, tiltconfig.globalYAMLDeps, []string{f.JoinPath("global.yaml")})
 }
 
-func TestGlobalYamlMultipleCallsThrowsError(t *testing.T) {
+func TestGlobalYAMLMultipleCallsThrowsError(t *testing.T) {
 	f := newGitRepoFixture(t)
 	defer f.TearDown()
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -63,7 +63,7 @@ func newGitRepoFixture(t *testing.T) *gitRepoFixture {
 	}
 }
 
-func (f *gitRepoFixture) LoadManifests(name string) []model.Manifest {
+func (f *gitRepoFixture) LoadManifests(names ...string) []model.Manifest {
 	// It's important that this uses a relative path, because
 	// that's how other places in Tilt call it. In the past, we've had
 	// a lot of bugs that come up due to relative paths vs. absolute paths.
@@ -72,7 +72,7 @@ func (f *gitRepoFixture) LoadManifests(name string) []model.Manifest {
 		f.T().Fatal("loading tiltconfig:", err)
 	}
 
-	manifests, err := tiltconfig.GetManifestConfigs(name)
+	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYaml(names...)
 	if err != nil {
 		f.T().Fatal("getting manifest config:", err)
 	}
@@ -93,7 +93,7 @@ func (f *gitRepoFixture) LoadManifestForError(name string) error {
 		f.T().Fatal("loading tiltconfig:", err)
 	}
 
-	_, err = tiltconfig.GetManifestConfigs(name)
+	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYaml(name)
 	if err == nil {
 		f.T().Fatal("Expected manifest load error")
 	}
@@ -663,7 +663,7 @@ def blorgly():
 	if err != nil {
 		t.Fatal("loading tiltconfig:", err)
 	}
-	_, err = tiltconfig.GetManifestConfigs("blorgly")
+	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYaml("blorgly")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "isn't a valid git repo")
 	}
@@ -918,7 +918,7 @@ def blorgly():
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	manifests, err := tiltconfig.GetManifestConfigs("blorgly")
+	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYaml("blorgly")
 	if err != nil {
 		t.Fatal("getting manifest config:", err)
 	}
@@ -1021,4 +1021,33 @@ def blorgly():
 		"service.yaml",
 	})
 	assert.Equal(t, expected, manifest.ConfigFiles)
+}
+
+func TestGlobalYaml(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+
+	f.WriteFile("global.yaml", "this is the global yaml")
+	f.WriteFile("Tiltfile", `yaml = read_file('./global.yaml')
+global_yaml(yaml)`)
+
+	tiltconfig, err := Load(f.ctx, FileName)
+	if err != nil {
+		f.T().Fatal("loading tiltconfig:", err)
+	}
+	assert.Equal(t, tiltconfig.globalYamlStr, "this is the global yaml")
+	assert.Equal(t, tiltconfig.globalYamlDeps, []string{f.JoinPath("global.yaml")})
+}
+
+func TestGlobalYamlMultipleCallsThrowsError(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+
+	f.WriteFile("Tiltfile", `global_yaml('abc')
+global_yaml('def')`)
+
+	_, err := Load(f.ctx, FileName)
+	if assert.Error(t, err, "expect multiple invocations of `global_yaml` to result in error") {
+		assert.Equal(t, err.Error(), "`global_yaml` can be called only once per Tiltfile")
+	}
 }


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/global-yaml-prelim-refactor:

7c44de9f85aafc86cdaa70010bcdd7a24e3986d6 (2018-10-26 17:14:32 -0400)
tiltfile: prelim refactor to support global yaml returned when we get manifests

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics