### PR TITLE
testutils: fix a bug in tempdir fixture that made it impossible to use in table-based tests

### DIFF
--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/windmilleng/wmclient/pkg/os/temp"
@@ -15,7 +16,9 @@ type TempDirFixture struct {
 }
 
 func NewTempDirFixture(t testing.TB) *TempDirFixture {
-	dir, err := temp.NewDir(t.Name())
+	name := t.Name()
+	name = strings.Replace(name, "/", "-", -1)
+	dir, err := temp.NewDir(name)
 	if err != nil {
 		t.Fatalf("Error making temp dir: %v", err)
 	}

--- a/internal/testutils/tempdir/temp_dir_fixture_test.go
+++ b/internal/testutils/tempdir/temp_dir_fixture_test.go
@@ -1,0 +1,17 @@
+package tempdir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNestedDirs(t *testing.T) {
+	t.Run("inner", func(t *testing.T) {
+		f := NewTempDirFixture(t)
+		defer f.TearDown()
+
+		assert.Contains(t, f.Path(), "inner")
+		assert.Contains(t, f.Path(), "NestedDirs")
+	})
+}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/tempdir:

cf980912833393786e48ffa4d6c2c34383c5f25c (2018-11-20 11:04:45 -0500)
testutils: fix a bug in tempdir fixture that made it impossible to use in table-based tests