### PR TITLE
engine: global YAML can be updated

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -85,3 +85,9 @@ type BuildStartedAction struct {
 }
 
 func (BuildStartedAction) Action() {}
+
+type GlobalYAMLManifestReloadedAction struct {
+	GlobalYAML model.YAMLManifest
+}
+
+func (GlobalYAMLManifestReloadedAction) Action() {}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -92,7 +92,10 @@ func (c *BuildController) OnChange(ctx context.Context, st *store.Store) {
 
 	go func() {
 		if entry.needsConfigReload {
-			newManifest, err := getNewManifestFromTiltfile(entry.ctx, entry.manifest.Name)
+			newManifest, globalYAML, err := getNewManifestFromTiltfile(entry.ctx, entry.manifest.Name)
+			st.Dispatch(GlobalYAMLManifestReloadedAction{
+				GlobalYAML: globalYAML,
+			})
 			st.Dispatch(ManifestReloadedAction{
 				OldManifest: entry.manifest,
 				NewManifest: newManifest,
@@ -143,22 +146,22 @@ func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry) {
 	}
 }
 
-func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (model.Manifest, *manifestErr) {
+func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (model.Manifest, model.YAMLManifest, *manifestErr) {
 	// Sends any output to the CurrentBuildLog
 	t, err := tiltfile.Load(ctx, tiltfile.FileName)
 	if err != nil {
-		return model.Manifest{}, manifestErrf(err.Error())
+		return model.Manifest{}, model.YAMLManifest{}, manifestErrf(err.Error())
 	}
-	newManifests, _, err := t.GetManifestConfigsAndGlobalYAML(string(name))
+	newManifests, globalYAML, err := t.GetManifestConfigsAndGlobalYAML(string(name))
 	if err != nil {
-		return model.Manifest{}, manifestErrf(err.Error())
+		return model.Manifest{}, model.YAMLManifest{}, manifestErrf(err.Error())
 	}
 	if len(newManifests) != 1 {
-		return model.Manifest{}, manifestErrf("Expected there to be 1 manifest for %s, got %d", name, len(newManifests))
+		return model.Manifest{}, model.YAMLManifest{}, manifestErrf("Expected there to be 1 manifest for %s, got %d", name, len(newManifests))
 	}
 	newManifest := newManifests[0]
 
-	return newManifest, nil
+	return newManifest, globalYAML, nil
 }
 
 var _ store.Subscriber = &BuildController{}

--- a/internal/engine/global_yaml_buildcontroller.go
+++ b/internal/engine/global_yaml_buildcontroller.go
@@ -1,0 +1,35 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/windmilleng/tilt/internal/logger"
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+type GlobalYAMLBuildController struct {
+	disabledForTesting     bool
+	lastGlobalYAMLManifest model.YAMLManifest
+}
+
+func NewGlobalYAMLBuildController() *GlobalYAMLBuildController {
+	return &GlobalYAMLBuildController{}
+}
+
+func (c *GlobalYAMLBuildController) OnChange(ctx context.Context, st *store.Store) {
+	if c.disabledForTesting {
+		return
+	}
+
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	if !state.GlobalYAML.Equal(c.lastGlobalYAMLManifest) {
+		// TOOD(dmiller) do a build
+		logger.Get(ctx).Debugf("Gotta rebuild/apply the global YAML!")
+
+		// assuming it succeeds
+		c.lastGlobalYAMLManifest = state.GlobalYAML
+	}
+}

--- a/internal/engine/global_yaml_buildcontroller.go
+++ b/internal/engine/global_yaml_buildcontroller.go
@@ -33,7 +33,7 @@ func (c *GlobalYAMLBuildController) OnChange(ctx context.Context, st *store.Stor
 	st.RUnlockState()
 
 	newK8sEntities := []k8s.K8sEntity{}
-	if !m.Equal(c.lastGlobalYAMLManifest) {
+	if m.K8sYAML() != c.lastGlobalYAMLManifest.K8sYAML() {
 		logger.Get(ctx).Debugf("Gotta rebuild/apply the global YAML!")
 		entities, err := k8s.ParseYAMLFromString(m.K8sYAML())
 		if err != nil {

--- a/internal/engine/global_yaml_buildcontroller.go
+++ b/internal/engine/global_yaml_buildcontroller.go
@@ -33,7 +33,7 @@ func (c *GlobalYAMLBuildController) OnChange(ctx context.Context, st *store.Stor
 	st.RUnlockState()
 
 	newK8sEntities := []k8s.K8sEntity{}
-	if !state.GlobalYAML.Equal(c.lastGlobalYAMLManifest) {
+	if !m.Equal(c.lastGlobalYAMLManifest) {
 		logger.Get(ctx).Debugf("Gotta rebuild/apply the global YAML!")
 		entities, err := k8s.ParseYAMLFromString(m.K8sYAML())
 		if err != nil {

--- a/internal/engine/global_yaml_buildcontroller.go
+++ b/internal/engine/global_yaml_buildcontroller.go
@@ -2,19 +2,25 @@ package engine
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
+	"k8s.io/api/core/v1"
 )
 
 type GlobalYAMLBuildController struct {
 	disabledForTesting     bool
 	lastGlobalYAMLManifest model.YAMLManifest
+	k8sClient              k8s.Client
 }
 
-func NewGlobalYAMLBuildController() *GlobalYAMLBuildController {
-	return &GlobalYAMLBuildController{}
+func NewGlobalYAMLBuildController(k8sClient k8s.Client) *GlobalYAMLBuildController {
+	return &GlobalYAMLBuildController{
+		k8sClient: k8sClient,
+	}
 }
 
 func (c *GlobalYAMLBuildController) OnChange(ctx context.Context, st *store.Store) {
@@ -23,13 +29,42 @@ func (c *GlobalYAMLBuildController) OnChange(ctx context.Context, st *store.Stor
 	}
 
 	state := st.RLockState()
-	defer st.RUnlockState()
+	m := state.GlobalYAML
+	st.RUnlockState()
 
+	newK8sEntities := []k8s.K8sEntity{}
 	if !state.GlobalYAML.Equal(c.lastGlobalYAMLManifest) {
-		// TOOD(dmiller) do a build
 		logger.Get(ctx).Debugf("Gotta rebuild/apply the global YAML!")
+		entities, err := k8s.ParseYAMLFromString(m.K8sYAML())
+		if err != nil {
+			st.Dispatch(NewErrorAction(err))
+			return
+		}
 
-		// assuming it succeeds
-		c.lastGlobalYAMLManifest = state.GlobalYAML
+		for _, e := range entities {
+			e, err = k8s.InjectLabels(e, []k8s.LabelPair{TiltRunLabel(), {Key: ManifestNameLabel, Value: m.ManifestName().String()}})
+			if err != nil {
+				st.Dispatch(NewErrorAction(err))
+				return
+			}
+
+			// For development, image pull policy should never be set to "Always",
+			// even if it might make sense to use "Always" in prod. People who
+			// set "Always" for development are shooting their own feet.
+			e, err = k8s.InjectImagePullPolicy(e, v1.PullIfNotPresent)
+			if err != nil {
+				st.Dispatch(NewErrorAction(err))
+				return
+			}
+
+			newK8sEntities = append(newK8sEntities, e)
+		}
+
+		err = c.k8sClient.Upsert(ctx, newK8sEntities)
+		if err != nil {
+			st.Dispatch(NewErrorAction(fmt.Errorf("Unable to upsert global YAML: %v", err)))
+		} else {
+			c.lastGlobalYAMLManifest = m
+		}
 	}
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -65,7 +65,7 @@ func NewUpper(ctx context.Context, b BuildAndDeployer,
 	hud hud.HeadsUpDisplay, pw *PodWatcher, sw *ServiceWatcher,
 	st *store.Store, plm *PodLogManager, pfc *PortForwardController,
 	fwm *WatchManager, fswm FsWatcherMaker, bc *BuildController,
-	ic *ImageController) Upper {
+	ic *ImageController, gybc *GlobalYAMLBuildController) Upper {
 
 	st.AddSubscriber(bc)
 	st.AddSubscriber(hud)
@@ -75,7 +75,6 @@ func NewUpper(ctx context.Context, b BuildAndDeployer,
 	st.AddSubscriber(pw)
 	st.AddSubscriber(sw)
 	st.AddSubscriber(ic)
-	gybc := NewGlobalYAMLBuildController()
 	st.AddSubscriber(gybc)
 
 	return Upper{
@@ -493,7 +492,7 @@ func handlePodLogAction(state *store.EngineState, action PodLogAction) {
 
 func handleServiceEvent(ctx context.Context, state *store.EngineState, service *v1.Service) {
 	manifestName := model.ManifestName(service.ObjectMeta.Labels[ManifestNameLabel])
-	if manifestName == "" {
+	if manifestName == "" || manifestName == model.GlobalYAMLManifestName {
 		return
 	}
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -144,7 +144,7 @@ func TestUpper_Up(t *testing.T) {
 	manifest := f.newManifest("foobar", nil)
 
 	gYaml := model.NewYAMLManifest(model.ManifestName("my-global_yaml"),
-		"some great yaml", []string{"foo", "bar"})
+		testyaml.BlorgBackendYAML, []string{"foo", "bar"})
 	err := f.upper.CreateManifests(f.ctx, []model.Manifest{manifest}, gYaml, false)
 	close(f.b.calls)
 	assert.Nil(t, err)

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -39,6 +39,7 @@ var DeployerBaseWireSet = wire.NewSet(
 	NewCompositeBuildAndDeployer,
 	ProvideUpdateMode,
 	store.NewStore,
+	NewGlobalYAMLBuildController,
 )
 
 var DeployerWireSetTest = wire.NewSet(

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -6,23 +6,23 @@
 package engine
 
 import (
-	"context"
-	"github.com/google/go-cloud/wire"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/store"
-	"github.com/windmilleng/tilt/internal/synclet"
-	"github.com/windmilleng/wmclient/pkg/analytics"
-	"github.com/windmilleng/wmclient/pkg/dirs"
+	context "context"
+	wire "github.com/google/go-cloud/wire"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
+	store "github.com/windmilleng/tilt/internal/store"
+	synclet "github.com/windmilleng/tilt/internal/synclet"
+	analytics "github.com/windmilleng/wmclient/pkg/analytics"
+	dirs "github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 // Injectors from wire.go:
 
 func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode UpdateModeFlag, sCli synclet.SyncletClient, shouldFallBackToImgBuild FallbackTester) (BuildAndDeployer, error) {
 	reducer := _wireReducerValue
-	storeStore := store.NewStore(reducer)
-	deployDiscovery := NewDeployDiscovery(k8s2, storeStore)
+	store2 := store.NewStore(reducer)
+	deployDiscovery := NewDeployDiscovery(k8s2, store2)
 	syncletManager := NewSyncletManagerForTests(k8s2, sCli)
 	syncletBuildAndDeployer := NewSyncletBuildAndDeployer(deployDiscovery, syncletManager)
 	containerUpdater := build.NewContainerUpdater(docker2)
@@ -33,12 +33,12 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(docker2, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
-	engineUpdateMode, err := ProvideUpdateMode(updateMode, env)
+	updateMode2, err := ProvideUpdateMode(updateMode, env)
 	if err != nil {
 		return nil, err
 	}
-	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, k8s2, env, memoryAnalytics, engineUpdateMode)
-	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, engineUpdateMode)
+	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, k8s2, env, memoryAnalytics, updateMode2)
+	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode2)
 	compositeBuildAndDeployer := NewCompositeBuildAndDeployer(buildOrder, shouldFallBackToImgBuild)
 	return compositeBuildAndDeployer, nil
 }
@@ -54,7 +54,7 @@ var DeployerBaseWireSet = wire.NewSet(build.DefaultConsole, build.DefaultOut, wi
 	NewLocalContainerBuildAndDeployer,
 	DefaultBuildOrder,
 	NewDeployDiscovery, wire.Bind(new(BuildAndDeployer), new(CompositeBuildAndDeployer)), NewCompositeBuildAndDeployer,
-	ProvideUpdateMode, store.NewStore,
+	ProvideUpdateMode, store.NewStore, NewGlobalYAMLBuildController,
 )
 
 var DeployerWireSetTest = wire.NewSet(

--- a/internal/model/globalyaml.go
+++ b/internal/model/globalyaml.go
@@ -56,10 +56,3 @@ func (YAMLManifest) DockerRef() reference.Named {
 func (y YAMLManifest) Empty() bool {
 	return y.k8sYAML == ""
 }
-
-func (y1 YAMLManifest) Equal(y2 YAMLManifest) bool {
-	// TODO(dmiller): do I neeed to check config files here?
-	// Presumably if they change but it doesn't result in a change to
-	// `k8syaml` we don't care
-	return y1.name == y2.name && y1.k8sYAML == y2.k8sYAML
-}

--- a/internal/model/globalyaml.go
+++ b/internal/model/globalyaml.go
@@ -52,3 +52,14 @@ func (YAMLManifest) DockerRef() reference.Named {
 
 	return n
 }
+
+func (y YAMLManifest) Empty() bool {
+	return y.k8sYAML == ""
+}
+
+func (y1 YAMLManifest) Equal(y2 YAMLManifest) bool {
+	// TODO(dmiller): do I neeed to check config files here?
+	// Presumably if they change but it doesn't result in a change to
+	// `k8syaml` we don't care
+	return y1.name == y2.name && y1.k8sYAML == y2.k8sYAML
+}

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -6,10 +6,10 @@
 package synclet
 
 import (
-	"context"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
+	context "context"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
Adds a new subscriber and some actions to detect when the global YAML manifest has changed correctly, and trigger a global YAML build (to be defined) in that case.