### PR TITLE
better type support for Events from docker compose [ch1277]

### DIFF
--- a/internal/dockercompose/event.go
+++ b/internal/dockercompose/event.go
@@ -51,25 +51,46 @@ func (t *Type) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type Action string
+type Action int
 
 const (
-	// Add 'actions' here (and to `UnmarshalJSON` below`) as we support them
+	// Add 'actions' here (and to `stringToAction` below`) as we support them
 
 	// CONTAINER actions
-	ActionAttach     Action = "attach"
-	ActionCreate     Action = "create"
-	ActionDie        Action = "die"
-	ActionExecDie    Action = "exec_die"
-	ActionExecAttach Action = "exec_attach"
-	ActionExecCreate Action = "exec_create"
-	ActionKill       Action = "kill"
-	ActionRename     Action = "rename"
-	ActionRestart    Action = "restart"
-	ActionStart      Action = "start"
-	ActionStop       Action = "stop"
-	ActionUpdate     Action = "update"
+	ActionAttach = iota
+	ActionCommit
+	ActionCopy
+	ActionCreate
+	ActionDestroy
+	ActionDie
+	ActionExecAttach
+	ActionExecCreate
+	ActionExecDie
+	ActionKill
+	ActionRename
+	ActionRestart
+	ActionStart
+	ActionStop
+	ActionUpdate
 )
+
+var stringToAction = map[string]Action{
+	"attach":      ActionAttach,
+	"commit":      ActionCommit,
+	"copy":        ActionCopy,
+	"create":      ActionCreate,
+	"destroy":     ActionDestroy,
+	"die":         ActionDie,
+	"exec_attach": ActionExecAttach,
+	"exec_create": ActionExecCreate,
+	"exec_die":    ActionExecDie,
+	"kill":        ActionKill,
+	"rename":      ActionRename,
+	"restart":     ActionRestart,
+	"start":       ActionStart,
+	"stop":        ActionStop,
+	"update":      ActionUpdate,
+}
 
 func (a *Action) UnmarshalJSON(b []byte) error {
 	s := string(b)
@@ -77,32 +98,10 @@ func (a *Action) UnmarshalJSON(b []byte) error {
 		s = unquoted
 	}
 
-	if s == "attach" {
-		*a = ActionAttach
-	} else if s == "create" {
-		*a = ActionCreate
-	} else if s == "die" {
-		*a = ActionDie
-	} else if s == "exec_attach" {
-		*a = ActionExecAttach
-	} else if s == "exec_die" {
-		*a = ActionExecDie
-	} else if s == "exec_create" {
-		*a = ActionExecCreate
-	} else if s == "kill" {
-		*a = ActionKill
-	} else if s == "rename" {
-		*a = ActionRename
-	} else if s == "restart" {
-		*a = ActionRestart
-	} else if s == "start" {
-		*a = ActionStart
-	} else if s == "stop" {
-		*a = ActionStop
-	} else if s == "update" {
-		*a = ActionUpdate
-	} else {
+	action, ok := stringToAction[s]
+	if !ok {
 		return fmt.Errorf("unknown `Action` in docker-compose event: %s", s)
 	}
+	*a = action
 	return nil
 }

--- a/internal/dockercompose/event.go
+++ b/internal/dockercompose/event.go
@@ -62,7 +62,7 @@ func (t *Type) UnmarshalJSON(b []byte) error {
 		s = unquoted
 	}
 
-	typ := stringToType[s]
+	typ := stringToType[s] // if type not in map, this returns 0 (i.e. TypeUnknown)
 	*t = typ
 	return nil
 }
@@ -145,7 +145,7 @@ func (a *Action) UnmarshalJSON(b []byte) error {
 		s = unquoted
 	}
 
-	action := stringToAction[s]
+	action := stringToAction[s] // if action not in map, this returns 0 (i.e. ActionUnknown)
 	*a = action
 	return nil
 }

--- a/internal/dockercompose/event.go
+++ b/internal/dockercompose/event.go
@@ -2,6 +2,7 @@ package dockercompose
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 )
 
@@ -33,12 +34,26 @@ type Type int
 
 const (
 	// Add 'types' here (and to `stringToType` below) as we support them
-	TypeUnknown = iota
+	TypeUnknown Type = iota
 	TypeContainer
 )
 
 var stringToType = map[string]Type{
 	"container": TypeContainer,
+}
+
+func (t Type) String() string {
+	for str, typ := range stringToType {
+		if typ == t {
+			return str
+		}
+	}
+	return "unknown"
+}
+
+func (t Type) MarshalJSON() ([]byte, error) {
+	s := t.String()
+	return []byte(fmt.Sprintf("%q", s)), nil
 }
 
 func (t *Type) UnmarshalJSON(b []byte) error {
@@ -47,8 +62,8 @@ func (t *Type) UnmarshalJSON(b []byte) error {
 		s = unquoted
 	}
 
-	evtType := stringToType[s]
-	*t = evtType
+	typ := stringToType[s]
+	*t = typ
 	return nil
 }
 
@@ -58,7 +73,7 @@ const (
 	// Add 'actions' here (and to `stringToAction` below`) as we support them
 
 	// CONTAINER actions
-	ActionUnknown = iota
+	ActionUnknown Action = iota
 	ActionAttach
 	ActionCommit
 	ActionCopy
@@ -108,6 +123,20 @@ var stringToAction = map[string]Action{
 	"top":           ActionTop,
 	"unpause":       ActionUnpause,
 	"update":        ActionUpdate,
+}
+
+func (a Action) String() string {
+	for str, act := range stringToAction {
+		if act == a {
+			return str
+		}
+	}
+	return "unknown"
+}
+
+func (a Action) MarshalJSON() ([]byte, error) {
+	s := a.String()
+	return []byte(fmt.Sprintf("%q", s)), nil
 }
 
 func (a *Action) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Hello @jazzdan, @nicks,

Please review the following commits I made in branch maiamcc/dc-action-enum:

3a44420f5d96d862506408b56a6cfb138fe31ca8 (2019-01-09 14:01:04 -0500)
fix types while i'm here

2b5e07897242c019a6edc3c89ff4cbade3dfc706 (2019-01-09 13:53:55 -0500)
compose: change container actions to be enums, don't barf on unknown actions

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics