### PR TITLE
engine: record more metadata on tiltfile execution

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -86,7 +86,10 @@ type InitAction struct {
 	ConfigFiles        []string
 	InitManifests      []model.ManifestName
 	TriggerMode        model.TriggerMode
-	Err                error
+
+	StartTime  time.Time
+	FinishTime time.Time
+	Err        error
 }
 
 func (InitAction) Action() {}
@@ -138,7 +141,10 @@ type ConfigsReloadedAction struct {
 	Manifests   []model.Manifest
 	GlobalYAML  model.YAMLManifest
 	ConfigFiles []string
-	Err         error
+
+	StartTime  time.Time
+	FinishTime time.Time
+	Err        error
 }
 
 func (ConfigsReloadedAction) Action() {}

--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"time"
 
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/tiltfile2"
@@ -37,6 +38,7 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
 	}
 	// TODO(dbentley): there's a race condition where we start it before we clear it, so we could start many tiltfile reloads...
 	go func() {
+		startTime := time.Now()
 		st.Dispatch(ConfigsReloadStartedAction{FilesChanged: filesChanged})
 
 		matching := map[string]bool{}
@@ -48,6 +50,8 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
 			Manifests:   manifests,
 			GlobalYAML:  globalYAML,
 			ConfigFiles: configFiles,
+			StartTime:   startTime,
+			FinishTime:  time.Now(),
 			Err:         err,
 		})
 	}()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -689,7 +689,7 @@ k8s_resource('foobar', yaml='snack.yaml')`
 	f.assertNoCall("Tiltfile error should prevent BuildAndDeploy from being called")
 
 	f.WaitUntil("error set", func(st store.EngineState) bool {
-		return st.LastTiltfileError != nil
+		return st.LastTiltfileError() != nil
 	})
 
 	f.withState(func(es store.EngineState) {
@@ -718,13 +718,13 @@ k8s_resource('foobar', yaml='snack.yaml')`
 	// Second call: change Tiltfile, break manifest
 	f.WriteConfigFiles("Tiltfile", "borken")
 	f.WaitUntil("state is broken", func(st store.EngineState) bool {
-		return st.LastTiltfileError != nil
+		return st.LastTiltfileError() != nil
 	})
 
 	// Third call: put Tiltfile back. No change to manifest or to mounted files, so expect no build.
 	f.WriteConfigFiles("Tiltfile", origTiltfile)
 	f.WaitUntil("state is restored", func(st store.EngineState) bool {
-		return st.LastTiltfileError == nil
+		return st.LastTiltfileError() == nil
 	})
 
 	f.withState(func(state store.EngineState) {
@@ -760,7 +760,7 @@ k8s_resource('foobar', 'snack.yaml')
 	// Second call: change Tiltfile, break manifest
 	f.WriteConfigFiles("Tiltfile", "borken")
 	f.WaitUntil("manifest load error", func(st store.EngineState) bool {
-		return st.LastTiltfileError != nil
+		return st.LastTiltfileError() != nil
 	})
 
 	f.withState(func(state store.EngineState) {
@@ -776,7 +776,7 @@ k8s_resource('foobar', 'snack.yaml')
 
 	f.withState(func(state store.EngineState) {
 		assert.Equal(t, "", nextManifestToBuild(state).String())
-		assert.NoError(t, state.LastTiltfileError)
+		assert.NoError(t, state.LastTiltfileError())
 	})
 
 	f.withManifestState(name, func(ms store.ManifestState) {

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -91,6 +91,13 @@ func TestEmptyState(t *testing.T) {
 	es := newState([]model.Manifest{}, model.YAMLManifest{})
 
 	v := StateToView(*es)
+	assert.Equal(t, "", v.TiltfileErrorMessage)
+
+	es.LastTiltfileBuild = model.BuildStatus{
+		StartTime:  time.Now(),
+		FinishTime: time.Now(),
+	}
+	v = StateToView(*es)
 	assert.Equal(t, emptyTiltfileMsg, v.TiltfileErrorMessage)
 
 	yaml := "yamlyaml"


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch1187/flash:

40e7f99238727ba8c89b0d89b524382212bb9c59 (2019-01-03 15:41:09 -0500)
engine: record more metadata on tiltfile execution