### PR TITLE
tiltfile: store global yaml and deps on skylark thread instead of tiltfile obj [ch707]

### DIFF
--- a/internal/tiltfile/thread_local.go
+++ b/internal/tiltfile/thread_local.go
@@ -2,6 +2,7 @@ package tiltfile
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/google/skylark"
 )
@@ -9,6 +10,36 @@ import (
 const buildContextKey = "buildContext"
 const readFilesKey = "readFiles"
 const reposKey = "repos"
+const globalYAMLKey = "globalYaml"
+const globalYAMLDepsKey = "globalYamlDeps"
+
+func getGlobalYAML(t *skylark.Thread) (string, error) {
+	obj := t.Local(globalYAMLKey)
+	if obj == nil {
+		return "", nil
+	}
+
+	yaml, ok := obj.(string)
+	if !ok {
+		return "", fmt.Errorf(
+			"internal error: %s thread local was not of type string", globalYAMLKey)
+	}
+	return yaml, nil
+}
+
+func getGlobalYAMLDeps(t *skylark.Thread) ([]string, error) {
+	obj := t.Local(globalYAMLDepsKey)
+	if obj == nil {
+		return nil, nil
+	}
+
+	deps, ok := obj.([]string)
+	if !ok {
+		return nil, fmt.Errorf(
+			"internal error: %s thread local was not of type []string", globalYAMLDepsKey)
+	}
+	return deps, nil
+}
 
 func getAndClearBuildContext(t *skylark.Thread) (*dockerImage, error) {
 	obj := t.Local(buildContextKey)


### PR DESCRIPTION
Hello @jazzdan, @nicks,

Please review the following commits I made in branch maiamcc/gyaml-tiltfile-thread:

d19aa1e5b36ed6d409659ca0c4dd0fff6a152cfb (2018-10-30 12:06:41 -0400)
tiltfile: store global yaml and deps on skylark thread instead of tiltfile obj

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics