### PR TITLE
build: in verbose mode, print more info on what files we tar

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -307,6 +307,13 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 	// TODO(Han): Extend output to print without newline
 	ps.StartBuildStep(ctx, "Tarring context…")
 
+	// NOTE(maia): some people want to know what files we're adding (b/c `ADD . /` isn't descriptive)
+	if logger.Get(ctx).Level() >= logger.VerboseLvl {
+		for _, pm := range paths {
+			ps.Printf(ctx, pm.prettyStr())
+		}
+	}
+
 	archive, err := tarContextAndUpdateDf(ctx, df, paths, filter)
 	if err != nil {
 		return nil, err

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -36,6 +36,8 @@ type pathMapping struct {
 	ContainerPath string
 }
 
+func (m pathMapping) prettyStr() string { return fmt.Sprintf("%s --> %s", m.LocalPath, m.ContainerPath) }
+
 func (m pathMapping) Filter(matcher model.PathMatcher) ([]pathMapping, error) {
 	result := make([]pathMapping, 0)
 	err := filepath.Walk(m.LocalPath, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Hello tbd,

Please review the following commits I made in branch maiamcc/verbose-tar-info:

fdc795adc541049bc8b7ed9eb5bc43fe13504e56 (2019-01-10 12:15:00 -0500)
build: in verbose mode, print more info on what files we tar

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics