### PR TITLE
build: clear UID and GID before adding to tar

### DIFF
--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -29,8 +29,9 @@ func TestArchiveDf(t *testing.T) {
 	actual := tar.NewReader(ab.buf)
 
 	f.assertFileInTar(actual, expectedFile{
-		Path:     "Dockerfile",
-		Contents: dfText,
+		Path:                   "Dockerfile",
+		Contents:               dfText,
+		AssertUidAndGidAreZero: true,
 	})
 }
 
@@ -58,7 +59,7 @@ func TestArchivePathsIfExists(t *testing.T) {
 		f.t.Fatal(err)
 	}
 	actual := tar.NewReader(ab.buf)
-	f.assertFileInTar(actual, expectedFile{Path: "a", Contents: "a"})
+	f.assertFileInTar(actual, expectedFile{Path: "a", Contents: "a", AssertUidAndGidAreZero: true})
 	f.assertFileInTar(actual, expectedFile{Path: "b", Missing: true})
 }
 

--- a/internal/testutils/tar.go
+++ b/internal/testutils/tar.go
@@ -7,12 +7,17 @@ import (
 	"testing"
 )
 
+const expectedUidAndGid = 0
+
 type ExpectedFile struct {
 	Path     string
 	Contents string
 
 	// If true, we will assert that the file is not in the tarball.
 	Missing bool
+
+	// If true, we will assert that UID and GIF are 0
+	AssertUidAndGidAreZero bool
 }
 
 // Asserts whether or not this file is in the tar.
@@ -52,6 +57,14 @@ func AssertFilesInTar(t testing.TB, tr *tar.Reader, expectedFiles []ExpectedFile
 		if header.Typeflag != tar.TypeReg {
 			t.Errorf("Path %q exists but is not a regular file", expected.Path)
 			continue
+		}
+
+		if expected.AssertUidAndGidAreZero && header.Uid != expectedUidAndGid {
+			t.Errorf("Expected %s to have UID 0, got %d", header.Name, header.Uid)
+		}
+
+		if expected.AssertUidAndGidAreZero && header.Gid != expectedUidAndGid {
+			t.Errorf("Expected %s to have GID 0, got %d", header.Name, header.Gid)
 		}
 
 		contents := bytes.NewBuffer(nil)


### PR DESCRIPTION
I couldn't think of a good way to test this since `chown` requires root. Open to any ideas!