### PR TITLE
tiltfile2: resolve docker-compose path relative to tiltfile root

### DIFF
--- a/internal/tiltfile2/docker_compose.go
+++ b/internal/tiltfile2/docker_compose.go
@@ -2,12 +2,10 @@ package tiltfile2
 
 import (
 	"fmt"
-	"path/filepath"
 	"reflect"
 
 	"github.com/google/skylark"
 	"github.com/windmilleng/tilt/internal/dockercompose"
-	"github.com/windmilleng/tilt/internal/ospath"
 )
 
 // dcResource represents a single docker-compose config file and all its associated services
@@ -25,24 +23,21 @@ func (s *tiltfileState) dockerCompose(thread *skylark.Thread, fn *skylark.Builti
 	if err != nil {
 		return nil, err
 	}
-	if !filepath.IsAbs(configPath) {
-		configPath = filepath.Join(s.absWorkingDir(), configPath)
-	}
-	absConfigPath, err := ospath.RealAbs(configPath)
+	configPath = s.absPath(configPath)
 	if err != nil {
 		return nil, err
 	}
 
-	services, err := dockercompose.ParseConfig(s.ctx, absConfigPath)
+	services, err := dockercompose.ParseConfig(s.ctx, configPath)
 	if err != nil {
 		return nil, err
 	}
 
 	if !s.dc.Empty() {
-		return skylark.None, fmt.Errorf("already have a docker-compose resource declared (%s), cannot declare another (%s)", s.dc.configPath, absConfigPath)
+		return skylark.None, fmt.Errorf("already have a docker-compose resource declared (%s), cannot declare another (%s)", s.dc.configPath, configPath)
 	}
 
-	s.dc = dcResource{configPath: absConfigPath, services: services}
+	s.dc = dcResource{configPath: configPath, services: services}
 
 	return skylark.None, nil
 }

--- a/internal/tiltfile2/docker_compose.go
+++ b/internal/tiltfile2/docker_compose.go
@@ -26,7 +26,7 @@ func (s *tiltfileState) dockerCompose(thread *skylark.Thread, fn *skylark.Builti
 		return nil, err
 	}
 	if !filepath.IsAbs(configPath) {
-		configPath = filepath.Join(s.root, configPath)
+		configPath = filepath.Join(s.absWorkingDir(), configPath)
 	}
 	absConfigPath, err := ospath.RealAbs(configPath)
 	if err != nil {

--- a/internal/tiltfile2/docker_compose.go
+++ b/internal/tiltfile2/docker_compose.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/skylark"
 	"github.com/windmilleng/tilt/internal/dockercompose"
+	"github.com/windmilleng/tilt/internal/ospath"
 )
 
 // dcResource represents a single docker-compose config file and all its associated services
@@ -24,7 +25,10 @@ func (s *tiltfileState) dockerCompose(thread *skylark.Thread, fn *skylark.Builti
 	if err != nil {
 		return nil, err
 	}
-	absConfigPath, err := filepath.Abs(configPath)
+	if !filepath.IsAbs(configPath) {
+		configPath = filepath.Join(s.root, configPath)
+	}
+	absConfigPath, err := ospath.RealAbs(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile2/tiltfile.go
+++ b/internal/tiltfile2/tiltfile.go
@@ -30,7 +30,9 @@ func Load(ctx context.Context, filename string, matching map[string]bool) (manif
 		return nil, model.YAMLManifest{}, []string{absFilename}, err
 	}
 
-	s := newTiltfileState(ctx, absFilename)
+	tfRoot, _ := filepath.Split(absFilename)
+
+	s := newTiltfileState(ctx, absFilename, tfRoot)
 	defer func() {
 		configFiles = s.configFiles
 	}()

--- a/internal/tiltfile2/tiltfile_state.go
+++ b/internal/tiltfile2/tiltfile_state.go
@@ -23,6 +23,7 @@ type tiltfileState struct {
 	// set at creation
 	ctx      context.Context
 	filename string
+	root     string
 
 	// added to during execution
 	configFiles    []string
@@ -37,10 +38,11 @@ type tiltfileState struct {
 	usedImages map[string]bool
 }
 
-func newTiltfileState(ctx context.Context, filename string) *tiltfileState {
+func newTiltfileState(ctx context.Context, filename string, tfRoot string) *tiltfileState {
 	return &tiltfileState{
 		ctx:          ctx,
 		filename:     filename,
+		root:         tfRoot,
 		imagesByName: make(map[string]*dockerImage),
 		k8sByName:    make(map[string]*k8sResource),
 		configFiles:  []string{filename},

--- a/internal/tiltfile2/tiltfile_state.go
+++ b/internal/tiltfile2/tiltfile_state.go
@@ -23,7 +23,6 @@ type tiltfileState struct {
 	// set at creation
 	ctx      context.Context
 	filename string
-	root     string
 
 	// added to during execution
 	configFiles    []string
@@ -42,7 +41,6 @@ func newTiltfileState(ctx context.Context, filename string, tfRoot string) *tilt
 	return &tiltfileState{
 		ctx:          ctx,
 		filename:     filename,
-		root:         tfRoot,
 		imagesByName: make(map[string]*dockerImage),
 		k8sByName:    make(map[string]*k8sResource),
 		configFiles:  []string{filename},


### PR DESCRIPTION
Also introduce the concept of a tiltfileRoot which could, in the future,
allow the Tiltfile and the directory we operate in to be disjoint paths.