### PR TITLE
tilt: remove redundant error message from starlark errors

### DIFF
--- a/internal/tiltfile2/tiltfile.go
+++ b/internal/tiltfile2/tiltfile.go
@@ -40,7 +40,7 @@ func Load(ctx context.Context, filename string, matching map[string]bool) (manif
 
 	if err := s.exec(); err != nil {
 		if err, ok := err.(*starlark.EvalError); ok {
-			return nil, model.YAMLManifest{}, nil, errors.Wrap(err, err.Backtrace())
+			return nil, model.YAMLManifest{}, nil, errors.New(err.Backtrace())
 		}
 		return nil, model.YAMLManifest{}, nil, err
 	}


### PR DESCRIPTION
k8s errors manifest in tilt as, e.g.:
```
Tiltfile error:
Traceback (most recent call last):
  /Users/matt/go/src/github.com/windmilleng/servantes/Tiltfile:52: in <toplevel>
Error: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec:
v1.PodSpec.Containers: []v1.Container: v1.Container.Ports: []v1.ContainerPort:
v1.ContainerPort.ContainerPort: readUint32: unexpected character: �, error found in
#10 byte of ...|nerPort":"808e"}],"r|..., bigger context
...|igoda","name":"vigoda","ports":[{"containerPort":"808e"}],"resources":{"requests
":{"memory":"200Gi"}|...: v1.Deployment.Spec: v1.DeploymentSpec.Template:
v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Ports:
[]v1.ContainerPort: v1.ContainerPort.ContainerPort: readUint32: unexpected
character: �, error found in #10 byte of ...|nerPort":"808e"}],"r|..., bigger
context
...|igoda","name":"vigoda","ports":[{"containerPort":"808e"}],"resources":{"requests
":{"memory":"200Gi"}|...
```

`EvalError.BackTrace()` [already includes](https://github.com/windmilleng/tilt/blob/04c1cdb1868e60b48c823f218c7ea040558485f2/vendor/go.starlark.net/starlark/eval.go#L163) `Msg()`, so we shouldn't include it twice.

After this change, we get:
```
Tiltfile error:
Traceback (most recent call last):
  /Users/matt/go/src/github.com/windmilleng/servantes/Tiltfile:52: in <toplevel>
Error: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec:
v1.PodSpec.Containers: []v1.Container: v1.Container.Ports: []v1.ContainerPort:
v1.ContainerPort.ContainerPort: readUint32: unexpected character: �, error found in
#10 byte of ...|nerPort":"808e"}],"r|..., bigger context
...|igoda","name":"vigoda","ports":[{"containerPort":"808e"}],"resources":{"requests"
:{"memory":"200Gi"}|...
```