### PR TITLE
cli: tilt down deletes k8s resources created via global yaml [ch698]

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log"
@@ -63,7 +64,12 @@ type tiltCmd interface {
 
 func preCommand(ctx context.Context) (context.Context, func() error) {
 	cleanup := func() error { return nil }
-	l := logger.NewLogger(logLevel(verbose, debug), os.Stdout)
+	f, err := os.Create("./tilt.log")
+	if err != nil {
+		panic(err)
+	}
+	writer := bufio.NewWriter(f)
+	l := logger.NewLogger(logLevel(verbose, debug), writer)
 	ctx = logger.WithLogger(ctx, l)
 
 	if trace {


### PR DESCRIPTION
Hello @jazzdan, @nicks,

Please review the following commits I made in branch maiamcc/tilt-down:

b12b00a67a0002ed403ab511d6e2aff417344e99 (2018-11-05 17:01:54 -0500)
cli: tilt down deletes k8s resources created via global yaml [ch698]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics