### PR TITLE
engine: store InitManifests from command line; not first non-empty Tiltfile load

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -84,6 +84,7 @@ type InitAction struct {
 	GlobalYAMLManifest model.YAMLManifest
 	TiltfilePath       string
 	ConfigFiles        []string
+	InitManifests      []model.ManifestName
 	TriggerMode        model.TriggerMode
 	Err                error
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -657,16 +657,10 @@ func handleServiceEvent(ctx context.Context, state *store.EngineState, action Se
 
 func handleInitAction(ctx context.Context, engineState *store.EngineState, action InitAction) error {
 	watchMounts := action.WatchMounts
-	manifests := action.Manifests
-	manifestNames := make([]model.ManifestName, len(manifests))
-	for i, m := range manifests {
-		manifestNames[i] = m.ManifestName()
-	}
-
 	engineState.TiltfilePath = action.TiltfilePath
 	engineState.TriggerMode = action.TriggerMode
 	engineState.ConfigFiles = action.ConfigFiles
-	engineState.InitManifests = manifestNames
+	engineState.InitManifests = action.InitManifests
 	engineState.GlobalYAML = action.GlobalYAMLManifest
 	engineState.GlobalYAMLState = store.NewYAMLManifestState()
 
@@ -674,6 +668,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 		handleTiltfileError(engineState, action.Err)
 	}
 
+	manifests := action.Manifests
 	for _, m := range manifests {
 		engineState.ManifestDefinitionOrder = append(engineState.ManifestDefinitionOrder, m.Name)
 		engineState.ManifestStates[m.Name] = store.NewManifestState(m)

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -120,6 +120,7 @@ func (u Upper) Start(ctx context.Context, args []string, watchMounts bool, trigg
 		GlobalYAMLManifest: globalYAML,
 		TiltfilePath:       absTfPath,
 		ConfigFiles:        configFiles,
+		InitManifests:      manifestNames,
 		TriggerMode:        triggerMode,
 		Err:                err,
 	})

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -515,7 +515,6 @@ k8s_resource("quux", 'doggos.yaml')
 	f.assertAllBuildsConsumed()
 }
 
-// We had a bug where we
 func TestSecondResourceIsBuilt(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
@@ -549,7 +548,7 @@ k8s_resource("baz", 'snack.yaml')
 k8s_resource("quux", 'doggos.yaml')
 `)
 
-	// we expect to build quux, because it is new
+	// Expect a build of quux, the new resource
 	call = f.nextCall("changed config file --> new manifest")
 	assert.Equal(t, "quux", string(call.manifest.Name))
 	assert.ElementsMatch(t, []string{}, call.state.FilesChanged())

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -515,6 +515,50 @@ k8s_resource("quux", 'doggos.yaml')
 	f.assertAllBuildsConsumed()
 }
 
+// We had a bug where we
+func TestSecondResourceIsBuilt(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	f.WriteFile("Tiltfile", `
+fast_build("gcr.io/windmill-public-containers/servantes/snack", "Dockerfile1")
+
+k8s_resource("baz", 'snack.yaml')
+`)
+	f.WriteFile("snack.yaml", simpleYAML)
+	f.WriteFile("Dockerfile1", `FROM iron/go:dev1`)
+	f.WriteFile("Dockerfile2", `FROM iron/go:dev2`)
+	f.WriteFile("doggos.yaml", testyaml.DoggosDeploymentYaml)
+
+	mount1 := model.Mount{LocalPath: f.JoinPath("mount1"), ContainerPath: "/go"}
+	manifest1 := f.newManifest("baz", []model.Mount{mount1})
+
+	f.Start([]model.Manifest{manifest1}, true)
+
+	// First call: with one resource
+	call := f.nextCall("old manifest (baz)")
+	assert.Empty(t, call.manifest.BaseDockerfile)
+	assert.Equal(t, "baz", string(call.manifest.Name))
+
+	// Now add a second resource
+	f.WriteConfigFiles("Tiltfile", `
+fast_build("gcr.io/windmill-public-containers/servantes/snack", "Dockerfile1")
+fast_build("gcr.io/windmill-public-containers/servantes/doggos", "Dockerfile2")
+
+k8s_resource("baz", 'snack.yaml')
+k8s_resource("quux", 'doggos.yaml')
+`)
+
+	// we expect to build quux, because it is new
+	call = f.nextCall("changed config file --> new manifest")
+	assert.Equal(t, "quux", string(call.manifest.Name))
+	assert.ElementsMatch(t, []string{}, call.state.FilesChanged())
+
+	err := f.Stop()
+	assert.Nil(t, err)
+	f.assertAllBuildsConsumed()
+}
+
 func TestNoOpChangeToDockerfile(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
fixes [ch1161]