### PR TITLE
watch: fix a bug when a file and its ancestor both have direct watches

### DIFF
--- a/internal/watch/ospath.go
+++ b/internal/watch/ospath.go
@@ -1,24 +1,8 @@
 package watch
 
-import (
-	"os"
-	"path/filepath"
-	"strings"
-)
+import "github.com/windmilleng/tilt/internal/ospath"
 
 func pathIsChildOf(path string, parent string) bool {
-	relPath, err := filepath.Rel(parent, path)
-	if err != nil {
-		return true
-	}
-
-	if relPath == "." {
-		return true
-	}
-
-	if filepath.IsAbs(relPath) || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
-		return false
-	}
-
-	return true
+	_, isChild := ospath.Child(parent, path)
+	return isChild
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch1153/nested:

6e1dac10a22c699124aac826689b7492df4ea3bc (2018-12-19 19:07:52 -0500)
watch: fix a bug when a file and its ancestor both have direct watches