### PR TITLE
engine: remove possible panic when handling config reload

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -384,7 +384,6 @@ func handleConfigsReloaded(
 			ms = &store.ManifestState{}
 		}
 		ms.LastManifestLoadError = nil
-		state.ManifestStates[m.ManifestName()].LastManifestLoadError = nil
 
 		newDefOrder[i] = m.ManifestName()
 		if !m.Equal(ms.Manifest) {


### PR DESCRIPTION
pretty sure the line i removed is redundant with the one before it,
since `ms` is a pointer to whatever lives in the map? but in the case
where there isn't an entry for the given manifest in `state.ManifestStates`,
we'll get a panic here.