### PR TITLE
tiltfile: when extracting per manifest yaml from global yaml, also grab services that select for k8s entities matching the image [ch688]

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -35,7 +35,7 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(args...)
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(ctx, args...)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -85,7 +85,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(args...)
+	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, args...)
 	if err != nil {
 		return err
 	}

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -181,7 +181,7 @@ func (s Script) Run(ctx context.Context) error {
 			return err
 		}
 
-		manifests, _, err := tf.GetManifestConfigsAndGlobalYAML("tiltdemo")
+		manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(ctx, "tiltdemo")
 		if err != nil {
 			return err
 		}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -152,7 +152,7 @@ func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (m
 	if err != nil {
 		return model.Manifest{}, model.YAMLManifest{}, manifestErrf(err.Error())
 	}
-	newManifests, globalYAML, err := t.GetManifestConfigsAndGlobalYAML(string(name))
+	newManifests, globalYAML, err := t.GetManifestConfigsAndGlobalYAML(ctx, string(name))
 	if err != nil {
 		return model.Manifest{}, model.YAMLManifest{}, manifestErrf(err.Error())
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1746,7 +1746,7 @@ func (f *testFixture) loadManifest(name string) model.Manifest {
 	if err != nil {
 		f.T().Fatal(err)
 	}
-	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML("foobar")
+	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(f.ctx, "foobar")
 	if err != nil {
 		f.T().Fatal(err)
 	}

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -174,3 +174,7 @@ func Filter(entities []K8sEntity, test func(e K8sEntity) (bool, error)) (passing
 func FilterByImage(entities []K8sEntity, img reference.Named) (passing, rest []K8sEntity, err error) {
 	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img) })
 }
+
+func FilterByLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.MatchesLabels(labels), nil })
+}

--- a/internal/k8s/extract.go
+++ b/internal/k8s/extract.go
@@ -25,7 +25,7 @@ func ExtractPods(obj interface{}) ([]*v1.PodSpec, error) {
 	return result, nil
 }
 
-func extractPodTemplateSpec(obj interface{}) ([]*v1.PodTemplateSpec, error) {
+func ExtractPodTemplateSpec(obj interface{}) ([]*v1.PodTemplateSpec, error) {
 	extracted, err := extractPointersOf(obj, reflect.TypeOf(v1.PodTemplateSpec{}))
 	if err != nil {
 		return nil, err

--- a/internal/k8s/extract_test.go
+++ b/internal/k8s/extract_test.go
@@ -60,7 +60,7 @@ func TestExtractSanchoPodTemplateSpecs(t *testing.T) {
 	}
 
 	entity := entities[0]
-	tempSpecs, err := extractPodTemplateSpec(&entity)
+	tempSpecs, err := ExtractPodTemplateSpec(&entity)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -72,7 +72,7 @@ func (f *gitRepoFixture) LoadManifestsAndGlobalYAML(names ...string) ([]model.Ma
 		f.T().Fatal("loading tiltconfig:", err)
 	}
 
-	manifests, globalYAML, err := tiltconfig.GetManifestConfigsAndGlobalYAML(names...)
+	manifests, globalYAML, err := tiltconfig.GetManifestConfigsAndGlobalYAML(f.ctx, names...)
 	if err != nil {
 		f.T().Fatal("getting manifest config:", err)
 	}
@@ -103,7 +103,7 @@ func (f *gitRepoFixture) LoadManifestForError(name string) error {
 		f.T().Fatal("loading tiltconfig:", err)
 	}
 
-	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYAML(name)
+	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYAML(f.ctx, name)
 	if err == nil {
 		f.T().Fatal("Expected manifest load error")
 	}
@@ -673,7 +673,7 @@ def blorgly():
 	if err != nil {
 		t.Fatal("loading tiltconfig:", err)
 	}
-	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYAML("blorgly")
+	_, _, err = tiltconfig.GetManifestConfigsAndGlobalYAML(output.CtxForTest(), "blorgly")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "isn't a valid git repo")
 	}
@@ -928,7 +928,7 @@ def blorgly():
 		t.Fatal("loading tiltconfig:", err)
 	}
 
-	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYAML("blorgly")
+	manifests, _, err := tiltconfig.GetManifestConfigsAndGlobalYAML(f.ctx, "blorgly")
 	if err != nil {
 		t.Fatal("getting manifest config:", err)
 	}


### PR DESCRIPTION
Hello @nicks, @jazzda,

Please review the following commits I made in branch maiamcc/assoc-services:

7f7759c4e96f5173bde1116ce10daadefc97a708 (2018-10-31 17:50:08 -0400)
tiltfile: when extracting per manifest yaml from global yaml, also grab services that select for k8s entities matching the image

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics