### PR TITLE
cli: down takes --file flag [ch1215]

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -15,24 +15,27 @@ import (
 )
 
 type downCmd struct {
+	fileName string
 }
 
-func (c downCmd) register() *cobra.Command {
+func (c *downCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "down",
 		Short: "delete kubernetes resources",
 	}
 
+	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")
+
 	return cmd
 }
 
-func (c downCmd) run(ctx context.Context, args []string) error {
+func (c *downCmd) run(ctx context.Context, args []string) error {
 	analyticsService.Incr("cmd.down", map[string]string{
 		"count": fmt.Sprintf("%d", len(args)),
 	})
 	defer analyticsService.Flush(time.Second)
 
-	manifests, globalYaml, _, err := tiltfile.Load(ctx, tiltfile.FileName, nil)
+	manifests, globalYaml, _, err := tiltfile.Load(ctx, c.fileName, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/down-file-flag:

2a700bf956bef4f238f4ab88c98765a266e8819a (2019-01-11 14:51:02 -0500)
cli: down takes --file flag

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics