### PR TITLE
tiltfile: on manifest creation, pull matching yaml l out of globalYAML and add to manifest [ch681]

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"reflect"
 
+	"github.com/docker/distribution/reference"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,4 +169,8 @@ func Filter(entities []K8sEntity, test func(e K8sEntity) (bool, error)) (passing
 		}
 	}
 	return passing, rest, nil
+}
+
+func FilterByImage(entities []K8sEntity, img reference.Named) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img) })
 }

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -365,3 +365,60 @@ spec:
   selector:
    app: postgres
 `
+
+const DoggosYaml = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: doggos
+  labels:
+    app: doggos
+spec:
+  selector:
+    matchLabels:
+      app: doggos
+  template:
+    metadata:
+      labels:
+        app: doggos
+        tier: web
+    spec:
+      containers:
+      - name: doggos
+        image: gcr.io/windmill-public-containers/servantes/doggos
+        command: ["/go/bin/doggos"]
+`
+
+const SnackYaml = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snack
+  labels:
+    app: snack
+spec:
+  selector:
+    matchLabels:
+      app: snack
+  template:
+    metadata:
+      labels:
+        app: snack
+        tier: web
+    spec:
+      containers:
+      - name: snack
+        image: gcr.io/windmill-public-containers/servantes/snack
+        command: ["/go/bin/snack"]
+`
+
+const SecretYaml = `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+`

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -258,7 +258,7 @@ func (m Manifest) AppendK8sYAML(y string) Manifest {
 		return m
 	}
 
-	return m.WithK8sYAML(yaml.ConcatYaml(m.k8sYaml, y))
+	return m.WithK8sYAML(yaml.ConcatYAML(m.k8sYaml, y))
 }
 
 func (m Manifest) WithK8sYAML(y string) Manifest {

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/windmilleng/tilt/internal/sliceutils"
+	"github.com/windmilleng/tilt/internal/yaml"
 )
 
 type ManifestName string
@@ -247,6 +248,17 @@ func (m Manifest) WithTiltFilename(f string) Manifest {
 
 func (m Manifest) K8sYAML() string {
 	return m.k8sYaml
+}
+
+func (m Manifest) AppendK8sYAML(y string) Manifest {
+	if m.k8sYaml == "" {
+		return m.WithK8sYAML(y)
+	}
+	if y == "" {
+		return m
+	}
+
+	return m.WithK8sYAML(yaml.ConcatYaml(m.k8sYaml, y))
 }
 
 func (m Manifest) WithK8sYAML(y string) Manifest {

--- a/internal/tiltfile/thread_local.go
+++ b/internal/tiltfile/thread_local.go
@@ -13,6 +13,14 @@ const reposKey = "repos"
 const globalYAMLKey = "globalYaml"
 const globalYAMLDepsKey = "globalYamlDeps"
 
+func setGlobalYAML(t *skylark.Thread, yaml string) {
+	t.SetLocal(globalYAMLKey, yaml)
+}
+
+func setGlobalYAMLDeps(t *skylark.Thread, deps []string) {
+	t.SetLocal(globalYAMLDepsKey, deps)
+}
+
 func getGlobalYAML(t *skylark.Thread) (string, error) {
 	obj := t.Local(globalYAMLKey)
 	if obj == nil {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -10,7 +10,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/yaml"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/ignore"
@@ -1067,17 +1070,17 @@ func TestAllManifestsHaveGlobalYAMLDependencies(t *testing.T) {
 	f.WriteFile("fileB", "bananas")
 	f.WriteFile("Dockerfile", "FROM iron/go:dev")
 
-	f.WriteFile("global.yaml", "this is the global yaml")
+	f.WriteFile("global.yaml", testyaml.SecretYaml)
 	f.WriteFile("Tiltfile", `yaml = read_file('./global.yaml')
 global_yaml(yaml)
 
 def manifestA():
-  stuff = read_file('./fileA')  # this is a dependency now
+  stuff = read_file('./fileA')  # this is a dependency of manifestA now
   image = static_build('Dockerfile', 'tag-a')
   return k8s_service("yamlA", image)
 
 def manifestB():
-  stuff = read_file('./fileB')  # this is a dependency now
+  stuff = read_file('./fileB')  # this is a dependency of manifestB now
   image = static_build('Dockerfile', 'tag-b')
   return k8s_service("yamlB", image)
 `)
@@ -1088,4 +1091,84 @@ def manifestB():
 	expectedDepsB := []string{"fileB", "Dockerfile", "Tiltfile", "global.yaml"}
 	assert.ElementsMatch(t, manifests[0].ConfigFiles, f.JoinPaths(expectedDepsA))
 	assert.ElementsMatch(t, manifests[1].ConfigFiles, f.JoinPaths(expectedDepsB))
+}
+
+func TestPerManifestYAMLExtractedFromGlobalYAML(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+
+	multiManifestYAML := yaml.ConcatYaml(testyaml.DoggosYaml, testyaml.SnackYaml, testyaml.SecretYaml)
+	f.WriteFile("global.yaml", multiManifestYAML)
+	f.WriteFile("Dockerfile", "FROM iron/go:dev")
+	f.WriteFile("Tiltfile", `global_yaml(read_file('./global.yaml'))
+
+def doggos():
+  image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/doggos')
+  return k8s_service("", image)
+
+def snack():
+  image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/snack')
+  return k8s_service("", image)
+`)
+
+	manifests, gYAML := f.LoadManifestsAndGlobalYAML("doggos", "snack")
+
+	assertYAMLEqual(t, testyaml.DoggosYaml, manifests[0].K8sYAML())
+	assertYAMLEqual(t, testyaml.SnackYaml, manifests[1].K8sYAML())
+	assertYAMLEqual(t, testyaml.SecretYaml, gYAML.K8sYAML())
+}
+
+func TestExtractedGlobalYAMLStacksWithExplicitYaml(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+
+	multiManifestYAML := yaml.ConcatYaml(testyaml.DoggosYaml, testyaml.SnackYaml, testyaml.SecretYaml)
+	f.WriteFile("global.yaml", multiManifestYAML)
+	f.WriteFile("Dockerfile", "FROM iron/go:dev")
+	f.WriteFile("Tiltfile", fmt.Sprintf(`global_yaml(read_file('./global.yaml'))
+
+def doggos_with_secret():
+  image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/doggos')
+  return k8s_service("""%s""", image)
+`, testyaml.SecretYaml))
+
+	manifests, _ := f.LoadManifestsAndGlobalYAML("doggos_with_secret")
+
+	assertYAMLContains(t, manifests[0].K8sYAML(), testyaml.DoggosYaml)
+	assertYAMLContains(t, manifests[0].K8sYAML(), testyaml.SecretYaml)
+}
+
+func assertYAMLEqual(t *testing.T, y1, y2 string) {
+	// Obviously equal
+	if y1 == y2 {
+		return
+	}
+
+	// Strings aren't equal, but compare as k8sEntities -- can be equivalent but
+	// lose string equivalency in un/parsing
+	e1, err := k8s.ParseYAMLFromString(y1)
+	if err != nil {
+		t.Fatal("parsing y1 to assert equality:", err)
+	}
+	e2, err := k8s.ParseYAMLFromString(y2)
+	if err != nil {
+		t.Fatal("parsing y2 to assert equality:", err)
+	}
+
+	assert.ElementsMatch(t, e1, e2)
+}
+
+func assertYAMLContains(t *testing.T, yaml, check string) {
+	entities, err := k8s.ParseYAMLFromString(yaml)
+	if err != nil {
+		t.Fatal("parsing yaml to assert YAML-contains:", err)
+	}
+	checkEntities, err := k8s.ParseYAMLFromString(check)
+	if err != nil {
+		t.Fatal("parsing 'contains' yaml to assert YAML-contains:", err)
+	}
+
+	for _, chk := range checkEntities {
+		assert.Contains(t, entities, chk)
+	}
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1097,7 +1097,7 @@ func TestPerManifestYAMLExtractedFromGlobalYAML(t *testing.T) {
 	f := newGitRepoFixture(t)
 	defer f.TearDown()
 
-	multiManifestYAML := yaml.ConcatYaml(testyaml.DoggosYaml, testyaml.SnackYaml, testyaml.SecretYaml)
+	multiManifestYAML := yaml.ConcatYAML(testyaml.DoggosYaml, testyaml.SnackYaml, testyaml.SecretYaml)
 	f.WriteFile("global.yaml", multiManifestYAML)
 	f.WriteFile("Dockerfile", "FROM iron/go:dev")
 	f.WriteFile("Tiltfile", `global_yaml(read_file('./global.yaml'))
@@ -1122,7 +1122,7 @@ func TestExtractedGlobalYAMLStacksWithExplicitYaml(t *testing.T) {
 	f := newGitRepoFixture(t)
 	defer f.TearDown()
 
-	multiManifestYAML := yaml.ConcatYaml(testyaml.DoggosYaml, testyaml.SnackYaml, testyaml.SecretYaml)
+	multiManifestYAML := yaml.ConcatYAML(testyaml.DoggosYaml, testyaml.SnackYaml, testyaml.SecretYaml)
 	f.WriteFile("global.yaml", multiManifestYAML)
 	f.WriteFile("Dockerfile", "FROM iron/go:dev")
 	f.WriteFile("Tiltfile", fmt.Sprintf(`global_yaml(read_file('./global.yaml'))

--- a/internal/yaml/utils.go
+++ b/internal/yaml/utils.go
@@ -1,0 +1,41 @@
+package yaml
+
+import (
+	"fmt"
+	"strings"
+)
+
+const separator = "---"
+
+func ConcatYaml(yaml ...string) string {
+	if len(yaml) == 0 {
+		return ""
+	} else if len(yaml) == 1 {
+		return yaml[0]
+	}
+
+	result := yaml[0]
+	for _, y := range yaml[1:] {
+		result = concatYaml(result, y)
+	}
+	return result
+}
+
+func concatYaml(y1, y2 string) string {
+	y1 = strings.TrimSpace(y1)
+	y2 = strings.TrimSpace(y2)
+	if !hasEndingSeparator(y1) && !hasStartingSeparator(y2) {
+		return fmt.Sprintf("%s\n%s\n%s", y1, separator, y2)
+	} else if hasEndingSeparator(y1) && hasStartingSeparator(y2) {
+		y1 = strings.TrimSpace(strings.TrimSuffix(y1, separator))
+	}
+	return fmt.Sprintf("%s\n%s", y1, y2)
+}
+
+func hasStartingSeparator(y string) bool {
+	return strings.HasPrefix(y, separator)
+}
+
+func hasEndingSeparator(y string) bool {
+	return strings.HasSuffix(y, separator)
+}

--- a/internal/yaml/utils.go
+++ b/internal/yaml/utils.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 )
 
+// TODO(maia): store yaml strings as []string so we don't need to parse strings for separators?
 const separator = "---"
 
-func ConcatYaml(yaml ...string) string {
+func ConcatYAML(yaml ...string) string {
 	if len(yaml) == 0 {
 		return ""
 	} else if len(yaml) == 1 {
@@ -16,12 +17,12 @@ func ConcatYaml(yaml ...string) string {
 
 	result := yaml[0]
 	for _, y := range yaml[1:] {
-		result = concatYaml(result, y)
+		result = concatYAML(result, y)
 	}
 	return result
 }
 
-func concatYaml(y1, y2 string) string {
+func concatYAML(y1, y2 string) string {
 	y1 = strings.TrimSpace(y1)
 	y2 = strings.TrimSpace(y2)
 	if !hasEndingSeparator(y1) && !hasStartingSeparator(y2) {

--- a/internal/yaml/utils_test.go
+++ b/internal/yaml/utils_test.go
@@ -1,0 +1,84 @@
+package yaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	noSep = `this: is
+some: yaml`
+	endSep = `iLoveYaml: meh
+betterThanXml: true
+---`
+	startSep = `---
+someMap:
+    stuff: yes
+    things: also yes
+`
+)
+
+func TestConcatYamlNoSeparators(t *testing.T) {
+	expected := `---
+someMap:
+    stuff: yes
+    things: also yes
+---
+this: is
+some: yaml`
+	assert.Equal(t, expected, ConcatYaml(startSep, noSep))
+}
+
+func TestConcatYamlBothSeparators(t *testing.T) {
+	expected := `iLoveYaml: meh
+betterThanXml: true
+---
+someMap:
+    stuff: yes
+    things: also yes`
+	assert.Equal(t, expected, ConcatYaml(endSep, startSep))
+}
+
+func TestConcatYamlEndSep(t *testing.T) {
+	expected := `iLoveYaml: meh
+betterThanXml: true
+---
+this: is
+some: yaml`
+	assert.Equal(t, expected, ConcatYaml(endSep, noSep))
+}
+
+func TestConcatYamlStartSep(t *testing.T) {
+	expected := `---
+someMap:
+    stuff: yes
+    things: also yes
+---
+someMap:
+    stuff: yes
+    things: also yes`
+	assert.Equal(t, expected, ConcatYaml(startSep, startSep))
+}
+
+func TestConcatManyYamls(t *testing.T) {
+	expected := `---
+someMap:
+    stuff: yes
+    things: also yes
+---
+this: is
+some: yaml
+---
+iLoveYaml: meh
+betterThanXml: true
+---`
+
+	assert.Equal(t, expected, ConcatYaml(startSep, noSep, endSep))
+}
+
+func TestNoopConcatYaml(t *testing.T) {
+	assert.Equal(t, "", ConcatYaml())
+
+	assert.Equal(t, noSep, ConcatYaml(noSep))
+}

--- a/internal/yaml/utils_test.go
+++ b/internal/yaml/utils_test.go
@@ -27,7 +27,7 @@ someMap:
 ---
 this: is
 some: yaml`
-	assert.Equal(t, expected, ConcatYaml(startSep, noSep))
+	assert.Equal(t, expected, ConcatYAML(startSep, noSep))
 }
 
 func TestConcatYamlBothSeparators(t *testing.T) {
@@ -37,7 +37,7 @@ betterThanXml: true
 someMap:
     stuff: yes
     things: also yes`
-	assert.Equal(t, expected, ConcatYaml(endSep, startSep))
+	assert.Equal(t, expected, ConcatYAML(endSep, startSep))
 }
 
 func TestConcatYamlEndSep(t *testing.T) {
@@ -46,7 +46,7 @@ betterThanXml: true
 ---
 this: is
 some: yaml`
-	assert.Equal(t, expected, ConcatYaml(endSep, noSep))
+	assert.Equal(t, expected, ConcatYAML(endSep, noSep))
 }
 
 func TestConcatYamlStartSep(t *testing.T) {
@@ -58,7 +58,7 @@ someMap:
 someMap:
     stuff: yes
     things: also yes`
-	assert.Equal(t, expected, ConcatYaml(startSep, startSep))
+	assert.Equal(t, expected, ConcatYAML(startSep, startSep))
 }
 
 func TestConcatManyYamls(t *testing.T) {
@@ -74,11 +74,11 @@ iLoveYaml: meh
 betterThanXml: true
 ---`
 
-	assert.Equal(t, expected, ConcatYaml(startSep, noSep, endSep))
+	assert.Equal(t, expected, ConcatYAML(startSep, noSep, endSep))
 }
 
 func TestNoopConcatYaml(t *testing.T) {
-	assert.Equal(t, "", ConcatYaml())
+	assert.Equal(t, "", ConcatYAML())
 
-	assert.Equal(t, noSep, ConcatYaml(noSep))
+	assert.Equal(t, noSep, ConcatYAML(noSep))
 }


### PR DESCRIPTION
Hello @jazzdan, @nicks,

Please review the following commits I made in branch maiamcc/parse-global-yaml:

9574cf099829caded9a8feefedcd161a57f22a5b (2018-10-30 18:06:06 -0400)
tiltfile: on manifest creation, pull matching yaml l out of globalYAML and add to manifest [ch681]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics