### PR TITLE
engine: check if we can connect to k8s during start

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -89,7 +89,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	tiltfileWatcher := engine.NewTiltfileWatcher(fsWatcherMaker)
-	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, tiltfileWatcher)
+	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, tiltfileWatcher, k8sClient)
 	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, storeStore, branch)
 	return script, nil
 }
@@ -167,7 +167,7 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	tiltfileWatcher := engine.NewTiltfileWatcher(fsWatcherMaker)
-	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, tiltfileWatcher)
+	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, tiltfileWatcher, k8sClient)
 	hudAndUpper := provideHudAndUpper(headsUpDisplay, upper)
 	return hudAndUpper, nil
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -43,6 +43,7 @@ const maxChangedFilesToPrint = 5
 type Upper struct {
 	b     BuildAndDeployer
 	store *store.Store
+	kcli  k8s.Client
 }
 
 type FsWatcherMaker func() (watch.Notify, error)
@@ -66,7 +67,7 @@ func NewUpper(ctx context.Context, b BuildAndDeployer,
 	hud hud.HeadsUpDisplay, pw *PodWatcher, sw *ServiceWatcher,
 	st *store.Store, plm *PodLogManager, pfc *PortForwardController,
 	fwm *WatchManager, fswm FsWatcherMaker, bc *BuildController,
-	ic *ImageController, gybc *GlobalYAMLBuildController, tfw *TiltfileWatcher) Upper {
+	ic *ImageController, gybc *GlobalYAMLBuildController, tfw *TiltfileWatcher, kcli k8s.Client) Upper {
 
 	st.AddSubscriber(bc)
 	st.AddSubscriber(hud)
@@ -82,6 +83,7 @@ func NewUpper(ctx context.Context, b BuildAndDeployer,
 	return Upper{
 		b:     b,
 		store: st,
+		kcli:  kcli,
 	}
 }
 
@@ -92,6 +94,11 @@ func (u Upper) Dispatch(action store.Action) {
 func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Start")
 	defer span.Finish()
+
+	err := u.kcli.ConnectedToCluster(ctx)
+	if err != nil {
+		return err
+	}
 
 	absTfPath, err := filepath.Abs(tiltfile.FileName)
 	if err != nil {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1660,7 +1660,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	gybc := NewGlobalYAMLBuildController(k8s)
 	tfw := NewTiltfileWatcher(tfwm)
 	tfw.DisableForTesting(true)
-	upper := NewUpper(ctx, b, fakeHud, pw, sw, st, plm, pfc, fwm, fswm, bc, ic, gybc, tfw)
+	upper := NewUpper(ctx, b, fakeHud, pw, sw, st, plm, pfc, fwm, fswm, bc, ic, gybc, tfw, k8s)
 
 	go func() {
 		fakeHud.Run(ctx, upper.Dispatch, hud.DefaultRefreshInterval)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -81,6 +81,8 @@ type Client interface {
 	WatchPods(ctx context.Context, lps []LabelPair) (<-chan *v1.Pod, error)
 
 	WatchServices(ctx context.Context, lps []LabelPair) (<-chan *v1.Service, error)
+
+	ConnectedToCluster(ctx context.Context) error
 }
 
 type K8sClient struct {
@@ -201,6 +203,15 @@ func (k K8sClient) Upsert(ctx context.Context, entities []K8sEntity) error {
 			}
 		}
 	}
+	return nil
+}
+
+func (k K8sClient) ConnectedToCluster(ctx context.Context) error {
+	stdout, stderr, err := k.kubectlRunner.exec(ctx, []string{"cluster-info"})
+	if err != nil {
+		return fmt.Errorf("Unable to connect to cluster via `kubectl cluster-info`: %s\nstdout: %s\nstderr: %s", err.Error(), stdout, stderr)
+	}
+
 	return nil
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -51,6 +51,10 @@ func NewFakeK8sClient() *FakeK8sClient {
 	return &FakeK8sClient{}
 }
 
+func (c *FakeK8sClient) ConnectedToCluster(ctx context.Context) error {
+	return nil
+}
+
 func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity) error {
 	yaml, err := SerializeYAML(entities)
 	if err != nil {


### PR DESCRIPTION
Output looks like this if it can't:

```
> tilt up foo
Error: Unable to connect to cluster via `kubectl cluster-info`: exit status 1
stdout: Kubernetes master is running at https://localhost:6443

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

stderr: The connection to the server localhost:6443 was refused - did you specify the right host or port?
```