### PR TITLE
model: use go-cmp for equality checking, which is slightly better for flexibility/correctness

### DIFF
--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"reflect"
-
 	"github.com/windmilleng/tilt/internal/yaml"
 )
 
@@ -17,7 +15,7 @@ type DCInfo struct {
 }
 
 func (DCInfo) deployInfo()    {}
-func (dc DCInfo) Empty() bool { return reflect.DeepEqual(dc, DCInfo{}) }
+func (dc DCInfo) Empty() bool { return DeepEqual(dc, DCInfo{}) }
 
 type K8sInfo struct {
 	YAML         string
@@ -25,7 +23,7 @@ type K8sInfo struct {
 }
 
 func (K8sInfo) deployInfo()     {}
-func (k8s K8sInfo) Empty() bool { return reflect.DeepEqual(k8s, K8sInfo{}) }
+func (k8s K8sInfo) Empty() bool { return DeepEqual(k8s, K8sInfo{}) }
 
 func (k8s K8sInfo) AppendYAML(y string) K8sInfo {
 	if k8s.YAML == "" {

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -3,14 +3,14 @@ package model
 import (
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 
+	"github.com/docker/distribution/reference"
 	"github.com/windmilleng/tilt/internal/sliceutils"
 
-	_ "github.com/google/go-cmp/cmp"
-	_ "github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 type ManifestName string
@@ -154,19 +154,19 @@ func (m Manifest) ValidateDockerK8sManifest() error {
 func (m1 Manifest) Equal(m2 Manifest) bool {
 	primitivesMatch := m1.Name == m2.Name && m1.BaseDockerfile == m2.BaseDockerfile && m1.tiltFilename == m2.tiltFilename
 	entrypointMatch := m1.Entrypoint.Equal(m2.Entrypoint)
-	mountsMatch := reflect.DeepEqual(m1.Mounts, m2.Mounts)
-	reposMatch := reflect.DeepEqual(m1.repos, m2.repos)
+	mountsMatch := DeepEqual(m1.Mounts, m2.Mounts)
+	reposMatch := DeepEqual(m1.repos, m2.repos)
 	stepsMatch := m1.stepsEqual(m2.Steps)
-	dockerignoresMatch := reflect.DeepEqual(m1.dockerignores, m2.dockerignores)
-	dockerEqual := reflect.DeepEqual(m1.DockerInfo, m2.DockerInfo)
+	dockerignoresMatch := DeepEqual(m1.dockerignores, m2.dockerignores)
+	dockerEqual := DeepEqual(m1.DockerInfo, m2.DockerInfo)
 
 	dc1 := m1.DCInfo()
 	dc2 := m2.DCInfo()
-	dockerComposeEqual := reflect.DeepEqual(dc1, dc2)
+	dockerComposeEqual := DeepEqual(dc1, dc2)
 
 	k8s1 := m1.K8sInfo()
 	k8s2 := m2.K8sInfo()
-	k8sEqual := reflect.DeepEqual(k8s1, k8s2)
+	k8sEqual := DeepEqual(k8s1, k8s2)
 
 	return primitivesMatch &&
 		entrypointMatch &&
@@ -410,4 +410,23 @@ type PortForward struct {
 	// The port to connect to inside the deployed container.
 	// If 0, we will connect to the first containerPort.
 	ContainerPort int
+}
+
+var dockerInfoAllowUnexported = cmp.AllowUnexported(DockerInfo{})
+var dockerRefEqual = cmp.Comparer(func(a, b reference.Named) bool {
+	aNil := a == nil
+	bNil := b == nil
+	if aNil && bNil {
+		return true
+	}
+
+	if aNil != bNil {
+		return false
+	}
+
+	return a.String() == b.String()
+})
+
+func DeepEqual(x, y interface{}) bool {
+	return cmp.Equal(x, y, cmpopts.EquateEmpty(), dockerInfoAllowUnexported, dockerRefEqual)
 }

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -311,6 +311,11 @@ var equalitytests = []struct {
 		Manifest{}.WithDeployInfo(K8sInfo{YAML: "goodbye world"}),
 		false,
 	},
+	{
+		Manifest{Mounts: nil},
+		Manifest{Mounts: []Mount{}},
+		true,
+	},
 }
 
 func TestManifestEquality(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/comp2:

70b8d63b707e22a58193037f9fe8f5cc53a6de5c (2018-12-21 10:20:20 -0500)
model: use go-cmp for equality checking, which is slightly better for flexibility/correctness
most notably, it has an option for treating `nil` and the empty slice as equivalent

42fd268ed2edca557d5c0027ccf36aa1fc71bb0c (2018-12-21 10:15:31 -0500)
vendor: go-cmp