### PR TITLE
[docker-compose] prelim log support [ch978]

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -43,7 +43,8 @@ var BaseWireSet = wire.NewSet(
 	engine.NewServiceWatcher,
 	engine.NewImageController,
 	engine.NewConfigsController,
-	engine.NewDockerComposeWatcher,
+	engine.NewDockerComposeEventWatcher,
+	engine.NewDockerComposeLogManager,
 
 	provideClock,
 	hud.NewRenderer,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -6,17 +6,17 @@
 package cli
 
 import (
-	context "context"
-	wire "github.com/google/go-cloud/wire"
-	build "github.com/windmilleng/tilt/internal/build"
-	demo "github.com/windmilleng/tilt/internal/demo"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	dockerfile "github.com/windmilleng/tilt/internal/dockerfile"
-	engine "github.com/windmilleng/tilt/internal/engine"
-	hud "github.com/windmilleng/tilt/internal/hud"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
-	store "github.com/windmilleng/tilt/internal/store"
-	time "time"
+	"context"
+	"github.com/google/go-cloud/wire"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/demo"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/dockerfile"
+	"github.com/windmilleng/tilt/internal/engine"
+	"github.com/windmilleng/tilt/internal/hud"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/store"
+	"time"
 )
 
 // Injectors from wire.go:
@@ -49,8 +49,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	}
 	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
 	reducer := _wireReducerValue
-	logActionsFlag2 := provideLogActions()
-	store2 := store.NewStore(reducer, logActionsFlag2)
+	storeLogActionsFlag := provideLogActions()
+	storeStore := store.NewStore(reducer, storeLogActionsFlag)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -74,8 +74,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(dockerCli)
-	updateModeFlag2 := provideUpdateModeFlag()
-	updateMode, err := engine.ProvideUpdateMode(updateModeFlag2, env)
+	engineUpdateModeFlag := provideUpdateModeFlag()
+	updateMode, err := engine.ProvideUpdateMode(engineUpdateModeFlag, env)
 	if err != nil {
 		return demo.Script{}, err
 	}
@@ -88,9 +88,10 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	configsController := engine.NewConfigsController()
-	dockerComposeWatcher := engine.NewDockerComposeWatcher()
-	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, store2, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, k8sClient, dockerComposeWatcher)
-	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, store2, branch)
+	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher()
+	dockerComposeLogManager := engine.NewDockerComposeLogManager()
+	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, k8sClient, dockerComposeEventWatcher, dockerComposeLogManager)
+	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, storeStore, branch)
 	return script, nil
 }
 
@@ -127,8 +128,8 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	}
 	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
 	reducer := _wireReducerValue
-	logActionsFlag2 := provideLogActions()
-	store2 := store.NewStore(reducer, logActionsFlag2)
+	storeLogActionsFlag := provideLogActions()
+	storeStore := store.NewStore(reducer, storeLogActionsFlag)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -152,8 +153,8 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(dockerCli)
-	updateModeFlag2 := provideUpdateModeFlag()
-	updateMode, err := engine.ProvideUpdateMode(updateModeFlag2, env)
+	engineUpdateModeFlag := provideUpdateModeFlag()
+	updateMode, err := engine.ProvideUpdateMode(engineUpdateModeFlag, env)
 	if err != nil {
 		return HudAndUpper{}, err
 	}
@@ -166,8 +167,9 @@ func wireHudAndUpper(ctx context.Context) (HudAndUpper, error) {
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	configsController := engine.NewConfigsController()
-	dockerComposeWatcher := engine.NewDockerComposeWatcher()
-	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, store2, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, k8sClient, dockerComposeWatcher)
+	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher()
+	dockerComposeLogManager := engine.NewDockerComposeLogManager()
+	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, k8sClient, dockerComposeEventWatcher, dockerComposeLogManager)
 	hudAndUpper := provideHudAndUpper(headsUpDisplay, upper)
 	return hudAndUpper, nil
 }
@@ -195,7 +197,7 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 var K8sWireSet = wire.NewSet(k8s.DetectEnv, k8s.DetectNodeIP, k8s.ProvidePortForwarder, k8s.ProvideRESTClient, k8s.ProvideRESTConfig, k8s.NewK8sClient, wire.Bind(new(k8s.Client), k8s.K8sClient{}))
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, docker.DefaultDockerClient, wire.Bind(new(docker.DockerClient), new(docker.DockerCli)), build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeWatcher, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, engine.NewUpper, provideAnalytics,
+	K8sWireSet, docker.DefaultDockerClient, wire.Bind(new(docker.DockerClient), new(docker.DockerCli)), build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, engine.NewUpper, provideAnalytics,
 	provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideHudAndUpper,
 )
 

--- a/internal/dockercompose/event.go
+++ b/internal/dockercompose/event.go
@@ -55,15 +55,20 @@ type Action string
 
 const (
 	// Add 'actions' here (and to `UnmarshalJSON` below`) as we support them
-	ActionAttach  Action = "attach"
-	ActionCreate  Action = "create"
-	ActionDie     Action = "die"
-	ActionKill    Action = "kill"
-	ActionRename  Action = "rename"
-	ActionRestart Action = "restart"
-	ActionStart   Action = "start"
-	ActionStop    Action = "stop"
-	ActionUpdate  Action = "update"
+
+	// CONTAINER actions
+	ActionAttach     Action = "attach"
+	ActionCreate     Action = "create"
+	ActionDie        Action = "die"
+	ActionExecDie    Action = "exec_die"
+	ActionExecAttach Action = "exec_attach"
+	ActionExecCreate Action = "exec_create"
+	ActionKill       Action = "kill"
+	ActionRename     Action = "rename"
+	ActionRestart    Action = "restart"
+	ActionStart      Action = "start"
+	ActionStop       Action = "stop"
+	ActionUpdate     Action = "update"
 )
 
 func (a *Action) UnmarshalJSON(b []byte) error {
@@ -78,6 +83,12 @@ func (a *Action) UnmarshalJSON(b []byte) error {
 		*a = ActionCreate
 	} else if s == "die" {
 		*a = ActionDie
+	} else if s == "exec_attach" {
+		*a = ActionExecAttach
+	} else if s == "exec_die" {
+		*a = ActionExecDie
+	} else if s == "exec_create" {
+		*a = ActionExecCreate
 	} else if s == "kill" {
 		*a = ActionKill
 	} else if s == "rename" {

--- a/internal/dockercompose/info.go
+++ b/internal/dockercompose/info.go
@@ -27,24 +27,10 @@ func (evt Event) GuessState() (string, bool) {
 }
 
 type Info struct {
-	State string
+	State      string
+	CurrentLog string
 }
 
 func (i Info) Log() string {
-	return `What rolls down stairs
-Alone or in pairs,
-And over your neighbor's dog?
-What's great for a snack,
-And fits on your back?
-It's log, log, log!
-
-It's log, it's log,
-It's big, it's heavy, it's wood.
-It's log, it's log, it's better than bad, it's good!
-
-Everyone wants a log
-You're gonna love it, log
-Come on and get your log
-Everyone needs a log
-Log log log!`
+	return i.CurrentLog
 }

--- a/internal/dockercompose/info.go
+++ b/internal/dockercompose/info.go
@@ -28,9 +28,9 @@ func (evt Event) GuessState() (string, bool) {
 
 type Info struct {
 	State      string
-	CurrentLog string
+	CurrentLog []byte
 }
 
 func (i Info) Log() string {
-	return i.CurrentLog
+	return string(i.CurrentLog)
 }

--- a/internal/dockercompose/logs.go
+++ b/internal/dockercompose/logs.go
@@ -1,23 +1,28 @@
 package dockercompose
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os/exec"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/logger"
 )
 
 func LogReaderForService(ctx context.Context, svcName, configPath string) (io.ReadCloser, error) {
 	// TODO(maia): --since time
 	// (may need to implement with `docker log <cID>` instead since `d-c log` doesn't support `--since`
-	args := []string{"-f", configPath, "-f", "-t", "logs", svcName} // ~~ don't need -t probs
+	args := []string{"-f", configPath, "logs", "-f", "-t", svcName} // ~~ don't need -t probs
 	cmd := exec.CommandContext(ctx, "docker-compose", args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, errors.Wrap(err, "making stdout pipe for `docker-compose logs`")
 	}
+
+	errBuf := bytes.Buffer{}
+	cmd.Stderr = &errBuf
 
 	err = cmd.Start()
 	if err != nil {
@@ -25,5 +30,12 @@ func LogReaderForService(ctx context.Context, svcName, configPath string) (io.Re
 			strings.Join(args, " "))
 	}
 
+	go func() {
+		err = cmd.Wait()
+		if err != nil {
+			logger.Get(ctx).Debugf("cmd `docker-compose %s` exited with error: \"%v\" (stderr: %s)",
+				strings.Join(args, " "), err, errBuf.String())
+		}
+	}()
 	return stdout, nil
 }

--- a/internal/dockercompose/logs.go
+++ b/internal/dockercompose/logs.go
@@ -1,0 +1,29 @@
+package dockercompose
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func LogReaderForService(ctx context.Context, svcName, configPath string) (io.ReadCloser, error) {
+	// TODO(maia): --since time
+	// (may need to implement with `docker log <cID>` instead since `d-c log` doesn't support `--since`
+	args := []string{"-f", configPath, "-f", "-t", "logs", svcName} // ~~ don't need -t probs
+	cmd := exec.CommandContext(ctx, "docker-compose", args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "making stdout pipe for `docker-compose logs`")
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, errors.Wrapf(err, "`docker-compose %s`",
+			strings.Join(args, " "))
+	}
+
+	return stdout, nil
+}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -147,3 +147,12 @@ type DockerComposeEventAction struct {
 }
 
 func (DockerComposeEventAction) Action() {}
+
+type DockerComposeLogAction struct {
+	ManifestName model.ManifestName
+
+	PodID k8s.PodID
+	Log   []byte
+}
+
+func (DockerComposeLogAction) Action() {}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -150,9 +150,7 @@ func (DockerComposeEventAction) Action() {}
 
 type DockerComposeLogAction struct {
 	ManifestName model.ManifestName
-
-	PodID k8s.PodID
-	Log   []byte
+	Log          []byte
 }
 
 func (DockerComposeLogAction) Action() {}

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -29,7 +29,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, man
 		return store.BuildResult{}, RedirectToNextBuilderf("not a docker compose manifest")
 	}
 
-	cmd := exec.CommandContext(ctx, "docker-compose", "-f", manifest.DcYAMLPath, "up", "--force-recreate", "-d", manifest.Name.String())
+	cmd := exec.CommandContext(ctx, "docker-compose", "-f", manifest.DcYAMLPath, "up", "--no-deps", "--build", "--force-recreate", "-d", manifest.Name.String())
 	cmd.Stdout = logger.Get(ctx).Writer(logger.InfoLvl)
 	cmd.Stderr = logger.Get(ctx).Writer(logger.InfoLvl)
 

--- a/internal/engine/docker_compose_log_manager.go
+++ b/internal/engine/docker_compose_log_manager.go
@@ -13,18 +13,18 @@ import (
 
 // Collects logs from running docker-compose services.
 type DockerComposeLogManager struct {
-	watches map[model.ManifestName]DockerComposeLogWatch
+	watches map[model.ManifestName]dockerComposeLogWatch
 }
 
 func NewDockerComposeLogManager() *DockerComposeLogManager {
 	return &DockerComposeLogManager{
-		watches: make(map[model.ManifestName]DockerComposeLogWatch),
+		watches: make(map[model.ManifestName]dockerComposeLogWatch),
 	}
 }
 
 // Diff the current watches against set of current docker-compose services, i.e.
 // what we SHOULD be watching, returning the changes we need to make.
-func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (setup []DockerComposeLogWatch, teardown []DockerComposeLogWatch) {
+func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (setup []dockerComposeLogWatch, teardown []dockerComposeLogWatch) {
 	state := st.RLockState()
 	defer st.RUnlockState()
 
@@ -52,7 +52,7 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 		}
 
 		ctx, cancel := context.WithCancel(ctx)
-		w := DockerComposeLogWatch{
+		w := dockerComposeLogWatch{
 			ctx:             ctx,
 			cancel:          cancel,
 			name:            ms.Manifest.Name,
@@ -87,7 +87,7 @@ func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore)
 	}
 }
 
-func (m *DockerComposeLogManager) consumeLogs(watch DockerComposeLogWatch, st store.RStore) {
+func (m *DockerComposeLogManager) consumeLogs(watch dockerComposeLogWatch, st store.RStore) {
 	defer func() {
 		watch.terminationTime <- time.Now()
 		watch.cancel()
@@ -119,7 +119,7 @@ func (m *DockerComposeLogManager) consumeLogs(watch DockerComposeLogWatch, st st
 	}
 }
 
-type DockerComposeLogWatch struct {
+type dockerComposeLogWatch struct {
 	ctx             context.Context
 	cancel          func()
 	name            model.ManifestName

--- a/internal/engine/docker_compose_log_manager.go
+++ b/internal/engine/docker_compose_log_manager.go
@@ -1,0 +1,153 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/windmilleng/tilt/internal/dockercompose"
+	"github.com/windmilleng/tilt/internal/logger"
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+// Collects logs from deployed containers.
+type DockerComposeLogManager struct {
+	watches map[model.ManifestName]DockerComposeLogWatch
+}
+
+func NewDockerComposeLogManager() *DockerComposeLogManager {
+	return &DockerComposeLogManager{
+		watches: make(map[model.ManifestName]DockerComposeLogWatch),
+	}
+}
+
+// Diff the current watches against the state store of what
+// we're supposed to be watching, returning the changes
+// we need to make.
+func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (setup []DockerComposeLogWatch, teardown []DockerComposeLogWatch) {
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	// If we're not watching the mounts, then don't bother watching logs.
+	if !state.WatchMounts {
+		return nil, nil
+	}
+
+	for _, ms := range state.ManifestStates {
+		if !ms.Manifest.IsDockerCompose() {
+			continue
+		}
+
+		existing, isActive := m.watches[ms.Manifest.Name]
+		startWatchTime := time.Unix(0, 0)
+		if isActive {
+			if existing.ctx.Err() == nil {
+				// Watcher is still active, no action needed.
+				continue
+			}
+
+			// The active log watcher got cancelled somehow,
+			// so we need to create a new one that picks up
+			// where it left off.
+			startWatchTime = <-existing.terminationTime
+		}
+
+		ctx, cancel := context.WithCancel(ctx)
+		w := DockerComposeLogWatch{
+			ctx:             ctx,
+			cancel:          cancel,
+			name:            ms.Manifest.Name,
+			dcYAMLPath:      ms.Manifest.DcYAMLPath,
+			startWatchTime:  startWatchTime,
+			terminationTime: make(chan time.Time, 1),
+		}
+		m.watches[ms.Manifest.Name] = w
+		setup = append(setup, w)
+	}
+
+	for key, value := range m.watches {
+		_, inState := state.ManifestStates[key]
+		if !inState {
+			delete(m.watches, key)
+
+			teardown = append(teardown, value)
+		}
+	}
+
+	return setup, teardown
+}
+
+func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore) {
+	setup, teardown := m.diff(ctx, st)
+	for _, watch := range teardown {
+		fmt.Println("Tearing down watch:", watch.name)
+		watch.cancel()
+	}
+
+	for _, watch := range setup {
+		fmt.Println("Setting up watch:", watch.name)
+		go m.consumeLogs(watch, st)
+	}
+}
+
+func (m *DockerComposeLogManager) consumeLogs(watch DockerComposeLogWatch, st store.RStore) {
+	defer func() {
+		watch.terminationTime <- time.Now()
+		watch.cancel()
+	}()
+
+	name := watch.name
+	readCloser, err := dockercompose.LogReaderForService(watch.ctx, watch.name.String(), watch.dcYAMLPath)
+	if err != nil {
+		logger.Get(watch.ctx).Infof("Error streaming %s logs: %v", name, err)
+		return
+	}
+	defer func() {
+		_ = readCloser.Close()
+	}()
+
+	logWriter := logger.Get(watch.ctx).Writer(logger.InfoLvl)      // write to master logger
+	prefix := logPrefix(name.String())                             // calculate prefix for pod log (i.e. service name?)
+	prefixLogWriter := logger.NewPrefixedWriter(prefix, logWriter) // new writer that prefixes all lines
+	actionWriter := DockerComposeLogActionWriter{                  // `Write` message dispatches NewPodLog action
+		store:        st,
+		manifestName: name,
+	}
+	multiWriter := io.MultiWriter(prefixLogWriter, actionWriter) // write to both at once
+
+	_, err = io.Copy(multiWriter, NewHardCancelReader(watch.ctx, readCloser)) // til reader done, take all from readCloser (unless ctx.canceled) --> multiWriter
+	if err != nil && watch.ctx.Err() == nil {
+		logger.Get(watch.ctx).Infof("Error streaming %s logs: %v", name, err)
+		return
+	}
+}
+
+type DockerComposeLogWatch struct {
+	ctx             context.Context
+	cancel          func()
+	name            model.ManifestName
+	dcYAMLPath      string
+	startWatchTime  time.Time
+	terminationTime chan time.Time
+
+	// TODO(maia): do we need to track these? (maybe if we implement with `docker logs <cID>`...)
+	// cID             container.ID
+	// cName           container.Name
+}
+
+type DockerComposeLogActionWriter struct {
+	store        store.RStore
+	manifestName model.ManifestName
+}
+
+func (w DockerComposeLogActionWriter) Write(p []byte) (n int, err error) {
+	w.store.Dispatch(DockerComposeLogAction{
+		ManifestName: w.manifestName,
+		Log:          append([]byte{}, p...),
+	})
+	return len(p), nil
+}
+
+var _ store.Subscriber = &DockerComposeLogManager{}

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -155,17 +155,17 @@ func (m *PodLogManager) consumeLogs(watch PodLogWatch, st store.RStore) {
 		_ = readCloser.Close()
 	}()
 
-	logWriter := logger.Get(watch.ctx).Writer(logger.InfoLvl)
-	prefix := logPrefix(name.String())
-	prefixLogWriter := logger.NewPrefixedWriter(prefix, logWriter)
-	actionWriter := PodLogActionWriter{
+	logWriter := logger.Get(watch.ctx).Writer(logger.InfoLvl)      // write to master logger
+	prefix := logPrefix(name.String())                             // calculate prefix for pod log (i.e. service name?)
+	prefixLogWriter := logger.NewPrefixedWriter(prefix, logWriter) // new writer that prefixes all lines
+	actionWriter := PodLogActionWriter{                            // `Write` message dispatches NewPodLog action
 		store:        st,
 		manifestName: name,
 		podID:        pID,
 	}
-	multiWriter := io.MultiWriter(prefixLogWriter, actionWriter)
+	multiWriter := io.MultiWriter(prefixLogWriter, actionWriter) // write to both at once
 
-	_, err = io.Copy(multiWriter, NewHardCancelReader(watch.ctx, readCloser))
+	_, err = io.Copy(multiWriter, NewHardCancelReader(watch.ctx, readCloser)) // til reader done, take all from readCloser (unless ctx.canceled) --> multiWriter
 	if err != nil && watch.ctx.Err() == nil {
 		logger.Get(watch.ctx).Infof("Error streaming %s logs: %v", name, err)
 		return
@@ -207,6 +207,7 @@ type PodLogActionWriter struct {
 	manifestName model.ManifestName
 }
 
+// implements writer interface
 func (w PodLogActionWriter) Write(p []byte) (n int, err error) {
 	w.store.Dispatch(PodLogAction{
 		PodID:        w.podID,

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -196,7 +196,7 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 	case DockerComposeEventAction:
 		handleDockerComposeEvent(ctx, state, action)
 	case DockerComposeLogAction:
-		// handleDockerComposeLogAction(ctx, state, action)
+		handleDockerComposeLogAction(state, action)
 	default:
 		err = fmt.Errorf("unrecognized action: %T", action)
 	}
@@ -218,7 +218,7 @@ func handleBuildStarted(ctx context.Context, state *store.EngineState, action Bu
 		pod.CurrentLog = []byte{}
 	}
 
-	ms.DCInfo.CurrentLog = "" // TODO(maia): when reset(/not) CrashLog for DC service?
+	ms.DCInfo.CurrentLog = []byte{} // TODO(maia): when reset(/not) CrashLog for DC service?
 
 	// Keep the crash log around until we have a rebuild
 	// triggered by a explicit change (i.e., not a crash rebuild)
@@ -670,9 +670,7 @@ func handleDockerComposeEvent(ctx context.Context, engineState *store.EngineStat
 
 	// For now, just guess at state.
 	state, ok := evt.GuessState()
-	logger.Get(ctx).Infof("guessing state for %s event: %s", evt.Type, evt.Action)
 	if ok {
-		logger.Get(ctx).Infof("state is probably: %s", state)
 		ms.DCInfo.State = state
 	}
 }
@@ -686,11 +684,9 @@ func handleDockerComposeLogAction(state *store.EngineState, action DockerCompose
 		return
 	}
 
-	// TODO: what if log comes from an inactive container?
+	// fmt.Printf("<via action> got log for %s:\n\t%s\n", ms.Manifest.Name, string(action.Log))
 
-	// ~~ add log info to the current log
-	podInfo := ms.PodSet.Pods["abc"]
-	podInfo.CurrentLog = append(podInfo.CurrentLog, action.Log...)
+	ms.DCInfo.CurrentLog = append(ms.DCInfo.CurrentLog, action.Log...)
 }
 
 // Check if the filesChangedSet only contains spurious changes that

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -684,7 +685,12 @@ func handleDockerComposeLogAction(state *store.EngineState, action DockerCompose
 		return
 	}
 
-	// fmt.Printf("<via action> got log for %s:\n\t%s\n", ms.Manifest.Name, string(action.Log))
+	// filter out bogus log
+	// TODO(maia): this still shows up in the top-level tilt log and it's annoying :-/
+	logStr := string(action.Log)
+	if strings.TrimSpace(logStr) == "Attaching to" {
+		return
+	}
 
 	ms.DCInfo.CurrentLog = append(ms.DCInfo.CurrentLog, action.Log...)
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1545,7 +1545,6 @@ func newTestFixture(t *testing.T) *testFixture {
 	cc := NewConfigsController()
 	dcw := NewDockerComposeEventWatcher()
 	dclm := NewDockerComposeLogManager()
-
 	upper := NewUpper(ctx, fakeHud, pw, sw, st, plm, pfc, fwm, bc, ic, gybc, cc, k8s, dcw, dclm)
 
 	go func() {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1543,9 +1543,10 @@ func newTestFixture(t *testing.T) *testFixture {
 	ic := NewImageController(reaper)
 	gybc := NewGlobalYAMLBuildController(k8s)
 	cc := NewConfigsController()
-	dcw := NewDockerComposeWatcher()
+	dcw := NewDockerComposeEventWatcher()
+	dclm := NewDockerComposeLogManager()
 
-	upper := NewUpper(ctx, fakeHud, pw, sw, st, plm, pfc, fwm, bc, ic, gybc, cc, k8s, dcw)
+	upper := NewUpper(ctx, fakeHud, pw, sw, st, plm, pfc, fwm, bc, ic, gybc, cc, k8s, dcw, dclm)
 
 	go func() {
 		fakeHud.Run(ctx, upper.Dispatch, hud.DefaultRefreshInterval)

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -6,15 +6,15 @@
 package engine
 
 import (
-	context "context"
-	wire "github.com/google/go-cloud/wire"
-	build "github.com/windmilleng/tilt/internal/build"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	dockerfile "github.com/windmilleng/tilt/internal/dockerfile"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
-	synclet "github.com/windmilleng/tilt/internal/synclet"
-	analytics "github.com/windmilleng/wmclient/pkg/analytics"
-	dirs "github.com/windmilleng/wmclient/pkg/dirs"
+	"context"
+	"github.com/google/go-cloud/wire"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/dockerfile"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/synclet"
+	"github.com/windmilleng/wmclient/pkg/analytics"
+	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 // Injectors from wire.go:
@@ -31,13 +31,13 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k
 	dockerImageBuilder := build.NewDockerImageBuilder(docker2, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(docker2)
-	updateMode2, err := ProvideUpdateMode(updateMode, env)
+	engineUpdateMode, err := ProvideUpdateMode(updateMode, env)
 	if err != nil {
 		return nil, err
 	}
-	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8s2, env, memoryAnalytics, updateMode2)
+	imageBuildAndDeployer := NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8s2, env, memoryAnalytics, engineUpdateMode)
 	dockerComposeBuildAndDeployer := NewDockerComposeBuildAndDeployer()
-	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, dockerComposeBuildAndDeployer, env, updateMode2)
+	buildOrder := DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, dockerComposeBuildAndDeployer, env, engineUpdateMode)
 	compositeBuildAndDeployer := NewCompositeBuildAndDeployer(buildOrder)
 	return compositeBuildAndDeployer, nil
 }

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -6,10 +6,10 @@
 package synclet
 
 import (
-	context "context"
-	build "github.com/windmilleng/tilt/internal/build"
-	docker "github.com/windmilleng/tilt/internal/docker"
-	k8s "github.com/windmilleng/tilt/internal/k8s"
+	"context"
+	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/k8s"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
Known bug: doesn't support getting logs since a certain time. usually
not a problem since we rebuild with --force-recreate so have a clean
container every time. however, it's annoying if there are already dc
services running when the user calls `tilt up` -- then we periodically
get old error logs for the old versions of the services as their deps
all die, until the services themselves reboot. not great.