### PR TITLE
tiltfile/engine: enforce correct parsing of global yaml when loading manifests [ch776]

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -42,7 +42,7 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 		manifestNames[i] = model.ManifestName(a)
 	}
 
-	manifests, gYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
+	manifests, gYAML, err := tf.GetAllManifests(ctx, manifestNames)
 	if err != nil {
 		return err
 	}

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -175,7 +175,7 @@ func (s Script) Run(ctx context.Context) error {
 			return err
 		}
 
-		manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(ctx, "tiltdemo")
+		manifests, _, err := tf.GetAllManifests(ctx, []model.ManifestName{"tiltdemo"})
 		if err != nil {
 			return err
 		}

--- a/internal/engine/tiltfile_watcher.go
+++ b/internal/engine/tiltfile_watcher.go
@@ -76,7 +76,7 @@ func (t *TiltfileWatcher) watchLoop(ctx context.Context, st store.RStore, initMa
 				return
 			}
 
-			manifests, globalYAML, err := getNewManifestsFromTiltfile(ctx, initManifests)
+			manifests, globalYAML, err := getAllManifestsFromTiltfile(ctx, initManifests)
 			st.Dispatch(TiltfileReloadedAction{
 				Manifests:  manifests,
 				GlobalYAML: globalYAML,

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -108,7 +108,7 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 		manifestNames[i] = model.ManifestName(a)
 	}
 
-	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
+	manifests, globalYAML, err := tf.GetAllManifests(ctx, manifestNames)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -471,10 +471,10 @@ func TestMultipleChangesOnlyDeployOneManifest(t *testing.T) {
   image = stop_build()
   return k8s_service(image, yaml="yaaaaaaaaml")
 
-  def bazqux():
-    start_fast_build("Dockerfile2", "docker-tag2")
-    image = stop_build()
-    return k8s_service(image, yaml="yaaaaaaaaml")
+def bazqux():
+  start_fast_build("Dockerfile2", "docker-tag2")
+  image = stop_build()
+  return k8s_service(image, yaml="yaaaaaaaaml")
 `)
 	f.WriteFile("Dockerfile1", `FROM iron/go:dev1`)
 	f.WriteFile("Dockerfile2", `FROM iron/go:dev2`)
@@ -536,7 +536,7 @@ func TestNoOpChangeToDockerfile(t *testing.T) {
   return k8s_service(image, yaml="yaaaaaaaaml")`)
 	f.WriteFile("Dockerfile", `FROM iron/go:dev1`)
 
-	manifest := f.loadManifest("foobar")
+	manifest := f.loadTheOnlyManifest("foobar")
 	f.Start([]model.Manifest{manifest}, true)
 
 	// First call: with the old manifests
@@ -641,7 +641,7 @@ func TestBreakManifest(t *testing.T) {
 	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
 
 	name := "foobar"
-	manifest := f.loadManifest(name)
+	manifest := f.loadTheOnlyManifest(name)
 	f.Start([]model.Manifest{manifest}, true)
 
 	// First call: all is well
@@ -685,7 +685,7 @@ func TestBreakAndUnbreakManifestWithNoChange(t *testing.T) {
 	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
 
 	name := "foobar"
-	manifest := f.loadManifest(name)
+	manifest := f.loadTheOnlyManifest(name)
 	f.Start([]model.Manifest{manifest}, true)
 
 	// First call: all is well
@@ -733,7 +733,7 @@ func TestBreakAndUnbreakManifestWithChange(t *testing.T) {
 	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
 
 	name := "foobar"
-	manifest := f.loadManifest(name)
+	manifest := f.loadTheOnlyManifest(name)
 	f.Start([]model.Manifest{manifest}, true)
 
 	f.WaitUntil("first build finished", func(state store.EngineState) bool {
@@ -788,7 +788,7 @@ func TestFilterOutNonMountedConfigFiles(t *testing.T) {
 	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
 	f.MkdirAll("nested/.git") // Spoof a git directory -- this is what we'll mount.
 
-	manifest := f.loadManifest("foobar")
+	manifest := f.loadTheOnlyManifest("foobar")
 	f.Start([]model.Manifest{manifest}, true)
 
 	// First call: with the old manifests (should be image build)
@@ -1889,12 +1889,16 @@ func (f *testFixture) assertAllBuildsConsumed() {
 	}
 }
 
-func (f *testFixture) loadManifest(name string) model.Manifest {
+// NOTE: use this if the Tiltfile defines only a single manifest. If you want to load a manifest
+// from a Tiltfile that defines more than one manifest and/or your test relies on accurate
+// GlobalYAML, write a new test util that takes an allManifestNames arg.
+func (f *testFixture) loadTheOnlyManifest(name string) model.Manifest {
 	tf, err := tiltfile.Load(f.ctx, f.JoinPath("Tiltfile"))
 	if err != nil {
 		f.T().Fatal(err)
 	}
-	manifests, _, err := tf.GetManifestConfigsAndGlobalYAML(f.ctx, "foobar")
+
+	manifests, _, err := tf.GetAllManifests(f.ctx, []model.ManifestName{model.ManifestName(name)})
 	if err != nil {
 		f.T().Fatal(err)
 	}


### PR DESCRIPTION
Tests coming soon but wanted to push the bulk of this up before I headed out.