### PR TITLE
engine: print newline before Tilt meta-logs

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -170,7 +170,7 @@ func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry) {
 
 	l := logger.Get(ctx)
 	if firstBuild {
-		p := logger.Blue(l).Sprintf("──┤ Building: ")
+		p := logger.Blue(l).Sprintf("\n──┤ Building: ")
 		s := logger.Blue(l).Sprintf(" ├──────────────────────────────────────────────")
 		l.Infof("%s%s%s", p, manifest.Name, s)
 	} else {
@@ -188,7 +188,7 @@ func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry) {
 			l.Infof("%s%v\n", p, ospath.TryAsCwdChildren(changedPathsToPrint))
 		}
 
-		rp := logger.Blue(l).Sprintf("──┤ Rebuilding: ")
+		rp := logger.Blue(l).Sprintf("\n──┤ Rebuilding: ")
 		rs := logger.Blue(l).Sprintf(" ├────────────────────────────────────────────")
 		l.Infof("%s%s%s", rp, manifest.Name, rs)
 	}


### PR DESCRIPTION
Some processes that could be printing to the context.Context writer will
not nicely end their strings with a newline. Let's prepend our logs with
a newline so that they stand out and don't get lost.