### PR TITLE
k8s: ignore delete errors when the resource isn't found

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -50,7 +50,10 @@ type Client interface {
 	// we might need to fallback to deleting and re-creating them.
 	Upsert(ctx context.Context, entities []K8sEntity) error
 
-	// Deletes all given entities
+	// Deletes all given entities.
+	//
+	// Currently ignores any "not found" errors, because that seems like the correct
+	// behavior for our use cases.
 	Delete(ctx context.Context, entities []K8sEntity) error
 
 	// Find all the pods that match the given image, namespace, and labels.
@@ -226,8 +229,12 @@ func maybeImmutableFieldStderr(stderr string) bool {
 		strings.Contains(stderr, "Forbidden")
 }
 
+// Deletes all given entities.
+//
+// Currently ignores any "not found" errors, because that seems like the correct
+// behavior for our use cases.
 func (k K8sClient) Delete(ctx context.Context, entities []K8sEntity) error {
-	_, stderr, err := k.actOnEntities(ctx, []string{"delete"}, entities)
+	_, stderr, err := k.actOnEntities(ctx, []string{"delete", "--ignore-not-found"}, entities)
 	if err != nil {
 		return fmt.Errorf("kubectl delete: %v\nstderr: %s", err, stderr)
 	}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch768/down:

752143ca166bd39a7f8e9c8410984c82800340ac (2018-11-28 14:10:21 -0500)
k8s: ignore delete errors when the resource isn't found