### PR TITLE
engine: image build and deployer substeps take an interface

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -20,20 +20,6 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-type imageManifest interface {
-	Validate() error
-}
-
-type buildableImageManifest interface {
-	DockerRef() reference.Named
-	IsStaticBuild() bool
-	StaticDockerfile() string
-	StaticBuildPath() string
-	Mounts() []model.Mount
-	Steps() []model.Cmd
-	Entrypoint() model.Cmd
-}
-
 type deployableImageManifest interface {
 	K8sYAML() string
 	ManifestName() model.ManifestName

--- a/internal/engine/parse.go
+++ b/internal/engine/parse.go
@@ -8,7 +8,7 @@ import (
 func ParseYAMLFromManifests(manifests ...model.Manifest) ([]k8s.K8sEntity, error) {
 	allEntities := []k8s.K8sEntity{}
 	for _, m := range manifests {
-		entities, err := k8s.ParseYAMLFromString(m.K8sYaml)
+		entities, err := k8s.ParseYAMLFromString(m.K8sYAML())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -41,10 +41,8 @@ FROM go:1.10
 var SanchoRef, _ = reference.ParseNormalizedNamed("gcr.io/some-project-162817/sancho")
 
 func NewSanchoManifest() model.Manifest {
-	return model.Manifest{
+	m := model.Manifest{
 		Name:           "sancho",
-		DockerRef:      SanchoRef,
-		K8sYaml:        SanchoYAML,
 		BaseDockerfile: SanchoBaseDockerfile,
 		Mounts: []model.Mount{
 			model.Mount{
@@ -57,6 +55,10 @@ func NewSanchoManifest() model.Manifest {
 		}),
 		Entrypoint: model.Cmd{Argv: []string{"/go/bin/sancho"}},
 	}
+
+	m = m.WithDockerRef(SanchoRef).WithK8sYAML(SanchoYAML)
+
+	return m
 }
 
 var SanchoManifest = NewSanchoManifest()

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -468,7 +468,7 @@ func handlePodEvent(ctx context.Context, state *store.EngineState, pod *v1.Pod) 
 	ms.Pod.Status = podStatusToString(*pod)
 
 	// Check if the container is ready.
-	cStatus, err := k8s.ContainerMatching(pod, ms.Manifest.DockerRef)
+	cStatus, err := k8s.ContainerMatching(pod, ms.Manifest.DockerRef())
 	if err != nil {
 		logger.Get(ctx).Debugf("Error matching container: %v", err)
 		return
@@ -617,7 +617,7 @@ func (u Upper) resolveLB(ctx context.Context, spec k8s.LoadBalancerSpec) *url.UR
 func (u Upper) reapOldWatchBuilds(ctx context.Context, manifests []model.Manifest, createdBefore time.Time) error {
 	refs := make([]reference.Named, len(manifests))
 	for i, s := range manifests {
-		refs[i] = s.DockerRef
+		refs[i] = s.DockerRef()
 	}
 
 	watchFilter := build.FilterByLabelValue(build.BuildMode, build.BuildModeExisting)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -84,7 +84,7 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest mode
 		return store.BuildResult{}, err
 	}
 
-	return b.nextBuildResult(manifest.DockerRef), nil
+	return b.nextBuildResult(manifest.DockerRef()), nil
 }
 
 func (b *fakeBuildAndDeployer) haveContainerForImage(img reference.NamedTagged) bool {
@@ -434,7 +434,7 @@ func TestRebuildDockerfileViaImageBuild(t *testing.T) {
 		// Second call: new manifest!
 		call = <-f.b.calls
 		assert.Equal(t, "FROM iron/go:dev", call.manifest.BaseDockerfile)
-		assert.Equal(t, "yaaaaaaaaml", call.manifest.K8sYaml)
+		assert.Equal(t, "yaaaaaaaaml", call.manifest.K8sYAML())
 
 		// Since the manifest changed, we cleared the previous build state to force an image build
 		assert.False(t, call.state.HasImage())
@@ -1660,7 +1660,7 @@ func (f *testFixture) imageNameForManifest(manifestName string) reference.Named 
 
 func (f *testFixture) newManifest(name string, mounts []model.Mount) model.Manifest {
 	ref := f.imageNameForManifest(name)
-	return model.Manifest{Name: model.ManifestName(name), DockerRef: ref, Mounts: mounts}
+	return model.Manifest{Name: model.ManifestName(name), Mounts: mounts}.WithDockerRef(ref)
 }
 
 func (f *testFixture) assertAllBuildsConsumed() {

--- a/internal/model/globalyaml.go
+++ b/internal/model/globalyaml.go
@@ -1,8 +1,10 @@
 package model
 
+import "github.com/docker/distribution/reference"
+
 type YAMLManifest struct {
 	name    ManifestName
-	k8sYaml string
+	k8sYAML string
 
 	configFiles []string
 }
@@ -10,7 +12,7 @@ type YAMLManifest struct {
 func NewYAMLManifest(name ManifestName, k8sYaml string, configFiles []string) YAMLManifest {
 	return YAMLManifest{
 		name:        name,
-		k8sYaml:     k8sYaml,
+		k8sYAML:     k8sYaml,
 		configFiles: configFiles,
 	}
 }
@@ -33,4 +35,18 @@ func (y YAMLManifest) ConfigMatcher() (PathMatcher, error) {
 
 func (YAMLManifest) LocalRepos() []LocalGithubRepo {
 	return []LocalGithubRepo{}
+}
+
+func (y YAMLManifest) K8sYAML() string {
+	return y.k8sYAML
+}
+
+// TODO(dmiller): not sure if this is right
+func (YAMLManifest) DockerRef() reference.Named {
+	n, err := reference.ParseNamed("")
+	if err != nil {
+		// This space intentionally left blank
+	}
+
+	return n
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -16,9 +16,9 @@ func (m ManifestName) String() string { return string(m) }
 type Manifest struct {
 	// Properties for all builds.
 	Name         ManifestName
-	K8sYaml      string
+	k8sYaml      string
 	tiltFilename string
-	DockerRef    reference.Named
+	dockerRef    reference.Named
 	portForwards []PortForward
 
 	// Local files read while reading the Tilt configuration.
@@ -77,11 +77,11 @@ func (m Manifest) validate() *ValidateErr {
 		return validateErrf("[validate] manifest missing name: %+v", m)
 	}
 
-	if m.DockerRef == nil {
+	if m.dockerRef == nil {
 		return validateErrf("[validate] manifest %q missing image ref", m.Name)
 	}
 
-	if m.K8sYaml == "" {
+	if m.K8sYAML() == "" {
 		return validateErrf("[validate] manifest %q missing YAML file", m.Name)
 	}
 
@@ -106,7 +106,7 @@ func (m Manifest) validate() *ValidateErr {
 }
 
 func (m1 Manifest) Equal(m2 Manifest) bool {
-	primitivesMatch := m1.Name == m2.Name && m1.K8sYaml == m2.K8sYaml && m1.DockerRef == m2.DockerRef && m1.BaseDockerfile == m2.BaseDockerfile && m1.StaticDockerfile == m2.StaticDockerfile && m1.StaticBuildPath == m2.StaticBuildPath && m1.tiltFilename == m2.tiltFilename
+	primitivesMatch := m1.Name == m2.Name && m1.k8sYaml == m2.k8sYaml && m1.dockerRef == m2.dockerRef && m1.BaseDockerfile == m2.BaseDockerfile && m1.StaticDockerfile == m2.StaticDockerfile && m1.StaticBuildPath == m2.StaticBuildPath && m1.tiltFilename == m2.tiltFilename
 	entrypointMatch := m1.Entrypoint.Equal(m2.Entrypoint)
 	configFilesMatch := m1.configFilesEqual(m2.ConfigFiles)
 	mountsMatch := m1.mountsEqual(m2.Mounts)
@@ -236,6 +236,24 @@ func (m Manifest) TiltFilename() string {
 
 func (m Manifest) WithTiltFilename(f string) Manifest {
 	m.tiltFilename = f
+	return m
+}
+
+func (m Manifest) K8sYAML() string {
+	return m.k8sYaml
+}
+
+func (m Manifest) WithK8sYAML(y string) Manifest {
+	m.k8sYaml = y
+	return m
+}
+
+func (m Manifest) DockerRef() reference.Named {
+	return m.dockerRef
+}
+
+func (m Manifest) WithDockerRef(ref reference.Named) Manifest {
+	m.dockerRef = ref
 	return m
 }
 

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -267,9 +267,9 @@ func TestManifestValidateMountRelativePath(t *testing.T) {
 		},
 	}
 	manifest := Manifest{
+		k8sYaml:        "yamlll",
 		Name:           "test",
-		K8sYaml:        "yamlll",
-		DockerRef:      container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef"),
+		dockerRef:      container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef"),
 		BaseDockerfile: "FROM node",
 		Mounts:         mounts,
 	}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -491,12 +491,10 @@ func skylarkManifestToDomain(manifest *k8sManifest) (model.Manifest, error) {
 	}
 
 	m := model.Manifest{
-		K8sYaml:        k8sYaml,
 		BaseDockerfile: string(baseDockerfileBytes),
 		Mounts:         skylarkMountsToDomain(image.mounts),
 		Steps:          image.steps,
 		Entrypoint:     model.ToShellCmd(image.entrypoint),
-		DockerRef:      image.ref,
 		Name:           model.ManifestName(manifest.name),
 		ConfigFiles:    SkylarkConfigFilesToDomain(manifest.configFiles),
 
@@ -506,7 +504,7 @@ func skylarkManifestToDomain(manifest *k8sManifest) (model.Manifest, error) {
 		Repos: SkylarkReposToDomain(image),
 	}
 
-	m = m.WithPortForwards(manifest.portForwards).WithTiltFilename(image.tiltFilename)
+	m = m.WithPortForwards(manifest.portForwards).WithTiltFilename(image.tiltFilename).WithK8sYAML(k8sYaml).WithDockerRef(image.ref)
 
 	return m, nil
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -153,8 +153,8 @@ func TestGetManifestConfig(t *testing.T) {
 
 	manifest := f.LoadManifest("blorgly")
 	assert.Equal(t, "docker text", manifest.BaseDockerfile)
-	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerRef.String())
-	assert.Equal(t, "yaaaaaaaaml", manifest.K8sYaml)
+	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerRef().String())
+	assert.Equal(t, "yaaaaaaaaml", manifest.K8sYAML())
 	assert.Equal(t, 1, len(manifest.Mounts), "number of mounts")
 	assert.Equal(t, "/mount_points/1", manifest.Mounts[0].ContainerPath)
 	assert.Equal(t, f.Path(), manifest.Mounts[0].LocalPath, "mount path")
@@ -361,8 +361,8 @@ func TestGetManifestConfigWithLocalCmd(t *testing.T) {
 
 	manifest := f.LoadManifest("blorgly")
 	assert.Equal(t, "docker text", manifest.BaseDockerfile)
-	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerRef.String())
-	assert.Equal(t, "yaaaaaaaaml\n", manifest.K8sYaml)
+	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerRef().String())
+	assert.Equal(t, "yaaaaaaaaml\n", manifest.K8sYAML())
 	assert.Equal(t, 2, len(manifest.Steps))
 	assert.Equal(t, []string{"sh", "-c", "go install github.com/windmilleng/blorgly-frontend/server/..."}, manifest.Steps[0].Cmd.Argv)
 	assert.Equal(t, []string{"sh", "-c", "echo hi"}, manifest.Steps[1].Cmd.Argv)
@@ -502,7 +502,7 @@ func TestReadFile(t *testing.T) {
 `)
 
 	manifest := f.LoadManifest("blorgly")
-	assert.Equal(t, manifest.K8sYaml, "hello world")
+	assert.Equal(t, "hello world", manifest.K8sYAML())
 }
 
 func TestConfigMatcherWithFastBuild(t *testing.T) {
@@ -868,7 +868,7 @@ def blorgly():
 	manifest := f.LoadManifest("blorgly")
 	assert.Equal(t, "dockerfile text", manifest.StaticDockerfile)
 	assert.Equal(t, f.Path(), manifest.StaticBuildPath)
-	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerRef.String())
+	assert.Equal(t, "docker.io/library/docker-tag", manifest.DockerRef().String())
 }
 
 func TestPortForward(t *testing.T) {


### PR DESCRIPTION
Mostly renaming and hiding struct fields behind functions. Next PR will pass the global YAML manifest, which now implements, albeit questionably, `buildableImageManifest`.