### PR TITLE
tilt: clean up global yaml error handling

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -109,15 +109,11 @@ type GlobalYAMLApplyStartedAction struct{}
 
 func (GlobalYAMLApplyStartedAction) Action() {}
 
-type GlobalYAMLApplyCompleteAction struct{}
-
-func (GlobalYAMLApplyCompleteAction) Action() {}
-
-type GlobalYAMLApplyError struct {
+type GlobalYAMLApplyCompleteAction struct {
 	Error error
 }
 
-func (GlobalYAMLApplyError) Action() {}
+func (GlobalYAMLApplyCompleteAction) Action() {}
 
 type HudStoppedAction struct {
 	err error

--- a/internal/engine/global_yaml_buildcontroller.go
+++ b/internal/engine/global_yaml_buildcontroller.go
@@ -32,50 +32,49 @@ func (c *GlobalYAMLBuildController) OnChange(ctx context.Context, st store.RStor
 	m := state.GlobalYAML
 	st.RUnlockState()
 
-	newK8sEntities := []k8s.K8sEntity{}
 	if m.K8sYAML() != c.lastGlobalYAMLManifest.K8sYAML() {
 		c.lastGlobalYAMLManifest = m
 		st.Dispatch(GlobalYAMLApplyStartedAction{})
 
-		entities, err := k8s.ParseYAMLFromString(m.K8sYAML())
+		err := handleGlobalYamlChange(ctx, m, c.k8sClient)
+
 		if err != nil {
-			err = errors.Wrap(err, "Error parsing global_yaml")
 			logger.Get(ctx).Infof(err.Error())
-			st.Dispatch(GlobalYAMLApplyCompleteAction{Error: err})
-			return
 		}
 
-		for _, e := range entities {
-			e, err = k8s.InjectLabels(e, []k8s.LabelPair{TiltRunLabel(), {Key: ManifestNameLabel, Value: m.ManifestName().String()}})
-			if err != nil {
-				err = errors.Wrap(err, "Error injecting labels in to global_yaml")
-				logger.Get(ctx).Infof(err.Error())
-				st.Dispatch(GlobalYAMLApplyCompleteAction{Error: err})
-				return
-			}
-
-			// For development, image pull policy should never be set to "Always",
-			// even if it might make sense to use "Always" in prod. People who
-			// set "Always" for development are shooting their own feet.
-			e, err = k8s.InjectImagePullPolicy(e, v1.PullIfNotPresent)
-			if err != nil {
-				err = errors.Wrap(err, "Error injecting image pull policy in to global_yaml")
-				logger.Get(ctx).Infof(err.Error())
-				st.Dispatch(GlobalYAMLApplyCompleteAction{Error: err})
-				return
-			}
-
-			newK8sEntities = append(newK8sEntities, e)
-		}
-
-		err = c.k8sClient.Upsert(ctx, newK8sEntities)
-		if err != nil {
-			err = errors.Wrap(err, "Error upserting global_yaml")
-			logger.Get(ctx).Infof(err.Error())
-			st.Dispatch(GlobalYAMLApplyCompleteAction{Error: err})
-			return
-		}
-
-		st.Dispatch(GlobalYAMLApplyCompleteAction{})
+		st.Dispatch(GlobalYAMLApplyCompleteAction{Error: err})
 	}
+}
+
+func handleGlobalYamlChange(ctx context.Context, m model.YAMLManifest, kCli k8s.Client) error {
+	entities, err := k8s.ParseYAMLFromString(m.K8sYAML())
+	if err != nil {
+		return errors.Wrap(err, "Error parsing global_yaml")
+	}
+
+	newK8sEntities := []k8s.K8sEntity{}
+
+	for _, e := range entities {
+		e, err = k8s.InjectLabels(e, []k8s.LabelPair{TiltRunLabel(), {Key: ManifestNameLabel, Value: m.ManifestName().String()}})
+		if err != nil {
+			return errors.Wrap(err, "Error injecting labels in to global_yaml")
+		}
+
+		// For development, image pull policy should never be set to "Always",
+		// even if it might make sense to use "Always" in prod. People who
+		// set "Always" for development are shooting their own feet.
+		e, err = k8s.InjectImagePullPolicy(e, v1.PullIfNotPresent)
+		if err != nil {
+			return errors.Wrap(err, "Error injecting image pull policy in to global_yaml")
+		}
+
+		newK8sEntities = append(newK8sEntities, e)
+	}
+
+	err = kCli.Upsert(ctx, newK8sEntities)
+	if err != nil {
+		return errors.Wrap(err, "Error upserting global_yaml")
+	}
+
+	return nil
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -197,8 +197,6 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		handleGlobalYAMLApplyStarted(ctx, state, action)
 	case GlobalYAMLApplyCompleteAction:
 		handleGlobalYAMLApplyComplete(ctx, state, action)
-	case GlobalYAMLApplyError:
-		handleGlobalYAMLApplyError(ctx, state, action)
 	case ConfigsReloadStartedAction:
 		handleConfigsReloadStarted(ctx, state, action)
 	case ConfigsReloadedAction:
@@ -337,21 +335,16 @@ func handleGlobalYAMLApplyComplete(
 	event GlobalYAMLApplyCompleteAction,
 ) {
 	ms := state.GlobalYAMLState
-	ms.HasBeenDeployed = true
 	ms.LastApplyFinishTime = time.Now()
 	ms.LastApplyDuration = time.Since(ms.CurrentApplyStartTime)
 	ms.CurrentApplyStartTime = time.Time{}
 
-	ms.LastSuccessfulApplyTime = time.Now()
-	ms.LastError = nil
-}
+	ms.LastError = event.Error
 
-func handleGlobalYAMLApplyError(
-	ctx context.Context,
-	state *store.EngineState,
-	event GlobalYAMLApplyError,
-) {
-	state.GlobalYAMLState.LastError = event.Error
+	if event.Error == nil {
+		ms.HasBeenDeployed = true
+		ms.LastSuccessfulApplyTime = time.Now()
+	}
 }
 
 func handleConfigsReloadStarted(

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -37,6 +37,8 @@ type FakeK8sClient struct {
 
 	LastForwardPortPodID      PodID
 	LastForwardPortRemotePort int
+
+	UpsertError error
 }
 
 func (c *FakeK8sClient) WatchServices(ctx context.Context, lps []LabelPair) (<-chan *v1.Service, error) {
@@ -56,6 +58,9 @@ func (c *FakeK8sClient) ConnectedToCluster(ctx context.Context) error {
 }
 
 func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity) error {
+	if c.UpsertError != nil {
+		return c.UpsertError
+	}
 	yaml, err := SerializeYAML(entities)
 	if err != nil {
 		return fmt.Errorf("kubectl apply: %v", err)


### PR DESCRIPTION
this addresses [ch920](https://app.clubhouse.io/windmill/story/920/errors-in-global-yaml-are-handled-poorly)

also fixes bad `LastApplyDuration` on parse errors (due to not emitting a `GlobalYAMLApplyStartedAction`)