### PR TITLE
engine: when tiltfile changes re execute all the manifests

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 )
 
@@ -36,7 +37,12 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, gYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, args...)
+	manifestNames := make([]model.ManifestName, len(args))
+	for i, a := range args {
+		manifestNames[i] = model.ManifestName(a)
+	}
+
+	manifests, gYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -42,6 +42,7 @@ var BaseWireSet = wire.NewSet(
 	engine.NewPodWatcher,
 	engine.NewServiceWatcher,
 	engine.NewImageController,
+	engine.NewTiltfileWatcher,
 
 	provideClock,
 	hud.NewRenderer,

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -75,7 +75,7 @@ type InitAction struct {
 	Manifests          []model.Manifest
 	GlobalYAMLManifest model.YAMLManifest
 	TiltfilePath       string
-	ManifestNames      []string
+	ManifestNames      []model.ManifestName
 }
 
 func (InitAction) Action() {}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -75,6 +75,7 @@ type InitAction struct {
 	Manifests          []model.Manifest
 	GlobalYAMLManifest model.YAMLManifest
 	TiltfilePath       string
+	ManifestNames      []string
 }
 
 func (InitAction) Action() {}
@@ -124,3 +125,11 @@ func (HudStoppedAction) Action() {}
 func NewHudStoppedAction(err error) HudStoppedAction {
 	return HudStoppedAction{err}
 }
+
+type TiltfileReloadedAction struct {
+	Manifests  []model.Manifest
+	GlobalYAML model.YAMLManifest
+	Err        error
+}
+
+func (TiltfileReloadedAction) Action() {}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -153,7 +153,7 @@ func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (m
 	if err != nil {
 		return model.Manifest{}, model.YAMLManifest{}, err
 	}
-	newManifests, globalYAML, err := t.GetManifestConfigsAndGlobalYAML(ctx, string(name))
+	newManifests, globalYAML, err := t.GetManifestConfigsAndGlobalYAML(ctx, name)
 	if err != nil {
 		return model.Manifest{}, model.YAMLManifest{}, err
 	}
@@ -165,7 +165,7 @@ func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (m
 	return newManifest, globalYAML, nil
 }
 
-func getNewManifestsFromTiltfile(ctx context.Context, names []string) ([]model.Manifest, model.YAMLManifest, error) {
+func getNewManifestsFromTiltfile(ctx context.Context, names []model.ManifestName) ([]model.Manifest, model.YAMLManifest, error) {
 	// Sends any output to the CurrentBuildLog
 	t, err := tiltfile.Load(ctx, tiltfile.FileName)
 	if err != nil {

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -171,7 +171,6 @@ func getNewManifestsFromTiltfile(ctx context.Context, names []string) ([]model.M
 	if err != nil {
 		return []model.Manifest{}, model.YAMLManifest{}, err
 	}
-	// TODO(dmiller): make this be passed through from CLI
 	newManifests, globalYAML, err := t.GetManifestConfigsAndGlobalYAML(ctx, names...)
 	if err != nil {
 		return []model.Manifest{}, model.YAMLManifest{}, err

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -165,16 +165,16 @@ func getNewManifestFromTiltfile(ctx context.Context, name model.ManifestName) (m
 	return newManifest, globalYAML, nil
 }
 
-func getNewManifestsFromTiltfile(ctx context.Context, names []string) ([]model.Manifest, model.YAMLManifest, *manifestErr) {
+func getNewManifestsFromTiltfile(ctx context.Context, names []string) ([]model.Manifest, model.YAMLManifest, error) {
 	// Sends any output to the CurrentBuildLog
 	t, err := tiltfile.Load(ctx, tiltfile.FileName)
 	if err != nil {
-		return []model.Manifest{}, model.YAMLManifest{}, manifestErrf(err.Error())
+		return []model.Manifest{}, model.YAMLManifest{}, err
 	}
 	// TODO(dmiller): make this be passed through from CLI
 	newManifests, globalYAML, err := t.GetManifestConfigsAndGlobalYAML(ctx, names...)
 	if err != nil {
-		return []model.Manifest{}, model.YAMLManifest{}, manifestErrf(err.Error())
+		return []model.Manifest{}, model.YAMLManifest{}, err
 	}
 
 	return newManifests, globalYAML, nil

--- a/internal/engine/tiltfile_watcher.go
+++ b/internal/engine/tiltfile_watcher.go
@@ -21,8 +21,8 @@ func NewTiltfileWatcher(watcherMaker FsWatcherMaker) *TiltfileWatcher {
 	}
 }
 
-func (t *TiltfileWatcher) EnableForTesting(enabled bool) {
-	t.disabledForTesting = !enabled
+func (t *TiltfileWatcher) DisableForTesting(disabled bool) {
+	t.disabledForTesting = disabled
 }
 
 func (t *TiltfileWatcher) OnChange(ctx context.Context, st *store.Store) {

--- a/internal/engine/tiltfile_watcher.go
+++ b/internal/engine/tiltfile_watcher.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 
+	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/watch"
 )
@@ -59,7 +60,7 @@ func (t *TiltfileWatcher) setupWatch(path string) error {
 	return nil
 }
 
-func (t *TiltfileWatcher) watchLoop(ctx context.Context, st *store.Store, initManifests []string) {
+func (t *TiltfileWatcher) watchLoop(ctx context.Context, st *store.Store, initManifests []model.ManifestName) {
 	watcher := t.tiltfileWatcher
 	for {
 		select {

--- a/internal/engine/tiltfile_watcher.go
+++ b/internal/engine/tiltfile_watcher.go
@@ -1,0 +1,86 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/watch"
+)
+
+type TiltfileWatcher struct {
+	tiltfilePath       string
+	fsWatcherMaker     FsWatcherMaker
+	disabledForTesting bool
+	tiltfileWatcher    watch.Notify
+}
+
+func NewTiltfileWatcher(watcherMaker FsWatcherMaker) *TiltfileWatcher {
+	return &TiltfileWatcher{
+		fsWatcherMaker: watcherMaker,
+	}
+}
+
+func (t *TiltfileWatcher) EnableForTesting(enabled bool) {
+	t.disabledForTesting = enabled
+}
+
+func (t *TiltfileWatcher) OnChange(ctx context.Context, st *store.Store) {
+	if t.disabledForTesting {
+		return
+	}
+	state := st.RLockState()
+	defer st.RUnlockState()
+	initManifests := state.InitManifests
+
+	if t.tiltfilePath != state.TiltfilePath {
+		err := t.setupWatch(state.TiltfilePath)
+		if err != nil {
+			st.Dispatch(NewErrorAction(err))
+			return
+		}
+		go t.watchLoop(ctx, st, initManifests)
+	}
+}
+
+func (t *TiltfileWatcher) setupWatch(path string) error {
+	watcher, err := t.fsWatcherMaker()
+	if err != nil {
+		return err
+	}
+
+	err = watcher.Add(path)
+	if err != nil {
+		return err
+	}
+
+	t.tiltfileWatcher = watcher
+	t.tiltfilePath = path
+
+	return nil
+}
+
+func (t *TiltfileWatcher) watchLoop(ctx context.Context, st *store.Store, initManifests []string) {
+	watcher := t.tiltfileWatcher
+	for {
+		select {
+		case err, ok := <-watcher.Errors():
+			if !ok {
+				return
+			}
+			st.Dispatch(NewErrorAction(err))
+		case <-ctx.Done():
+			return
+		case _, ok := <-watcher.Events():
+			if !ok {
+				return
+			}
+
+			manifests, globalYAML, err := getNewManifestsFromTiltfile(ctx, initManifests)
+			st.Dispatch(TiltfileReloadedAction{
+				Manifests:  manifests,
+				GlobalYAML: globalYAML,
+				Err:        err,
+			})
+		}
+	}
+}

--- a/internal/engine/tiltfile_watcher.go
+++ b/internal/engine/tiltfile_watcher.go
@@ -22,7 +22,7 @@ func NewTiltfileWatcher(watcherMaker FsWatcherMaker) *TiltfileWatcher {
 }
 
 func (t *TiltfileWatcher) EnableForTesting(enabled bool) {
-	t.disabledForTesting = enabled
+	t.disabledForTesting = !enabled
 }
 
 func (t *TiltfileWatcher) OnChange(ctx context.Context, st *store.Store) {
@@ -33,7 +33,7 @@ func (t *TiltfileWatcher) OnChange(ctx context.Context, st *store.Store) {
 	defer st.RUnlockState()
 	initManifests := state.InitManifests
 
-	if t.tiltfilePath != state.TiltfilePath {
+	if t.tiltfilePath != state.TiltfilePath || t.tiltfilePath == "" {
 		err := t.setupWatch(state.TiltfilePath)
 		if err != nil {
 			st.Dispatch(NewErrorAction(err))

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -102,7 +102,13 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 		return err
 	}
 
-	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, args...)
+	manifestNames := make([]model.ManifestName, len(args))
+
+	for i, a := range args {
+		manifestNames[i] = model.ManifestName(a)
+	}
+
+	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
 	if err != nil {
 		return err
 	}
@@ -112,7 +118,7 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 		Manifests:          manifests,
 		GlobalYAMLManifest: globalYAML,
 		TiltfilePath:       absTfPath,
-		ManifestNames:      args,
+		ManifestNames:      manifestNames,
 	})
 
 	return u.store.Loop(ctx)
@@ -121,10 +127,10 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 func (u Upper) StartForTesting(ctx context.Context, manifests []model.Manifest,
 	globalYAML model.YAMLManifest, watchMounts bool, tiltfilePath string) error {
 
-	manifestNames := make([]string, len(manifests))
+	manifestNames := make([]model.ManifestName, len(manifests))
 
 	for i, m := range manifests {
-		manifestNames[i] = m.ManifestName().String()
+		manifestNames[i] = m.ManifestName()
 	}
 
 	u.store.Dispatch(InitAction{

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -432,6 +432,7 @@ func handleTiltfileReloaded(
 	err := event.Err
 	if err != nil {
 		logger.Get(ctx).Infof("Unable to parse Tiltfile: %v", err)
+		return
 	}
 	newDefOrder := make([]model.ManifestName, len(manifests))
 	for i, m := range manifests {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -445,8 +445,7 @@ func handleTiltfileReloaded(
 
 		newDefOrder[i] = m.ManifestName()
 		if !oldManifest.Equal(m) {
-			newManifestState := store.NewManifestState(m)
-			state.ManifestStates[m.ManifestName()] = newManifestState
+			state.ManifestStates[m.ManifestName()].Manifest = m
 			enqueueBuild(state, m.ManifestName())
 		}
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -65,7 +65,7 @@ func NewUpper(ctx context.Context, b BuildAndDeployer,
 	hud hud.HeadsUpDisplay, pw *PodWatcher, sw *ServiceWatcher,
 	st *store.Store, plm *PodLogManager, pfc *PortForwardController,
 	fwm *WatchManager, fswm FsWatcherMaker, bc *BuildController,
-	ic *ImageController, gybc *GlobalYAMLBuildController) Upper {
+	ic *ImageController, gybc *GlobalYAMLBuildController, tfw *TiltfileWatcher) Upper {
 
 	st.AddSubscriber(bc)
 	st.AddSubscriber(hud)
@@ -76,6 +76,7 @@ func NewUpper(ctx context.Context, b BuildAndDeployer,
 	st.AddSubscriber(sw)
 	st.AddSubscriber(ic)
 	st.AddSubscriber(gybc)
+	st.AddSubscriber(tfw)
 
 	return Upper{
 		b:     b,
@@ -111,6 +112,7 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 		Manifests:          manifests,
 		GlobalYAMLManifest: globalYAML,
 		TiltfilePath:       absTfPath,
+		ManifestNames:      args,
 	})
 
 	return u.store.Loop(ctx)
@@ -119,11 +121,18 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 func (u Upper) StartForTesting(ctx context.Context, manifests []model.Manifest,
 	globalYAML model.YAMLManifest, watchMounts bool, tiltfilePath string) error {
 
+	manifestNames := make([]string, len(manifests))
+
+	for i, m := range manifests {
+		manifestNames[i] = m.ManifestName().String()
+	}
+
 	u.store.Dispatch(InitAction{
 		WatchMounts:        watchMounts,
 		Manifests:          manifests,
 		GlobalYAMLManifest: globalYAML,
 		TiltfilePath:       tiltfilePath,
+		ManifestNames:      manifestNames,
 	})
 
 	return u.store.Loop(ctx)
@@ -164,6 +173,8 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		handleGlobalYAMLApplyComplete(ctx, state, action)
 	case GlobalYAMLApplyError:
 		handleGlobalYAMLApplyError(ctx, state, action)
+	case TiltfileReloadedAction:
+		handleTiltfileReloaded(ctx, state, action)
 	default:
 		err = fmt.Errorf("unrecognized action: %T", action)
 	}
@@ -405,6 +416,32 @@ func handleGlobalYAMLApplyError(
 	state.GlobalYAMLState.LastError = event.Error
 }
 
+func handleTiltfileReloaded(
+	ctx context.Context,
+	state *store.EngineState,
+	event TiltfileReloadedAction,
+) {
+	manifests := event.Manifests
+	globalYAML := event.GlobalYAML
+	err := event.Err
+	if err != nil {
+		logger.Get(ctx).Infof("Unable to parse Tiltfile: %v", err)
+	}
+	newDefOrder := make([]model.ManifestName, len(manifests))
+	for i, m := range manifests {
+		oldManifest := state.ManifestStates[m.ManifestName()].Manifest
+
+		newDefOrder[i] = m.ManifestName()
+		if !oldManifest.Equal(m) {
+			state.ManifestStates[m.ManifestName()] = store.NewManifestState(m)
+			enqueueBuild(state, m.ManifestName())
+		}
+	}
+	// TODO(dmiller) handle deleting manifests
+	state.ManifestDefinitionOrder = newDefOrder
+	state.GlobalYAML = globalYAML
+}
+
 func enqueueBuild(state *store.EngineState, mn model.ManifestName) {
 	state.ManifestsToBuild = append(state.ManifestsToBuild, mn)
 	state.ManifestStates[mn].QueueEntryTime = time.Now()
@@ -561,6 +598,7 @@ func handleServiceEvent(ctx context.Context, state *store.EngineState, action Se
 
 func handleInitAction(ctx context.Context, engineState *store.EngineState, action InitAction) error {
 	engineState.TiltfilePath = action.TiltfilePath
+	engineState.InitManifests = action.ManifestNames
 	watchMounts := action.WatchMounts
 	manifests := action.Manifests
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1573,6 +1573,7 @@ type testFixture struct {
 	store                 *store.Store
 	pod                   *v1.Pod
 	bc                    *BuildController
+	fwm                   *WatchManager
 
 	onchangeCh chan bool
 }
@@ -1614,7 +1615,9 @@ func newTestFixture(t *testing.T) *testFixture {
 	ic := NewImageController(reaper)
 
 	gybc := NewGlobalYAMLBuildController(k8s)
-	upper := NewUpper(ctx, b, fakeHud, pw, sw, st, plm, pfc, fwm, fswm, bc, ic, gybc)
+	tfw := NewTiltfileWatcher(fswm)
+	tfw.EnableForTesting(false)
+	upper := NewUpper(ctx, b, fakeHud, pw, sw, st, plm, pfc, fwm, fswm, bc, ic, gybc, tfw)
 
 	go func() {
 		fakeHud.Run(ctx, upper.Dispatch, hud.DefaultRefreshInterval)
@@ -1634,6 +1637,7 @@ func newTestFixture(t *testing.T) *testFixture {
 		store:          st,
 		bc:             bc,
 		onchangeCh:     fSub.ch,
+		fwm:            fwm,
 	}
 }
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -628,7 +628,7 @@ func TestRebuildDockerfileFailed(t *testing.T) {
 func TestBreakManifest(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	f.tfw.EnableForTesting(true)
+	f.tfw.DisableForTesting(false)
 
 	origTiltfile := `def foobar():
 	start_fast_build("Dockerfile", "docker-tag1")
@@ -672,7 +672,7 @@ func TestBreakManifest(t *testing.T) {
 func TestBreakAndUnbreakManifestWithNoChange(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	f.tfw.EnableForTesting(true)
+	f.tfw.DisableForTesting(false)
 
 	origTiltfile := `def foobar():
 	start_fast_build("Dockerfile", "docker-tag1")
@@ -717,7 +717,7 @@ func TestBreakAndUnbreakManifestWithNoChange(t *testing.T) {
 func TestBreakAndUnbreakManifestWithChange(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	f.tfw.EnableForTesting(true)
+	f.tfw.DisableForTesting(false)
 
 	tiltfileString := func(cmd string) string {
 		return fmt.Sprintf(`def foobar():
@@ -1614,7 +1614,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	gybc := NewGlobalYAMLBuildController(k8s)
 	tfw := NewTiltfileWatcher(tfwm)
-	tfw.EnableForTesting(false)
+	tfw.DisableForTesting(true)
 	upper := NewUpper(ctx, b, fakeHud, pw, sw, st, plm, pfc, fwm, fswm, bc, ic, gybc, tfw)
 
 	go func() {

--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -51,8 +51,7 @@ func (w *WatchManager) DisableForTesting() {
 	w.disabledForTesting = true
 }
 
-// TODO(dmiller) rename this
-func (w *WatchManager) diffAndMaybeSetupTFWatch(ctx context.Context, st *store.Store) (setup []WatchableManifest, teardown []WatchableManifest) {
+func (w *WatchManager) diff(ctx context.Context, st *store.Store) (setup []WatchableManifest, teardown []WatchableManifest) {
 	state := st.RLockState()
 	defer st.RUnlockState()
 
@@ -78,7 +77,7 @@ func (w *WatchManager) diffAndMaybeSetupTFWatch(ctx context.Context, st *store.S
 }
 
 func (w *WatchManager) OnChange(ctx context.Context, st *store.Store) {
-	setup, teardown := w.diffAndMaybeSetupTFWatch(ctx, st)
+	setup, teardown := w.diff(ctx, st)
 
 	for _, m := range teardown {
 		p, ok := w.manifestWatches[m.ManifestName()]

--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -32,10 +32,11 @@ type manifestNotifyCancel struct {
 }
 
 type WatchManager struct {
-	manifestWatches map[model.ManifestName]manifestNotifyCancel
-	fsWatcherMaker  FsWatcherMaker
-	timerMaker      timerMaker
-	tiltfileWatch   watch.Notify
+	manifestWatches    map[model.ManifestName]manifestNotifyCancel
+	fsWatcherMaker     FsWatcherMaker
+	timerMaker         timerMaker
+	tiltfileWatch      watch.Notify
+	disabledForTesting bool
 }
 
 func NewWatchManager(watcherMaker FsWatcherMaker, timerMaker timerMaker) *WatchManager {
@@ -46,14 +47,14 @@ func NewWatchManager(watcherMaker FsWatcherMaker, timerMaker timerMaker) *WatchM
 	}
 }
 
+func (w *WatchManager) DisableForTesting() {
+	w.disabledForTesting = true
+}
+
+// TODO(dmiller) rename this
 func (w *WatchManager) diffAndMaybeSetupTFWatch(ctx context.Context, st *store.Store) (setup []WatchableManifest, teardown []WatchableManifest) {
 	state := st.RLockState()
 	defer st.RUnlockState()
-
-	err := w.maybeSetupTFWatch(state)
-	if err != nil {
-		st.Dispatch(NewErrorAction(err))
-	}
 
 	setup = []WatchableManifest{}
 	teardown = []WatchableManifest{}
@@ -74,25 +75,6 @@ func (w *WatchManager) diffAndMaybeSetupTFWatch(ctx context.Context, st *store.S
 	}
 
 	return setup, teardown
-}
-
-func (w *WatchManager) maybeSetupTFWatch(state store.EngineState) error {
-	if w.tiltfileWatch != nil {
-		return nil
-	}
-
-	watcher, err := w.fsWatcherMaker()
-	if err != nil {
-		return err
-	}
-	err = watcher.Add(state.TiltfilePath)
-	if err != nil {
-		return err
-	}
-
-	w.tiltfileWatch = watcher
-
-	return nil
 }
 
 func (w *WatchManager) OnChange(ctx context.Context, st *store.Store) {
@@ -178,26 +160,6 @@ func (w *WatchManager) dispatchFileChangesLoop(ctx context.Context, manifest Wat
 			if len(watchEvent.files) > 0 {
 				st.Dispatch(watchEvent)
 			}
-		}
-	}
-}
-
-func (w *WatchManager) dispatchTiltfileChangesLoop(ctx context.Context, st *store.Store) {
-	watcher := w.tiltfileWatch
-	for {
-		select {
-		case err, ok := <-watcher.Errors():
-			if !ok {
-				return
-			}
-			st.Dispatch(NewErrorAction(err))
-		case <-ctx.Done():
-			return
-		case _, ok := <-watcher.Events():
-			if !ok {
-				return
-			}
-			// TODO(dmiller) dispatch action that tells us that the tiltfile has changed
 		}
 	}
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -54,6 +54,9 @@ type EngineState struct {
 	GlobalYAMLState *YAMLManifestState
 
 	TiltfilePath string
+
+	// InitManifests is the list of manifest names that we were told to init from the CLI.
+	InitManifests []string
 }
 
 type ManifestState struct {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -56,7 +56,7 @@ type EngineState struct {
 	TiltfilePath string
 
 	// InitManifests is the list of manifest names that we were told to init from the CLI.
-	InitManifests []string
+	InitManifests []model.ManifestName
 }
 
 type ManifestState struct {

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -6,10 +6,10 @@
 package synclet
 
 import (
-	"context"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
+	context "context"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
 )
 
 // Injectors from wire.go:

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -178,10 +178,6 @@ func (t *Tiltfile) makeSkylarkCompositeManifest(thread *skylark.Thread, fn *skyl
 			if !ok {
 				return nil, fmt.Errorf("composite_service: function %v returned %v %T; expected k8s_service", v.Name(), r, r)
 			}
-			err = t.recordReadToTiltFile(thread)
-			if err != nil {
-				return nil, err
-			}
 
 			files, err := getAndClearReadFiles(thread)
 			if err != nil {
@@ -387,7 +383,7 @@ func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 }
 
 // GetManifestConfigsAndGlobalYAML executes the Tiltfile to create manifests for all resources and
-// a manifest representing the global yaml
+// a manifest representing the global yaml. If no names are given, all manifests are returned
 func (t Tiltfile) GetManifestConfigsAndGlobalYAML(ctx context.Context, names ...string) ([]model.Manifest, model.YAMLManifest, error) {
 	var manifests []model.Manifest
 
@@ -450,11 +446,6 @@ func (t Tiltfile) getManifestConfigsHelper(ctx context.Context, manifestName str
 
 	thread := t.thread
 	thread.SetLocal(readFilesKey, []string{})
-
-	err := t.recordReadToTiltFile(thread)
-	if err != nil {
-		return nil, err
-	}
 
 	val, err := manifestFunction.Call(t.thread, nil, nil)
 	if err != nil {
@@ -645,13 +636,4 @@ func skylarkMountsToDomain(sMounts []mount) []model.Mount {
 		}
 	}
 	return dMounts
-}
-
-func (t *Tiltfile) recordReadToTiltFile(thread *skylark.Thread) error {
-	err := t.recordReadFile(thread, FileName)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -383,7 +383,7 @@ func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 }
 
 // GetManifestConfigsAndGlobalYAML executes the Tiltfile to create manifests for all resources and
-// a manifest representing the global yaml. If no names are given, all manifests are returned
+// a manifest representing the global yaml.
 func (t Tiltfile) GetManifestConfigsAndGlobalYAML(ctx context.Context, names ...string) ([]model.Manifest, model.YAMLManifest, error) {
 	var manifests []model.Manifest
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -384,7 +384,7 @@ func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 
 // GetManifestConfigsAndGlobalYAML executes the Tiltfile to create manifests for all resources and
 // a manifest representing the global yaml.
-func (t Tiltfile) GetManifestConfigsAndGlobalYAML(ctx context.Context, names ...string) ([]model.Manifest, model.YAMLManifest, error) {
+func (t Tiltfile) GetManifestConfigsAndGlobalYAML(ctx context.Context, names ...model.ManifestName) ([]model.Manifest, model.YAMLManifest, error) {
 	var manifests []model.Manifest
 
 	gYAMLDeps, err := getGlobalYAMLDeps(t.thread)
@@ -393,7 +393,7 @@ func (t Tiltfile) GetManifestConfigsAndGlobalYAML(ctx context.Context, names ...
 	}
 
 	for _, manifestName := range names {
-		curManifests, err := t.getManifestConfigsHelper(ctx, manifestName)
+		curManifests, err := t.getManifestConfigsHelper(ctx, manifestName.String())
 		if err != nil {
 			return manifests, model.YAMLManifest{}, err
 		}

--- a/internal/tiltfile/tiltfile_global_yaml_test.go
+++ b/internal/tiltfile/tiltfile_global_yaml_test.go
@@ -16,7 +16,13 @@ func TestGlobalYAML(t *testing.T) {
 
 	f.WriteFile("global.yaml", "this is the global yaml")
 	f.WriteFile("Tiltfile", `yaml = read_file('./global.yaml')
-global_yaml(yaml)`)
+global_yaml(yaml)
+
+def manifestA():
+  stuff = read_file('./fileA')
+  image = static_build('Dockerfile', 'tag-a')
+  return k8s_service("yamlA", image)
+	`)
 
 	globalYAML := f.LoadGlobalYAML()
 	assert.Equal(t, globalYAML.K8sYAML(), "this is the global yaml")
@@ -61,8 +67,8 @@ def manifestB():
 
 	manifests := f.LoadManifests("manifestA", "manifestB")
 
-	expectedDepsA := []string{"fileA", "Dockerfile", "Tiltfile", "global.yaml"}
-	expectedDepsB := []string{"fileB", "Dockerfile", "Tiltfile", "global.yaml"}
+	expectedDepsA := []string{"fileA", "Dockerfile", "global.yaml"}
+	expectedDepsB := []string{"fileB", "Dockerfile", "global.yaml"}
 	assert.ElementsMatch(t, manifests[0].ConfigFiles, f.JoinPaths(expectedDepsA))
 	assert.ElementsMatch(t, manifests[1].ConfigFiles, f.JoinPaths(expectedDepsB))
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -63,7 +63,7 @@ func newGitRepoFixture(t *testing.T) *gitRepoFixture {
 	}
 }
 
-func (f *gitRepoFixture) LoadManifestsAndGlobalYAML(names ...string) ([]model.Manifest, model.YAMLManifest) {
+func (f *gitRepoFixture) LoadManifestsAndGlobalYAML(names ...model.ManifestName) ([]model.Manifest, model.YAMLManifest) {
 	// It's important that this uses a relative path, because
 	// that's how other places in Tilt call it. In the past, we've had
 	// a lot of bugs that come up due to relative paths vs. absolute paths.
@@ -79,12 +79,12 @@ func (f *gitRepoFixture) LoadManifestsAndGlobalYAML(names ...string) ([]model.Ma
 	return manifests, globalYAML
 }
 
-func (f *gitRepoFixture) LoadManifests(names ...string) []model.Manifest {
+func (f *gitRepoFixture) LoadManifests(names ...model.ManifestName) []model.Manifest {
 	manifests, _ := f.LoadManifestsAndGlobalYAML(names...)
 	return manifests
 }
 
-func (f *gitRepoFixture) LoadManifest(name string) model.Manifest {
+func (f *gitRepoFixture) LoadManifest(name model.ManifestName) model.Manifest {
 	manifests := f.LoadManifests(name)
 	if len(manifests) != 1 {
 		f.T().Fatalf("expected 1 manifest, actual: %d", len(manifests))
@@ -97,7 +97,7 @@ func (f *gitRepoFixture) LoadGlobalYAML() model.YAMLManifest {
 	return globalYAML
 }
 
-func (f *gitRepoFixture) LoadManifestForError(name string) error {
+func (f *gitRepoFixture) LoadManifestForError(name model.ManifestName) error {
 	tiltconfig, err := Load(f.ctx, f.JoinPath("Tiltfile"))
 	if err != nil {
 		f.T().Fatal("loading tiltconfig:", err)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -557,7 +557,6 @@ func TestConfigMatcherWithFastBuild(t *testing.T) {
 		return ok
 	}
 	assert.True(t, matches(f.JoinPath("Dockerfile.base")))
-	assert.True(t, matches(f.JoinPath("Tiltfile")))
 	assert.True(t, matches(f.JoinPath("a.txt")))
 	assert.False(t, matches(f.JoinPath("b.txt")))
 }
@@ -581,7 +580,6 @@ func TestConfigMatcherWithStaticBuild(t *testing.T) {
 		return ok
 	}
 	assert.True(t, matches(f.JoinPath("Dockerfile")))
-	assert.True(t, matches(f.JoinPath("Tiltfile")))
 	assert.False(t, matches(f.JoinPath("b.txt")))
 }
 
@@ -1039,7 +1037,6 @@ def blorgly():
 	manifest := f.LoadManifest("blorgly")
 	expected := f.JoinPaths([]string{
 		"Dockerfile",
-		"Tiltfile",
 		"configMap.yaml",
 		"deployment.yaml",
 		"kustomization.yaml",


### PR DESCRIPTION
Note there are a couple tests that fail, I think I'm just going to rewrite them? For the record they are:

* `TestRebuildDockerfileFailed`
* `TestBreakManifest`
* `TestBreakAndUnbreakManifestWithNoChange`
* `TestBreakAndUnbreakManifestWithChange`

Wanted to get folk's eyes on this while I work on that solicit ideas for what could be wrong with those tests in the meantime. :)