### PR TITLE
tilt: disable glog to avoid problems where TTY is garbage

### DIFF
--- a/cmd/tilt/main.go
+++ b/cmd/tilt/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"flag"
+	"log"
+
 	"github.com/windmilleng/tilt/internal/cli"
 )
 
@@ -10,9 +13,27 @@ var commit string
 var date string
 
 func main() {
+	disableGlog()
+
 	cli.SetBuildInfo(cli.BuildInfo{
 		Version: version,
 		Date:    date,
 	})
 	cli.Execute()
+}
+
+// HACK(nick): The Kubernetes libs we use sometimes use glog to log things to
+// os.Stderr. There are no API hooks to configure this. And printing to Stderr
+// scrambles the HUD tty.
+//
+// Fortunately, glog does initialize itself from flags, so we can backdoor
+// configure it by setting our own flags. Don't do this at home! This works
+// OK because we use Cobra for flags.
+func disableGlog() {
+	err := flag.CommandLine.Parse([]string{
+		"--stderrthreshold", "FATAL",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/glog:

6b1e0582d3ca46279f035a1bbdf3249af90abf98 (2018-11-16 17:29:12 -0500)
tilt: disable glog to avoid problems where TTY is garbage