### PR TITLE
build: support mounting files to directories

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -98,6 +98,28 @@ func TestMount(t *testing.T) {
 	f.assertFilesInImage(ref, pcs)
 }
 
+func TestMountFileToDirectory(t *testing.T) {
+	f := newDockerBuildFixture(t)
+	defer f.teardown()
+
+	f.WriteFile("sup", "my name is dan")
+
+	m := model.Mount{
+		LocalPath:     f.JoinPath("sup"),
+		ContainerPath: "/src/",
+	}
+
+	ref, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, []model.Mount{m}, model.EmptyMatcher, nil, model.Cmd{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pcs := []expectedFile{
+		expectedFile{Path: "/src/sup", Contents: "my name is dan"},
+	}
+	f.assertFilesInImage(ref, pcs)
+}
+
 func TestMultipleMounts(t *testing.T) {
 	f := newDockerBuildFixture(t)
 	defer f.teardown()

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -133,9 +133,8 @@ func fileToPathMapping(file string, mounts []model.Mount) (pathMapping, *PathMap
 	return pathMapping{}, pathMappingErrf("file %s matches no mounts", file)
 }
 
-// TODO(dmiller): this won't work in Windows
 func endsWithSlash(path string) bool {
-	return strings.HasSuffix(path, "/")
+	return strings.HasSuffix(path, string(filepath.Separator))
 }
 
 func isFile(path string) (bool, error) {
@@ -144,7 +143,7 @@ func isFile(path string) (bool, error) {
 		return false, err
 	}
 	mode := fi.Mode()
-	return mode.IsRegular(), nil
+	return !mode.IsDir(), nil
 }
 
 func FileBelongsToMount(file string, mounts []model.Mount) bool {

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -111,13 +113,38 @@ func fileToPathMapping(file string, mounts []model.Mount) (pathMapping, *PathMap
 		// need ospath.RealChild -- but then can't deal with deleted local files.
 		relPath, isChild := ospath.Child(m.LocalPath, file)
 		if isChild {
+			localPathIsFile, err := isFile(m.LocalPath)
+			if err != nil {
+				return pathMapping{}, pathMappingErrf("error stat'ing: %v", err)
+			}
+			var containerPath string
+			if endsWithSlash(m.ContainerPath) && localPathIsFile {
+				fileName := path.Base(m.LocalPath)
+				containerPath = filepath.Join(m.ContainerPath, fileName)
+			} else {
+				containerPath = filepath.Join(m.ContainerPath, relPath)
+			}
 			return pathMapping{
 				LocalPath:     file,
-				ContainerPath: filepath.Join(m.ContainerPath, relPath),
+				ContainerPath: containerPath,
 			}, nil
 		}
 	}
 	return pathMapping{}, pathMappingErrf("file %s matches no mounts", file)
+}
+
+// TODO(dmiller): this won't work in Windows
+func endsWithSlash(path string) bool {
+	return strings.HasSuffix(path, "/")
+}
+
+func isFile(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	mode := fi.Mode()
+	return mode.IsRegular(), nil
 }
 
 func FileBelongsToMount(file string, mounts []model.Mount) bool {

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -65,6 +65,42 @@ func TestFilesToPathMappings(t *testing.T) {
 	assert.ElementsMatch(t, expected, actual)
 }
 
+func TestFileToDirectoryPathMapping(t *testing.T) {
+	f := tempdir.NewTempDirFixture(t)
+	defer f.TearDown()
+
+	paths := []string{
+		"mount1/fileA",
+	}
+	f.TouchFiles(paths)
+
+	absPaths := make([]string, len(paths))
+	for i, p := range paths {
+		absPaths[i] = f.JoinPath(p)
+	}
+
+	mounts := []model.Mount{
+		model.Mount{
+			LocalPath:     f.JoinPath("mount1", "fileA"),
+			ContainerPath: "/dest1/",
+		},
+	}
+
+	actual, err := FilesToPathMappings(absPaths, mounts)
+	if err != nil {
+		f.T().Fatal(err)
+	}
+
+	expected := []pathMapping{
+		pathMapping{
+			LocalPath:     filepath.Join(f.Path(), "mount1/fileA"),
+			ContainerPath: "/dest1/fileA",
+		},
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
+
 func TestFileNotInMountThrowsErr(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
 	defer f.TearDown()

--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -132,9 +132,13 @@ func (a *ArchiveBuilder) tarPath(ctx context.Context, source, dest string) error
 			header.Name = strings.TrimPrefix(path, source)
 			// ...and live inside `dest`
 			header.Name = filepath.Join(dest, header.Name)
+		} else if strings.HasSuffix(dest, "/") { // TODO(dmiller): this won't work in Windows
+			header.Name = filepath.Join(dest, filepath.Base(source))
 		} else {
 			header.Name = dest
 		}
+
+		header.Name = filepath.Clean(header.Name)
 
 		err = a.tw.WriteHeader(header)
 		if err != nil {

--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -132,7 +132,7 @@ func (a *ArchiveBuilder) tarPath(ctx context.Context, source, dest string) error
 			header.Name = strings.TrimPrefix(path, source)
 			// ...and live inside `dest`
 			header.Name = filepath.Join(dest, header.Name)
-		} else if strings.HasSuffix(dest, "/") { // TODO(dmiller): this won't work in Windows
+		} else if strings.HasSuffix(dest, string(filepath.Separator)) {
 			header.Name = filepath.Join(dest, filepath.Base(source))
 		} else {
 			header.Name = dest


### PR DESCRIPTION
My one big question: is there a better way to indicate that the destination of a mount is a directory other than requiring that a `/` be appended?

Also I'm pretty sure this approach won't work in Windows.