### PR TITLE
engine: make image builders act on ImageTargets instead of on Manifests

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -355,12 +355,13 @@ func TestIgnoredFiles(t *testing.T) {
 
 	manifest := NewSanchoFastBuildManifest(f)
 
-	manifest = manifest.WithRepos([]model.LocalGitRepo{
+	tiltfile := filepath.Join(f.Path(), "Tiltfile")
+	manifest.ImageTarget = manifest.ImageTarget.WithRepos([]model.LocalGitRepo{
 		model.LocalGitRepo{
 			LocalPath: f.Path(),
 		},
-	})
-	manifest = manifest.WithTiltFilename(filepath.Join(f.Path(), "Tiltfile"))
+	}).WithTiltFilename(tiltfile)
+	manifest = manifest.WithTiltFilename(tiltfile)
 	f.WriteFile("Tiltfile", "# hello world")
 	f.WriteFile("a.txt", "a")
 	f.WriteFile(".git/index", "garbage")

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -55,7 +55,8 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 		return store.BuildResult{}, RedirectToNextBuilderf("prev. build state is empty; container build does not support initial deploy")
 	}
 
-	fbInfo, ok := manifest.ImageTarget.BuildDetails.(model.FastBuild)
+	image := manifest.ImageTarget
+	fbInfo, ok := image.BuildDetails.(model.FastBuild)
 	if !ok {
 		return store.BuildResult{}, RedirectToNextBuilderf("container build only supports FastBuilds")
 	}
@@ -79,7 +80,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, m
 	// TODO - use PipelineState here when we actually do pipeline output for container builds
 	writer := logger.Get(ctx).Writer(logger.InfoLvl)
 
-	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, cf, ignore.CreateBuildContextFilter(manifest), boiledSteps, writer)
+	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, cf, ignore.CreateBuildContextFilter(image), boiledSteps, writer)
 	if err != nil {
 		if build.IsUserBuildFailure(err) {
 			return store.BuildResult{}, WrapDontFallBackError(err)

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -1,6 +1,9 @@
 package model
 
 import (
+	"sort"
+
+	"github.com/windmilleng/tilt/internal/sliceutils"
 	"github.com/windmilleng/tilt/internal/yaml"
 )
 
@@ -10,6 +13,13 @@ type DockerComposeTarget struct {
 	Mounts     []Mount
 	YAMLRaw    []byte // for diff'ing when config files change
 	DfRaw      []byte // for diff'ing when config files change
+
+	// TODO(nick): It might eventually make sense to represent
+	// Tiltfile as a separate nodes in the build graph, rather
+	// than duplicating it in each DockerComposeTarget.
+	tiltFilename  string
+	dockerignores []Dockerignore
+	repos         []LocalGitRepo
 }
 
 func (t DockerComposeTarget) ID() TargetID {
@@ -17,6 +27,59 @@ func (t DockerComposeTarget) ID() TargetID {
 		Type: TargetTypeDockerCompose,
 		Name: t.Name,
 	}
+}
+
+func (t DockerComposeTarget) LocalPaths() []string {
+	result := make([]string, len(t.Mounts))
+	for i, mount := range t.Mounts {
+		result[i] = mount.LocalPath
+	}
+	return result
+}
+
+func (t DockerComposeTarget) WithRepos(repos []LocalGitRepo) DockerComposeTarget {
+	t.repos = append(append([]LocalGitRepo{}, t.repos...), repos...)
+	return t
+}
+
+func (t DockerComposeTarget) WithDockerignores(dockerignores []Dockerignore) DockerComposeTarget {
+	t.dockerignores = append(append([]Dockerignore{}, t.dockerignores...), dockerignores...)
+	return t
+}
+
+func (t DockerComposeTarget) Dockerignores() []Dockerignore {
+	return append([]Dockerignore{}, t.dockerignores...)
+}
+
+func (t DockerComposeTarget) LocalRepos() []LocalGitRepo {
+	return t.repos
+}
+
+func (t DockerComposeTarget) TiltFilename() string {
+	return t.tiltFilename
+}
+
+func (t DockerComposeTarget) WithTiltFilename(f string) DockerComposeTarget {
+	t.tiltFilename = f
+	return t
+}
+
+// TODO(nick): This method should be deleted. We should just de-dupe and sort LocalPaths once
+// when we create it, rather than have a duplicate method that does the "right" thing.
+func (t DockerComposeTarget) Dependencies() []string {
+	// TODO(dmiller) we can know the length of this slice
+	deps := []string{}
+
+	for _, p := range t.LocalPaths() {
+		deps = append(deps, p)
+	}
+
+	deduped := sliceutils.DedupeStringSlice(deps)
+
+	// Sort so that any nested paths come after their parents
+	sort.Strings(deduped)
+
+	return deduped
 }
 
 type K8sTarget struct {

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -5,18 +5,27 @@ import (
 	"sort"
 
 	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/sliceutils"
 )
 
 type ImageTarget struct {
-	cachePaths   []string
 	Ref          reference.Named
 	BuildDetails BuildDetails
+
+	cachePaths []string
+
+	// TODO(nick): It might eventually make sense to represent
+	// Tiltfile as a separate nodes in the build graph, rather
+	// than duplicating it in each ImageTarget.
+	tiltFilename  string
+	dockerignores []Dockerignore
+	repos         []LocalGitRepo
 }
 
-func (di ImageTarget) ID() TargetID {
+func (i ImageTarget) ID() TargetID {
 	return TargetID{
 		Type: TargetTypeImage,
-		Name: TargetName(di.Ref.String()),
+		Name: TargetName(i.Ref.String()),
 	}
 }
 
@@ -24,19 +33,98 @@ type BuildDetails interface {
 	buildDetails()
 }
 
-func (di ImageTarget) WithBuildDetails(details BuildDetails) ImageTarget {
-	di.BuildDetails = details
-	return di
+func (i ImageTarget) StaticBuildInfo() StaticBuild {
+	ret, _ := i.BuildDetails.(StaticBuild)
+	return ret
 }
 
-func (di ImageTarget) WithCachePaths(paths []string) ImageTarget {
-	di.cachePaths = append(append([]string{}, di.cachePaths...), paths...)
-	sort.Strings(di.cachePaths)
-	return di
+func (i ImageTarget) IsStaticBuild() bool {
+	_, ok := i.BuildDetails.(StaticBuild)
+	return ok
 }
 
-func (di ImageTarget) CachePaths() []string {
-	return di.cachePaths
+func (i ImageTarget) FastBuildInfo() FastBuild {
+	ret, _ := i.BuildDetails.(FastBuild)
+	return ret
+}
+
+func (i ImageTarget) IsFastBuild() bool {
+	_, ok := i.BuildDetails.(FastBuild)
+	return ok
+}
+
+func (i ImageTarget) WithBuildDetails(details BuildDetails) ImageTarget {
+	i.BuildDetails = details
+	return i
+}
+
+func (i ImageTarget) WithCachePaths(paths []string) ImageTarget {
+	i.cachePaths = append(append([]string{}, i.cachePaths...), paths...)
+	sort.Strings(i.cachePaths)
+	return i
+}
+
+func (i ImageTarget) CachePaths() []string {
+	return i.cachePaths
+}
+
+func (i ImageTarget) WithRepos(repos []LocalGitRepo) ImageTarget {
+	i.repos = append(append([]LocalGitRepo{}, i.repos...), repos...)
+	return i
+}
+
+func (i ImageTarget) WithDockerignores(dockerignores []Dockerignore) ImageTarget {
+	i.dockerignores = append(append([]Dockerignore{}, i.dockerignores...), dockerignores...)
+	return i
+}
+
+func (i ImageTarget) Dockerignores() []Dockerignore {
+	return append([]Dockerignore{}, i.dockerignores...)
+}
+
+func (i ImageTarget) LocalPaths() []string {
+	switch bd := i.BuildDetails.(type) {
+	case StaticBuild:
+		return []string{bd.BuildPath}
+	case FastBuild:
+		result := make([]string, len(bd.Mounts))
+		for i, mount := range bd.Mounts {
+			result[i] = mount.LocalPath
+		}
+		return result
+	}
+	return nil
+}
+
+func (i ImageTarget) LocalRepos() []LocalGitRepo {
+	return i.repos
+}
+
+func (i ImageTarget) TiltFilename() string {
+	return i.tiltFilename
+}
+
+func (i ImageTarget) WithTiltFilename(f string) ImageTarget {
+	i.tiltFilename = f
+	return i
+}
+
+// TODO(nick): This method should be deleted. We should just de-dupe and sort LocalPaths once
+// when we create it, rather than have a duplicate method that does the "right" thing.
+func (i ImageTarget) Dependencies() []string {
+	// TODO(dmiller) we can know the length of this slice
+	deps := []string{}
+
+	for _, p := range i.LocalPaths() {
+		deps = append(deps, p)
+	}
+
+	deduped := sliceutils.DedupeStringSlice(deps)
+
+	// Sort so that any nested paths come after their parents
+	sort.Strings(deduped)
+
+	return deduped
 }
 
 type StaticBuild struct {

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -164,18 +164,22 @@ var equalitytests = []struct {
 	},
 	{
 		Manifest{
-			repos: []LocalGitRepo{
-				LocalGitRepo{
-					LocalPath:         "/foo/baz",
-					GitignoreContents: "*.exe",
+			ImageTarget: ImageTarget{
+				repos: []LocalGitRepo{
+					LocalGitRepo{
+						LocalPath:         "/foo/baz",
+						GitignoreContents: "*.exe",
+					},
 				},
 			},
 		},
 		Manifest{
-			repos: []LocalGitRepo{
-				LocalGitRepo{
-					LocalPath:         "/foo/baz",
-					GitignoreContents: "*.so",
+			ImageTarget: ImageTarget{
+				repos: []LocalGitRepo{
+					LocalGitRepo{
+						LocalPath:         "/foo/baz",
+						GitignoreContents: "*.so",
+					},
 				},
 			},
 		},
@@ -183,18 +187,22 @@ var equalitytests = []struct {
 	},
 	{
 		Manifest{
-			repos: []LocalGitRepo{
-				LocalGitRepo{
-					LocalPath:         "/foo/baz",
-					GitignoreContents: "*.exe",
+			ImageTarget: ImageTarget{
+				repos: []LocalGitRepo{
+					LocalGitRepo{
+						LocalPath:         "/foo/baz",
+						GitignoreContents: "*.exe",
+					},
 				},
 			},
 		},
 		Manifest{
-			repos: []LocalGitRepo{
-				LocalGitRepo{
-					LocalPath:         "/foo/baz",
-					GitignoreContents: "*.exe",
+			ImageTarget: ImageTarget{
+				repos: []LocalGitRepo{
+					LocalGitRepo{
+						LocalPath:         "/foo/baz",
+						GitignoreContents: "*.exe",
+					},
 				},
 			},
 		},
@@ -325,13 +333,13 @@ var equalitytests = []struct {
 		true,
 	},
 	{
-		Manifest{dockerignores: []Dockerignore{{"a", "b"}}},
-		Manifest{dockerignores: []Dockerignore{{"b", "a"}}},
+		Manifest{ImageTarget: ImageTarget{dockerignores: []Dockerignore{{"a", "b"}}}},
+		Manifest{ImageTarget: ImageTarget{dockerignores: []Dockerignore{{"b", "a"}}}},
 		false,
 	},
 	{
-		Manifest{dockerignores: []Dockerignore{{"a", "b"}}},
-		Manifest{dockerignores: []Dockerignore{{"a", "b"}}},
+		Manifest{ImageTarget: ImageTarget{dockerignores: []Dockerignore{{"a", "b"}}}},
+		Manifest{ImageTarget: ImageTarget{dockerignores: []Dockerignore{{"a", "b"}}}},
 		true,
 	},
 	{

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -20,7 +20,6 @@ type dockerImage struct {
 	mounts             []mount
 	steps              []model.Step
 	entrypoint         string
-	tiltfilePath       localPath
 	cachePaths         []string
 
 	staticDockerfilePath localPath
@@ -95,7 +94,6 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		staticDockerfile:     dockerfile.Dockerfile(bs),
 		staticBuildPath:      context,
 		ref:                  ref,
-		tiltfilePath:         s.filename,
 		staticBuildArgs:      sba,
 		cachePaths:           cachePaths,
 	}
@@ -155,7 +153,6 @@ func (s *tiltfileState) fastBuild(thread *starlark.Thread, fn *starlark.Builtin,
 		ref:                ref,
 		entrypoint:         entrypoint,
 		cachePaths:         cachePaths,
-		tiltfilePath:       s.filename,
 	}
 	s.imagesByName[ref.Name()] = r
 	s.images = append(s.images, r)
@@ -337,7 +334,7 @@ func (s *tiltfileState) reposForImage(image *dockerImage) []model.LocalGitRepo {
 		image.baseDockerfilePath,
 		image.staticDockerfilePath,
 		image.staticBuildPath,
-		image.tiltfilePath)
+		s.filename)
 
 	return reposForPaths(paths)
 }

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -218,20 +218,23 @@ func (s *tiltfileState) dcServiceToManifest(service dcService, dcConfigPath stri
 	}
 
 	dcInfo.Mounts = mounts
-	m = m.WithDeployTarget(dcInfo)
 
 	paths := []string{path.Dir(service.DfPath), path.Dir(dcConfigPath)}
 	for _, mount := range mounts {
 		paths = append(paths, mount.LocalPath)
 	}
 
-	m = m.WithDockerignores(dockerignoresForPaths(append(paths, path.Dir(s.filename.path))))
+	dcInfo = dcInfo.WithDockerignores(dockerignoresForPaths(append(paths, path.Dir(s.filename.path))))
 
 	localPaths := []localPath{s.filename}
 	for _, p := range paths {
 		localPaths = append(localPaths, s.localPathFromString(p))
 	}
-	m = m.WithRepos(reposForPaths(localPaths))
+	dcInfo = dcInfo.WithRepos(reposForPaths(localPaths)).
+		WithTiltFilename(s.filename.path)
+
+	m = m.WithDeployTarget(dcInfo).
+		WithTiltFilename(s.filename.path)
 
 	return m, []string{service.DfPath}, nil
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -337,10 +337,11 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 				dInfo = dInfo.WithBuildDetails(fastBuild)
 			}
 
-			m.ImageTarget = dInfo
-			m = m.WithTiltFilename(image.tiltfilePath.path).
+			m.ImageTarget = dInfo.
 				WithRepos(s.reposForImage(image)).
-				WithDockerignores(s.dockerignoresForImage(image))
+				WithDockerignores(s.dockerignoresForImage(image)).
+				WithTiltFilename(s.filename.path)
+			m = m.WithTiltFilename(s.filename.path)
 		}
 		result = append(result, m)
 	}


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ibd:

1fa859f352eaaaef10dfdaeff5a2ce13e7e536c0 (2019-01-11 11:53:50 -0500)
engine: make image builders act on ImageTargets instead of on Manifests