### PR TITLE
engine: represent build logs as an action so that the ui responds to build log updates

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -41,6 +41,13 @@ func NewServiceChangeAction(service *v1.Service, url *url.URL) ServiceChangeActi
 	return ServiceChangeAction{Service: service, URL: url}
 }
 
+type BuildLogAction struct {
+	ManifestName model.ManifestName
+	Log          []byte
+}
+
+func (BuildLogAction) Action() {}
+
 type PodLogAction struct {
 	ManifestName model.ManifestName
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -113,10 +113,12 @@ func (c *BuildController) needsBuild(ctx context.Context, st store.RStore) (buil
 		WithDeployInfo(store.NewDeployInfo(ms.PodSet))
 	buildReason := ms.NextBuildReason()
 
-	// TODO(nick): This is...not great, because it modifies the build log in place.
-	// A better solution would dispatch actions (like PodLogManager does) so that
-	// they go thru the state loop and immediately update in the UX.
-	ctx = logger.CtxWithForkedOutput(ctx, ms.CurrentBuildLog)
+	// Send the logs to both the EngineState and the normal log stream.
+	actionWriter := BuildLogActionWriter{
+		store:        st,
+		manifestName: mn,
+	}
+	ctx = logger.CtxWithForkedOutput(ctx, actionWriter)
 
 	return buildEntry{
 		ctx:          ctx,
@@ -183,6 +185,19 @@ func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry) {
 		rs := logger.Blue(l).Sprintf(" ├────────────────────────────────────────────")
 		l.Infof("%s%s%s", rp, manifest.Name, rs)
 	}
+}
+
+type BuildLogActionWriter struct {
+	store        store.RStore
+	manifestName model.ManifestName
+}
+
+func (w BuildLogActionWriter) Write(p []byte) (n int, err error) {
+	w.store.Dispatch(BuildLogAction{
+		ManifestName: w.manifestName,
+		Log:          append([]byte{}, p...),
+	})
+	return len(p), nil
 }
 
 var _ store.Subscriber = &BuildController{}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -186,6 +185,8 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		handleServiceEvent(ctx, state, action)
 	case PodLogAction:
 		handlePodLogAction(state, action)
+	case BuildLogAction:
+		handleBuildLogAction(state, action)
 	case BuildCompleteAction:
 		err = handleCompletedBuild(ctx, state, action)
 	case BuildStartedAction:
@@ -253,7 +254,7 @@ func handleCompletedBuild(ctx context.Context, engineState *store.EngineState, c
 
 	ms.CurrentBuildStartTime = time.Time{}
 	ms.CurrentBuildReason = store.BuildReasonNone
-	ms.CurrentBuildLog = &bytes.Buffer{}
+	ms.CurrentBuildLog = nil
 	ms.NeedsRebuildFromCrash = false
 
 	if err != nil {
@@ -602,6 +603,18 @@ func handlePodLogAction(state *store.EngineState, action PodLogAction) {
 
 	podInfo := ms.PodSet.Pods[podID]
 	podInfo.CurrentLog = append(podInfo.CurrentLog, action.Log...)
+}
+
+func handleBuildLogAction(state *store.EngineState, action BuildLogAction) {
+	manifestName := action.ManifestName
+	ms, ok := state.ManifestStates[manifestName]
+
+	if !ok || state.CurrentlyBuilding != manifestName {
+		// This is OK. The user could have edited the manifest recently.
+		return
+	}
+
+	ms.CurrentBuildLog = append(ms.CurrentBuildLog, action.Log...)
 }
 
 func handleLogAction(state *store.EngineState, action LogAction) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -159,7 +159,7 @@ func TestUpper_Up(t *testing.T) {
 
 	state := f.upper.store.RLockState()
 	defer f.upper.store.RUnlockState()
-	lines := strings.Split(state.ManifestStates[manifest.Name].LastBuildLog.String(), "\n")
+	lines := strings.Split(string(state.ManifestStates[manifest.Name].LastBuildLog), "\n")
 	assert.Contains(t, lines, "fake building foobar")
 	assert.Equal(t, gYaml, state.GlobalYAML)
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"bytes"
 	"fmt"
 	"net/url"
 	"os"
@@ -75,7 +74,7 @@ type ManifestState struct {
 	CurrentlyBuildingReason      BuildReason
 
 	CurrentBuildStartTime     time.Time
-	CurrentBuildLog           *bytes.Buffer `testdiff:"ignore"`
+	CurrentBuildLog           []byte `testdiff:"ignore"`
 	CurrentBuildReason        BuildReason
 	LastManifestLoadError     error
 	LastSuccessfulDeployEdits []string
@@ -85,7 +84,7 @@ type ManifestState struct {
 	LastBuildReason           BuildReason
 	LastSuccessfulDeployTime  time.Time
 	LastBuildDuration         time.Duration
-	LastBuildLog              *bytes.Buffer `testdiff:"ignore"`
+	LastBuildLog              []byte `testdiff:"ignore"`
 
 	// If the pod isn't running this container then it's possible we're running stale code
 	ExpectedContainerID container.ID
@@ -106,7 +105,7 @@ func NewManifestState(manifest model.Manifest) *ManifestState {
 		Manifest:           manifest,
 		PendingFileChanges: make(map[string]time.Time),
 		LBs:                make(map[k8s.ServiceName]*url.URL),
-		CurrentBuildLog:    &bytes.Buffer{},
+		CurrentBuildLog:    []byte{},
 	}
 }
 
@@ -389,10 +388,7 @@ func StateToView(s EngineState) view.View {
 
 		endpoints := ManifestStateEndpoints(ms)
 
-		lastBuildLog := ""
-		if ms.LastBuildLog != nil {
-			lastBuildLog = ms.LastBuildLog.String()
-		}
+		lastBuildLog := string(ms.LastBuildLog)
 
 		// NOTE(nick): Right now, the UX is designed to show the output exactly one
 		// pod. A better UI might summarize the pods in other ways (e.g., show the


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch719/panic2:

b76d038716c9dcceef124a33493961dd7e9dd25f (2018-11-27 11:56:08 -0500)
engine: represent build logs as an action so that the ui responds to build log updates