### PR TITLE
tiltfile: add syntax for cache paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ def backend():
       trigger=['package.json'])
   run('go install github.com/companyname/backend/server')
   img = stop_build()
+  img.cache('/root/.cache/go-cache')
 
   yaml = read_file('backend.yaml')
   s = k8s_service(img, yaml=yaml)
@@ -178,6 +179,16 @@ Represents a built Docker image
 
 ```python
 class Image
+  def cache(path: string) -> None:
+    """Caches the given path between image builds.
+
+    Popular directories to cache include:
+    - Go projects: /root/.cache/go-cache
+    - NodeJS projects: /src/node_modules, /src/yarn.lock
+
+    Args:
+      path: The path to cache. May be a file or a directory.
+    """
 ```
 
 #### composite_service

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -644,7 +644,11 @@ func skylarkManifestToDomain(manifest *k8sManifest) (model.Manifest, error) {
 		Repos: SkylarkReposToDomain(image),
 	}
 
-	m = m.WithPortForwards(manifest.portForwards).WithTiltFilename(image.tiltFilename).WithK8sYAML(k8sYaml).WithDockerRef(image.ref)
+	m = m.WithPortForwards(manifest.portForwards).
+		WithTiltFilename(image.tiltFilename).
+		WithK8sYAML(k8sYaml).
+		WithDockerRef(image.ref).
+		WithCachePaths(image.cachePaths)
 
 	return m, nil
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -946,6 +946,24 @@ def blorgly():
 	}, manifest.PortForwards())
 }
 
+func TestCachePaths(t *testing.T) {
+	f := newGitRepoFixture(t)
+	defer f.TearDown()
+
+	f.WriteFile("Dockerfile", "dockerfile text")
+	f.WriteFile("Tiltfile", `
+def blorgly():
+  yaml = local('echo yaaaaaaaaml')
+  img = static_build("Dockerfile", "docker-tag")
+  img.cache("/app/node_modules")
+  img.cache("/app/yarn.lock")
+  return k8s_service(img)
+`)
+
+	manifest := f.LoadManifest("blorgly")
+	assert.Equal(t, []string{"/app/node_modules", "/app/yarn.lock"}, manifest.CachePaths())
+}
+
 func TestSymlinkInPath(t *testing.T) {
 	f := newGitRepoFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch728/cache:

d4cd1f0bdbb2f6c6c0beb28d50f05d64c5319a7f (2018-11-09 16:50:05 -0500)
tiltfile: add syntax for cache paths