### PR TITLE
k8s: fix betav1 and betav2 deployments before injecting labels

### DIFF
--- a/internal/k8s/label.go
+++ b/internal/k8s/label.go
@@ -1,7 +1,10 @@
 package k8s
 
 import (
+	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -24,6 +27,14 @@ func makeLabelSelector(lps []LabelPair) string {
 
 func InjectLabels(entity K8sEntity, labels []LabelPair) (K8sEntity, error) {
 	entity = entity.DeepCopy()
+
+	switch obj := entity.Obj.(type) {
+	case *v1beta1.Deployment:
+		allowLabelChangesInDeploymentBeta1(obj)
+	case *v1beta2.Deployment:
+		allowLabelChangesInDeploymentBeta2(obj)
+	}
+
 	metas, err := extractObjectMetas(&entity)
 	if err != nil {
 		return K8sEntity{}, err
@@ -38,6 +49,54 @@ func InjectLabels(entity K8sEntity, labels []LabelPair) (K8sEntity, error) {
 		}
 	}
 	return entity, nil
+}
+
+// In the v1beta1 API, if a Deployment didn't have a selector,
+// Kubernetes would automatically infer a selector based on the labels
+// in the pod.
+//
+// The problem is that Selectors are immutable. So this had the unintended
+// side-effect of making pod labels immutable. Since many tools attach
+// arbitrary labels to pods, v1beta1 Deployments broke lots of tools.
+//
+// The v1 Deployment fixed this problem by making Selector mandatory.
+// But for old versions of Deployment, we need to auto-infer the selector
+// before we add labels to the pod.
+func allowLabelChangesInDeploymentBeta1(dep *v1beta1.Deployment) {
+	selector := dep.Spec.Selector
+	if selector != nil &&
+		(len(selector.MatchLabels) > 0 || len(selector.MatchExpressions) > 0) {
+		return
+	}
+
+	podSpecLabels := dep.Spec.Template.Labels
+	matchLabels := make(map[string]string, len(podSpecLabels))
+	for k, v := range podSpecLabels {
+		matchLabels[k] = v
+	}
+	if dep.Spec.Selector == nil {
+		dep.Spec.Selector = &metav1.LabelSelector{}
+	}
+	dep.Spec.Selector.MatchLabels = matchLabels
+}
+
+// see notes on allowLabelChangesInDeploymentBeta1
+func allowLabelChangesInDeploymentBeta2(dep *v1beta2.Deployment) {
+	selector := dep.Spec.Selector
+	if selector != nil &&
+		(len(selector.MatchLabels) > 0 || len(selector.MatchExpressions) > 0) {
+		return
+	}
+
+	podSpecLabels := dep.Spec.Template.Labels
+	matchLabels := make(map[string]string, len(podSpecLabels))
+	for k, v := range podSpecLabels {
+		matchLabels[k] = v
+	}
+	if dep.Spec.Selector == nil {
+		dep.Spec.Selector = &metav1.LabelSelector{}
+	}
+	dep.Spec.Selector.MatchLabels = matchLabels
 }
 
 // MatchesLevel indicates whether the selector of the given entity matches the given label(s).

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -97,6 +97,58 @@ spec:
                 key: token
 `
 
+const SanchoBeta1YAML = `
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: sancho
+  namespace: sancho-ns
+  labels:
+    app: sancho
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sancho
+    spec:
+      containers:
+      - name: sancho
+        image: gcr.io/some-project-162817/sancho
+        env:
+          - name: token
+            valueFrom:
+              secretKeyRef:
+                name: slacktoken
+                key: token
+`
+
+const SanchoBeta2YAML = `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: sancho
+  namespace: sancho-ns
+  labels:
+    app: sancho
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sancho
+    spec:
+      containers:
+      - name: sancho
+        image: gcr.io/some-project-162817/sancho
+        env:
+          - name: token
+            valueFrom:
+              secretKeyRef:
+                name: slacktoken
+                key: token
+`
+
 const SanchoTwinYAML = `
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch846/labels:

9969f3bbf9f80deabbd629fdd2ef4e27c62fe576 (2018-11-20 13:13:36 -0500)
k8s: fix betav1 and betav2 deployments before injecting labels