### PR TITLE
docker: reject older docker versions if we haven't tested them

### DIFF
--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -32,3 +32,24 @@ func TestSupportsBuildkit(t *testing.T) {
 		})
 	}
 }
+
+type versionTestCase struct {
+	v        types.Version
+	expected bool
+}
+
+func TestSupported(t *testing.T) {
+	cases := []buildkitTestCase{
+		{types.Version{APIVersion: "1.22"}, false},
+		{types.Version{APIVersion: "1.23"}, true},
+		{types.Version{APIVersion: "1.39"}, true},
+		{types.Version{APIVersion: "1.40"}, true},
+		{types.Version{APIVersion: "garbage"}, false},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
+			assert.Equal(t, c.expected, SupportedVersion(c.v))
+		})
+	}
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/dockernegotiation:

4256d7c498569d5adc24bfbc9f6b68d5e2931b23 (2018-12-20 15:06:08 -0500)
docker: reject older docker versions if we haven't tested them