### PR TITLE
testyaml: add tests for twin yamls (k8s resources with the same image)

### DIFF
--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -2,37 +2,13 @@ package engine
 
 import (
 	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
-const SanchoYAML = `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sancho
-  namespace: sancho-ns
-  labels:
-    app: sancho
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: sancho
-  template:
-    metadata:
-      labels:
-        app: sancho
-    spec:
-      containers:
-      - name: sancho
-        image: gcr.io/some-project-162817/sancho
-        env:
-          - name: token
-            valueFrom:
-              secretKeyRef:
-                name: slacktoken
-                key: token
-`
+const SanchoYAML = testyaml.SanchoYAML
+
+const SanchoTwinYAML = testyaml.SanchoTwinYAML
 
 const SanchoBaseDockerfile = `
 FROM go:1.10

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -73,6 +73,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sancho
+  namespace: sancho-ns
   labels:
     app: sancho
 spec:
@@ -84,6 +85,35 @@ spec:
     metadata:
       labels:
         app: sancho
+    spec:
+      containers:
+      - name: sancho
+        image: gcr.io/some-project-162817/sancho
+        env:
+          - name: token
+            valueFrom:
+              secretKeyRef:
+                name: slacktoken
+                key: token
+`
+
+const SanchoTwinYAML = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sancho-twin
+  namespace: sancho-ns
+  labels:
+    app: sancho-twin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sancho-twin
+  template:
+    metadata:
+      labels:
+        app: sancho-twin
     spec:
       containers:
       - name: sancho


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/doubleimages:

7b4baf218ab3b243c3fcce5b6b1cb7f3cad764e5 (2018-11-09 19:30:22 -0500)
testyaml: add tests for twin yamls (k8s resources with the same image)