### PR TITLE
tiltfile: add build_args param to static_build

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,17 @@ written in a Mill, a dialect of python. It's based on [starlark](https://github.
 
 Mill comes with built-in functions.
 
-#### static_build(dockerfile, ref, context?)
+#### static_build(dockerfile, ref, build_args?, context?)
 Builds a docker image.
 
 ```python
-def static_build(dockerfile: str, ref: str, context: str = "") -> Image:
+def static_build(dockerfile: str, ref: str, build_args: Dict[str, str] = {}, context: str = "") -> Image:
       """Builds a docker image.
 
     Args:
       dockerfile: The path to a Dockerfile
       ref: e.g. a blorgdev/backend or gcr.io/project-name/bucket-name
+      build_args?: the build-time variables that are accessed like regular environment variables in the `RUN` instruction of the Dockerfile.
       context?: The path to use as the Docker build context. Defaults to the Dockerfile directory.
     Returns:
       Image
@@ -158,7 +159,7 @@ class Service
 #### global_yaml
 Call this _on the top level of your Tiltfile_ with a string of YAML.
 
-We will infer what (if any) of the k8s resources defined in your YAML correspond to `Services` defined elsewhere in your Tiltfile (matching based on the DockerImage ref and on pod selectors). Any remaining YAML is _global YAML_, i.e. YAML that Tilt applies to your k8s cluster independently of any `Service` you define. 
+We will infer what (if any) of the k8s resources defined in your YAML correspond to `Services` defined elsewhere in your Tiltfile (matching based on the DockerImage ref and on pod selectors). Any remaining YAML is _global YAML_, i.e. YAML that Tilt applies to your k8s cluster independently of any `Service` you define.
 ```python
 def global_yaml(yaml: string) -> None
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ def static_build(dockerfile: str, ref: str, build_args: Dict[str, str] = {}, con
     Args:
       dockerfile: The path to a Dockerfile
       ref: e.g. a blorgdev/backend or gcr.io/project-name/bucket-name
-      build_args?: the build-time variables that are accessed like regular environment variables in the `RUN` instruction of the Dockerfile.
+      build_args?: the build-time variables that are accessed like regular environment variables in the `RUN` instruction of the Dockerfile. See https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg
       context?: The path to use as the Docker build context. Defaults to the Dockerfile directory.
     Returns:
       Image

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -42,6 +42,7 @@ type dockerImageBuilder struct {
 }
 
 type ImageBuilder interface {
+	// TODO(dmiller): this needs to take and handle buildArgs
 	BuildDockerfile(ctx context.Context, ps *PipelineState, ref reference.Named, df dockerfile.Dockerfile, buildPath string, filter model.PathMatcher) (reference.NamedTagged, error)
 	BuildImageFromScratch(ctx context.Context, ps *PipelineState, ref reference.Named, baseDockerfile dockerfile.Dockerfile, mounts []model.Mount, filter model.PathMatcher, steps []model.Step, entrypoint model.Cmd) (reference.NamedTagged, error)
 	BuildImageFromExisting(ctx context.Context, ps *PipelineState, existing reference.NamedTagged, paths []pathMapping, filter model.PathMatcher, steps []model.Step) (reference.NamedTagged, error)

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -38,6 +38,7 @@ type Manifest struct {
 	// we do not expect the iterative build fields to be populated.
 	StaticDockerfile string
 	StaticBuildPath  string // the absolute path to the files
+	StaticBuildArgs  map[string]string
 
 	Repos []LocalGithubRepo
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -116,8 +117,9 @@ func (m1 Manifest) Equal(m2 Manifest) bool {
 	reposMatch := m1.reposEqual(m2.Repos)
 	stepsMatch := m1.stepsEqual(m2.Steps)
 	portForwardsMatch := m1.portForwardsEqual(m2)
+	buildArgsMatch := reflect.DeepEqual(m1.StaticBuildArgs, m2.StaticBuildArgs)
 
-	return primitivesMatch && entrypointMatch && configFilesMatch && mountsMatch && reposMatch && portForwardsMatch && stepsMatch
+	return primitivesMatch && entrypointMatch && configFilesMatch && mountsMatch && reposMatch && portForwardsMatch && stepsMatch && buildArgsMatch
 }
 
 func (m1 Manifest) configFilesEqual(c2 []string) bool {

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -247,6 +247,36 @@ var equalitytests = []struct {
 		},
 		false,
 	},
+	{
+		Manifest{
+			StaticBuildArgs: map[string]string{
+				"foo":  "bar",
+				"baz:": "qux",
+			},
+		},
+		Manifest{
+			StaticBuildArgs: map[string]string{
+				"foo":  "bar",
+				"baz:": "quz",
+			},
+		},
+		false,
+	},
+	{
+		Manifest{
+			StaticBuildArgs: map[string]string{
+				"foo":  "bar",
+				"baz:": "qux",
+			},
+		},
+		Manifest{
+			StaticBuildArgs: map[string]string{
+				"foo":  "bar",
+				"baz:": "qux",
+			},
+		},
+		true,
+	},
 }
 
 func TestManifestEquality(t *testing.T) {

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -119,6 +119,7 @@ type dockerImage struct {
 
 	staticDockerfilePath localPath
 	staticBuildPath      localPath
+	staticBuildArgs      map[string]string
 }
 
 var _ skylark.Value = &dockerImage{}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -125,19 +125,19 @@ func (t *Tiltfile) makeStaticBuild(thread *skylark.Thread, fn *skylark.Builtin, 
 
 	dockerfileLocalPath, err := t.localPathFromSkylarkValue(dockerfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("Argument 0 (dockerfile): %v", err)
+		return nil, fmt.Errorf("Argument 1 (dockerfile): %v", err)
 	}
 
 	var sba map[string]string
 	if buildArgs != nil {
 		d, ok := buildArgs.(*skylark.Dict)
 		if !ok {
-			return nil, fmt.Errorf("Argument 2 (build_args): expected dict, got %T", buildArgs)
+			return nil, fmt.Errorf("Argument 3 (build_args): expected dict, got %T", buildArgs)
 		}
 
 		sba, err = skylarkStringDictToGoMap(d)
 		if err != nil {
-			return nil, fmt.Errorf("Argument 2 (build_args): %v", err)
+			return nil, fmt.Errorf("Argument 3 (build_args): %v", err)
 		}
 	}
 
@@ -150,7 +150,7 @@ func (t *Tiltfile) makeStaticBuild(thread *skylark.Thread, fn *skylark.Builtin, 
 	} else {
 		buildLocalPath, err = t.localPathFromSkylarkValue(buildPath)
 		if err != nil {
-			return nil, fmt.Errorf("Argument 3 (context): %v", err)
+			return nil, fmt.Errorf("Argument 4 (context): %v", err)
 		}
 	}
 


### PR DESCRIPTION
In a subsequent PR I will use the new `StaticBuildArgs` field on `model.Manifest` to apply the build args in the image builder.