### PR TITLE
watch: remove inotify-specific bits of watcher_linux

### DIFF
--- a/internal/watch/watcher_darwin.go
+++ b/internal/watch/watcher_darwin.go
@@ -8,6 +8,8 @@ import (
 	"github.com/windmilleng/fsevents"
 )
 
+// A file watcher optimized for Darwin.
+// Uses FSEvents to avoid the terrible perf characteristics of kqueue.
 type darwinNotify struct {
 	stream *fsevents.EventStream
 	events chan FileEvent


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/inotify:

176e76e6f1da0fc97b1d663a7e2ce0312b3b9c2b (2018-12-21 17:51:15 -0500)
watch: remove inotify-specific bits of watcher_linux
the tests on windows don't pass yet, but at least it compiles