### PR TITLE
tiltfile: k8s_service takes yaml as an OPTIONAL arg [ch715]

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class Service
 ```
 
 #### global_yaml
-Call this _on the top level of your Tiltfile_ on a string of YAML.
+Call this _on the top level of your Tiltfile_ with a string of YAML.
 
 We will infer what (if any) of the k8s resources defined in your YAML correspond to `Services` defined elsewhere in your Tiltfile (matching based on the DockerImage ref and on pod selectors). Any remaining YAML is _global YAML_, i.e. YAML that Tilt applies to your k8s cluster independently of any `Service` you define. 
 ```python

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Tilt reads from a Tiltfile. A simple Tiltfile is below:
 def backend():
   img = static_build('Dockerfile', 'gcr.io/companyname/backend')
   yaml = read_file('backend.yaml')
-  return k8s_service(yaml, img)
+  return k8s_service(img, yaml=yaml)
 ```
 
 ## Optimizing Tilt
@@ -50,7 +50,7 @@ def backend():
   img = stop_build()
 
   yaml = read_file('backend.yaml')
-  s = k8s_service(yaml, img)
+  s = k8s_service(img, yaml=yaml)
   s.port_forward(8080, 80)
   return s
 ```
@@ -146,12 +146,20 @@ class Service
     """
 ```
 
+#### global_yaml
+Call this _on the top level of your Tiltfile_ on a string of YAML.
+
+We will infer what (if any) of the k8s resources defined in your YAML correspond to `Services` defined elsewhere in your Tiltfile (matching based on the DockerImage ref and on pod selectors). Any remaining YAML is _global YAML_, i.e. YAML that Tilt applies to your k8s cluster independently of any `Service` you define. 
+```python
+def global_yaml(yaml: string) -> None
+```
+
 #### k8s_service
 
-Creates a kubernetes service that tilt can deploy using the yaml text and the image passed in.
+Creates a kubernetes service that tilt can deploy using the the image passed in. Optionally, you may also pass the Kubernetes resource YAML. If the YAML is not passed, we expect to be able to extract it from `global_yaml` (see above).
 
 ```python
-def k8s_service(yaml_text: str, img: Image) -> Service
+def k8s_service(img: Image, yaml: string="") -> Service
 ```
 
 #### Image

--- a/Tiltfile
+++ b/Tiltfile
@@ -7,7 +7,7 @@ def test():
   run('cd src/github.com/windmilleng/tilt && go build ./...')
   image = stop_build()
 
-  return k8s_service(read_file('tilt-test.yaml'), image)
+  return k8s_service(image, yaml=read_file('tilt-test.yaml'))
 
 def synclet():
   username = local('whoami').rstrip('\n')
@@ -18,5 +18,5 @@ def synclet():
   local('synclet/populate_config_template.py devel')
   image = stop_build()
 
-  return k8s_service(read_file('synclet/synclet-conf.generated.yaml'), image)
+  return k8s_service(image, yaml=read_file('synclet/synclet-conf.generated.yaml'))
 

--- a/integration/oneup/Tiltfile
+++ b/integration/oneup/Tiltfile
@@ -4,4 +4,4 @@ def oneup():
   yaml = read_file('oneup.yaml')
   image_name = 'gcr.io/windmill-test-containers/integration/oneup'
   image = static_build('Dockerfile', image_name)
-  return k8s_service(yaml, image)
+  return k8s_service(image, yaml=yaml)

--- a/integration/onewatch/Tiltfile
+++ b/integration/onewatch/Tiltfile
@@ -9,4 +9,4 @@ def onewatch():
   add(path, '/go/src/github.com/windmilleng/tilt/integration/onewatch')
   run('go install github.com/windmilleng/tilt/integration/onewatch')
   image = stop_build()
-  return k8s_service(yaml, image)
+  return k8s_service(image, yaml=yaml)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -40,7 +40,7 @@ const (
 	simpleTiltfile = `def foobar():
   start_fast_build("Dockerfile", "docker-tag")
   image = stop_build()
-  return k8s_service("yaaaaaaaaml", image)`
+  return k8s_service(image, yaml="yaaaaaaaaml")`
 	testContainer = "myTestContainer"
 )
 
@@ -468,12 +468,12 @@ func TestMultipleChangesOnlyDeployOneManifest(t *testing.T) {
 	f.WriteFile("Tiltfile", `def foobar():
   start_fast_build("Dockerfile1", "docker-tag1")
   image = stop_build()
-  return k8s_service("yaaaaaaaaml", image)
+  return k8s_service(image, yaml="yaaaaaaaaml")
 
   def bazqux():
     start_fast_build("Dockerfile2", "docker-tag2")
     image = stop_build()
-    return k8s_service("yaaaaaaaaml", image)
+    return k8s_service(image, yaml="yaaaaaaaaml")
 `)
 	f.WriteFile("Dockerfile1", `FROM iron/go:dev1`)
 	f.WriteFile("Dockerfile2", `FROM iron/go:dev2`)
@@ -532,7 +532,7 @@ func TestNoOpChangeToDockerfile(t *testing.T) {
   start_fast_build("Dockerfile", "docker-tag1")
   add(local_git_repo('.'), '.')
   image = stop_build()
-  return k8s_service("yaaaaaaaaml", image)`)
+  return k8s_service(image, yaml="yaaaaaaaaml")`)
 	f.WriteFile("Dockerfile", `FROM iron/go:dev1`)
 
 	manifest := f.loadManifest("foobar")
@@ -633,7 +633,7 @@ func TestBreakAndUnbreakManifestWithNoChange(t *testing.T) {
 	start_fast_build("Dockerfile", "docker-tag1")
 	add(local_git_repo('./nested'), '.')  # Tiltfile is not mounted
 	image = stop_build()
-	return k8s_service("yaaaaaaaaml", image)`
+	return k8s_service(image, yaml="yaaaaaaaaml")`
 
 	f.MkdirAll("nested/.git") // Spoof a git directory -- this is what we'll mount.
 	f.WriteFile("Tiltfile", origTiltfile)
@@ -677,7 +677,7 @@ func TestFilterOutNonMountedConfigFiles(t *testing.T) {
   start_fast_build("Dockerfile", "docker-tag1")
   add(local_git_repo('./nested'), '.')
   image = stop_build()
-  return k8s_service("yaaaaaaaaml", image)
+  return k8s_service(image, yaml="yaaaaaaaaml")
 `)
 	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
 	f.MkdirAll("nested/.git") // Spoof a git directory -- this is what we'll mount.

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -13,7 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 )
 
-const oldMountSyntaxError = "The syntax for `add` has changed. Before it was `add(dest: string, src: string)`. Now it is `add(src: localPath, dest: string)`."
+const oldMountSyntaxError = "the syntax for `add` has changed. Before it was `add(dest: string, src: string)`. Now it is `add(src: localPath, dest: string)`."
 const noActiveBuildError = "No active build"
 
 type compManifest struct {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -24,7 +24,7 @@ import (
 
 const FileName = "Tiltfile"
 
-const oldK8sServiceSyntaxError = "he syntax for `k8s_service` has changed. Before it was `k8s_service(yaml: string, dockerImage: Image)`. " +
+const oldK8sServiceSyntaxError = "the syntax for `k8s_service` has changed. Before it was `k8s_service(yaml: string, dockerImage: Image)`. " +
 	"Now it is `k8s_service(dockerImage: Image, yaml: string = \"\")` (`yaml` is an optional arg)."
 
 type Tiltfile struct {

--- a/internal/tiltfile/tiltfile_global_yaml_test.go
+++ b/internal/tiltfile/tiltfile_global_yaml_test.go
@@ -51,12 +51,12 @@ global_yaml(yaml)
 def manifestA():
   stuff = read_file('./fileA')  # this is a dependency of manifestA now
   image = static_build('Dockerfile', 'tag-a')
-  return k8s_service("yamlA", image)
+  return k8s_service(image, yaml="yamlA")
 
 def manifestB():
   stuff = read_file('./fileB')  # this is a dependency of manifestB now
   image = static_build('Dockerfile', 'tag-b')
-  return k8s_service("yamlB", image)
+  return k8s_service(image, yaml="yamlB")
 `)
 
 	manifests := f.LoadManifests("manifestA", "manifestB")
@@ -78,11 +78,11 @@ func TestPerManifestYAMLExtractedFromGlobalYAML(t *testing.T) {
 
 def doggos():
   image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/doggos')
-  return k8s_service("", image)
+  return k8s_service(image)
 
 def snack():
   image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/snack')
-  return k8s_service("", image)
+  return k8s_service(image)
 `)
 
 	manifests, gYAML := f.LoadManifestsAndGlobalYAML("doggos", "snack")
@@ -103,11 +103,11 @@ func TestAllYAMLExtractedFromGlobalYAML(t *testing.T) {
 
 def doggos():
   image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/doggos')
-  return k8s_service("", image)
+  return k8s_service(image)
 
 def snack():
   image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/snack')
-  return k8s_service("", image)
+  return k8s_service(image)
 `)
 
 	manifests, gYAML := f.LoadManifestsAndGlobalYAML("doggos", "snack")
@@ -128,7 +128,7 @@ func TestExtractedGlobalYAMLStacksWithExplicitYaml(t *testing.T) {
 
 def doggos_with_secret():
   image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/doggos')
-  return k8s_service("""%s""", image)
+  return k8s_service(image, yaml="""%s""")
 `, testyaml.DoggosServiceYaml))
 
 	manifests, _ := f.LoadManifestsAndGlobalYAML("doggos_with_secret")
@@ -148,7 +148,7 @@ func TestExtractedYAMLAssociatesViaImageAndSelector(t *testing.T) {
 
 def doggos():
   image = static_build('Dockerfile', 'gcr.io/windmill-public-containers/servantes/doggos')
-  return k8s_service("", image)
+  return k8s_service(image)
 `)
 
 	manifests, gYAML := f.LoadManifestsAndGlobalYAML("doggos")


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/yaml-opt-arg:

671c8cda19dbf0dc3d8cb718a863e2b9771edf89 (2018-11-01 18:00:01 -0400)
tiltfile: k8s_service takes yaml as an OPTIONAL arg

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics