### PR TITLE
tilt: redirect go logs to tilt logs

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -81,6 +81,8 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	l := NewLogActionLogger(ctx, upper.Dispatch)
 	ctx = logger.WithLogger(ctx, l)
 
+	log.SetOutput(l.Writer(logger.InfoLvl))
+
 	logOutput(fmt.Sprintf("Starting Tilt (%s)…\n", buildStamp()))
 
 	if trace {


### PR DESCRIPTION
Problem:
A couple of libraries we use (k8s, fswatch) log using golang's `log` package, which writes to the screen and screws up the hud.

Solution:
Tell golang's `log` package to write to the tilt logger.