### PR TITLE
tiltfile: fix error on typo'd resource names

### DIFF
--- a/internal/tiltfile2/tiltfile.go
+++ b/internal/tiltfile2/tiltfile.go
@@ -45,17 +45,15 @@ func Load(ctx context.Context, filename string, matching map[string]bool) (manif
 	if err != nil {
 		return nil, model.YAMLManifest{}, nil, err
 	}
-	manifests, err = s.translate(assembled)
 
-	if len(matching) > 0 {
-		var result []model.Manifest
-		for _, m := range manifests {
-			if !matching[string(m.Name)] {
-				continue
-			}
-			result = append(result, m)
-		}
-		manifests = result
+	manifests, err = s.translate(assembled)
+	if err != nil {
+		return nil, model.YAMLManifest{}, nil, err
+	}
+
+	manifests, err = match(manifests, matching)
+	if err != nil {
+		return nil, model.YAMLManifest{}, nil, err
 	}
 
 	yamlManifest := model.YAMLManifest{}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch1000/garbage:

f5d592ce7381d6d89344585245ec4c2b8bbd038f (2018-12-10 17:54:54 -0500)
tiltfile: fix error on typo'd resource names