### PR TITLE
engine: call init with global yaml [ch708]

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -85,7 +85,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(args...)
+	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(args...)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	}()
 
 	// TODO(maia): send along globalYamlManifest (returned by GetManifest...Yaml above)
-	err = upper.CreateManifests(ctx, manifests, c.watch)
+	err = upper.CreateManifests(ctx, manifests, globalYAML, c.watch)
 	s, ok := status.FromError(err)
 	if ok && s.Code() == codes.Unknown {
 		return errors.New(s.Message())

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -189,7 +189,7 @@ func (s Script) Run(ctx context.Context) error {
 		defer s.cleanUp(context.Background(), manifests)
 
 		// TODO(maia): send along globalYamlManifest (returned by GetManifest...Yaml above)
-		return s.upper.CreateManifests(ctx, manifests, true)
+		return s.upper.CreateManifests(ctx, manifests, model.YAMLManifest{}, true)
 	})
 
 	return g.Wait()

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -99,13 +99,15 @@ func (u Upper) RunHud(ctx context.Context) error {
 	return err
 }
 
-func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest, watchMounts bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-Up")
+func (u Upper) CreateManifests(ctx context.Context, manifests []model.Manifest,
+	globalYAML model.YAMLManifest, watchMounts bool) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Up")
 	defer span.Finish()
 
 	u.store.Dispatch(InitAction{
-		WatchMounts: watchMounts,
-		Manifests:   manifests,
+		WatchMounts:        watchMounts,
+		Manifests:          manifests,
+		GlobalYAMLManifest: globalYAML,
 	})
 
 	defer func() {


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/gyaml-to-init:

5b6bdca2f4df4bea6620d02ed5d11f8eedc3c961 (2018-10-30 12:17:28 -0400)
engine: call init with global yaml [ch708]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics