### PR TITLE
rty: don't set cells to 0

### DIFF
--- a/internal/rty/canvas.go
+++ b/internal/rty/canvas.go
@@ -70,6 +70,9 @@ func (c *TempCanvas) makeRow() []cell {
 }
 
 func (c *TempCanvas) SetContent(x int, y int, mainc rune, combc []rune, style tcell.Style) error {
+	if mainc == 0 {
+		mainc = ' '
+	}
 	if x < 0 || x >= c.width || y < 0 || y >= c.height {
 		return fmt.Errorf("cell %v,%v outside canvas %v,%v", x, y, c.width, c.height)
 	}
@@ -138,6 +141,9 @@ func (c *SubCanvas) Close() (int, int) {
 }
 
 func (c *SubCanvas) SetContent(x int, y int, mainc rune, combc []rune, style tcell.Style) error {
+	if mainc == 0 {
+		mainc = ' '
+	}
 	if x < 0 || x >= c.width || y < 0 || y >= c.height {
 		return fmt.Errorf("coord %d,%d is outside bounds %d,%d", x, y, c.width, c.height)
 	}
@@ -161,7 +167,7 @@ func (c *SubCanvas) fill(lastFilled int) error {
 	}
 	for y := startY; y < maxY; y++ {
 		for x := 0; x < c.width; x++ {
-			if err := c.del.SetContent(c.startX+x, c.startY+y, 0, nil, c.style); err != nil {
+			if err := c.del.SetContent(c.startX+x, c.startY+y, ' ', nil, c.style); err != nil {
 				return err
 			}
 		}
@@ -189,6 +195,9 @@ func (c *ScreenCanvas) Size() (int, int) {
 }
 
 func (c *ScreenCanvas) SetContent(x int, y int, mainc rune, combc []rune, style tcell.Style) error {
+	if mainc == 0 {
+		mainc = ' '
+	}
 	c.del.SetContent(x, y, mainc, combc, style)
 	return nil
 }

--- a/internal/rty/render.go
+++ b/internal/rty/render.go
@@ -96,6 +96,9 @@ type renderFrame struct {
 var _ Writer = renderFrame{}
 
 func (f renderFrame) SetContent(x int, y int, mainc rune, combc []rune) {
+	if mainc == 0 {
+		mainc = ' '
+	}
 	if err := f.canvas.SetContent(x, y, mainc, combc, f.style); err != nil {
 		f.error(err)
 	}


### PR DESCRIPTION
When tcell renders a cell with value `0`, it converts it to `\x20` (space) and saves that as its value, and remembers that it was already a space.

RTY is then going through and setting it back to `0` on every iteration, resulting in no difference in appearance, but a huge number of extra calls to change the screen, resulting in lots of extra CPU usage (#943) and breaking copy/paste.

tcell's `drawCell` was responsible for ~70% of Tilt's CPU usage. This brings it down to ~2%.