### PR TITLE
tiltfile: store all manifest names on tiltfile [ch776]

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -32,15 +32,12 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 	})
 	defer analyticsService.Flush(time.Second)
 
-	tf, err := tiltfile.Load(ctx, tiltfile.FileName)
+	tf, err := tiltfile.Load(ctx, args, tiltfile.FileName)
 	if err != nil {
 		return err
 	}
 
-	manifestNames := make([]model.ManifestName, len(args))
-	for i, a := range args {
-		manifestNames[i] = model.ManifestName(a)
-	}
+	manifestNames := model.StringsToMNames(args)
 
 	manifests, gYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
 	if err != nil {

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -170,7 +170,7 @@ func (s Script) Run(ctx context.Context) error {
 		}
 
 		tfPath := filepath.Join(dir, tiltfile.FileName)
-		tf, err := tiltfile.Load(ctx, tfPath)
+		tf, err := tiltfile.Load(ctx, []string{"tiltdemo"}, tfPath)
 		if err != nil {
 			return err
 		}

--- a/internal/engine/tiltfile_watcher.go
+++ b/internal/engine/tiltfile_watcher.go
@@ -76,7 +76,7 @@ func (t *TiltfileWatcher) watchLoop(ctx context.Context, st store.RStore, initMa
 				return
 			}
 
-			manifests, globalYAML, err := getNewManifestsFromTiltfile(ctx, initManifests)
+			manifests, globalYAML, err := getNewManifestsFromTiltfile(ctx, model.MNamesToStrings(initManifests))
 			st.Dispatch(TiltfileReloadedAction{
 				Manifests:  manifests,
 				GlobalYAML: globalYAML,

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -92,7 +92,7 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Start")
 	defer span.Finish()
 
-	tf, err := tiltfile.Load(ctx, tiltfile.FileName)
+	tf, err := tiltfile.Load(ctx, args, tiltfile.FileName)
 	if err != nil {
 		return err
 	}
@@ -102,11 +102,7 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 		return err
 	}
 
-	manifestNames := make([]model.ManifestName, len(args))
-
-	for i, a := range args {
-		manifestNames[i] = model.ManifestName(a)
-	}
+	manifestNames := model.StringsToMNames(args)
 
 	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
 	if err != nil {

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -16,6 +16,22 @@ type ManifestName string
 
 func (m ManifestName) String() string { return string(m) }
 
+func StringsToMNames(strNames []string) []ManifestName {
+	result := make([]ManifestName, len(strNames))
+	for i, s := range strNames {
+		result[i] = ManifestName(s)
+	}
+	return result
+}
+
+func MNamesToStrings(mNames []ManifestName) []string {
+	result := make([]string, len(mNames))
+	for i, m := range mNames {
+		result[i] = m.String()
+	}
+	return result
+}
+
 // NOTE: If you modify Manifest, make sure to modify `Manifest.Equal` appropriately
 type Manifest struct {
 	// Properties for all builds.

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -31,6 +31,10 @@ type Tiltfile struct {
 	globals skylark.StringDict
 	thread  *skylark.Thread
 
+	// All manifests defined in this Tiltfile. Regardless of what manifest the user asks
+	// for, we need to be able to parse all manifests to correctly generate Global YAML
+	allManifestNames []string
+
 	// The filename we're executing. Must be absolute.
 	filename string
 }
@@ -403,7 +407,7 @@ func (t *Tiltfile) globalYaml(thread *skylark.Thread, fn *skylark.Builtin, args 
 	return skylark.None, nil
 }
 
-func Load(ctx context.Context, filename string) (*Tiltfile, error) {
+func Load(ctx context.Context, allManifestNames []string, filename string) (*Tiltfile, error) {
 	thread := &skylark.Thread{
 		Print: func(_ *skylark.Thread, msg string) {
 			logger.Get(ctx).Infof("%s", msg)
@@ -416,8 +420,9 @@ func Load(ctx context.Context, filename string) (*Tiltfile, error) {
 	}
 
 	tiltfile := &Tiltfile{
-		filename: filename,
-		thread:   thread,
+		thread:           thread,
+		allManifestNames: allManifestNames,
+		filename:         filename,
 	}
 
 	predeclared := skylark.StringDict{


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/tiltfile-knows-all-manifests:

168497bcd16635bc97b9cc7a752f267b56f8a76f (2018-11-12 18:02:13 -0500)
tiltfile: store all manifest names on tiltfile

480f7e3745a97bced0f34b8ef64d25dcba8edd34 (2018-11-12 14:20:56 -0500)
wip

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics