### PR TITLE
engine test: get next buildAndDeployer call with a timeout so tests don't hang if broken

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -18,14 +18,14 @@ func TestBuildControllerOnePod(t *testing.T) {
 	manifest := f.newManifest("fe", []model.Mount{mount})
 	f.Start([]model.Manifest{manifest}, true)
 
-	call := <-f.b.calls
+	call := f.nextCall()
 	assert.Equal(t, manifest, call.manifest)
 	assert.Equal(t, []string{}, call.state.FilesChanged())
 
 	f.podEvent(f.testPod("pod-id", "fe", "Running", testContainer, time.Now()))
 	f.fsWatcher.events <- watch.FileEvent{Path: "main.go"}
 
-	call = <-f.b.calls
+	call = f.nextCall()
 	assert.Equal(t, "pod-id", call.state.DeployInfo.PodID.String())
 
 	err := f.Stop()
@@ -41,7 +41,7 @@ func TestBuildControllerTwoPods(t *testing.T) {
 	manifest := f.newManifest("fe", []model.Mount{mount})
 	f.Start([]model.Manifest{manifest}, true)
 
-	call := <-f.b.calls
+	call := f.nextCall()
 	assert.Equal(t, manifest, call.manifest)
 	assert.Equal(t, []string{}, call.state.FilesChanged())
 
@@ -54,10 +54,11 @@ func TestBuildControllerTwoPods(t *testing.T) {
 	f.podEvent(podB)
 	f.fsWatcher.events <- watch.FileEvent{Path: "main.go"}
 
-	call = <-f.b.calls
+	call = f.nextCall()
 	assert.Equal(t, "", call.state.DeployInfo.PodID.String())
 
 	err := f.Stop()
 	assert.NoError(t, err)
 	f.assertAllBuildsConsumed()
 }
+g

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -61,4 +61,3 @@ func TestBuildControllerTwoPods(t *testing.T) {
 	assert.NoError(t, err)
 	f.assertAllBuildsConsumed()
 }
-g


### PR DESCRIPTION
If you break Engine tests, they hang in annoying and hard-to-debug ways.

This should help.