### PR TITLE
ospath: check ospath.Child for nonsensical args

### DIFF
--- a/internal/ospath/ospath.go
+++ b/internal/ospath/ospath.go
@@ -10,6 +10,10 @@ import (
 //
 // Returns true if successful. If `file` is not under `dir`, returns false.
 func Child(dir string, file string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+
 	current := file
 	child := "."
 	for true {

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -52,6 +52,14 @@ func TestIsBrokenSymlink(t *testing.T) {
 	f.assertBrokenSymlink("symlinkFileB", true)
 }
 
+func TestInvalidDir(t *testing.T) {
+	f := NewOspathFixture(t)
+	defer f.TearDown()
+
+	// Passing "" as dir used to make Child hang forever. Let's make sure it doesn't do that.
+	f.assertChild("", "random", "")
+}
+
 func TestTryAsCwdChildren(t *testing.T) {
 	f := NewOspathFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @dbentley,

Please review the following commits I made in branch child-bug:

adaa2deafcf06c85b6e0719cc4e3a8581b91f0b2 (2018-12-20 19:21:06 -0500)
ospath: check ospath.Child for nonsensical args

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics