### PR TITLE
tiltfile: extract per yaml manifest from global yaml when loading composite services [ch771]

### DIFF
--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -86,7 +86,7 @@ func (m Manifest) validate() *ValidateErr {
 	}
 
 	if m.K8sYAML() == "" {
-		return validateErrf("[validate] manifest %q missing YAML file", m.Name)
+		return validateErrf("[validate] manifest %q missing k8s YAML", m.Name)
 	}
 
 	for _, m := range m.Mounts {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/gyaml-composite:

4e86a85d2d8606cb075d0f3365ef7d121d1c8692 (2018-11-09 15:54:17 -0500)
tiltfile: extract per yaml manifest from global yaml when loading composite services

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics