### PR TITLE
model: move k8s-specific info to model.deployInfo [ch1136]

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -22,13 +22,6 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-// ~~TODO(maia): uhhh delete this?
-// type deployableImageManifest interface {
-// 	K8sYAML() string
-// 	ManifestName() model.ManifestName
-// 	DockerRef() reference.Named
-// }
-
 var _ BuildAndDeployer = &ImageBuildAndDeployer{}
 
 type ImageBuildAndDeployer struct {

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -22,11 +22,12 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-type deployableImageManifest interface {
-	K8sYAML() string
-	ManifestName() model.ManifestName
-	DockerRef() reference.Named
-}
+// ~~TODO(maia): uhhh delete this?
+// type deployableImageManifest interface {
+// 	K8sYAML() string
+// 	ManifestName() model.ManifestName
+// 	DockerRef() reference.Named
+// }
 
 var _ BuildAndDeployer = &ImageBuildAndDeployer{}
 
@@ -83,7 +84,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, manifest m
 	ps := build.NewPipelineState(ctx, numStages)
 	defer func() { ps.End(ctx, err) }()
 
-	err = manifest.ValidateK8sManifest()
+	err = manifest.ValidateDockerK8sManifest()
 	if err != nil {
 		return store.BuildResult{}, err
 	}
@@ -182,7 +183,15 @@ func (ibd *ImageBuildAndDeployer) build(ctx context.Context, manifest model.Mani
 }
 
 // Returns: the entities deployed and the namespace of the pod with the given image name/tag.
-func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.PipelineState, manifest deployableImageManifest, ref reference.NamedTagged) ([]k8s.K8sEntity, k8s.Namespace, error) {
+func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.PipelineState, manifest model.Manifest, ref reference.NamedTagged) ([]k8s.K8sEntity, k8s.Namespace, error) {
+	k8sInfo := manifest.K8sInfo()
+	if k8sInfo.Empty() {
+		// If a non-yaml manifest reaches this code, something is wrong.
+		// If we change BaD structure such that that might reasonably happen,
+		// this should be a `RedirectToNextBuilder` error.
+		return nil, "", fmt.Errorf("manifest %s has no k8s deploy info", manifest.Name)
+	}
+
 	ps.StartPipelineStep(ctx, "Deploying")
 	defer ps.EndPipelineStep(ctx)
 
@@ -190,7 +199,7 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.Pipeline
 
 	// TODO(nick): The parsed YAML should probably be a part of the model?
 	// It doesn't make much sense to re-parse it and inject labels on every deploy.
-	entities, err := k8s.ParseYAMLFromString(manifest.K8sYAML())
+	entities, err := k8s.ParseYAMLFromString(k8sInfo.YAML)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -67,7 +67,8 @@ func TestDeployTwinImages(t *testing.T) {
 	f := newIBDFixture(t)
 	defer f.TearDown()
 
-	manifest := NewSanchoManifest().AppendK8sYAML(SanchoTwinYAML)
+	sancho := NewSanchoManifest()
+	manifest := sancho.WithDeployInfo(sancho.K8sInfo().AppendYAML(SanchoTwinYAML))
 	result, err := f.ibd.BuildAndDeploy(f.ctx, manifest, store.BuildStateClean)
 	assert.NoError(t, err)
 

--- a/internal/engine/parse.go
+++ b/internal/engine/parse.go
@@ -6,9 +6,13 @@ import (
 )
 
 func ParseYAMLFromManifests(manifests ...model.Manifest) ([]k8s.K8sEntity, error) {
-	allEntities := []k8s.K8sEntity{}
+	var allEntities []k8s.K8sEntity
 	for _, m := range manifests {
-		entities, err := k8s.ParseYAMLFromString(m.K8sYAML())
+		k8sInfo := m.K8sInfo()
+		if k8sInfo.Empty() {
+			continue
+		}
+		entities, err := k8s.ParseYAMLFromString(k8sInfo.YAML)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/portforwardcontroller.go
+++ b/internal/engine/portforwardcontroller.go
@@ -124,17 +124,14 @@ type portForwardEntry struct {
 	cancel             func()
 }
 
-type portForwardableManifest interface {
-	PortForwards() []model.PortForward
-}
-
 // Extract the port-forward specs from the manifest. If any of them
 // have ContainerPort = 0, populate them with the default port in the pod spec.
 // Quietly drop forwards that we can't populate.
-func PopulatePortForwards(m portForwardableManifest, pod store.Pod) []model.PortForward {
+func PopulatePortForwards(m model.Manifest, pod store.Pod) []model.PortForward {
 	cPorts := pod.ContainerPorts
-	forwards := make([]model.PortForward, 0, len(m.PortForwards()))
-	for _, forward := range m.PortForwards() {
+	fwds := m.K8sInfo().PortForwards
+	forwards := make([]model.PortForward, 0, len(fwds))
+	for _, forward := range fwds {
 		if forward.ContainerPort == 0 {
 			if len(cPorts) == 0 {
 				continue

--- a/internal/engine/portforwardcontroller_test.go
+++ b/internal/engine/portforwardcontroller_test.go
@@ -20,10 +20,12 @@ func TestPortForward(t *testing.T) {
 	m := model.Manifest{
 		Name: "fe",
 	}
-	m = m.WithPortForwards([]model.PortForward{
-		{
-			LocalPort:     8080,
-			ContainerPort: 8081,
+	m = m.WithDeployInfo(model.K8sInfo{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort:     8080,
+				ContainerPort: 8081,
+			},
 		},
 	})
 	state.ManifestStates["fe"] = &store.ManifestState{
@@ -66,9 +68,11 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 	m := model.Manifest{
 		Name: "fe",
 	}
-	m = m.WithPortForwards([]model.PortForward{
-		{
-			LocalPort: 8080,
+	m = m.WithDeployInfo(model.K8sInfo{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort: 8080,
+			},
 		},
 	})
 	state.ManifestStates["fe"] = &store.ManifestState{

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -39,7 +39,7 @@ func NewSanchoManifest() model.Manifest {
 		Entrypoint: model.Cmd{Argv: []string{"/go/bin/sancho"}},
 	}
 
-	m = m.WithDockerRef(SanchoRef).WithK8sYAML(SanchoYAML)
+	m = m.WithDockerRef(SanchoRef).WithDeployInfo(model.K8sInfo{YAML: SanchoYAML})
 
 	return m
 }
@@ -51,7 +51,7 @@ func NewSanchoStaticManifest() model.Manifest {
 		StaticBuildPath:  "/path/to/build",
 	}
 
-	m = m.WithDockerRef(SanchoRef).WithK8sYAML(SanchoYAML)
+	m = m.WithDockerRef(SanchoRef).WithDeployInfo(model.K8sInfo{YAML: SanchoYAML})
 	return m
 }
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -501,7 +501,7 @@ func populateContainerStatus(ctx context.Context, ms *store.ManifestState, podIn
 	podInfo.ContainerPorts = ports
 
 	forwards := PopulatePortForwards(ms.Manifest, *podInfo)
-	if len(forwards) < len(ms.Manifest.PortForwards()) {
+	if len(forwards) < len(ms.Manifest.K8sInfo().PortForwards) {
 		logger.Get(ctx).Infof(
 			"WARNING: Resource %s is using port forwards, but no container ports on pod %s",
 			ms.Manifest.Name, podInfo.PodID)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -446,7 +446,7 @@ func TestRebuildDockerfileViaImageBuild(t *testing.T) {
 	// Second call: new manifest!
 	call = f.nextCall("new manifest")
 	assert.Equal(t, "FROM iron/go:dev", call.manifest.BaseDockerfile)
-	assert.Equal(t, testyaml.SnackYAMLPostConfig, call.manifest.K8sYAML())
+	assert.Equal(t, testyaml.SnackYAMLPostConfig, call.manifest.K8sInfo().YAML)
 
 	// Since the manifest changed, we cleared the previous build state to force an image build
 	assert.False(t, call.state.HasImage())

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -21,7 +21,7 @@ func (dc DCInfo) Empty() bool { return reflect.DeepEqual(dc, DCInfo{}) }
 
 type K8sInfo struct {
 	YAML         string
-	portForwards []PortForward
+	PortForwards []PortForward
 }
 
 func (K8sInfo) deployInfo()     {}

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"reflect"
+
+	"github.com/windmilleng/tilt/internal/yaml"
 )
 
 type deployInfo interface {
@@ -18,9 +20,18 @@ func (DCInfo) deployInfo()    {}
 func (dc DCInfo) Empty() bool { return reflect.DeepEqual(dc, DCInfo{}) }
 
 type K8sInfo struct {
-	k8sYaml      string
+	YAML         string
 	portForwards []PortForward
 }
 
 func (K8sInfo) deployInfo()     {}
 func (k8s K8sInfo) Empty() bool { return reflect.DeepEqual(k8s, K8sInfo{}) }
+
+func (k8s K8sInfo) AppendYAML(y string) K8sInfo {
+	if k8s.YAML == "" {
+		k8s.YAML = y
+	} else {
+		k8s.YAML = yaml.ConcatYAML(k8s.YAML, y)
+	}
+	return k8s
+}

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -1,6 +1,8 @@
 package model
 
-import "reflect"
+import (
+	"reflect"
+)
 
 type deployInfo interface {
 	deployInfo()
@@ -14,3 +16,11 @@ type DCInfo struct {
 
 func (DCInfo) deployInfo()    {}
 func (dc DCInfo) Empty() bool { return reflect.DeepEqual(dc, DCInfo{}) }
+
+type K8sInfo struct {
+	k8sYaml      string
+	portForwards []PortForward
+}
+
+func (K8sInfo) deployInfo()     {}
+func (k8s K8sInfo) Empty() bool { return reflect.DeepEqual(k8s, K8sInfo{}) }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -26,9 +26,6 @@ type Manifest struct {
 	// Info needed to deploy. Can be k8s yaml, docker compose, etc.
 	deployInfo deployInfo
 
-	// Properties for all k8s builds
-	portForwards []PortForward
-
 	// All docker stuff
 	cachePaths []string
 	dockerRef  reference.Named
@@ -167,7 +164,6 @@ func (m1 Manifest) Equal(m2 Manifest) bool {
 	mountsMatch := reflect.DeepEqual(m1.Mounts, m2.Mounts)
 	reposMatch := reflect.DeepEqual(m1.repos, m2.repos)
 	stepsMatch := m1.stepsEqual(m2.Steps)
-	portForwardsMatch := reflect.DeepEqual(m1.portForwards, m2.portForwards)
 	dockerignoresMatch := reflect.DeepEqual(m1.dockerignores, m2.dockerignores)
 	buildArgsMatch := reflect.DeepEqual(m1.StaticBuildArgs, m2.StaticBuildArgs)
 	cachePathsMatch := stringSlicesEqual(m1.cachePaths, m2.cachePaths)
@@ -184,7 +180,6 @@ func (m1 Manifest) Equal(m2 Manifest) bool {
 		entrypointMatch &&
 		mountsMatch &&
 		reposMatch &&
-		portForwardsMatch &&
 		stepsMatch &&
 		buildArgsMatch &&
 		cachePathsMatch &&
@@ -249,15 +244,6 @@ func (m Manifest) LocalRepos() []LocalGithubRepo {
 	return m.repos
 }
 
-func (m Manifest) WithPortForwards(pf []PortForward) Manifest {
-	m.portForwards = pf
-	return m
-}
-
-func (m Manifest) PortForwards() []PortForward {
-	return m.portForwards
-}
-
 func (m Manifest) TiltFilename() string {
 	return m.tiltFilename
 }
@@ -265,12 +251,6 @@ func (m Manifest) TiltFilename() string {
 func (m Manifest) WithTiltFilename(f string) Manifest {
 	m.tiltFilename = f
 	return m
-}
-
-func (m Manifest) WithK8sYAML(y string) Manifest {
-	k8sInfo := m.K8sInfo()
-	k8sInfo.YAML = y
-	return m.WithDeployInfo(k8sInfo)
 }
 
 func (m Manifest) DockerRef() reference.Named {

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/windmilleng/tilt/internal/container"
 )
 
+var portFwd8000 = []PortForward{{LocalPort: 8080}}
+var portFwd8001 = []PortForward{{LocalPort: 8081}}
+
 var equalitytests = []struct {
 	m1       Manifest
 	m2       Manifest
@@ -90,37 +93,13 @@ var equalitytests = []struct {
 		true,
 	},
 	{
-		Manifest{
-			portForwards: []PortForward{
-				{
-					LocalPort: 8080,
-				},
-			},
-		},
-		Manifest{
-			portForwards: []PortForward{
-				{
-					LocalPort: 8081,
-				},
-			},
-		},
+		Manifest{}.WithDeployInfo(K8sInfo{PortForwards: portFwd8000}),
+		Manifest{}.WithDeployInfo(K8sInfo{PortForwards: portFwd8001}),
 		false,
 	},
 	{
-		Manifest{
-			portForwards: []PortForward{
-				{
-					LocalPort: 8080,
-				},
-			},
-		},
-		Manifest{
-			portForwards: []PortForward{
-				{
-					LocalPort: 8080,
-				},
-			},
-		},
+		Manifest{}.WithDeployInfo(K8sInfo{PortForwards: portFwd8000}),
+		Manifest{}.WithDeployInfo(K8sInfo{PortForwards: portFwd8000}),
 		true,
 	},
 	{
@@ -345,18 +324,4 @@ func TestManifestValidateMountRelativePath(t *testing.T) {
 	err = manifest.Validate()
 	assert.Nil(t, err)
 
-}
-
-func TestSetPortForwards(t *testing.T) {
-	m := Manifest{
-		Name: "test",
-	}
-
-	m2 := m.WithPortForwards([]PortForward{
-		PortForward{
-			LocalPort: 8080,
-		},
-	})
-
-	assert.Equal(t, 8080, m2.PortForwards()[0].LocalPort)
 }

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -300,6 +300,16 @@ var equalitytests = []struct {
 		Manifest{}.WithDeployInfo(DCInfo{DfRaw: []byte("goodbye world")}),
 		false,
 	},
+	{
+		Manifest{}.WithDeployInfo(K8sInfo{YAML: "hello world"}),
+		Manifest{}.WithDeployInfo(K8sInfo{YAML: "hello world"}),
+		true,
+	},
+	{
+		Manifest{}.WithDeployInfo(K8sInfo{YAML: "hello world"}),
+		Manifest{}.WithDeployInfo(K8sInfo{YAML: "goodbye world"}),
+		false,
+	},
 }
 
 func TestManifestEquality(t *testing.T) {
@@ -320,7 +330,6 @@ func TestManifestValidateMountRelativePath(t *testing.T) {
 		},
 	}
 	manifest := Manifest{
-		k8sYaml:        "yamlll",
 		Name:           "test",
 		dockerRef:      container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef"),
 		BaseDockerfile: "FROM node",

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -370,7 +370,7 @@ func ManifestStateEndpoints(ms *ManifestState) (endpoints []string) {
 
 	// If the user specified port-forwards in the Tiltfile, we
 	// assume that's what they want to see in the UI
-	portForwards := ms.Manifest.PortForwards()
+	portForwards := ms.Manifest.K8sInfo().PortForwards
 	if len(portForwards) > 0 {
 		for _, pf := range portForwards {
 			endpoints = append(endpoints, fmt.Sprintf("http://localhost:%d/", pf.LocalPort))

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -46,9 +46,11 @@ func TestStateToViewMultipleMounts(t *testing.T) {
 func TestStateToViewPortForwards(t *testing.T) {
 	m := model.Manifest{
 		Name: "foo",
-	}.WithPortForwards([]model.PortForward{
-		{LocalPort: 8000, ContainerPort: 5000},
-		{LocalPort: 7000, ContainerPort: 5001},
+	}.WithDeployInfo(model.K8sInfo{
+		PortForwards: []model.PortForward{
+			{LocalPort: 8000, ContainerPort: 5000},
+			{LocalPort: 7000, ContainerPort: 5001},
+		},
 	})
 	state := newState([]model.Manifest{m}, model.YAMLManifest{})
 	v := StateToView(*state)

--- a/internal/tiltfile2/tiltfile_state.go
+++ b/internal/tiltfile2/tiltfile_state.go
@@ -303,8 +303,10 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 			return nil, err
 		}
 
-		m = m.WithPortForwards(s.portForwardsToDomain(r)). // FIXME(dbentley)
-									WithDeployInfo(model.K8sInfo{YAML: k8sYaml})
+		m = m.WithDeployInfo(model.K8sInfo{
+			YAML:         k8sYaml,
+			PortForwards: s.portForwardsToDomain(r), // FIXME(dbentley)
+		})
 
 		if r.imageRef != "" {
 			image := s.imagesByName[r.imageRef]

--- a/internal/tiltfile2/tiltfile_state.go
+++ b/internal/tiltfile2/tiltfile_state.go
@@ -304,7 +304,7 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 		}
 
 		m = m.WithPortForwards(s.portForwardsToDomain(r)). // FIXME(dbentley)
-									WithK8sYAML(k8sYaml)
+									WithDeployInfo(model.K8sInfo{YAML: k8sYaml})
 
 		if r.imageRef != "" {
 			image := s.imagesByName[r.imageRef]

--- a/internal/tiltfile2/tiltfile_test.go
+++ b/internal/tiltfile2/tiltfile_test.go
@@ -891,19 +891,16 @@ func (f *fixture) assertManifest(name string, opts ...interface{}) model.Manifes
 				}
 			}
 		case deploymentHelper:
-			k8sInfo := m.K8sInfo()
-			if k8sInfo.Empty() {
-				f.t.Fatalf("%s has no k8s deployment info", m.Name)
-			}
+			yaml := m.K8sInfo().YAML
 			found := false
-			for _, e := range f.entities(k8sInfo.YAML) {
+			for _, e := range f.entities(yaml) {
 				if e.Kind.Kind == "Deployment" && f.k8sName(e) == opt.name {
 					found = true
 					break
 				}
 			}
 			if !found {
-				f.t.Fatalf("deployment %v not found in yaml %q", opt.name, k8sInfo.YAML)
+				f.t.Fatalf("deployment %v not found in yaml %q", opt.name, yaml)
 			}
 		case numEntitiesHelper:
 			yaml := m.K8sInfo().YAML
@@ -952,7 +949,7 @@ func (f *fixture) assertManifest(name string, opts ...interface{}) model.Manifes
 			}
 
 		case []model.PortForward:
-			assert.Equal(f.t, opt, m.PortForwards())
+			assert.Equal(f.t, opt, m.K8sInfo().PortForwards)
 		case dcConfigPathHelper:
 			dcInfo := m.DCInfo()
 			if assert.False(f.t, dcInfo.Empty(), "expected a docker-compose manifest") {


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/move-k8s-info:

c59c7a9cec4357bdb285159394838b4a36bcb87d (2018-12-20 16:23:22 -0500)
all k8s properties off manifest

7182e25ac562135b21a03efd6fff6057abf3f206 (2018-12-20 16:02:10 -0500)
yaml moved over

8e2e68dd0f94dbd3cbe3a3c8e7e597251c1c9b4f (2018-12-20 15:31:00 -0500)
prelim code reorg

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics