### PR TITLE
tiltfile2: basic test for loading a docker compose manifest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - homebrew_cache_v5
-      - run: brew install go@1.10 kustomize # bump cache version when changing this
+            - homebrew_cache_v6
+      - run: brew install go@1.10 kustomize docker-compose # bump cache version when changing this
       - save_cache:
           paths:
             - /usr/local/Homebrew
-          key: homebrew_cache_v5
+          key: homebrew_cache_v6
       - run: echo 'export PATH="/usr/local/opt/go@1.10/bin:$PATH"' >> $BASH_ENV
       # We can't run the container tests on macos because nested
       # VMs don't work on circleci.

--- a/internal/tiltfile2/docker_compose.go
+++ b/internal/tiltfile2/docker_compose.go
@@ -2,6 +2,7 @@ package tiltfile2
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 
 	"github.com/google/skylark"
@@ -23,17 +24,21 @@ func (s *tiltfileState) dockerCompose(thread *skylark.Thread, fn *skylark.Builti
 	if err != nil {
 		return nil, err
 	}
+	absConfigPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, err
+	}
 
-	services, err := dockercompose.ParseConfig(s.ctx, configPath)
+	services, err := dockercompose.ParseConfig(s.ctx, absConfigPath)
 	if err != nil {
 		return nil, err
 	}
 
 	if !s.dc.Empty() {
-		return skylark.None, fmt.Errorf("already have a docker-compose resource declared (%s), cannot declare another (%s)", s.dc.configPath, configPath)
+		return skylark.None, fmt.Errorf("already have a docker-compose resource declared (%s), cannot declare another (%s)", s.dc.configPath, absConfigPath)
 	}
 
-	s.dc = dcResource{configPath: configPath, services: services}
+	s.dc = dcResource{configPath: absConfigPath, services: services}
 
 	return skylark.None, nil
 }


### PR DESCRIPTION
@maiamcc any other assertions I should add for this basic test?

I also changed the docker compose yaml path to be absolute to match how we treat other files that we read and store in memory.