### PR TITLE
engine: fix crash-rebuilds when the pod updates before the build finishes

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1023,6 +1023,108 @@ func TestPodUnexpectedContainerStartsImageBuild(t *testing.T) {
 	f.waitForCompletedBuildCount(1)
 }
 
+func TestPodUnexpectedContainerStartsImageBuildOutOfOrderEvents(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+	f.bc.DisableForTesting()
+
+	mount := model.Mount{LocalPath: "/go", ContainerPath: "/go"}
+	name := model.ManifestName("foobar")
+	manifest := f.newManifest(name.String(), []model.Mount{mount})
+
+	f.Start([]model.Manifest{manifest}, true)
+
+	// Start a fake build to set manifestState.ExpectedContainerId
+	f.store.Dispatch(manifestFilesChangedAction{
+		manifestName: manifest.Name,
+		files:        []string{"/go/a"},
+	})
+	f.WaitUntil("waiting for builds to be ready", func(st store.EngineState) bool {
+		return nextManifestToBuild(st) == manifest.Name
+	})
+	f.store.Dispatch(BuildStartedAction{
+		Manifest:  manifest,
+		StartTime: time.Now(),
+	})
+
+	// Simulate k8s restarting the container due to a crash.
+	f.podEvent(f.testPod("mypod", "foobar", "Running", "myfunnycontainerid", time.Now()))
+	f.store.Dispatch(BuildCompleteAction{
+		Result: store.BuildResult{
+			Image:       nil,
+			ContainerID: "theOriginalContainer",
+		},
+	})
+
+	f.WaitUntilManifest("NeedsRebuildFromCrash set to True", "foobar", func(state store.ManifestState) bool {
+		return state.NeedsRebuildFromCrash
+	})
+	// wait for triggered image build (count is 1 because our fake build above doesn't increment this number).
+	f.waitForCompletedBuildCount(1)
+}
+
+func TestPodUnexpectedContainerAfterInPlaceUpdate(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+	f.bc.DisableForTesting()
+
+	mount := model.Mount{LocalPath: "/go", ContainerPath: "/go"}
+	name := model.ManifestName("foobar")
+	manifest := f.newManifest(name.String(), []model.Mount{mount})
+
+	f.Start([]model.Manifest{manifest}, true)
+
+	// Start a fake build to set manifestState.ExpectedContainerId
+	f.store.Dispatch(manifestFilesChangedAction{
+		manifestName: manifest.Name,
+		files:        []string{"/go/a"},
+	})
+	f.WaitUntil("waiting for builds to be ready", func(st store.EngineState) bool {
+		return nextManifestToBuild(st) == manifest.Name
+	})
+
+	f.store.Dispatch(BuildStartedAction{
+		Manifest:  manifest,
+		StartTime: time.Now(),
+	})
+
+	// Simulate a normal build completion
+	podStartTime := time.Now()
+	f.store.Dispatch(BuildCompleteAction{
+		Result: store.BuildResult{
+			Image:       nil,
+			ContainerID: "normal-container-id",
+		},
+	})
+	f.podEvent(f.testPod("mypod", "foobar", "Running", "normal-container-id", podStartTime))
+
+	// Start another fake build to set manifestState.ExpectedContainerId
+	f.store.Dispatch(manifestFilesChangedAction{
+		manifestName: manifest.Name,
+		files:        []string{"/go/a"},
+	})
+	f.WaitUntil("waiting for builds to be ready", func(st store.EngineState) bool {
+		return nextManifestToBuild(st) == manifest.Name
+	})
+	f.store.Dispatch(BuildStartedAction{
+		Manifest:  manifest,
+		StartTime: time.Now(),
+	})
+
+	// Simulate a pod crash, then a build compltion
+	f.podEvent(f.testPod("mypod", "foobar", "Running", "funny-container-id", podStartTime))
+	f.store.Dispatch(BuildCompleteAction{
+		Result: store.BuildResult{
+			Image:       nil,
+			ContainerID: "normal-container-id",
+		},
+	})
+
+	f.WaitUntilManifest("NeedsRebuildFromCrash set to True", "foobar", func(state store.ManifestState) bool {
+		return state.NeedsRebuildFromCrash
+	})
+}
+
 func TestPodEventUpdateByTimestamp(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/crash:

97336d23e7bc06a1e0d74924aa17b36f861a9d6b (2018-12-10 15:50:40 -0500)
engine: fix crash-rebuilds when the pod updates before the build finishes