### PR TITLE
engine: more robust logic about when BaD falls back (and cleaner logging)

### DIFF
--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/logger"
@@ -64,7 +65,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 			if isExitErr {
 				return UserBuildFailure{ExitCode: exitErr.ExitCode}
 			}
-			return fmt.Errorf("executing step %v on container %s: %v", s.Argv, cID.ShortStr(), err)
+			return errors.Wrapf(err, "executing step %v on container %s", s.Argv, cID.ShortStr())
 		}
 	}
 

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -36,7 +36,6 @@ var BaseWireSet = wire.NewSet(
 	build.NewImageReaper,
 
 	engine.DeployerWireSet,
-	engine.DefaultShouldFallBack,
 	engine.NewPodLogManager,
 	engine.NewPortForwardController,
 	engine.NewBuildController,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -61,8 +61,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	}
 	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8sClient, env, analytics, updateMode)
 	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode)
-	fallbackTester := engine.DefaultShouldFallBack()
-	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder, fallbackTester)
+	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder)
 	v := provideClock()
 	renderer := hud.NewRenderer(v)
 	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer)
@@ -144,8 +143,7 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	}
 	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8sClient, env, analytics, updateMode)
 	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode)
-	fallbackTester := engine.DefaultShouldFallBack()
-	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder, fallbackTester)
+	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder)
 	podWatcher := engine.NewPodWatcher(k8sClient)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
@@ -193,7 +191,7 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 var K8sWireSet = wire.NewSet(k8s.DetectEnv, k8s.DetectNodeIP, k8s.ProvidePortForwarder, k8s.ProvideRESTClient, k8s.ProvideRESTConfig, k8s.NewK8sClient, wire.Bind(new(k8s.Client), k8s.K8sClient{}))
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, docker.DefaultDockerClient, wire.Bind(new(docker.DockerClient), new(docker.DockerCli)), build.NewImageReaper, engine.DeployerWireSet, engine.DefaultShouldFallBack, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, engine.NewUpper, provideAnalytics,
+	K8sWireSet, docker.DefaultDockerClient, wire.Bind(new(docker.DockerClient), new(docker.DockerCli)), build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, engine.NewUpper, provideAnalytics,
 	provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideHudAndUpper,
 )
 

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/windmilleng/tilt/internal/store"
 
-	"github.com/pkg/errors"
-	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
@@ -35,21 +33,13 @@ type FallbackTester func(error) bool
 // critical enough to stop the whole pipeline, or to fallback to the next
 // builder.
 type CompositeBuildAndDeployer struct {
-	builders       BuildOrder
-	shouldFallBack FallbackTester
+	builders BuildOrder
 }
 
 var _ BuildAndDeployer = &CompositeBuildAndDeployer{}
 
-func DefaultShouldFallBack() FallbackTester {
-	return FallbackTester(shouldImageBuild)
-}
-
-func NewCompositeBuildAndDeployer(builders BuildOrder, shouldFallBack FallbackTester) *CompositeBuildAndDeployer {
-	return &CompositeBuildAndDeployer{
-		builders:       builders,
-		shouldFallBack: shouldFallBack,
-	}
+func NewCompositeBuildAndDeployer(builders BuildOrder) *CompositeBuildAndDeployer {
+	return &CompositeBuildAndDeployer{builders: builders}
 }
 
 func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, currentState store.BuildState) (store.BuildResult, error) {
@@ -57,49 +47,27 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 	for _, builder := range composite.builders {
 		br, err := builder.BuildAndDeploy(ctx, manifest, currentState)
 		if err == nil {
-			// TODO(maia): maybe this only needs to be called after certain builds?
-			// I.e. should be called after image build but not after a successful container build?
+			// TODO(maia): this should be reactive (i.e. happen as a response to `BuildCompleteAction`
 			composite.PostProcessBuild(ctx, br, currentState.LastResult)
 			return br, err
 		}
 
-		if !composite.shouldFallBack(err) {
+		if !shouldFallBackForErr(err) {
+			// We can't recover from this, so don't try to fall back
 			return store.BuildResult{}, err
 		}
-		logger.Get(ctx).Verbosef("falling back to next build and deploy method after error: %v", err)
+
+		if _, ok := err.(ExpectedError); !ok {
+			logger.Get(ctx).Verbosef("falling back to next build and deploy method "+
+				"after unexpected error: %v", err)
+		} else {
+			logger.Get(ctx).Debugf("(expected error) falling back to next build and deploy method "+
+				"after error: %v", err)
+		}
+
 		lastErr = err
 	}
 	return store.BuildResult{}, lastErr
-}
-
-// A permanent error indicates that the whole build pipeline needs to stop.
-// It will never recover, even on subsequent rebuilds.
-func isPermanentError(err error) bool {
-	if _, ok := err.(*model.ValidateErr); ok {
-		return true
-	}
-
-	cause := errors.Cause(err)
-	if cause == context.Canceled {
-		return true
-	}
-	return false
-}
-
-// Given the error from our initial BuildAndDeploy attempt, shouldImageBuild determines
-// whether we should fall back to an ImageBuild.
-func shouldImageBuild(err error) bool {
-	if _, ok := err.(*build.PathMappingErr); ok {
-		return false
-	}
-	if isPermanentError(err) {
-		return false
-	}
-
-	if build.IsUserBuildFailure(err) {
-		return false
-	}
-	return true
 }
 
 func (composite *CompositeBuildAndDeployer) PostProcessBuild(ctx context.Context, result, prevResult store.BuildResult) {

--- a/internal/engine/build_errors.go
+++ b/internal/engine/build_errors.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/model"
+)
+
+// Nothing is on fire, this is an expected case like a container builder being
+// passed a build with no attached container. Don't need to show this to a user.
+type ExpectedError struct {
+	error
+}
+
+func WrapExpectedError(err error) ExpectedError {
+	return ExpectedError{err}
+}
+
+func ExpectedErrorf(msg string, a ...interface{}) ExpectedError {
+	return ExpectedError{fmt.Errorf(msg, a...)}
+}
+
+var _ error = ExpectedError{}
+
+// Something is wrong enough that we shouldn't bother falling back to other
+// BaD's -- they won't work.
+type DontFallBackError struct {
+	error
+}
+
+func WrapDontFallBackError(err error) DontFallBackError {
+	return DontFallBackError{err}
+}
+
+func DontFallBackErrorf(msg string, a ...interface{}) DontFallBackError {
+	return DontFallBackError{fmt.Errorf(msg, a...)}
+}
+
+var _ error = DontFallBackError{}
+
+// A permanent error indicates that the whole build pipeline needs to stop.
+// It will never recover, even on subsequent rebuilds.
+func isPermanentError(err error) bool {
+	// TODO(maia): invalid manifests will soon no longer be cause to stop Tilt...
+	if _, ok := err.(*model.ValidateErr); ok {
+		return true
+	}
+
+	cause := errors.Cause(err)
+	if cause == context.Canceled {
+		return true
+	}
+	return false
+}
+
+func shouldFallBackForErr(err error) bool {
+	if isPermanentError(err) {
+		return false
+	}
+
+	cause := errors.Cause(err)
+	if _, ok := cause.(DontFallBackError); ok {
+		return false
+	}
+	return true
+}

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -42,28 +41,26 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 		cbd.analytics.Timer("build.container", time.Since(startTime), nil)
 	}()
 
-	// TODO(maia): proper output for this stuff
-
 	// TODO(maia): put manifest.Validate() upstream if we're gonna want to call it regardless
 	// of implementation of BuildAndDeploy?
 	err = manifest.Validate()
 	if err != nil {
-		return store.BuildResult{}, err
+		return store.BuildResult{}, WrapDontFallBackError(err)
 	}
 
 	// LocalContainerBuildAndDeployer doesn't support initial build
 	if state.IsEmpty() {
-		return store.BuildResult{}, fmt.Errorf("prev. build state is empty; container build does not support initial deploy")
+		return store.BuildResult{}, ExpectedErrorf("prev. build state is empty; container build does not support initial deploy")
 	}
 
 	if manifest.IsStaticBuild() {
-		return store.BuildResult{}, fmt.Errorf("container build does not support static dockerfiles")
+		return store.BuildResult{}, ExpectedErrorf("container build does not support static dockerfiles")
 	}
 
 	// Otherwise, manifest has already been deployed; try to update in the running container
 	deployInfo := state.DeployInfo
 	if deployInfo.Empty() {
-		return store.BuildResult{}, fmt.Errorf("no deploy info")
+		return store.BuildResult{}, ExpectedErrorf("no deploy info")
 	}
 
 	cf, err := build.FilesToPathMappings(state.FilesChanged(), manifest.Mounts)
@@ -81,6 +78,9 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 
 	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, cf, ignore.CreateBuildContextFilter(manifest), boiledSteps, writer)
 	if err != nil {
+		if build.IsUserBuildFailure(err) {
+			return store.BuildResult{}, WrapDontFallBackError(err)
+		}
 		return store.BuildResult{}, err
 	}
 	logger.Get(ctx).Infof("  → Container updated!")

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -49,10 +49,8 @@ func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest
 	span.SetTag("manifest", manifest.Name.String())
 	defer span.Finish()
 
-	// TODO(maia): proper output for this stuff
-
 	if err := sbd.canSyncletBuild(ctx, manifest, state); err != nil {
-		return store.BuildResult{}, err
+		return store.BuildResult{}, WrapExpectedError(err)
 	}
 
 	return sbd.updateViaSynclet(ctx, manifest, state)
@@ -137,6 +135,9 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 
 	err = sCli.UpdateContainer(ctx, deployInfo.ContainerID, archive.Bytes(), containerPathsToRm, cmds)
 	if err != nil {
+		if build.IsUserBuildFailure(err) {
+			return store.BuildResult{}, WrapDontFallBackError(err)
+		}
 		return store.BuildResult{}, err
 	}
 

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -58,8 +58,7 @@ func provideBuildAndDeployer(
 	dir *dirs.WindmillDir,
 	env k8s.Env,
 	updateMode UpdateModeFlag,
-	sCli synclet.SyncletClient,
-	shouldFallBackToImgBuild FallbackTester) (BuildAndDeployer, error) {
+	sCli synclet.SyncletClient) (BuildAndDeployer, error) {
 	wire.Build(
 		DeployerWireSetTest,
 		analytics.NewMemoryAnalytics,

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -19,7 +19,7 @@ import (
 
 // Injectors from wire.go:
 
-func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode UpdateModeFlag, sCli synclet.SyncletClient, shouldFallBackToImgBuild FallbackTester) (BuildAndDeployer, error) {
+func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode UpdateModeFlag, sCli synclet.SyncletClient) (BuildAndDeployer, error) {
 	syncletManager := NewSyncletManagerForTests(k8s2, sCli)
 	syncletBuildAndDeployer := NewSyncletBuildAndDeployer(syncletManager)
 	containerUpdater := build.NewContainerUpdater(docker2)
@@ -37,7 +37,7 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k
 	}
 	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8s2, env, memoryAnalytics, updateMode2)
 	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode2)
-	compositeBuildAndDeployer := NewCompositeBuildAndDeployer(buildOrder, shouldFallBackToImgBuild)
+	compositeBuildAndDeployer := NewCompositeBuildAndDeployer(buildOrder)
 	return compositeBuildAndDeployer, nil
 }
 

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -430,6 +430,7 @@ func ToShellSteps(cwd string, cmds []string) []Step {
 	return ToSteps(cwd, ToShellCmds(cmds))
 }
 
+// TODO(maia): remove this now that we have a more robust way of checking fallback errors
 type ValidateErr struct {
 	s string
 }


### PR DESCRIPTION
This seemed easier than putting things in a halfway state as I worked
on DB's commit for docker compose stuff.

Instead of checking "ShouldFallBack" via "is it <this specific error type>?",
we explicitly mark errs that should not cause a fallback at the time at which
they are thrown.

Also, this PR impelemnts `ExpectedError` -- if an `error` is thrown but isn't
of concern to the user (e.g. we can't container build this b/c it hasn't been
built yet), we wrap it as an `ExpectedError` and it doesn't get logged (except in
debug mode).