### PR TITLE
tiltfile: move base dockerfile validation to Tiltfile

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -101,16 +101,11 @@ func (d *dockerImageBuilder) BuildImageFromScratch(ctx context.Context, ps *Pipe
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-BuildImageFromScratch")
 	defer span.Finish()
 
-	err := baseDockerfile.ValidateBaseDockerfile()
-	if err != nil {
-		return nil, err
-	}
-
 	hasEntrypoint := !entrypoint.Empty()
 
 	paths := MountsToPathMappings(mounts)
 	df := baseDockerfile
-	df, steps, err = d.addConditionalSteps(df, steps, paths)
+	df, steps, err := d.addConditionalSteps(df, steps, paths)
 	if err != nil {
 		return nil, fmt.Errorf("BuildImageFromScratch: %v", err)
 	}

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/google/skylark"
+	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -111,6 +112,7 @@ type mount struct {
 // See model.Manifest for more information on what all these fields mean.
 type dockerImage struct {
 	baseDockerfilePath localPath
+	baseDockerfile     dockerfile.Dockerfile
 	ref                reference.Named
 	mounts             []mount
 	steps              []model.Step
@@ -118,6 +120,7 @@ type dockerImage struct {
 	tiltFilename       string
 
 	staticDockerfilePath localPath
+	staticDockerfile     dockerfile.Dockerfile
 	staticBuildPath      localPath
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1049,3 +1049,20 @@ def blorgly():
 	})
 	assert.Equal(t, expected, manifest.ConfigFiles)
 }
+
+func TestValidateBaseDockerfile(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+
+	f.WriteFile("Dockerfile.base", `FROM golang:10
+ADD . .
+`)
+	f.WriteFile("Tiltfile", `def blorgly():
+  start_fast_build("Dockerfile.base", "docker-tag", "the entrypoint")
+  image = stop_build()
+  return k8s_service(image, yaml="yaaaaaaaaml")
+`)
+
+	err := f.LoadManifestForError("blorgly")
+	assert.Contains(t, err.Error(), "base Dockerfile contains an ADD/COPY")
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/validate:

a3e381f7966969f13fa01fdd397e44859be6320f (2018-11-08 17:38:02 -0500)
tiltfile: move base dockerfile validation to Tiltfile
this should help produce better error messages, and also fixes an issue
where directory caches do have COPYs from other images