### PR TITLE
store: keep track of whether a watched path is a dir or a file

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -859,7 +859,14 @@ func TestReapOldBuilds(t *testing.T) {
 func TestHudUpdated(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
-	mount := model.Mount{LocalPath: "/go", ContainerPath: "/go"}
+	oldPWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldPWD)
+	os.Chdir(f.TempDirFixture.Path())
+
+	mount := model.Mount{LocalPath: f.TempDirFixture.Path(), ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Mount{mount})
 
 	f.Start([]model.Manifest{manifest}, true)
@@ -870,13 +877,13 @@ func TestHudUpdated(t *testing.T) {
 		return len(v.Resources) > 0
 	})
 
-	err := f.Stop()
+	err = f.Stop()
 	assert.Equal(t, nil, err)
 
 	assert.Equal(t, 1, len(f.hud.LastView.Resources))
 	rv := f.hud.LastView.Resources[0]
 	assert.Equal(t, manifest.Name, model.ManifestName(rv.Name))
-	assert.Equal(t, manifest.Mounts[0].LocalPath, rv.DirectoriesWatched[0])
+	assert.Equal(t, ".", rv.DirectoriesWatched[0])
 	f.assertAllBuildsConsumed()
 }
 
@@ -1436,7 +1443,7 @@ func TestInitSetsTiltfilePath(t *testing.T) {
 		Manifests:    []model.Manifest{},
 		TiltfilePath: "/Tiltfile",
 	})
-	f.WaitUntil("global YAML manifest gets set on init", func(st store.EngineState) bool {
+	f.WaitUntil("tiltfile path gets set on init", func(st store.EngineState) bool {
 		return st.TiltfilePath == "/Tiltfile"
 	})
 }

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -5,6 +5,7 @@ import "time"
 type Resource struct {
 	Name               string
 	DirectoriesWatched []string
+	PathsWatched       []string
 	LastDeployTime     time.Time
 	LastDeployEdits    []string
 

--- a/internal/ospath/ospath.go
+++ b/internal/ospath/ospath.go
@@ -11,7 +11,7 @@ import (
 // Returns true if successful. If `file` is not under `dir`, returns false.
 func Child(dir string, file string) (string, bool) {
 	current := file
-	child := ""
+	child := "."
 	for true {
 		if dir == current {
 			return child, true

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -27,6 +27,8 @@ func TestChild(t *testing.T) {
 	f.assertChild("parent", "parent/child/grandchild/fileC", "child/grandchild/fileC")
 
 	f.assertChild("parent/child", "parent/child/fileB", "fileB")
+
+	f.assertChild("parent", "parent", ".")
 }
 
 func TestIsBrokenSymlink(t *testing.T) {
@@ -48,6 +50,29 @@ func TestIsBrokenSymlink(t *testing.T) {
 	f.assertBrokenSymlink("child/grandchild/fileC", false)
 	f.assertBrokenSymlink("symlinkFileA", false)
 	f.assertBrokenSymlink("symlinkFileB", true)
+}
+
+func TestTryAsCwdChildren(t *testing.T) {
+	f := NewOspathFixture(t)
+	defer f.TearDown()
+	oldPWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldPWD)
+	os.Chdir(f.Path())
+
+	results := TryAsCwdChildren([]string{f.Path()})
+
+	if len(results) == 0 {
+		t.Fatal("Expected 1 result, got 0")
+	}
+
+	r := results[0]
+
+	if r != "." {
+		t.Errorf("Expected %s to equal \".\"", r)
+	}
 }
 
 type OspathFixture struct {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"sort"
 	"time"
 
@@ -254,10 +255,18 @@ func StateToView(s EngineState) view.View {
 		ms := s.ManifestStates[name]
 
 		var absWatchDirs []string
+		var absWatchPaths []string
 		for _, p := range ms.Manifest.LocalPaths() {
-			absWatchDirs = append(absWatchDirs, p)
+			fi, err := os.Stat(p)
+			if err == nil && !fi.IsDir() {
+				absWatchPaths = append(absWatchPaths, p)
+			} else {
+				absWatchDirs = append(absWatchDirs, p)
+			}
 		}
+		absWatchPaths = append(absWatchPaths, s.TiltfilePath)
 		relWatchDirs := ospath.TryAsCwdChildren(absWatchDirs)
+		relWatchPaths := ospath.TryAsCwdChildren(absWatchPaths)
 
 		var pendingBuildEdits []string
 		for f := range ms.PendingFileChanges {
@@ -291,6 +300,7 @@ func StateToView(s EngineState) view.View {
 		r := view.Resource{
 			Name:                  name.String(),
 			DirectoriesWatched:    relWatchDirs,
+			PathsWatched:          relWatchPaths,
 			LastDeployTime:        ms.LastSuccessfulDeployTime,
 			LastDeployEdits:       lastDeployEdits,
 			LastManifestLoadError: lastManifestLoadError,


### PR DESCRIPTION
@yuindustries this should let you differentiate files and directories in the view code and render them differently, with or without a trailing slash.