### PR TITLE
docker: some versions of docker reject requests for buildkit with error if it's not supported :sob:

### DIFF
--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -1,0 +1,34 @@
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type buildkitTestCase struct {
+	v        types.Version
+	expected bool
+}
+
+func TestSupportsBuildkit(t *testing.T) {
+	cases := []buildkitTestCase{
+		{types.Version{APIVersion: "1.37", Experimental: true}, false},
+		{types.Version{APIVersion: "1.37", Experimental: false}, false},
+		{types.Version{APIVersion: "1.38", Experimental: true}, true},
+		{types.Version{APIVersion: "1.38", Experimental: false}, false},
+		{types.Version{APIVersion: "1.39", Experimental: true}, true},
+		{types.Version{APIVersion: "1.39", Experimental: false}, true},
+		{types.Version{APIVersion: "1.40", Experimental: true}, true},
+		{types.Version{APIVersion: "1.40", Experimental: false}, true},
+		{types.Version{APIVersion: "garbage", Experimental: false}, false},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
+			assert.Equal(t, c.expected, SupportsBuildkit(c.v))
+		})
+	}
+}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch1104/minikube:

e19ed6c02a570b45d3af177bb7cbc9f8c6a189ed (2018-12-12 11:09:58 -0500)
docker: some versions of docker reject requests for buildkit with error if it's not supported :sob: