### PR TITLE
tilt: add action logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1157,6 +1157,14 @@
   version = "v1.14.0"
 
 [[projects]]
+  digest = "1:653e04c4515b37169ef5874d752f4254e63b4aedb5c8b3a4118e9e3a4e3503e1"
+  name = "gopkg.in/d4l3k/messagediff.v1"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "29f32d820d112dbd66e58492a6ffb7cc3106312b"
+  version = "v1.2.1"
+
+[[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
@@ -1426,6 +1434,7 @@
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/status",
+    "gopkg.in/d4l3k/messagediff.v1",
     "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -20,6 +20,7 @@ import (
 )
 
 var updateModeFlag string = string(engine.UpdateModeAuto)
+var logActionsFlag bool = false
 
 type upCmd struct {
 	watch       bool
@@ -43,6 +44,8 @@ func (c *upCmd) register() *cobra.Command {
 	cmd.Flags().StringVar(&build.ImageTagPrefix, "image-tag-prefix", build.ImageTagPrefix,
 		"For integration tests. Customize the image tag prefix so tests can write to a public registry")
 	cmd.Flags().BoolVar(&c.hud, "hud", true, "If true, tilt will open in HUD mode.")
+	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
+	cmd.Flags().Lookup("logactions").Hidden = true
 	err := cmd.Flags().MarkHidden("image-tag-prefix")
 	if err != nil {
 		panic(err)
@@ -123,6 +126,10 @@ func logOutput(s string) {
 
 func provideUpdateModeFlag() engine.UpdateModeFlag {
 	return engine.UpdateModeFlag(updateModeFlag)
+}
+
+func provideLogActions() store.LogActionsFlag {
+	return store.LogActionsFlag(logActionsFlag)
 }
 
 func NewLogActionLogger(ctx context.Context, dispatch func(action store.Action)) logger.Logger {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -14,6 +14,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/store"
 )
 
 var K8sWireSet = wire.NewSet(
@@ -47,6 +48,9 @@ var BaseWireSet = wire.NewSet(
 	provideClock,
 	hud.NewRenderer,
 	hud.NewDefaultHeadsUpDisplay,
+
+	provideLogActions,
+	store.NewStore,
 
 	engine.NewUpper,
 	provideAnalytics,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -36,9 +36,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	}
 	portForwarder := k8s.ProvidePortForwarder()
 	k8sClient := k8s.NewK8sClient(ctx, env, coreV1Interface, config, portForwarder)
-	reducer := _wireReducerValue
-	storeStore := store.NewStore(reducer)
-	deployDiscovery := engine.NewDeployDiscovery(k8sClient, storeStore)
+	deployDiscovery := engine.NewDeployDiscovery(k8sClient)
 	syncletManager := engine.NewSyncletManager(k8sClient)
 	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(deployDiscovery, syncletManager)
 	dockerCli, err := docker.DefaultDockerClient(ctx, env)
@@ -77,6 +75,9 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 		return demo.Script{}, err
 	}
 	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
+	reducer := _wireReducerValue
+	storeLogActionsFlag := provideLogActions()
+	storeStore := store.NewStore(reducer, storeLogActionsFlag)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -93,8 +94,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 }
 
 var (
-	_wireReducerValue = engine.UpperReducer
 	_wireLabelsValue  = dockerfile.Labels{}
+	_wireReducerValue = engine.UpperReducer
 )
 
 func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
@@ -118,9 +119,7 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	}
 	portForwarder := k8s.ProvidePortForwarder()
 	k8sClient := k8s.NewK8sClient(ctx, env, coreV1Interface, config, portForwarder)
-	reducer := _wireReducerValue
-	storeStore := store.NewStore(reducer)
-	deployDiscovery := engine.NewDeployDiscovery(k8sClient, storeStore)
+	deployDiscovery := engine.NewDeployDiscovery(k8sClient)
 	syncletManager := engine.NewSyncletManager(k8sClient)
 	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(deployDiscovery, syncletManager)
 	dockerCli, err := docker.DefaultDockerClient(ctx, env)
@@ -153,6 +152,9 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 		return HudAndUpper{}, err
 	}
 	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
+	reducer := _wireReducerValue
+	storeLogActionsFlag := provideLogActions()
+	storeStore := store.NewStore(reducer, storeLogActionsFlag)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -191,7 +193,7 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 var K8sWireSet = wire.NewSet(k8s.DetectEnv, k8s.DetectNodeIP, k8s.ProvidePortForwarder, k8s.ProvideRESTClient, k8s.ProvideRESTConfig, k8s.NewK8sClient, wire.Bind(new(k8s.Client), k8s.K8sClient{}))
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, docker.DefaultDockerClient, wire.Bind(new(docker.DockerClient), new(docker.DockerCli)), build.NewImageReaper, engine.DeployerWireSet, engine.DefaultShouldFallBack, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewTiltfileWatcher, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, engine.NewUpper, provideAnalytics,
+	K8sWireSet, docker.DefaultDockerClient, wire.Bind(new(docker.DockerClient), new(docker.DockerCli)), build.NewImageReaper, engine.DeployerWireSet, engine.DefaultShouldFallBack, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewTiltfileWatcher, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, engine.NewUpper, provideAnalytics,
 	provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideHudAndUpper,
 )
 

--- a/internal/engine/deploy.go
+++ b/internal/engine/deploy.go
@@ -12,22 +12,19 @@ import (
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
-	"github.com/windmilleng/tilt/internal/store"
 )
 
 // Looks up containers after they've been deployed.
 type DeployDiscovery struct {
 	kCli       k8s.Client
-	store      *store.Store
 	deployInfo map[docker.ImgNameAndTag]*deployInfoEntry
 	mu         sync.Mutex
 }
 
-func NewDeployDiscovery(kCli k8s.Client, store *store.Store) *DeployDiscovery {
+func NewDeployDiscovery(kCli k8s.Client) *DeployDiscovery {
 	return &DeployDiscovery{
 		kCli:       kCli,
 		deployInfo: make(map[docker.ImgNameAndTag]*deployInfoEntry),
-		store:      store,
 	}
 }
 

--- a/internal/engine/deploy_test.go
+++ b/internal/engine/deploy_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/testutils/output"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
@@ -56,7 +55,7 @@ type deployFixture struct {
 func newDeployFixture(t *testing.T) *deployFixture {
 	f := tempdir.NewTempDirFixture(t)
 	kClient := k8s.NewFakeK8sClient()
-	dd := NewDeployDiscovery(kClient, store.NewStoreForTesting())
+	dd := NewDeployDiscovery(kClient)
 	return &deployFixture{
 		TempDirFixture: f,
 		ctx:            output.CtxForTest(),

--- a/internal/engine/local_container_build_and_deployer_test.go
+++ b/internal/engine/local_container_build_and_deployer_test.go
@@ -67,7 +67,7 @@ func newContainerBadFixture() *containerBaDFixture {
 
 	cu := build.NewContainerUpdater(fakeDocker)
 	a := analytics.NewMemoryAnalytics()
-	dd := NewDeployDiscovery(fakeK8s, store.NewStoreForTesting())
+	dd := NewDeployDiscovery(fakeK8s)
 
 	cbad := NewLocalContainerBuildAndDeployer(cu, a, dd)
 

--- a/internal/engine/podlogmanager_test.go
+++ b/internal/engine/podlogmanager_test.go
@@ -149,7 +149,7 @@ func newPLMFixture(t *testing.T) *plmFixture {
 		out.Write(podLog.Log)
 	}
 
-	st := store.NewStore(store.Reducer(reducer))
+	st := store.NewStore(store.Reducer(reducer), store.LogActionsFlag(false))
 	plm := NewPodLogManager(kClient)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1610,7 +1610,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	ctx, cancel := context.WithCancel(testoutput.ForkedCtxForTest(log))
 
 	fSub := fixtureSub{ch: make(chan bool, 1000)}
-	st := store.NewStore(UpperReducer)
+	st := store.NewStore(UpperReducer, store.LogActionsFlag(false))
 	st.AddSubscriber(fSub)
 
 	plm := NewPodLogManager(k8s)

--- a/internal/engine/watchmanager_test.go
+++ b/internal/engine/watchmanager_test.go
@@ -112,7 +112,7 @@ func newWatchManagerFixture(t *testing.T) *watchManagerFixture {
 		}
 		f.pathsSeen = append(f.pathsSeen, fileChange.files...)
 	}
-	st := store.NewStore(store.Reducer(reducer))
+	st := store.NewStore(store.Reducer(reducer), store.LogActionsFlag(false))
 	f.store = st
 
 	timerMaker := makeFakeTimerMaker(t)

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -11,7 +11,6 @@ import (
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/synclet"
 	"github.com/windmilleng/wmclient/pkg/analytics"
 	"github.com/windmilleng/wmclient/pkg/dirs"
@@ -39,7 +38,6 @@ var DeployerBaseWireSet = wire.NewSet(
 	wire.Bind(new(BuildAndDeployer), new(CompositeBuildAndDeployer)),
 	NewCompositeBuildAndDeployer,
 	ProvideUpdateMode,
-	store.NewStore,
 	NewGlobalYAMLBuildController,
 )
 

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -12,7 +12,6 @@ import (
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/synclet"
 	"github.com/windmilleng/wmclient/pkg/analytics"
 	"github.com/windmilleng/wmclient/pkg/dirs"
@@ -21,9 +20,7 @@ import (
 // Injectors from wire.go:
 
 func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode UpdateModeFlag, sCli synclet.SyncletClient, shouldFallBackToImgBuild FallbackTester) (BuildAndDeployer, error) {
-	reducer := _wireReducerValue
-	storeStore := store.NewStore(reducer)
-	deployDiscovery := NewDeployDiscovery(k8s2, storeStore)
+	deployDiscovery := NewDeployDiscovery(k8s2)
 	syncletManager := NewSyncletManagerForTests(k8s2, sCli)
 	syncletBuildAndDeployer := NewSyncletBuildAndDeployer(deployDiscovery, syncletManager)
 	containerUpdater := build.NewContainerUpdater(docker2)
@@ -45,8 +42,7 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k
 }
 
 var (
-	_wireReducerValue = UpperReducer
-	_wireLabelsValue  = dockerfile.Labels{}
+	_wireLabelsValue = dockerfile.Labels{}
 )
 
 // wire.go:
@@ -55,7 +51,8 @@ var DeployerBaseWireSet = wire.NewSet(build.DefaultConsole, build.DefaultOut, wi
 	NewLocalContainerBuildAndDeployer,
 	DefaultBuildOrder,
 	NewDeployDiscovery, wire.Bind(new(BuildAndDeployer), new(CompositeBuildAndDeployer)), NewCompositeBuildAndDeployer,
-	ProvideUpdateMode, store.NewStore, NewGlobalYAMLBuildController,
+	ProvideUpdateMode,
+	NewGlobalYAMLBuildController,
 )
 
 var DeployerWireSetTest = wire.NewSet(

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -45,7 +45,7 @@ type EngineState struct {
 	UserExited bool
 
 	// The full log stream for tilt. This might deserve gc or file storage at some point.
-	Log []byte
+	Log []byte `testdiff:"ignore"`
 
 	// GlobalYAML is a special manifest that has no images, but has dependencies
 	// and a bunch of YAML that is deployed when those dependencies change.
@@ -73,14 +73,14 @@ type ManifestState struct {
 	CurrentlyBuildingFileChanges []string
 
 	CurrentBuildStartTime     time.Time
-	CurrentBuildLog           *bytes.Buffer
+	CurrentBuildLog           *bytes.Buffer `testdiff:"ignore"`
 	LastManifestLoadError     error
 	LastSuccessfulDeployEdits []string
 	LastBuildError            error
 	LastBuildFinishTime       time.Time
 	LastSuccessfulDeployTime  time.Time
 	LastBuildDuration         time.Duration
-	LastBuildLog              *bytes.Buffer
+	LastBuildLog              *bytes.Buffer `testdiff:"ignore"`
 	QueueEntryTime            time.Time
 
 	// If the pod isn't running this container then it's possible we're running stale code
@@ -132,9 +132,9 @@ type Pod struct {
 	Phase     v1.PodPhase
 
 	// The log for the previously active pod, if any
-	PreRestartLog []byte
+	PreRestartLog []byte `testdiff:"ignore"`
 	// The log for the currently active pod, if any
-	CurrentLog []byte
+	CurrentLog []byte `testdiff:"ignore"`
 
 	// Corresponds to the deployed container.
 	ContainerName  container.Name

--- a/internal/store/subscriber_test.go
+++ b/internal/store/subscriber_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSubscriber(t *testing.T) {
-	st := NewStore(EmptyReducer)
+	st := NewStore(EmptyReducer, LogActionsFlag(false))
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(s)
@@ -18,7 +18,7 @@ func TestSubscriber(t *testing.T) {
 }
 
 func TestSubscriberInterleavedCalls(t *testing.T) {
-	st := NewStore(EmptyReducer)
+	st := NewStore(EmptyReducer, LogActionsFlag(false))
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(s)

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/.coveralls.yml
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: LWIe7rP7M3hBnAxpsMaZhrVBs2DSyhzoQ

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/.gitignore
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/.travis.yml
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/.travis.yml
@@ -1,0 +1,26 @@
+language: go
+
+os:
+  - linux
+
+go:
+  - 1
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7.x
+  - 1.8.x
+  - tip
+
+before_install:
+  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/modocache/gover
+  - go get github.com/mattn/goveralls
+
+script:
+  - go test -v -coverprofile=example.coverprofile ./example
+  - go test -v -coverprofile=main.coverprofile
+  - $HOME/gopath/bin/gover
+  - $HOME/gopath/bin/goveralls -service=travis-ci -coverprofile=gover.coverprofile

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/CHANGELOG.md
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/CHANGELOG.md
@@ -1,0 +1,14 @@
+## nightly
+* Added support for ignoring fields.
+
+## v1.1.0
+
+* Added support for recursive data structures.
+* Fixed bug with embedded fixed length arrays in structs.
+* Added `example/` directory.
+* Minor test bug fixes for future go versions.
+* Added change log.
+
+## v1.0.0
+
+Initial tagged release release.

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/LICENSE
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Tristan Rice
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/README.md
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/README.md
@@ -1,0 +1,90 @@
+# messagediff [![Build Status](https://travis-ci.org/d4l3k/messagediff.svg?branch=master)](https://travis-ci.org/d4l3k/messagediff) [![Coverage Status](https://coveralls.io/repos/github/d4l3k/messagediff/badge.svg?branch=master)](https://coveralls.io/github/d4l3k/messagediff?branch=master) [![GoDoc](https://godoc.org/github.com/d4l3k/messagediff?status.svg)](https://godoc.org/github.com/d4l3k/messagediff)
+
+A library for doing diffs of arbitrary Golang structs.
+
+If the unsafe package is available messagediff will diff unexported fields in
+addition to exported fields. This is primarily used for testing purposes as it
+allows for providing informative error messages.
+
+Optionally, fields in structs can be tagged as `testdiff:"ignore"` to make
+messagediff skip it when doing the comparison.
+
+
+## Example Usage
+In a normal file:
+```go
+package main
+
+import "gopkg.in/d4l3k/messagediff.v1"
+
+type someStruct struct {
+    A, b int
+    C []int
+}
+
+func main() {
+    a := someStruct{1, 2, []int{1}}
+    b := someStruct{1, 3, []int{1, 2}}
+    diff, equal := messagediff.PrettyDiff(a, b)
+    /*
+        diff =
+        `added: .C[1] = 2
+        modified: .b = 3`
+
+        equal = false
+    */
+}
+
+```
+In a test:
+```go
+import "gopkg.in/d4l3k/messagediff.v1"
+
+...
+
+type someStruct struct {
+    A, b int
+    C []int
+}
+
+func TestSomething(t *testing.T) {
+    want := someStruct{1, 2, []int{1}}
+    got := someStruct{1, 3, []int{1, 2}}
+    if diff, equal := messagediff.PrettyDiff(want, got); !equal {
+        t.Errorf("Something() = %#v\n%s", got, diff)
+    }
+}
+```
+To ignore a field in a struct, just annotate it with testdiff:"ignore" like
+this:
+```go
+package main
+
+import "gopkg.in/d4l3k/messagediff.v1"
+
+type someStruct struct {
+    A int
+    B int `testdiff:"ignore"`
+}
+
+func main() {
+    a := someStruct{1, 2}
+    b := someStruct{1, 3}
+    diff, equal := messagediff.PrettyDiff(a, b)
+    /*
+        equal = true
+        diff = ""
+    */
+}
+```
+
+See the `DeepDiff` function for using the diff results programmatically.
+
+## License
+Copyright (c) 2015 [Tristan Rice](https://fn.lc) <rice@fn.lc>
+
+messagediff is licensed under the MIT license. See the LICENSE file for more information.
+
+bypass.go and bypasssafe.go are borrowed from
+[go-spew](https://github.com/davecgh/go-spew) and have a seperate copyright
+notice.

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/bypass.go
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/bypass.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2015 Dave Collins <dave@davec.name>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// NOTE: Due to the following build constraints, this file will only be compiled
+// when the code is not running on Google App Engine and "-tags disableunsafe"
+// is not added to the go build command line.
+// +build !appengine,!disableunsafe
+
+package messagediff
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const (
+	// UnsafeDisabled is a build-time constant which specifies whether or
+	// not access to the unsafe package is available.
+	UnsafeDisabled = false
+
+	// ptrSize is the size of a pointer on the current arch.
+	ptrSize = unsafe.Sizeof((*byte)(nil))
+)
+
+var (
+	// offsetPtr, offsetScalar, and offsetFlag are the offsets for the
+	// internal reflect.Value fields.  These values are valid before golang
+	// commit ecccf07e7f9d which changed the format.  The are also valid
+	// after commit 82f48826c6c7 which changed the format again to mirror
+	// the original format.  Code in the init function updates these offsets
+	// as necessary.
+	offsetPtr    = uintptr(ptrSize)
+	offsetScalar = uintptr(0)
+	offsetFlag   = uintptr(ptrSize * 2)
+
+	// flagKindWidth and flagKindShift indicate various bits that the
+	// reflect package uses internally to track kind information.
+	//
+	// flagRO indicates whether or not the value field of a reflect.Value is
+	// read-only.
+	//
+	// flagIndir indicates whether the value field of a reflect.Value is
+	// the actual data or a pointer to the data.
+	//
+	// These values are valid before golang commit 90a7c3c86944 which
+	// changed their positions.  Code in the init function updates these
+	// flags as necessary.
+	flagKindWidth = uintptr(5)
+	flagKindShift = uintptr(flagKindWidth - 1)
+	flagRO        = uintptr(1 << 0)
+	flagIndir     = uintptr(1 << 1)
+)
+
+func init() {
+	// Older versions of reflect.Value stored small integers directly in the
+	// ptr field (which is named val in the older versions).  Versions
+	// between commits ecccf07e7f9d and 82f48826c6c7 added a new field named
+	// scalar for this purpose which unfortunately came before the flag
+	// field, so the offset of the flag field is different for those
+	// versions.
+	//
+	// This code constructs a new reflect.Value from a known small integer
+	// and checks if the size of the reflect.Value struct indicates it has
+	// the scalar field. When it does, the offsets are updated accordingly.
+	vv := reflect.ValueOf(0xf00)
+	if unsafe.Sizeof(vv) == (ptrSize * 4) {
+		offsetScalar = ptrSize * 2
+		offsetFlag = ptrSize * 3
+	}
+
+	// Commit 90a7c3c86944 changed the flag positions such that the low
+	// order bits are the kind.  This code extracts the kind from the flags
+	// field and ensures it's the correct type.  When it's not, the flag
+	// order has been changed to the newer format, so the flags are updated
+	// accordingly.
+	upf := unsafe.Pointer(uintptr(unsafe.Pointer(&vv)) + offsetFlag)
+	upfv := *(*uintptr)(upf)
+	flagKindMask := uintptr((1<<flagKindWidth - 1) << flagKindShift)
+	if (upfv&flagKindMask)>>flagKindShift != uintptr(reflect.Int) {
+		flagKindShift = 0
+		flagRO = 1 << 5
+		flagIndir = 1 << 6
+
+		// Commit adf9b30e5594 modified the flags to separate the
+		// flagRO flag into two bits which specifies whether or not the
+		// field is embedded.  This causes flagIndir to move over a bit
+		// and means that flagRO is the combination of either of the
+		// original flagRO bit and the new bit.
+		//
+		// This code detects the change by extracting what used to be
+		// the indirect bit to ensure it's set.  When it's not, the flag
+		// order has been changed to the newer format, so the flags are
+		// updated accordingly.
+		if upfv&flagIndir == 0 {
+			flagRO = 3 << 5
+			flagIndir = 1 << 7
+		}
+	}
+}
+
+// unsafeReflectValue converts the passed reflect.Value into a one that bypasses
+// the typical safety restrictions preventing access to unaddressable and
+// unexported data.  It works by digging the raw pointer to the underlying
+// value out of the protected value and generating a new unprotected (unsafe)
+// reflect.Value to it.
+//
+// This allows us to check for implementations of the Stringer and error
+// interfaces to be used for pretty printing ordinarily unaddressable and
+// inaccessible values such as unexported struct fields.
+func unsafeReflectValue(v reflect.Value) (rv reflect.Value) {
+	indirects := 1
+	vt := v.Type()
+	upv := unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetPtr)
+	rvf := *(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetFlag))
+	if rvf&flagIndir != 0 {
+		vt = reflect.PtrTo(v.Type())
+		indirects++
+	} else if offsetScalar != 0 {
+		// The value is in the scalar field when it's not one of the
+		// reference types.
+		switch vt.Kind() {
+		case reflect.Uintptr:
+		case reflect.Chan:
+		case reflect.Func:
+		case reflect.Map:
+		case reflect.Ptr:
+		case reflect.UnsafePointer:
+		default:
+			upv = unsafe.Pointer(uintptr(unsafe.Pointer(&v)) +
+				offsetScalar)
+		}
+	}
+
+	pv := reflect.NewAt(vt, upv)
+	rv = pv
+	for i := 0; i < indirects; i++ {
+		rv = rv.Elem()
+	}
+	return rv
+}

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/bypasssafe.go
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/bypasssafe.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015 Dave Collins <dave@davec.name>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// NOTE: Due to the following build constraints, this file will only be compiled
+// when either the code is running on Google App Engine or "-tags disableunsafe"
+// is added to the go build command line.
+// +build appengine disableunsafe
+
+package messagediff
+
+import "reflect"
+
+const (
+	// UnsafeDisabled is a build-time constant which specifies whether or
+	// not access to the unsafe package is available.
+	UnsafeDisabled = true
+)
+
+// unsafeReflectValue typically converts the passed reflect.Value into a one
+// that bypasses the typical safety restrictions preventing access to
+// unaddressable and unexported data.  However, doing this relies on access to
+// the unsafe package.  This is a stub version which simply returns the passed
+// reflect.Value when the unsafe package is not available.
+func unsafeReflectValue(v reflect.Value) reflect.Value {
+	return v
+}

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/messagediff.go
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/messagediff.go
@@ -1,0 +1,242 @@
+package messagediff
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"unsafe"
+)
+
+// PrettyDiff does a deep comparison and returns the nicely formated results.
+func PrettyDiff(a, b interface{}) (string, bool) {
+	d, equal := DeepDiff(a, b)
+	var dstr []string
+	for path, added := range d.Added {
+		dstr = append(dstr, fmt.Sprintf("added: %s = %#v\n", path.String(), added))
+	}
+	for path, removed := range d.Removed {
+		dstr = append(dstr, fmt.Sprintf("removed: %s = %#v\n", path.String(), removed))
+	}
+	for path, modified := range d.Modified {
+		dstr = append(dstr, fmt.Sprintf("modified: %s = %#v\n", path.String(), modified))
+	}
+	sort.Strings(dstr)
+	return strings.Join(dstr, ""), equal
+}
+
+// DeepDiff does a deep comparison and returns the results.
+func DeepDiff(a, b interface{}) (*Diff, bool) {
+	d := newDiff()
+	return d, d.diff(reflect.ValueOf(a), reflect.ValueOf(b), nil)
+}
+
+func newDiff() *Diff {
+	return &Diff{
+		Added:    make(map[*Path]interface{}),
+		Removed:  make(map[*Path]interface{}),
+		Modified: make(map[*Path]interface{}),
+		visited:  make(map[visit]bool),
+	}
+}
+
+func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
+	// The array underlying `path` could be modified in subsequent
+	// calls. Make sure we have a local copy.
+	localPath := make(Path, len(path))
+	copy(localPath, path)
+
+	// Validity checks. Should only trigger if nil is one of the original arguments.
+	if !aVal.IsValid() && !bVal.IsValid() {
+		return true
+	}
+	if !bVal.IsValid() {
+		d.Modified[&localPath] = nil
+		return false
+	} else if !aVal.IsValid() {
+		d.Modified[&localPath] = bVal.Interface()
+		return false
+	}
+
+	if aVal.Type() != bVal.Type() {
+		d.Modified[&localPath] = bVal.Interface()
+		return false
+	}
+	kind := aVal.Kind()
+
+	// Borrowed from the reflect package to handle recursive data structures.
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if aVal.CanAddr() && bVal.CanAddr() && hard(kind) {
+		addr1 := unsafe.Pointer(aVal.UnsafeAddr())
+		addr2 := unsafe.Pointer(bVal.UnsafeAddr())
+		if uintptr(addr1) > uintptr(addr2) {
+			// Canonicalize order to reduce number of entries in visited.
+			// Assumes non-moving garbage collector.
+			addr1, addr2 = addr2, addr1
+		}
+
+		// Short circuit if references are already seen.
+		typ := aVal.Type()
+		v := visit{addr1, addr2, typ}
+		if d.visited[v] {
+			return true
+		}
+
+		// Remember for later.
+		d.visited[v] = true
+	}
+	// End of borrowed code.
+
+	equal := true
+	switch kind {
+	case reflect.Map, reflect.Ptr, reflect.Func, reflect.Chan, reflect.Slice:
+		if aVal.IsNil() && bVal.IsNil() {
+			return true
+		}
+		if aVal.IsNil() || bVal.IsNil() {
+			d.Modified[&localPath] = bVal.Interface()
+			return false
+		}
+	}
+
+	switch kind {
+	case reflect.Array, reflect.Slice:
+		aLen := aVal.Len()
+		bLen := bVal.Len()
+		for i := 0; i < min(aLen, bLen); i++ {
+			localPath := append(localPath, SliceIndex(i))
+			if eq := d.diff(aVal.Index(i), bVal.Index(i), localPath); !eq {
+				equal = false
+			}
+		}
+		if aLen > bLen {
+			for i := bLen; i < aLen; i++ {
+				localPath := append(localPath, SliceIndex(i))
+				d.Removed[&localPath] = aVal.Index(i).Interface()
+				equal = false
+			}
+		} else if aLen < bLen {
+			for i := aLen; i < bLen; i++ {
+				localPath := append(localPath, SliceIndex(i))
+				d.Added[&localPath] = bVal.Index(i).Interface()
+				equal = false
+			}
+		}
+	case reflect.Map:
+		for _, key := range aVal.MapKeys() {
+			aI := aVal.MapIndex(key)
+			bI := bVal.MapIndex(key)
+			localPath := append(localPath, MapKey{key.Interface()})
+			if !bI.IsValid() {
+				d.Removed[&localPath] = aI.Interface()
+				equal = false
+			} else if eq := d.diff(aI, bI, localPath); !eq {
+				equal = false
+			}
+		}
+		for _, key := range bVal.MapKeys() {
+			aI := aVal.MapIndex(key)
+			if !aI.IsValid() {
+				bI := bVal.MapIndex(key)
+				localPath := append(localPath, MapKey{key.Interface()})
+				d.Added[&localPath] = bI.Interface()
+				equal = false
+			}
+		}
+	case reflect.Struct:
+		typ := aVal.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			index := []int{i}
+			field := typ.FieldByIndex(index)
+			if field.Tag.Get("testdiff") == "ignore" { // skip fields marked to be ignored
+				continue
+			}
+			localPath := append(localPath, StructField(field.Name))
+			aI := unsafeReflectValue(aVal.FieldByIndex(index))
+			bI := unsafeReflectValue(bVal.FieldByIndex(index))
+			if eq := d.diff(aI, bI, localPath); !eq {
+				equal = false
+			}
+		}
+	case reflect.Ptr:
+		equal = d.diff(aVal.Elem(), bVal.Elem(), localPath)
+	default:
+		if reflect.DeepEqual(aVal.Interface(), bVal.Interface()) {
+			equal = true
+		} else {
+			d.Modified[&localPath] = bVal.Interface()
+			equal = false
+		}
+	}
+	return equal
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// During deepValueEqual, must keep track of checks that are
+// in progress.  The comparison algorithm assumes that all
+// checks in progress are true when it reencounters them.
+// Visited comparisons are stored in a map indexed by visit.
+// This is borrowed from the reflect package.
+type visit struct {
+	a1  unsafe.Pointer
+	a2  unsafe.Pointer
+	typ reflect.Type
+}
+
+// Diff represents a change in a struct.
+type Diff struct {
+	Added, Removed, Modified map[*Path]interface{}
+	visited                  map[visit]bool
+}
+
+// Path represents a path to a changed datum.
+type Path []PathNode
+
+func (p Path) String() string {
+	var out string
+	for _, n := range p {
+		out += n.String()
+	}
+	return out
+}
+
+// PathNode represents one step in the path.
+type PathNode interface {
+	String() string
+}
+
+// StructField is a path element representing a field of a struct.
+type StructField string
+
+func (n StructField) String() string {
+	return fmt.Sprintf(".%s", string(n))
+}
+
+// MapKey is a path element representing a key of a map.
+type MapKey struct {
+	Key interface{}
+}
+
+func (n MapKey) String() string {
+	return fmt.Sprintf("[%#v]", n.Key)
+}
+
+// SliceIndex is a path element representing a index of a slice.
+type SliceIndex int
+
+func (n SliceIndex) String() string {
+	return fmt.Sprintf("[%d]", n)
+}


### PR DESCRIPTION
Add `--logactions` flag that causes every action and state change to be logged. Dan and I found this useful when debugging this afternoon.

e.g.:
```
action engine.BuildCompleteAction:
(engine.BuildCompleteAction) {
 Result: (store.BuildResult) {
  Image: (reference.taggedReference) gcr.io/windmill-public-containers/servantes/vigoda:tilt-e850a6711ff65719,
  ContainerID: (container.ID) ,
  Namespace: (k8s.Namespace) (len=7) default,
  Entities: ([]k8s.K8sEntity) (len=2 cap=2) {
   (k8s.K8sEntity) {
    Obj: (*v1.Deployment)(0xc000354000)(&Deployment{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:matt-vigoda,GenerateName:,Namespace:,SelfLink:,UID:,ResourceVersion:,Generation:0,CreationTimestamp:0001-01-01 00:00:00 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{app: vigoda,owner: matt,tilt-manifest: vigoda,tilt-runid: e0f3e508-4fd5-450b-b9d7-c6f17e029290,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:DeploymentSpec{Replicas:nil,Selector:&k8s_io_apimachinery_pkg_apis_meta_v1.LabelSelector{MatchLabels:map[string]string{app: vigoda,owner: matt,},MatchExpressions:[],},Template:k8s_io_api_core_v1.PodTemplateSpec{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:,GenerateName:,Namespace:,SelfLink:,UID:,ResourceVersion:,Generation:0,CreationTimestamp:0001-01-01 00:00:00 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{app: vigoda,owner: matt,tier: web,tilt-manifest: vigoda,tilt-runid: e0f3e508-4fd5-450b-b9d7-c6f17e029290,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{tilt-dockersock {HostPathVolumeSource{Path:/var/run/docker.sock,Type:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{vigoda gcr.io/windmill-public-containers/servantes/vigoda:tilt-e850a6711ff65719 [/go/bin/vigoda] []  [{ 0 8081  }] [] [{TEMPLATE_DIR /go/src/github.com/windmilleng/servantes/vigoda/web/templates nil}] {map[] map[cpu:{{20 -3} {<nil>} 20m DecimalSI}]} [] [] nil nil nil   IfNotPresent nil false false false} {tilt-synclet gcr.io/windmill-public-containers/tilt-synclet:v20181105 [] []  [] [] [] {map[] map[cpu:{{0 0} {<nil>}  BinarySI}]} [{tilt-dockersock false /var/run/docker.sock  <nil>}] [] nil nil nil   IfNotPresent SecurityContext{Capabilities:nil,Privileged:*true,SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:nil,RunAsGroup:nil,} false false false}],RestartPolicy:,TerminationGracePeriodSeconds:nil,ActiveDeadlineSeconds:nil,DNSPolicy:,NodeSelector:map[string]string{},ServiceAccountName:,DeprecatedServiceAccount:,NodeName:,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:nil,ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[],RuntimeClassName:nil,},},Strategy:DeploymentStrategy{Type:,RollingUpdate:nil,},MinReadySeconds:0,RevisionHistoryLimit:nil,Paused:false,ProgressDeadlineSeconds:nil,},Status:DeploymentStatus{ObservedGeneration:0,Replicas:0,UpdatedReplicas:0,AvailableReplicas:0,UnavailableReplicas:0,Conditions:[],ReadyReplicas:0,CollisionCount:nil,},}),
    Kind: (*schema.GroupVersionKind)(0xc000535140)(apps/v1, Kind=Deployment)
   },
   (k8s.K8sEntity) {
    Obj: (*v1.Service)(0xc0003512c0)(&Service{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:matt-vigoda,GenerateName:,Namespace:,SelfLink:,UID:,ResourceVersion:,Generation:0,CreationTimestamp:0001-01-01 00:00:00 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{app: vigoda,owner: matt,tilt-manifest: vigoda,tilt-runid: e0f3e508-4fd5-450b-b9d7-c6f17e029290,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:ServiceSpec{Ports:[{ TCP 80 {0 8081 } 0}],Selector:map[string]string{app: vigoda,owner: matt,},ClusterIP:,Type:,ExternalIPs:[],SessionAffinity:,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalName:,ExternalTrafficPolicy:,HealthCheckNodePort:0,PublishNotReadyAddresses:false,SessionAffinityConfig:nil,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingress:[],},},}),
    Kind: (*schema.GroupVersionKind)(0xc000535530)(/v1, Kind=Service)
   }
  },
  FilesReplacedSet: (map[string]bool) <nil>
 },
 Error: (error) <nil>
}

caused state change:
modified: .BuildControllerActionCount = 1
modified: .CompletedBuildCount = 1
modified: .CurrentlyBuilding = ""
```

This currently doesn't capture `ManifestState` changes, but that can come later.