### PR TITLE
logger: funcLogger should observe log levels

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -134,7 +134,9 @@ func provideLogActions() store.LogActionsFlag {
 func NewLogActionLogger(ctx context.Context, dispatch func(action store.Action)) logger.Logger {
 	l := logger.Get(ctx)
 	return logger.NewFuncLogger(l.SupportsColor(), l.Level(), func(level logger.Level, b []byte) error {
-		dispatch(engine.LogAction{Log: b})
+		if l.Level() >= level {
+			dispatch(engine.LogAction{Log: b})
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/log-levels:

6042cb0b0be05d978e293e5334c8c04cb95d3aac (2018-12-07 17:34:51 -0500)
logger: funcLogger should observe log levels

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics