### PR TITLE
model/manifest: sort result of manifest.Dependencies()

### DIFF
--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -188,7 +188,12 @@ func (m Manifest) Dependencies() []string {
 		deps = append(deps, p)
 	}
 
-	return sliceutils.DedupeStringSlice(deps)
+	deduped := sliceutils.DedupeStringSlice(deps)
+
+	// Sort so that any nested paths come after their parents
+	sort.Strings(deduped)
+
+	return deduped
 }
 
 func (m Manifest) WithConfigFiles(confFiles []string) Manifest {


### PR DESCRIPTION
Hello @nicks, @jazzdan,

idk if this is the right way to address this problem, but if you mount
/my/dir/nested and then mount /my/dir, the latter doesn't get properly watched.
This seemed like a cheap fix.