### PR TITLE
engine: don't bail out if tiltfile isn't present, wait for it to appear

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -92,11 +93,6 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Start")
 	defer span.Finish()
 
-	tf, err := tiltfile.Load(ctx, tiltfile.FileName)
-	if err != nil {
-		return err
-	}
-
 	absTfPath, err := filepath.Abs(tiltfile.FileName)
 	if err != nil {
 		return err
@@ -108,9 +104,20 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 		manifestNames[i] = model.ManifestName(a)
 	}
 
-	manifests, globalYAML, err := tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
-	if err != nil {
+	var manifests []model.Manifest
+	var globalYAML model.YAMLManifest
+	tf, err := tiltfile.Load(ctx, tiltfile.FileName)
+	if os.IsNotExist(err) {
+		manifests = []model.Manifest{}
+		globalYAML = model.YAMLManifest{}
+	} else if err != nil {
 		return err
+	} else {
+		manifests, globalYAML, err = tf.GetManifestConfigsAndGlobalYAML(ctx, manifestNames...)
+		if err != nil {
+			manifests = []model.Manifest{}
+			globalYAML = model.YAMLManifest{}
+		}
 	}
 
 	u.store.Dispatch(InitAction{


### PR DESCRIPTION
This _kind of_ works. @maiamcc I think that this ends up encountering the nil pointer reference that we saw with @dbentley when we were experimenting adding/removing resources.