### PR TITLE
docker: s/DockerClient/Client b/c name redundant with package name

### DIFF
--- a/internal/build/cache_builder.go
+++ b/internal/build/cache_builder.go
@@ -26,12 +26,12 @@ const CacheTagPrefix = "tilt-cache-"
 //
 // https://app.clubhouse.io/windmill/story/728/support-package-json-changes-gracefully
 type CacheBuilder struct {
-	dcli docker.DockerClient
+	dCli docker.Client
 }
 
-func NewCacheBuilder(dcli docker.DockerClient) CacheBuilder {
+func NewCacheBuilder(dCli docker.Client) CacheBuilder {
 	return CacheBuilder{
-		dcli: dcli,
+		dCli: dCli,
 	}
 }
 
@@ -73,7 +73,7 @@ func (b CacheBuilder) FetchCache(ctx context.Context, ref reference.Named, cache
 		return nil, err
 	}
 
-	_, _, err = b.dcli.ImageInspectWithRaw(ctx, cacheRef.String())
+	_, _, err = b.dCli.ImageInspectWithRaw(ctx, cacheRef.String())
 	if err == nil {
 		// We found it! yay!
 		return cacheRef, nil
@@ -111,7 +111,7 @@ func (b CacheBuilder) CreateCacheFrom(ctx context.Context, baseDf dockerfile.Doc
 	// be something that happens in the background without any user-visible output.
 	writer := logger.Get(ctx).Writer(logger.DebugLvl)
 	logger.Get(ctx).Debugf("Copying cache directories (%s)", sourceRef.String())
-	res, err := b.dcli.ImageBuild(ctx, dockerCtx, options)
+	res, err := b.dCli.ImageBuild(ctx, dockerCtx, options)
 	if err != nil {
 		return errors.Wrap(err, "ImageBuild")
 	}

--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -541,7 +541,7 @@ func TestUpdateInContainerE2E(t *testing.T) {
 	}
 	touchBar := model.ToShellCmd("touch /src/bar")
 
-	cUpdater := ContainerUpdater{dcli: f.dcli}
+	cUpdater := ContainerUpdater{dCli: f.dCli}
 	err = cUpdater.UpdateInContainer(f.ctx, cID, paths, model.EmptyMatcher, []model.Cmd{touchBar}, f.ps.Writer(f.ctx))
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/build/container_updater_test.go
+++ b/internal/build/container_updater_test.go
@@ -31,15 +31,15 @@ func TestUpdateInContainerCopiesAndRmsFiles(t *testing.T) {
 		f.t.Fatal(err)
 	}
 
-	if assert.Equal(f.t, 1, len(f.dcli.ExecCalls), "calls to ExecInContainer") {
-		assert.Equal(f.t, docker.TestContainer, f.dcli.ExecCalls[0].Container)
+	if assert.Equal(f.t, 1, len(f.dCli.ExecCalls), "calls to ExecInContainer") {
+		assert.Equal(f.t, docker.TestContainer, f.dCli.ExecCalls[0].Container)
 		expectedCmd := model.Cmd{Argv: []string{"rm", "-rf", "/src/does-not-exist"}}
-		assert.Equal(f.t, expectedCmd, f.dcli.ExecCalls[0].Cmd)
+		assert.Equal(f.t, expectedCmd, f.dCli.ExecCalls[0].Cmd)
 	}
 
-	if assert.Equal(f.t, 1, f.dcli.CopyCount, "calls to CopyToContainer") {
-		assert.Equal(f.t, docker.TestContainer, f.dcli.CopyContainer)
-		// TODO(maia): assert that the right stuff made it into the archive (f.dcli.CopyContent)
+	if assert.Equal(f.t, 1, f.dCli.CopyCount, "calls to CopyToContainer") {
+		assert.Equal(f.t, docker.TestContainer, f.dCli.CopyContainer)
+		// TODO(maia): assert that the right stuff made it into the archive (f.dCli.CopyContent)
 	}
 }
 
@@ -60,7 +60,7 @@ func TestUpdateInContainerExecsSteps(t *testing.T) {
 		docker.ExecCall{Container: docker.TestContainer, Cmd: cmdB},
 	}
 
-	assert.Equal(f.t, expectedExecs, f.dcli.ExecCalls)
+	assert.Equal(f.t, expectedExecs, f.dCli.ExecCalls)
 }
 
 func TestUpdateInContainerRestartsContainer(t *testing.T) {
@@ -72,28 +72,28 @@ func TestUpdateInContainerRestartsContainer(t *testing.T) {
 		f.t.Fatal(err)
 	}
 
-	assert.Equal(f.t, f.dcli.RestartsByContainer[docker.TestContainer], 1)
+	assert.Equal(f.t, f.dCli.RestartsByContainer[docker.TestContainer], 1)
 }
 
 type mockContainerUpdaterFixture struct {
 	*tempdir.TempDirFixture
 	t    testing.TB
 	ctx  context.Context
-	dcli *docker.FakeDockerClient
+	dCli *docker.FakeClient
 	cu   *ContainerUpdater
 }
 
 func newRemoteDockerFixture(t testing.TB) *mockContainerUpdaterFixture {
-	fakeCli := docker.NewFakeDockerClient()
+	fakeCli := docker.NewFakeClient()
 	cu := &ContainerUpdater{
-		dcli: fakeCli,
+		dCli: fakeCli,
 	}
 
 	return &mockContainerUpdaterFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
 		ctx:            output.CtxForTest(),
-		dcli:           fakeCli,
+		dCli:           fakeCli,
 		cu:             cu,
 	}
 }

--- a/internal/build/docker_client_benchmark_test.go
+++ b/internal/build/docker_client_benchmark_test.go
@@ -26,7 +26,7 @@ func BenchmarkExecInContainer(b *testing.B) {
 	cID := f.startContainer(f.ctx, containerConfigRunCmd(ref, model.Cmd{Argv: []string{"sleep", "300"}}))
 
 	run := func() {
-		err := f.dcli.ExecInContainer(f.ctx, cID, cmd, ioutil.Discard)
+		err := f.dCli.ExecInContainer(f.ctx, cID, cmd, ioutil.Discard)
 		if err != nil {
 			f.t.Fatal(err)
 		}

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -31,7 +31,7 @@ import (
 )
 
 type dockerImageBuilder struct {
-	dcli    docker.DockerClient
+	dCli    docker.Client
 	console console.Console
 	out     io.Writer
 
@@ -67,9 +67,9 @@ func DefaultOut() io.Writer {
 
 var _ ImageBuilder = &dockerImageBuilder{}
 
-func NewDockerImageBuilder(dcli docker.DockerClient, console console.Console, out io.Writer, extraLabels dockerfile.Labels) *dockerImageBuilder {
+func NewDockerImageBuilder(dCli docker.Client, console console.Console, out io.Writer, extraLabels dockerfile.Labels) *dockerImageBuilder {
 	return &dockerImageBuilder{
-		dcli:        dcli,
+		dCli:        dCli,
 		console:     console,
 		out:         out,
 		extraLabels: extraLabels,
@@ -226,7 +226,7 @@ func (d *dockerImageBuilder) TagImage(ctx context.Context, ref reference.Named, 
 		return nil, errors.Wrap(err, "TagImage")
 	}
 
-	err = d.dcli.ImageTag(ctx, dig.String(), namedTagged.String())
+	err = d.dCli.ImageTag(ctx, dig.String(), namedTagged.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "TagImage#ImageTag")
 	}
@@ -277,7 +277,7 @@ func (d *dockerImageBuilder) PushImage(ctx context.Context, ref reference.NamedT
 	}
 
 	l.Infof("%spushing the image", prefix)
-	imagePushResponse, err := d.dcli.ImagePush(
+	imagePushResponse, err := d.dCli.ImagePush(
 		ctx,
 		ref.String(),
 		options)
@@ -325,7 +325,7 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 
 	ps.StartBuildStep(ctx, "Building image")
 	spanBuild, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuild")
-	imageBuildResponse, err := d.dcli.ImageBuild(
+	imageBuildResponse, err := d.dCli.ImageBuild(
 		ctx,
 		archive,
 		Options(archive, buildArgs),
@@ -488,7 +488,7 @@ func (d *dockerImageBuilder) getDigestFromDockerOutput(ctx context.Context, outp
 	}
 
 	if output.shortDigest != "" {
-		data, _, err := d.dcli.ImageInspectWithRaw(ctx, output.shortDigest)
+		data, _, err := d.dCli.ImageInspectWithRaw(ctx, output.shortDigest)
 		if err != nil {
 			return "", err
 		}

--- a/internal/build/image_reaper.go
+++ b/internal/build/image_reaper.go
@@ -17,7 +17,7 @@ import (
 )
 
 type ImageReaper struct {
-	docker docker.DockerClient
+	docker docker.Client
 }
 
 func FilterByLabel(label dockerfile.Label) filters.KeyValuePair {
@@ -32,7 +32,7 @@ func FilterByRefName(ref reference.Named) filters.KeyValuePair {
 	return filters.Arg("reference", fmt.Sprintf("%s:*", ref.Name()))
 }
 
-func NewImageReaper(docker docker.DockerClient) ImageReaper {
+func NewImageReaper(docker docker.Client) ImageReaper {
 	return ImageReaper{
 		docker: docker,
 	}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -32,8 +32,8 @@ var K8sWireSet = wire.NewSet(
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,
 
-	docker.DefaultDockerClient,
-	wire.Bind(new(docker.DockerClient), new(docker.DockerCli)),
+	docker.DefaultClient,
+	wire.Bind(new(docker.Client), new(docker.Cli)),
 
 	dockercompose.NewDockerComposeClient,
 

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -60,11 +60,11 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	watchManager := engine.NewWatchManager(fsWatcherMaker, timerMaker)
 	syncletManager := engine.NewSyncletManager(k8sClient)
 	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(syncletManager)
-	dockerCli, err := docker.DefaultDockerClient(ctx, env)
+	cli, err := docker.DefaultClient(ctx, env)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	containerUpdater := build.NewContainerUpdater(dockerCli)
+	containerUpdater := build.NewContainerUpdater(cli)
 	analytics, err := provideAnalytics()
 	if err != nil {
 		return demo.Script{}, err
@@ -73,9 +73,9 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	console := build.DefaultConsole()
 	writer := build.DefaultOut()
 	labels := _wireLabelsValue
-	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer, labels)
+	dockerImageBuilder := build.NewDockerImageBuilder(cli, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
-	cacheBuilder := build.NewCacheBuilder(dockerCli)
+	cacheBuilder := build.NewCacheBuilder(cli)
 	engineUpdateModeFlag := provideUpdateModeFlag()
 	updateMode, err := engine.ProvideUpdateMode(engineUpdateModeFlag, env)
 	if err != nil {
@@ -87,7 +87,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, dockerComposeBuildAndDeployer, env, updateMode)
 	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder)
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
-	imageReaper := build.NewImageReaper(dockerCli)
+	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	configsController := engine.NewConfigsController()
@@ -141,11 +141,11 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	watchManager := engine.NewWatchManager(fsWatcherMaker, timerMaker)
 	syncletManager := engine.NewSyncletManager(k8sClient)
 	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(syncletManager)
-	dockerCli, err := docker.DefaultDockerClient(ctx, env)
+	cli, err := docker.DefaultClient(ctx, env)
 	if err != nil {
 		return Threads{}, err
 	}
-	containerUpdater := build.NewContainerUpdater(dockerCli)
+	containerUpdater := build.NewContainerUpdater(cli)
 	analytics, err := provideAnalytics()
 	if err != nil {
 		return Threads{}, err
@@ -154,9 +154,9 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	console := build.DefaultConsole()
 	writer := build.DefaultOut()
 	labels := _wireLabelsValue
-	dockerImageBuilder := build.NewDockerImageBuilder(dockerCli, console, writer, labels)
+	dockerImageBuilder := build.NewDockerImageBuilder(cli, console, writer, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
-	cacheBuilder := build.NewCacheBuilder(dockerCli)
+	cacheBuilder := build.NewCacheBuilder(cli)
 	engineUpdateModeFlag := provideUpdateModeFlag()
 	updateMode, err := engine.ProvideUpdateMode(engineUpdateModeFlag, env)
 	if err != nil {
@@ -168,7 +168,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	buildOrder := engine.DefaultBuildOrder(syncletBuildAndDeployer, localContainerBuildAndDeployer, imageBuildAndDeployer, dockerComposeBuildAndDeployer, env, updateMode)
 	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder)
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
-	imageReaper := build.NewImageReaper(dockerCli)
+	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
 	configsController := engine.NewConfigsController()
@@ -204,7 +204,7 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 var K8sWireSet = wire.NewSet(k8s.DetectEnv, k8s.DetectNodeIP, k8s.ProvidePortForwarder, k8s.ProvideRESTClient, k8s.ProvideRESTConfig, k8s.NewK8sClient, wire.Bind(new(k8s.Client), k8s.K8sClient{}))
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, docker.DefaultDockerClient, wire.Bind(new(docker.DockerClient), new(docker.DockerCli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics,
+	K8sWireSet, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics,
 	provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, server.ProvideHeadsUpServer, provideThreads,
 )
 

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -409,11 +409,11 @@ func TestIgnoredFiles(t *testing.T) {
 
 // The API boundaries between BuildAndDeployer and the ImageBuilder aren't obvious and
 // are likely to change in the future. So we test them together, using
-// a fake DockerClient and K8sClient
+// a fake Client and K8sClient
 type bdFixture struct {
 	*tempdir.TempDirFixture
 	ctx    context.Context
-	docker *docker.FakeDockerClient
+	docker *docker.FakeClient
 	k8s    *k8s.FakeK8sClient
 	sCli   *synclet.FakeSyncletClient
 	bd     BuildAndDeployer
@@ -422,7 +422,7 @@ type bdFixture struct {
 func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
 	f := tempdir.NewTempDirFixture(t)
 	dir := dirs.NewWindmillDirAt(f.Path())
-	docker := docker.NewFakeDockerClient()
+	docker := docker.NewFakeClient()
 	docker.ContainerListOutput = map[string][]types.Container{
 		"pod": []types.Container{
 			types.Container{

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -87,7 +87,7 @@ func TestDeployTwinImages(t *testing.T) {
 type ibdFixture struct {
 	*tempdir.TempDirFixture
 	ctx    context.Context
-	docker *docker.FakeDockerClient
+	docker *docker.FakeClient
 	k8s    *k8s.FakeK8sClient
 	ibd    *ImageBuildAndDeployer
 }
@@ -95,7 +95,7 @@ type ibdFixture struct {
 func newIBDFixture(t *testing.T) *ibdFixture {
 	f := tempdir.NewTempDirFixture(t)
 	dir := dirs.NewWindmillDirAt(f.Path())
-	docker := docker.NewFakeDockerClient()
+	docker := docker.NewFakeClient()
 	ctx := output.CtxForTest()
 	k8s := k8s.NewFakeK8sClient()
 	ibd, err := provideImageBuildAndDeployer(ctx, docker, k8s, dir)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1884,7 +1884,7 @@ type testFixture struct {
 	b                     *fakeBuildAndDeployer
 	fsWatcher             *fakeMultiWatcher
 	timerMaker            *fakeTimerMaker
-	docker                *docker.FakeDockerClient
+	docker                *docker.FakeClient
 	hud                   *hud.FakeHud
 	createManifestsResult chan error
 	log                   *bufsync.ThreadSafeBuffer
@@ -1906,7 +1906,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	timerMaker := makeFakeTimerMaker(t)
 
-	docker := docker.NewFakeDockerClient()
+	docker := docker.NewFakeClient()
 	reaper := build.NewImageReaper(docker)
 
 	k8s := k8s.NewFakeK8sClient()

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -54,7 +54,7 @@ var DeployerWireSet = wire.NewSet(
 
 func provideBuildAndDeployer(
 	ctx context.Context,
-	docker docker.DockerClient,
+	docker docker.Client,
 	k8s k8s.Client,
 	dir *dirs.WindmillDir,
 	env k8s.Env,
@@ -72,7 +72,7 @@ func provideBuildAndDeployer(
 
 func provideImageBuildAndDeployer(
 	ctx context.Context,
-	docker docker.DockerClient,
+	docker docker.Client,
 	kClient k8s.Client,
 	dir *dirs.WindmillDir) (*ImageBuildAndDeployer, error) {
 	wire.Build(

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -20,7 +20,7 @@ import (
 
 // Injectors from wire.go:
 
-func provideBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode UpdateModeFlag, sCli synclet.SyncletClient, dcc dockercompose.DockerComposeClient) (BuildAndDeployer, error) {
+func provideBuildAndDeployer(ctx context.Context, docker2 docker.Client, k8s2 k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode UpdateModeFlag, sCli synclet.SyncletClient, dcc dockercompose.DockerComposeClient) (BuildAndDeployer, error) {
 	syncletManager := NewSyncletManagerForTests(k8s2, sCli)
 	syncletBuildAndDeployer := NewSyncletBuildAndDeployer(syncletManager)
 	containerUpdater := build.NewContainerUpdater(docker2)
@@ -47,7 +47,7 @@ var (
 	_wireLabelsValue = dockerfile.Labels{}
 )
 
-func provideImageBuildAndDeployer(ctx context.Context, docker2 docker.DockerClient, kClient k8s.Client, dir *dirs.WindmillDir) (*ImageBuildAndDeployer, error) {
+func provideImageBuildAndDeployer(ctx context.Context, docker2 docker.Client, kClient k8s.Client, dir *dirs.WindmillDir) (*ImageBuildAndDeployer, error) {
 	console := build.DefaultConsole()
 	writer := build.DefaultOut()
 	labels := _wireLabelsValue

--- a/internal/synclet/synclet.go
+++ b/internal/synclet/synclet.go
@@ -21,11 +21,11 @@ import (
 const Port = 23551
 
 type Synclet struct {
-	dcli docker.DockerClient
+	dCli docker.Client
 }
 
-func NewSynclet(dcli docker.DockerClient) *Synclet {
-	return &Synclet{dcli: dcli}
+func NewSynclet(dCli docker.Client) *Synclet {
+	return &Synclet{dCli: dCli}
 }
 
 func (s Synclet) writeFiles(ctx context.Context, containerId container.ID, tarArchive []byte) error {
@@ -36,7 +36,7 @@ func (s Synclet) writeFiles(ctx context.Context, containerId container.ID, tarAr
 		return nil
 	}
 
-	return s.dcli.CopyToContainerRoot(ctx, containerId.String(), bytes.NewBuffer(tarArchive))
+	return s.dCli.CopyToContainerRoot(ctx, containerId.String(), bytes.NewBuffer(tarArchive))
 }
 
 func (s Synclet) rmFiles(ctx context.Context, containerId container.ID, filesToDelete []string) error {
@@ -50,7 +50,7 @@ func (s Synclet) rmFiles(ctx context.Context, containerId container.ID, filesToD
 	cmd := model.Cmd{Argv: append([]string{"rm", "-rf"}, filesToDelete...)}
 
 	out := bytes.NewBuffer(nil)
-	err := s.dcli.ExecInContainer(ctx, containerId, cmd, out)
+	err := s.dCli.ExecInContainer(ctx, containerId, cmd, out)
 	if err != nil {
 		dockerExitErr, ok := err.(docker.ExitError)
 		if ok {
@@ -70,7 +70,7 @@ func (s Synclet) execCmds(ctx context.Context, containerId container.ID, cmds []
 		log.Printf("[CMD %d/%d] %s", i+1, len(cmds), strings.Join(c.Argv, " "))
 		// TODO(matt) - plumb PipelineState through
 		l := logger.Get(ctx)
-		err := s.dcli.ExecInContainer(ctx, containerId, c, l.Writer(logger.InfoLvl))
+		err := s.dCli.ExecInContainer(ctx, containerId, c, l.Writer(logger.InfoLvl))
 		if err != nil {
 			exitError, isExitError := err.(docker.ExitError)
 			if isExitError {
@@ -86,7 +86,7 @@ func (s Synclet) restartContainer(ctx context.Context, containerId container.ID)
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Synclet-restartContainer")
 	defer span.Finish()
 
-	return s.dcli.ContainerRestartNoWait(ctx, containerId.String())
+	return s.dCli.ContainerRestartNoWait(ctx, containerId.String())
 }
 
 func (s Synclet) UpdateContainer(

--- a/internal/synclet/wire.go
+++ b/internal/synclet/wire.go
@@ -13,8 +13,8 @@ import (
 
 func WireSynclet(ctx context.Context, env k8s.Env) (*Synclet, error) {
 	wire.Build(
-		docker.DefaultDockerClient,
-		wire.Bind(new(docker.DockerClient), new(docker.DockerCli)),
+		docker.DefaultClient,
+		wire.Bind(new(docker.Client), new(docker.Cli)),
 
 		NewSynclet,
 	)

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -14,10 +14,10 @@ import (
 // Injectors from wire.go:
 
 func WireSynclet(ctx context.Context, env k8s.Env) (*Synclet, error) {
-	dockerCli, err := docker.DefaultDockerClient(ctx, env)
+	cli, err := docker.DefaultClient(ctx, env)
 	if err != nil {
 		return nil, err
 	}
-	synclet := NewSynclet(dockerCli)
+	synclet := NewSynclet(cli)
 	return synclet, nil
 }


### PR DESCRIPTION
renamed b/c lint errors in my IDE were bugging me, but there's no
super good reason for this PR, so if it's too much, np.