### PR TITLE
tiltfile: correctly handle k8s resources that aren't associated with a manifest

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -76,11 +76,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest m
 		ibd.analytics.Timer("build.image", time.Since(startTime), tags)
 	}()
 
-	hasBuild := manifest.DockerRef() != nil
 	numStages := 2
-	if !hasBuild {
-		numStages = 1
-	}
 	ps := build.NewPipelineState(ctx, numStages)
 	defer func() { ps.End(ctx, err) }()
 
@@ -89,12 +85,9 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest m
 		return store.BuildResult{}, err
 	}
 
-	var ref reference.NamedTagged
-	if hasBuild {
-		ref, err = ibd.build(ctx, manifest, state, ps)
-		if err != nil {
-			return store.BuildResult{}, err
-		}
+	ref, err := ibd.build(ctx, manifest, state, ps)
+	if err != nil {
+		return store.BuildResult{}, err
 	}
 
 	k8sEntities, namespace, err := ibd.deploy(ctx, ps, manifest, ref)

--- a/internal/engine/imagecontroller.go
+++ b/internal/engine/imagecontroller.go
@@ -59,11 +59,7 @@ func (c *ImageController) OnChange(ctx context.Context, st store.RStore) {
 func (c *ImageController) reapOldWatchBuilds(ctx context.Context, manifests []model.Manifest, createdBefore time.Time) error {
 	watchFilter := build.FilterByLabelValue(build.BuildMode, build.BuildModeExisting)
 	for _, manifest := range manifests {
-		ref := manifest.DockerRef()
-		if ref == nil {
-			continue
-		}
-		nameFilter := build.FilterByRefName(ref)
+		nameFilter := build.FilterByRefName(manifest.DockerRef())
 		err := c.reaper.RemoveTiltImages(ctx, createdBefore, false, watchFilter, nameFilter)
 		if err != nil {
 			return errors.Wrap(err, "reapOldWatchBuilds")

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -390,11 +390,6 @@ func ensureManifestStateWithPod(state *store.EngineState, pod *v1.Pod) (*store.M
 		return nil, nil
 	}
 
-	if ms.Manifest.DockerRef() == nil {
-		// We don't track pods if we didn't build the image for this manifest
-		return nil, nil
-	}
-
 	imageID, err := k8s.FindImageNamedTaggedMatching(pod.Spec, ms.Manifest.DockerRef())
 	if err != nil || imageID == nil {
 		// Ditto, this could happen if we get a pod from an old version of the manifest.

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -550,6 +550,7 @@ spec:
 status: {}
 `
 
+const SecretName = "mysecret"
 const SecretYaml = `
 apiVersion: v1
 kind: Secret

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -84,7 +84,7 @@ func (m Manifest) validate() *ValidateErr {
 	}
 
 	if m.dockerRef == nil {
-		return nil
+		return validateErrf("[validate] manifest %q missing image ref", m.Name)
 	}
 
 	if m.K8sYAML() == "" {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -431,7 +431,6 @@ func StateToView(s EngineState) view.View {
 			PodLog:                pod.Log(),
 			CrashLog:              ms.CrashLog,
 			Endpoints:             endpoints,
-			IsYAMLManifest:        ms.Manifest.DockerRef() == nil,
 		}
 
 		ret.Resources = append(ret.Resources, r)


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/globalyaml2:

1ce65986bee153c241971fbe9c47009b386f7628 (2018-12-10 15:04:10 -0500)
tiltfile: correctly handle k8s resources that aren't associated with a manifest