### PR TITLE
store: remove obsolete properties from BuildResult. this k8s info now comes from EngineState

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -97,15 +97,14 @@ func TestNamespaceGKE(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "sancho-ns", string(result.Namespace))
-
-	bs := store.NewBuildState(result, nil).WithDeployTarget(f.deployInfo())
+	deployInfo := f.deployInfo()
+	deployInfo.Namespace = "sancho-ns"
+	bs := store.NewBuildState(result, nil).WithDeployTarget(deployInfo)
 	result, err = f.bd.BuildAndDeploy(f.ctx, NewSanchoFastBuildManifest(f), bs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "sancho-ns", string(result.Namespace))
 	assert.Equal(t, "sancho-ns", string(f.sCli.Namespace))
 }
 

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -130,7 +130,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 	sbd.deploys[state.LastResult.Image.String()] = deployInfo
 	sbd.mu.Unlock()
 
-	sCli, err := sbd.sm.ClientForPod(ctx, deployInfo.PodID, state.LastResult.Namespace)
+	sCli, err := sbd.sm.ClientForPod(ctx, deployInfo.PodID, deployInfo.Namespace)
 	if err != nil {
 		return store.BuildResult{}, err
 	}

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -19,12 +19,6 @@ type BuildResult struct {
 	// If this build was a container build, containerID we built on top of
 	ContainerID container.ID
 
-	// The namespace where the pod was deployed.
-	Namespace k8s.Namespace
-
-	// The k8s entities deployed alongside the image.
-	Entities []k8s.K8sEntity
-
 	// Some of our build engines replace the files in-place, rather
 	// than building a new image. This captures how much the code
 	// running on-pod has diverged from the original image.
@@ -44,8 +38,6 @@ func (b BuildResult) HasImage() bool {
 func (b BuildResult) ShallowCloneForContainerUpdate(filesReplacedSet map[string]bool) BuildResult {
 	result := BuildResult{}
 	result.Image = b.Image
-	result.Namespace = b.Namespace
-	result.Entities = append([]k8s.K8sEntity{}, b.Entities...)
 
 	newSet := make(map[string]bool, len(b.FilesReplacedSet)+len(filesReplacedSet))
 	for k, v := range b.FilesReplacedSet {
@@ -149,6 +141,7 @@ type DeployInfo struct {
 	PodID         k8s.PodID
 	ContainerID   container.ID
 	ContainerName container.Name
+	Namespace     k8s.Namespace
 }
 
 func (d DeployInfo) Empty() bool {
@@ -171,6 +164,7 @@ func NewDeployInfo(podSet PodSet) DeployInfo {
 		PodID:         pod.PodID,
 		ContainerID:   pod.ContainerID,
 		ContainerName: pod.ContainerName,
+		Namespace:     pod.Namespace,
 	}
 }
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/entities:

e68c8977dd9aa39c278fb0ecd87d9cb074a302c5 (2019-01-10 18:58:35 -0500)
store: remove obsolete properties from BuildResult. this k8s info now comes from EngineState