### PR TITLE
docker-compose: support dc manifests from tiltfile, tilt up and down

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 )
@@ -63,5 +66,30 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	return kClient.Delete(ctx, entities)
+	err = kClient.Delete(ctx, entities)
+	if err != nil {
+		logger.Get(ctx).Infof("error deleting k8s entities: %v", err)
+	}
+
+	var dcManifests []model.Manifest
+	for _, m := range manifests {
+		if m.IsDockerCompose() {
+			dcManifests = append(dcManifests, m)
+		}
+	}
+
+	if len(dcManifests) > 0 {
+		// TODO(maia): when we support up-ing from multiple docker-compose files, we'll need to support down-ing as well
+		// TODO(maia): a way to `down` specific services?
+		cmd := exec.CommandContext(ctx, "docker-compose", "-f", dcManifests[0].DcYAMLPath, "down")
+		cmd.Stdout = logger.Get(ctx).Writer(logger.InfoLvl)
+		cmd.Stderr = logger.Get(ctx).Writer(logger.InfoLvl)
+
+		err = cmd.Run()
+		err = dockercompose.NiceError(cmd, nil, err)
+		if err != nil {
+			logger.Get(ctx).Infof("error running `docker-compose down`: %v", err)
+		}
+	}
+	return nil
 }

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -86,7 +86,7 @@ func (c downCmd) run(ctx context.Context, args []string) error {
 		cmd.Stderr = logger.Get(ctx).Writer(logger.InfoLvl)
 
 		err = cmd.Run()
-		err = dockercompose.NiceError(cmd, nil, err)
+		err = dockercompose.FormatError(cmd, nil, err)
 		if err != nil {
 			logger.Get(ctx).Infof("error running `docker-compose down`: %v", err)
 		}

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -6,17 +6,17 @@
 package cli
 
 import (
-	context "context"
-	wire "github.com/google/go-cloud/wire"
-	build "github.com/windmilleng/tilt/internal/build"
-	demo "github.com/windmilleng/tilt/internal/demo"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	dockerfile "github.com/windmilleng/tilt/internal/dockerfile"
-	engine "github.com/windmilleng/tilt/internal/engine"
-	hud "github.com/windmilleng/tilt/internal/hud"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
-	store "github.com/windmilleng/tilt/internal/store"
-	time "time"
+	"context"
+	"github.com/google/go-cloud/wire"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/demo"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/dockerfile"
+	"github.com/windmilleng/tilt/internal/engine"
+	"github.com/windmilleng/tilt/internal/hud"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/store"
+	"time"
 )
 
 // Injectors from wire.go:
@@ -54,14 +54,12 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(dockerCli)
-	updateModeFlag2 := provideUpdateModeFlag()
-	updateMode, err := engine.ProvideUpdateMode(updateModeFlag2, env)
+	engineUpdateModeFlag := provideUpdateModeFlag()
+	updateMode, err := engine.ProvideUpdateMode(engineUpdateModeFlag, env)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8sClient, env, analytics, updateMode)
-	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode)
-	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder)
+
 	v := provideClock()
 	renderer := hud.NewRenderer(v)
 	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer)
@@ -75,8 +73,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	}
 	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
 	reducer := _wireReducerValue
-	logActionsFlag2 := provideLogActions()
-	store2 := store.NewStore(reducer, logActionsFlag2)
+	storeLogActionsFlag := provideLogActions()
+	storeStore := store.NewStore(reducer, storeLogActionsFlag)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -87,8 +85,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	configsController := engine.NewConfigsController()
-	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, store2, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, configsController, k8sClient)
-	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, store2, branch)
+	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, configsController, k8sClient)
+	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, storeStore, branch)
 	return script, nil
 }
 
@@ -136,14 +134,21 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(dockerCli)
-	updateModeFlag2 := provideUpdateModeFlag()
-	updateMode, err := engine.ProvideUpdateMode(updateModeFlag2, env)
+	engineUpdateModeFlag := provideUpdateModeFlag()
+	updateMode, err := engine.ProvideUpdateMode(engineUpdateModeFlag, env)
 	if err != nil {
 		return HudAndUpper{}, err
 	}
 	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8sClient, env, analytics, updateMode)
+<<<<<<< HEAD
 	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode)
 	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder)
+=======
+	dockerComposeBuildAndDeployer := engine.NewDockerComposeBuildAndDeployer()
+	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, dockerComposeBuildAndDeployer, env, updateMode)
+	fallbackTester := engine.DefaultShouldFallBack()
+	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder, fallbackTester)
+>>>>>>> checkpoint
 	podWatcher := engine.NewPodWatcher(k8sClient)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
@@ -151,8 +156,8 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	}
 	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
 	reducer := _wireReducerValue
-	logActionsFlag2 := provideLogActions()
-	store2 := store.NewStore(reducer, logActionsFlag2)
+	storeLogActionsFlag := provideLogActions()
+	storeStore := store.NewStore(reducer, storeLogActionsFlag)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -163,7 +168,7 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	configsController := engine.NewConfigsController()
-	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, store2, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, configsController, k8sClient)
+	upper := engine.NewUpper(ctx, compositeBuildAndDeployer, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, fsWatcherMaker, buildController, imageController, globalYAMLBuildController, configsController, k8sClient)
 	hudAndUpper := provideHudAndUpper(headsUpDisplay, upper)
 	return hudAndUpper, nil
 }

--- a/internal/dockercompose/compose.go
+++ b/internal/dockercompose/compose.go
@@ -1,0 +1,70 @@
+package dockercompose
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Service struct {
+	Name string
+}
+
+func ParseConfig(ctx context.Context, files []string) ([]Service, []string, error) {
+	var args []string
+	for _, f := range files {
+		args = append(args, "-f", f)
+	}
+	args = append(args, "config")
+	_, err := DcOutput(ctx, args...)
+	if err != nil {
+		return nil, files, err
+	}
+
+	args = append(args, "--services")
+	servicesText, err := DcOutput(ctx, args...)
+	if err != nil {
+		return nil, files, err
+	}
+
+	serviceNames := strings.Split(string(servicesText), "\n")
+
+	var services []Service
+
+	for _, name := range serviceNames {
+		if name == "" {
+			continue
+		}
+		services = append(services, Service{Name: name})
+	}
+
+	return services, files, nil
+}
+
+func DcOutput(ctx context.Context, args ...string) (string, error) {
+	output, err := exec.CommandContext(ctx, "docker-compose", args...).Output()
+	if err != nil {
+		errorMessage := fmt.Sprintf("command 'docker-compose %q' failed.\nerror: '%v'\nstdout: '%v'", args, err, string(output))
+		if err, ok := err.(*exec.ExitError); ok {
+			errorMessage += fmt.Sprintf("\nstderr: '%v'", string(err.Stderr))
+		}
+		err = errors.New(errorMessage)
+	}
+	return string(output), err
+}
+
+func NiceError(cmd *exec.Cmd, stdout []byte, err error) error {
+	if err == nil {
+		return nil
+	}
+	errorMessage := fmt.Sprintf("command '%q %q' failed.\nerror: '%v'\n", cmd.Path, cmd.Args, err)
+	if len(stdout) > 0 {
+		errorMessage += fmt.Sprintf("\nstdout: '%v'", string(stdout))
+	}
+	if err, ok := err.(*exec.ExitError); ok && len(err.Stderr) > 0 {
+		errorMessage += fmt.Sprintf("\nstderr: '%v'", string(err.Stderr))
+	}
+	return errors.New(errorMessage)
+}

--- a/internal/dockercompose/compose.go
+++ b/internal/dockercompose/compose.go
@@ -18,13 +18,13 @@ func ParseConfig(ctx context.Context, files []string) ([]Service, []string, erro
 		args = append(args, "-f", f)
 	}
 	args = append(args, "config")
-	_, err := DcOutput(ctx, args...)
+	_, err := dcOutput(ctx, args...)
 	if err != nil {
 		return nil, files, err
 	}
 
 	args = append(args, "--services")
-	servicesText, err := DcOutput(ctx, args...)
+	servicesText, err := dcOutput(ctx, args...)
 	if err != nil {
 		return nil, files, err
 	}
@@ -43,7 +43,7 @@ func ParseConfig(ctx context.Context, files []string) ([]Service, []string, erro
 	return services, files, nil
 }
 
-func DcOutput(ctx context.Context, args ...string) (string, error) {
+func dcOutput(ctx context.Context, args ...string) (string, error) {
 	output, err := exec.CommandContext(ctx, "docker-compose", args...).Output()
 	if err != nil {
 		errorMessage := fmt.Sprintf("command 'docker-compose %q' failed.\nerror: '%v'\nstdout: '%v'", args, err, string(output))
@@ -55,7 +55,7 @@ func DcOutput(ctx context.Context, args ...string) (string, error) {
 	return string(output), err
 }
 
-func NiceError(cmd *exec.Cmd, stdout []byte, err error) error {
+func FormatError(cmd *exec.Cmd, stdout []byte, err error) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -84,6 +84,7 @@ type InitAction struct {
 	TiltfilePath       string
 	ConfigFiles        []string
 	ManifestNames      []model.ManifestName
+	Err                error
 }
 
 func (InitAction) Action() {}

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -28,12 +28,6 @@ type BuildAndDeployer interface {
 type BuildOrder []BuildAndDeployer
 type FallbackTester func(error) bool
 
-type CantHandleFailure struct {
-	error
-}
-
-var _ error = CantHandleFailure{}
-
 // CompositeBuildAndDeployer tries to run each builder in order.  If a builder
 // emits an error, it uses the FallbackTester to determine whether the error is
 // critical enough to stop the whole pipeline, or to fallback to the next
@@ -52,9 +46,6 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 	var lastErr error
 	for _, builder := range composite.builders {
 		br, err := builder.BuildAndDeploy(ctx, manifest, currentState)
-		if _, ok := err.(CantHandleFailure); ok {
-			continue
-		}
 		if err == nil {
 			// TODO(maia): this should be reactive (i.e. happen as a response to `BuildCompleteAction`)
 			composite.PostProcessBuild(ctx, br, currentState.LastResult)

--- a/internal/engine/build_errors.go
+++ b/internal/engine/build_errors.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/windmilleng/tilt/internal/model"
 )
 
 // Nothing is on fire, this is an expected case like a container builder being
@@ -43,11 +42,6 @@ var _ error = DontFallBackError{}
 // A permanent error indicates that the whole build pipeline needs to stop.
 // It will never recover, even on subsequent rebuilds.
 func isPermanentError(err error) bool {
-	// TODO(maia): invalid manifests will soon no longer be cause to stop Tilt...
-	if _, ok := err.(*model.ValidateErr); ok {
-		return true
-	}
-
 	cause := errors.Cause(err)
 	if cause == context.Canceled {
 		return true

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -1,0 +1,48 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/windmilleng/tilt/internal/dockercompose"
+	"github.com/windmilleng/tilt/internal/logger"
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+type DockerComposeBuildAndDeployer struct {
+}
+
+var _ BuildAndDeployer = &DockerComposeBuildAndDeployer{}
+
+func NewDockerComposeBuildAndDeployer() *DockerComposeBuildAndDeployer {
+	return &DockerComposeBuildAndDeployer{}
+}
+
+func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, state store.BuildState) (br store.BuildResult, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-DockerComposeBuildAndDeployer-BuildAndDeploy")
+	defer span.Finish()
+
+	if manifest.DcMeta {
+		return store.BuildResult{}, nil
+	}
+
+	if manifest.DcServiceName == "" {
+		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("no docker compose")}
+	}
+
+	cmd := exec.CommandContext(ctx, "docker-compose", "build", manifest.DcServiceName)
+	cmd.Stdout = logger.Get(ctx).Writer(logger.InfoLvl)
+	cmd.Stderr = logger.Get(ctx).Writer(logger.InfoLvl)
+
+	err = cmd.Run()
+	err = dockercompose.NiceError(cmd, nil, err)
+	return store.BuildResult{}, err
+}
+
+func (bd *DockerComposeBuildAndDeployer) PostProcessBuild(ctx context.Context, result, previousResult store.BuildResult) {
+	return
+}

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -34,7 +34,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, man
 	cmd.Stderr = logger.Get(ctx).Writer(logger.InfoLvl)
 
 	err = cmd.Run()
-	err = dockercompose.NiceError(cmd, nil, err)
+	err = dockercompose.FormatError(cmd, nil, err)
 	return store.BuildResult{}, err
 }
 

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 
 	"github.com/opentracing/opentracing-go"
@@ -27,7 +26,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, man
 	defer span.Finish()
 
 	if !manifest.IsDockerCompose() {
-		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("not a docker compose manifest")}
+		return store.BuildResult{}, RedirectToNextBuilderf("not a docker compose manifest")
 	}
 
 	cmd := exec.CommandContext(ctx, "docker-compose", "-f", manifest.DcYAMLPath, "up", "-d", manifest.Name.String())

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -63,6 +63,9 @@ func (ibd *ImageBuildAndDeployer) SetInjectSynclet(inject bool) {
 }
 
 func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, state store.BuildState) (br store.BuildResult, err error) {
+	if manifest.DcYaml != "" {
+		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("dc manifest")}
+	}
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuildAndDeployer-BuildAndDeploy")
 	defer span.Finish()
 
@@ -80,7 +83,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest m
 	ps := build.NewPipelineState(ctx, 2)
 	defer func() { ps.End(ctx, err) }()
 
-	err = manifest.Validate()
+	err = manifest.ValidateKubernetesBuildAndDeploy()
 	if err != nil {
 		return store.BuildResult{}, err
 	}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -63,7 +63,7 @@ func (ibd *ImageBuildAndDeployer) SetInjectSynclet(inject bool) {
 }
 
 func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, state store.BuildState) (br store.BuildResult, err error) {
-	if manifest.DcYaml != "" {
+	if manifest.IsDockerCompose() {
 		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("dc manifest")}
 	}
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuildAndDeployer-BuildAndDeploy")

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -83,7 +83,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest m
 	ps := build.NewPipelineState(ctx, 2)
 	defer func() { ps.End(ctx, err) }()
 
-	err = manifest.ValidateKubernetesBuildAndDeploy()
+	err = manifest.ValidateK8sManifest()
 	if err != nil {
 		return store.BuildResult{}, err
 	}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -64,7 +64,7 @@ func (ibd *ImageBuildAndDeployer) SetInjectSynclet(inject bool) {
 
 func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest model.Manifest, state store.BuildState) (br store.BuildResult, err error) {
 	if manifest.IsDockerCompose() {
-		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("dc manifest")}
+		return store.BuildResult{}, RedirectToNextBuilderf("dc manifest")
 	}
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuildAndDeployer-BuildAndDeploy")
 	defer span.Finish()

--- a/internal/engine/imagecontroller.go
+++ b/internal/engine/imagecontroller.go
@@ -39,6 +39,9 @@ func (c *ImageController) manifestsToReap(st store.RStore) []model.Manifest {
 	c.hasRunReaper = true
 	manifests := make([]model.Manifest, 0, len(state.ManifestStates))
 	for _, ms := range state.ManifestStates {
+		if ms.Manifest.DockerRef() == nil {
+			continue
+		}
 		manifests = append(manifests, ms.Manifest)
 	}
 	return manifests

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -37,7 +37,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 	defer span.Finish()
 
 	if manifest.IsDockerCompose() {
-		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("not implemented: DC container builds")}
+		return store.BuildResult{}, RedirectToNextBuilderf("not implemented: DC container builds")
 	}
 
 	startTime := time.Now()

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -36,6 +36,10 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 	span.SetTag("manifest", manifest.Name.String())
 	defer span.Finish()
 
+	if manifest.IsDockerCompose() {
+		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("not implemented: DC container builds")}
+	}
+
 	startTime := time.Now()
 	defer func() {
 		cbd.analytics.Timer("build.container", time.Since(startTime), nil)

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -50,7 +50,7 @@ func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest
 	defer span.Finish()
 
 	if manifest.IsDockerCompose() {
-		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("not implemented: DC container builds")}
+		return store.BuildResult{}, RedirectToNextBuilderf("not implemented: DC container builds")
 	}
 
 	if err := sbd.canSyncletBuild(ctx, manifest, state); err != nil {

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -49,6 +49,10 @@ func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest
 	span.SetTag("manifest", manifest.Name.String())
 	defer span.Finish()
 
+	if manifest.IsDockerCompose() {
+		return store.BuildResult{}, CantHandleFailure{fmt.Errorf("not implemented: DC container builds")}
+	}
+
 	if err := sbd.canSyncletBuild(ctx, manifest, state); err != nil {
 		return store.BuildResult{}, WrapRedirectToNextBuilder(err)
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -111,6 +111,10 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool) error
 	}
 
 	manifests, globalYAML, configFiles, err := loadAndGetManifests(ctx, manifestNames)
+	// ~~ maybe this is just for now...?
+	if err != nil {
+		return err
+	}
 
 	u.store.Dispatch(InitAction{
 		WatchMounts:        watchMounts,

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -33,6 +33,7 @@ var DeployerBaseWireSet = wire.NewSet(
 	build.NewContainerResolver,
 	NewSyncletBuildAndDeployer,
 	NewLocalContainerBuildAndDeployer,
+	NewDockerComposeBuildAndDeployer,
 	DefaultBuildOrder,
 
 	wire.Bind(new(BuildAndDeployer), new(CompositeBuildAndDeployer)),

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -6,16 +6,15 @@
 package engine
 
 import (
-	"context"
-
-	"github.com/google/go-cloud/wire"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/dockerfile"
-	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/synclet"
-	"github.com/windmilleng/wmclient/pkg/analytics"
-	"github.com/windmilleng/wmclient/pkg/dirs"
+	context "context"
+	wire "github.com/google/go-cloud/wire"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	dockerfile "github.com/windmilleng/tilt/internal/dockerfile"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
+	synclet "github.com/windmilleng/tilt/internal/synclet"
+	analytics "github.com/windmilleng/wmclient/pkg/analytics"
+	dirs "github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 // Injectors from wire.go:
@@ -32,10 +31,14 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k
 	dockerImageBuilder := build.NewDockerImageBuilder(docker2, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(docker2)
-	engineUpdateMode, err := ProvideUpdateMode(updateMode, env)
+	updateMode2, err := ProvideUpdateMode(updateMode, env)
 	if err != nil {
 		return nil, err
 	}
+	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8s2, env, memoryAnalytics, updateMode2)
+	dockerComposeBuildAndDeployer := NewDockerComposeBuildAndDeployer()
+	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, dockerComposeBuildAndDeployer, env, updateMode2)
+	compositeBuildAndDeployer := NewCompositeBuildAndDeployer(buildOrder)
 	return compositeBuildAndDeployer, nil
 }
 

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -6,15 +6,16 @@
 package engine
 
 import (
-	context "context"
-	wire "github.com/google/go-cloud/wire"
-	build "github.com/windmilleng/tilt/internal/build"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	dockerfile "github.com/windmilleng/tilt/internal/dockerfile"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
-	synclet "github.com/windmilleng/tilt/internal/synclet"
-	analytics "github.com/windmilleng/wmclient/pkg/analytics"
-	dirs "github.com/windmilleng/wmclient/pkg/dirs"
+	"context"
+
+	"github.com/google/go-cloud/wire"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/dockerfile"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/synclet"
+	"github.com/windmilleng/wmclient/pkg/analytics"
+	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 // Injectors from wire.go:
@@ -31,13 +32,10 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k
 	dockerImageBuilder := build.NewDockerImageBuilder(docker2, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(docker2)
-	updateMode2, err := ProvideUpdateMode(updateMode, env)
+	engineUpdateMode, err := ProvideUpdateMode(updateMode, env)
 	if err != nil {
 		return nil, err
 	}
-	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8s2, env, memoryAnalytics, updateMode2)
-	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, env, updateMode2)
-	compositeBuildAndDeployer := NewCompositeBuildAndDeployer(buildOrder)
 	return compositeBuildAndDeployer, nil
 }
 
@@ -72,6 +70,7 @@ var (
 
 var DeployerBaseWireSet = wire.NewSet(build.DefaultConsole, build.DefaultOut, wire.Value(dockerfile.Labels{}), wire.Value(UpperReducer), build.DefaultImageBuilder, build.NewCacheBuilder, build.NewDockerImageBuilder, NewImageBuildAndDeployer, build.NewContainerUpdater, build.NewContainerResolver, NewSyncletBuildAndDeployer,
 	NewLocalContainerBuildAndDeployer,
+	NewDockerComposeBuildAndDeployer,
 	DefaultBuildOrder, wire.Bind(new(BuildAndDeployer), new(CompositeBuildAndDeployer)), NewCompositeBuildAndDeployer,
 	ProvideUpdateMode,
 	NewGlobalYAMLBuildController,

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -26,6 +26,13 @@ type Manifest struct {
 	portForwards []PortForward
 	cachePaths   []string
 
+	// Properties for Docker Compose meta
+	DcMeta bool
+	DcYaml string
+
+	// Properties for Docker Compose Service
+	DcServiceName string
+
 	// Properties for fast_build (builds that support
 	// iteration based on past artifacts)
 	BaseDockerfile string
@@ -71,14 +78,15 @@ func (m Manifest) LocalPaths() []string {
 }
 
 func (m Manifest) Validate() error {
-	err := m.validate()
-	if err != nil {
-		return err
-	}
 	return nil
+	// err := m.validate()
+	// if err != nil {
+	// 	return err
+	// }
+	// return nil
 }
 
-func (m Manifest) validate() *ValidateErr {
+func (m Manifest) ValidateKubernetesBuildAndDeploy() *ValidateErr {
 	if m.Name == "" {
 		return validateErrf("[validate] manifest missing name: %+v", m)
 	}

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -20,18 +20,16 @@ func (m ManifestName) String() string { return string(m) }
 type Manifest struct {
 	// Properties for all builds.
 	Name         ManifestName
-	k8sYaml      string
 	tiltFilename string
+
+	// Properties for Docker Compose manifests
+	DcYAMLPath string
+
+	// Properties for all k8s builds
+	k8sYaml      string
 	dockerRef    reference.Named
 	portForwards []PortForward
 	cachePaths   []string
-
-	// Properties for Docker Compose meta
-	DcMeta bool
-	DcYaml string
-
-	// Properties for Docker Compose Service
-	DcServiceName string
 
 	// Properties for fast_build (builds that support
 	// iteration based on past artifacts)
@@ -50,6 +48,9 @@ type Manifest struct {
 }
 
 type DockerBuildArgs map[string]string
+
+// & m.k8sYaml == "" ?
+func (m Manifest) IsDockerCompose() bool { return m.DcYAMLPath != "" }
 
 func (m Manifest) WithCachePaths(paths []string) Manifest {
 	m.cachePaths = append(append([]string{}, m.cachePaths...), paths...)

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -124,8 +124,9 @@ func (m1 Manifest) Equal(m2 Manifest) bool {
 	portForwardsMatch := m1.portForwardsEqual(m2)
 	buildArgsMatch := reflect.DeepEqual(m1.StaticBuildArgs, m2.StaticBuildArgs)
 	cachePathsMatch := stringSlicesEqual(m1.cachePaths, m2.cachePaths)
+	dockerComposeEqual := m1.DcYAMLPath == m2.DcYAMLPath
 
-	return primitivesMatch && entrypointMatch && mountsMatch && reposMatch && portForwardsMatch && stepsMatch && buildArgsMatch && cachePathsMatch
+	return primitivesMatch && entrypointMatch && mountsMatch && reposMatch && portForwardsMatch && stepsMatch && buildArgsMatch && cachePathsMatch && dockerComposeEqual
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -23,6 +23,7 @@ type Manifest struct {
 	tiltFilename string
 
 	// Properties for Docker Compose manifests
+	// TODO(maia): pull out into separate type
 	DcYAMLPath string
 
 	// Properties for all k8s builds

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -6,10 +6,10 @@
 package synclet
 
 import (
-	context "context"
-	build "github.com/windmilleng/tilt/internal/build"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
+	"context"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/k8s"
 )
 
 // Injectors from wire.go:

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -6,10 +6,10 @@
 package synclet
 
 import (
-	"context"
-	"github.com/windmilleng/tilt/internal/build"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/k8s"
+	context "context"
+	build "github.com/windmilleng/tilt/internal/build"
+	docker "github.com/windmilleng/tilt/internal/docker"
+	k8s "github.com/windmilleng/tilt/internal/k8s"
 )
 
 // Injectors from wire.go:

--- a/internal/tiltfile/skylarkTypes.go
+++ b/internal/tiltfile/skylarkTypes.go
@@ -106,7 +106,7 @@ func (k *k8sManifest) createPortForward(thread *skylark.Thread, fn *skylark.Buil
 }
 
 type dcManifest struct {
-	name string
+	yamlPath string
 
 	services []dockercompose.Service
 }
@@ -131,24 +131,16 @@ func (m *dcManifest) Hash() (uint32, error) {
 	return 0, errors.New("unhashable type: dcManifest")
 }
 
-func (m *dcManifest) toDomain(metaName string) ([]model.Manifest, error) {
-	if metaName != "" {
-		m.name = metaName
-	}
-
+func (m *dcManifest) toDomain() ([]model.Manifest, error) {
 	var result []model.Manifest
 
-	for _, m := range m.services {
+	for _, svc := range m.services {
 		result = append(result, model.Manifest{
-			Name:          model.ManifestName(m.Name),
-			DcServiceName: m.Name,
+			Name:       model.ManifestName(svc.Name),
+			DcYAMLPath: m.yamlPath,
 		})
 	}
 
-	result = append(result, model.Manifest{
-		Name:   model.ManifestName(m.name),
-		DcMeta: true,
-	})
 	return result, nil
 }
 

--- a/internal/tiltfile/thread_local.go
+++ b/internal/tiltfile/thread_local.go
@@ -1,6 +1,7 @@
 package tiltfile
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,7 @@ const readFilesKey = "readFiles"
 const reposKey = "repos"
 const globalYAMLKey = "globalYaml"
 const globalYAMLDepsKey = "globalYamlDeps"
+const contextKey = "context"
 
 func setGlobalYAML(t *skylark.Thread, yaml string) {
 	t.SetLocal(globalYAMLKey, yaml)
@@ -33,6 +35,10 @@ func getGlobalYAML(t *skylark.Thread) (string, error) {
 			"internal error: %s thread local was not of type string", globalYAMLKey)
 	}
 	return yaml, nil
+}
+
+func getContext(t *skylark.Thread) context.Context {
+	return t.Local(contextKey).(context.Context)
 }
 
 func getGlobalYAMLDeps(t *skylark.Thread) ([]string, error) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -280,14 +280,16 @@ def blorgly_frontend():
 `)
 
 	manifests := f.LoadManifests("blorgly")
-	assert.Equal(t, "blorgly_backend", manifests[0].Name.String())
-	assert.Equal(t, 1, len(manifests[0].Repos))
-	assert.Equal(t, "", manifests[0].Repos[0].DockerignoreContents)
-	assert.Equal(t, "", manifests[0].Repos[0].GitignoreContents)
-	assert.Equal(t, "blorgly_frontend", manifests[1].Name.String())
-	assert.Equal(t, 1, len(manifests[1].Repos))
-	assert.Equal(t, "", manifests[1].Repos[0].DockerignoreContents)
-	assert.Equal(t, "", manifests[1].Repos[0].GitignoreContents)
+	if assert.Equal(t, 2, len(manifests)) {
+		assert.Equal(t, "blorgly_backend", manifests[0].Name.String())
+		assert.Equal(t, 1, len(manifests[0].Repos))
+		assert.Equal(t, "", manifests[0].Repos[0].DockerignoreContents)
+		assert.Equal(t, "", manifests[0].Repos[0].GitignoreContents)
+		assert.Equal(t, "blorgly_frontend", manifests[1].Name.String())
+		assert.Equal(t, 1, len(manifests[1].Repos))
+		assert.Equal(t, "", manifests[1].Repos[0].DockerignoreContents)
+		assert.Equal(t, "", manifests[1].Repos[0].GitignoreContents)
+	}
 }
 
 func TestGetManifestConfigUndefined(t *testing.T) {


### PR DESCRIPTION
(note -- this code doesn't have tests, I'm going to merge it onto a separate branch)

Hello @dbentley, @jazzdan,

Please review the following commits I made in branch maiamcc/dc-tiltfile-and-build-deploy:

9a2dd89a222da3230393b65b737e8073d15eb688 (2018-11-29 17:16:46 -0500)
down works with dc services

abe89e7441db4c6b4bf61a82464a2e08db844d3f (2018-11-29 17:01:22 -0500)
tests green

c674f0f113213743bafcb76a4ee677dbf7efcc52 (2018-11-29 16:53:11 -0500)
fix a million merge conflicts

84904c5c004f9515c807ec8eb604cfb2b347b15a (2018-11-29 16:49:55 -0500)
remove dcmeta manifest -- dcBad can now up -d docker compose svcs

80ec1317569c9617e7c86c62642909c1671f8190 (2018-11-29 16:49:03 -0500)
checkpoint

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics