### PR TITLE
build: make pathMapping public. it doesn't make sense to have public methods that take a non-public type

### DIFF
--- a/internal/build/boil_steps.go
+++ b/internal/build/boil_steps.go
@@ -5,7 +5,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 )
 
-func BoilSteps(steps []model.Step, pathMappings []pathMapping) ([]model.Cmd, error) {
+func BoilSteps(steps []model.Step, pathMappings []PathMapping) ([]model.Cmd, error) {
 	res := []model.Cmd{}
 	for _, step := range steps {
 		if step.Triggers == nil {

--- a/internal/build/boil_steps_test.go
+++ b/internal/build/boil_steps_test.go
@@ -14,8 +14,8 @@ func TestBoilStepsNoTrigger(t *testing.T) {
 		},
 	}
 
-	pathMappings := []pathMapping{
-		pathMapping{
+	pathMappings := []PathMapping{
+		PathMapping{
 			LocalPath:     "/home/tilt/code/test/foo",
 			ContainerPath: "/src/foo",
 		},
@@ -38,7 +38,7 @@ func TestBoilStepsNoFilesChanged(t *testing.T) {
 		},
 	}
 
-	pathMappings := []pathMapping{}
+	pathMappings := []PathMapping{}
 
 	expected := []model.Cmd{model.ToShellCmd("echo hello")}
 
@@ -60,8 +60,8 @@ func TestBoilStepsOneTriggerFilesDontMatch(t *testing.T) {
 		},
 	}
 
-	pathMappings := []pathMapping{
-		pathMapping{
+	pathMappings := []PathMapping{
+		PathMapping{
 			LocalPath:     "/home/tilt/code/test/foo",
 			ContainerPath: "/src/foo",
 		},
@@ -87,8 +87,8 @@ func TestBoilStepsOneTriggerMatchingFile(t *testing.T) {
 		},
 	}
 
-	pathMappings := []pathMapping{
-		pathMapping{
+	pathMappings := []PathMapping{
+		PathMapping{
 			LocalPath:     "/home/tilt/code/test/bar",
 			ContainerPath: "/src/bar",
 		},
@@ -121,12 +121,12 @@ func TestBoilStepsManyTriggersManyFiles(t *testing.T) {
 		},
 	}
 
-	pathMappings := []pathMapping{
-		pathMapping{
+	pathMappings := []PathMapping{
+		PathMapping{
 			LocalPath:     "/home/tilt/code/test/baz",
 			ContainerPath: "/src/baz",
 		},
-		pathMapping{
+		PathMapping{
 			LocalPath:     "/home/tilt/code/test/bar",
 			ContainerPath: "/src/bar",
 		},

--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -535,9 +535,9 @@ func TestUpdateInContainerE2E(t *testing.T) {
 	f.Rm("delete_me") // expect to be deleted from container on update
 	f.WriteFile("foo", "hello world")
 
-	paths := []pathMapping{
-		pathMapping{LocalPath: f.JoinPath("delete_me"), ContainerPath: "/src/delete_me"},
-		pathMapping{LocalPath: f.JoinPath("foo"), ContainerPath: "/src/foo"},
+	paths := []PathMapping{
+		PathMapping{LocalPath: f.JoinPath("delete_me"), ContainerPath: "/src/delete_me"},
+		PathMapping{LocalPath: f.JoinPath("foo"), ContainerPath: "/src/foo"},
 	}
 	touchBar := model.ToShellCmd("touch /src/bar")
 

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -22,7 +22,7 @@ func NewContainerUpdater(dCli docker.Client) *ContainerUpdater {
 	return &ContainerUpdater{dCli: dCli}
 }
 
-func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.ID, paths []pathMapping, filter model.PathMatcher, steps []model.Cmd, w io.Writer) error {
+func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.ID, paths []PathMapping, filter model.PathMatcher, steps []model.Cmd, w io.Writer) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-UpdateInContainer")
 	defer span.Finish()
 
@@ -77,7 +77,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 	return nil
 }
 
-func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID container.ID, paths []pathMapping) error {
+func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID container.ID, paths []PathMapping) error {
 	if len(paths) == 0 {
 		return nil
 	}
@@ -95,7 +95,7 @@ func (r *ContainerUpdater) RmPathsFromContainer(ctx context.Context, cID contain
 	return nil
 }
 
-func makeRmCmd(paths []pathMapping) []string {
+func makeRmCmd(paths []PathMapping) []string {
 	cmd := []string{"rm", "-rf"}
 	for _, p := range paths {
 		cmd = append(cmd, p.ContainerPath)

--- a/internal/build/container_updater_test.go
+++ b/internal/build/container_updater_test.go
@@ -20,10 +20,10 @@ func TestUpdateInContainerCopiesAndRmsFiles(t *testing.T) {
 	f.WriteFile("hi", "hello")
 	f.WriteFile("planets/earth", "world")
 
-	paths := []pathMapping{
-		pathMapping{LocalPath: f.JoinPath("hi"), ContainerPath: "/src/hi"},
-		pathMapping{LocalPath: f.JoinPath("planets/earth"), ContainerPath: "/src/planets/earth"},
-		pathMapping{LocalPath: f.JoinPath("does-not-exist"), ContainerPath: "/src/does-not-exist"},
+	paths := []PathMapping{
+		PathMapping{LocalPath: f.JoinPath("hi"), ContainerPath: "/src/hi"},
+		PathMapping{LocalPath: f.JoinPath("planets/earth"), ContainerPath: "/src/planets/earth"},
+		PathMapping{LocalPath: f.JoinPath("does-not-exist"), ContainerPath: "/src/does-not-exist"},
 	}
 
 	err := f.cu.UpdateInContainer(f.ctx, docker.TestContainer, paths, model.EmptyMatcher, nil, ioutil.Discard)
@@ -50,7 +50,7 @@ func TestUpdateInContainerExecsSteps(t *testing.T) {
 	cmdA := model.Cmd{Argv: []string{"a"}}
 	cmdB := model.Cmd{Argv: []string{"cu", "and cu", "another cu"}}
 
-	err := f.cu.UpdateInContainer(f.ctx, docker.TestContainer, []pathMapping{}, model.EmptyMatcher, []model.Cmd{cmdA, cmdB}, ioutil.Discard)
+	err := f.cu.UpdateInContainer(f.ctx, docker.TestContainer, []PathMapping{}, model.EmptyMatcher, []model.Cmd{cmdA, cmdB}, ioutil.Discard)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestUpdateInContainerRestartsContainer(t *testing.T) {
 	f := newRemoteDockerFixture(t)
 	defer f.teardown()
 
-	err := f.cu.UpdateInContainer(f.ctx, docker.TestContainer, []pathMapping{}, model.EmptyMatcher, nil, ioutil.Discard)
+	err := f.cu.UpdateInContainer(f.ctx, docker.TestContainer, []PathMapping{}, model.EmptyMatcher, nil, ioutil.Discard)
 	if err != nil {
 		f.t.Fatal(err)
 	}

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -45,7 +45,7 @@ type dockerImageBuilder struct {
 type ImageBuilder interface {
 	BuildDockerfile(ctx context.Context, ps *PipelineState, ref reference.Named, df dockerfile.Dockerfile, buildPath string, filter model.PathMatcher, buildArgs map[string]string) (reference.NamedTagged, error)
 	BuildImageFromScratch(ctx context.Context, ps *PipelineState, ref reference.Named, baseDockerfile dockerfile.Dockerfile, mounts []model.Mount, filter model.PathMatcher, steps []model.Step, entrypoint model.Cmd) (reference.NamedTagged, error)
-	BuildImageFromExisting(ctx context.Context, ps *PipelineState, existing reference.NamedTagged, paths []pathMapping, filter model.PathMatcher, steps []model.Step) (reference.NamedTagged, error)
+	BuildImageFromExisting(ctx context.Context, ps *PipelineState, existing reference.NamedTagged, paths []PathMapping, filter model.PathMatcher, steps []model.Step) (reference.NamedTagged, error)
 	PushImage(ctx context.Context, name reference.NamedTagged, writer io.Writer) (reference.NamedTagged, error)
 	TagImage(ctx context.Context, name reference.Named, dig digest.Digest) (reference.NamedTagged, error)
 }
@@ -80,7 +80,7 @@ func (d *dockerImageBuilder) BuildDockerfile(ctx context.Context, ps *PipelineSt
 	span, ctx := opentracing.StartSpanFromContext(ctx, "dib-BuildDockerfile")
 	defer span.Finish()
 
-	paths := []pathMapping{
+	paths := []PathMapping{
 		{
 			LocalPath:     buildPath,
 			ContainerPath: "/",
@@ -116,7 +116,7 @@ func (d *dockerImageBuilder) BuildImageFromScratch(ctx context.Context, ps *Pipe
 }
 
 func (d *dockerImageBuilder) BuildImageFromExisting(ctx context.Context, ps *PipelineState, existing reference.NamedTagged,
-	paths []pathMapping, filter model.PathMatcher, steps []model.Step) (reference.NamedTagged, error) {
+	paths []PathMapping, filter model.PathMatcher, steps []model.Step) (reference.NamedTagged, error) {
 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-BuildImageFromExisting")
 	defer span.Finish()
@@ -144,7 +144,7 @@ func (d *dockerImageBuilder) applyLabels(df dockerfile.Dockerfile, buildMode doc
 
 // If the build starts with conditional steps, add the dependent files first,
 // then add the runs, before we add the majority of the source.
-func (d *dockerImageBuilder) addConditionalSteps(df dockerfile.Dockerfile, steps []model.Step, paths []pathMapping) (dockerfile.Dockerfile, []model.Step, error) {
+func (d *dockerImageBuilder) addConditionalSteps(df dockerfile.Dockerfile, steps []model.Step, paths []PathMapping) (dockerfile.Dockerfile, []model.Step, error) {
 	consumed := 0
 	for _, step := range steps {
 		if step.Triggers == nil {
@@ -191,7 +191,7 @@ func (d *dockerImageBuilder) addConditionalSteps(df dockerfile.Dockerfile, steps
 	return df, remainingSteps, nil
 }
 
-func (d *dockerImageBuilder) addMountsAndRemovedFiles(ctx context.Context, df dockerfile.Dockerfile, paths []pathMapping) (dockerfile.Dockerfile, error) {
+func (d *dockerImageBuilder) addMountsAndRemovedFiles(ctx context.Context, df dockerfile.Dockerfile, paths []PathMapping) (dockerfile.Dockerfile, error) {
 	df = df.AddAll()
 	toRemove, err := MissingLocalPaths(ctx, paths)
 	if err != nil {
@@ -300,7 +300,7 @@ func (d *dockerImageBuilder) PushImage(ctx context.Context, ref reference.NamedT
 	return ref, nil
 }
 
-func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState, df dockerfile.Dockerfile, paths []pathMapping, filter model.PathMatcher, ref reference.Named, buildArgs model.DockerBuildArgs) (reference.NamedTagged, error) {
+func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState, df dockerfile.Dockerfile, paths []PathMapping, filter model.PathMatcher, ref reference.Named, buildArgs model.DockerBuildArgs) (reference.NamedTagged, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-buildFromDf")
 	defer span.Finish()
 

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -14,7 +14,7 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 )
 
-// pathMapping represents a mapping from the local path to the tarball path
+// PathMapping represents a mapping from the local path to the tarball path
 //
 // To send a local file into a container, we copy it into a tarball, send the
 // tarball to docker, and then run a sequence of steps to unpack the tarball in
@@ -31,15 +31,15 @@ import (
 // In static builds, this is no longer the case.
 //
 // TODO(nick): Do a pass on renaming all the path types
-type pathMapping struct {
+type PathMapping struct {
 	LocalPath     string
 	ContainerPath string
 }
 
-func (m pathMapping) prettyStr() string { return fmt.Sprintf("%s --> %s", m.LocalPath, m.ContainerPath) }
+func (m PathMapping) prettyStr() string { return fmt.Sprintf("%s --> %s", m.LocalPath, m.ContainerPath) }
 
-func (m pathMapping) Filter(matcher model.PathMatcher) ([]pathMapping, error) {
-	result := make([]pathMapping, 0)
+func (m PathMapping) Filter(matcher model.PathMatcher) ([]PathMapping, error) {
+	result := make([]PathMapping, 0)
 	err := filepath.Walk(m.LocalPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -59,7 +59,7 @@ func (m pathMapping) Filter(matcher model.PathMatcher) ([]pathMapping, error) {
 			return err
 		}
 
-		result = append(result, pathMapping{
+		result = append(result, PathMapping{
 			LocalPath:     path,
 			ContainerPath: filepath.Join(m.ContainerPath, rp),
 		})
@@ -72,8 +72,8 @@ func (m pathMapping) Filter(matcher model.PathMatcher) ([]pathMapping, error) {
 	return result, nil
 }
 
-func FilterMappings(mappings []pathMapping, matcher model.PathMatcher) ([]pathMapping, error) {
-	result := make([]pathMapping, 0)
+func FilterMappings(mappings []PathMapping, matcher model.PathMatcher) ([]PathMapping, error) {
+	result := make([]PathMapping, 0)
 	for _, mapping := range mappings {
 		filtered, err := mapping.Filter(matcher)
 		if err != nil {
@@ -87,7 +87,7 @@ func FilterMappings(mappings []pathMapping, matcher model.PathMatcher) ([]pathMa
 
 // FilesToPathMappings converts a list of absolute local filepaths into pathMappings (i.e.
 // associates local filepaths with their mounts and destination paths).
-func FilesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, error) {
+func FilesToPathMappings(files []string, mounts []model.Mount) ([]PathMapping, error) {
 	pms, err := filesToPathMappings(files, mounts)
 	if err != nil {
 		return pms, err
@@ -95,8 +95,8 @@ func FilesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, e
 	return pms, nil
 }
 
-func filesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, *PathMappingErr) {
-	var pms []pathMapping
+func filesToPathMappings(files []string, mounts []model.Mount) ([]PathMapping, *PathMappingErr) {
+	var pms []PathMapping
 	for _, f := range files {
 		pm, err := fileToPathMapping(f, mounts)
 		if err != nil {
@@ -108,7 +108,7 @@ func filesToPathMappings(files []string, mounts []model.Mount) ([]pathMapping, *
 	return pms, nil
 }
 
-func fileToPathMapping(file string, mounts []model.Mount) (pathMapping, *PathMappingErr) {
+func fileToPathMapping(file string, mounts []model.Mount) (PathMapping, *PathMappingErr) {
 	for _, m := range mounts {
 		// Open Q: can you mount inside of mounts?! o_0
 		// TODO(maia): are symlinks etc. gonna kick our asses here? If so, will
@@ -117,7 +117,7 @@ func fileToPathMapping(file string, mounts []model.Mount) (pathMapping, *PathMap
 		if isChild {
 			localPathIsFile, err := isFile(m.LocalPath)
 			if err != nil {
-				return pathMapping{}, pathMappingErrf("error stat'ing: %v", err)
+				return PathMapping{}, pathMappingErrf("error stat'ing: %v", err)
 			}
 			var containerPath string
 			if endsWithSlash(m.ContainerPath) && localPathIsFile {
@@ -126,13 +126,13 @@ func fileToPathMapping(file string, mounts []model.Mount) (pathMapping, *PathMap
 			} else {
 				containerPath = filepath.Join(m.ContainerPath, relPath)
 			}
-			return pathMapping{
+			return PathMapping{
 				LocalPath:     file,
 				ContainerPath: containerPath,
 			}, nil
 		}
 	}
-	return pathMapping{}, pathMappingErrf("file %s matches no mounts", file)
+	return PathMapping{}, pathMappingErrf("file %s matches no mounts", file)
 }
 
 func endsWithSlash(path string) bool {
@@ -153,10 +153,10 @@ func FileBelongsToMount(file string, mounts []model.Mount) bool {
 	return err == nil
 }
 
-func MountsToPathMappings(mounts []model.Mount) []pathMapping {
-	pms := make([]pathMapping, len(mounts))
+func MountsToPathMappings(mounts []model.Mount) []PathMapping {
+	pms := make([]PathMapping, len(mounts))
 	for i, m := range mounts {
-		pms[i] = pathMapping{
+		pms[i] = PathMapping{
 			LocalPath:     m.LocalPath,
 			ContainerPath: m.ContainerPath,
 		}
@@ -165,10 +165,10 @@ func MountsToPathMappings(mounts []model.Mount) []pathMapping {
 }
 
 // Return all the path mappings for local paths that do not exist.
-func MissingLocalPaths(ctx context.Context, mappings []pathMapping) ([]pathMapping, error) {
+func MissingLocalPaths(ctx context.Context, mappings []PathMapping) ([]PathMapping, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "MissingLocalPaths")
 	defer span.Finish()
-	result := make([]pathMapping, 0)
+	result := make([]PathMapping, 0)
 	for _, mapping := range mappings {
 		_, err := os.Stat(mapping.LocalPath)
 		if err == nil {
@@ -184,7 +184,7 @@ func MissingLocalPaths(ctx context.Context, mappings []pathMapping) ([]pathMappi
 	return result, nil
 }
 
-func PathMappingsToContainerPaths(mappings []pathMapping) []string {
+func PathMappingsToContainerPaths(mappings []PathMapping) []string {
 	res := make([]string, len(mappings))
 	for i, m := range mappings {
 		res[i] = m.ContainerPath

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -43,20 +43,20 @@ func TestFilesToPathMappings(t *testing.T) {
 		f.T().Fatal(err)
 	}
 
-	expected := []pathMapping{
-		pathMapping{
+	expected := []PathMapping{
+		PathMapping{
 			LocalPath:     filepath.Join(f.Path(), "mount1/fileA"),
 			ContainerPath: "/dest1/fileA",
 		},
-		pathMapping{
+		PathMapping{
 			LocalPath:     filepath.Join(f.Path(), "mount1/child/fileB"),
 			ContainerPath: "/dest1/child/fileB",
 		},
-		pathMapping{
+		PathMapping{
 			LocalPath:     filepath.Join(f.Path(), "mount2/fileC"),
 			ContainerPath: "/nested/dest2/fileC",
 		},
-		pathMapping{
+		PathMapping{
 			LocalPath:     filepath.Join(f.Path(), "mount2/file_deleted"),
 			ContainerPath: "/nested/dest2/file_deleted",
 		},
@@ -91,8 +91,8 @@ func TestFileToDirectoryPathMapping(t *testing.T) {
 		f.T().Fatal(err)
 	}
 
-	expected := []pathMapping{
-		pathMapping{
+	expected := []PathMapping{
+		PathMapping{
 			LocalPath:     filepath.Join(f.Path(), "mount1/fileA"),
 			ContainerPath: "/dest1/fileA",
 		},

--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -72,7 +72,7 @@ func (a *ArchiveBuilder) archiveDf(ctx context.Context, df dockerfile.Dockerfile
 }
 
 // ArchivePathsIfExist creates a tar archive of all local files in `paths`. It quietly skips any paths that don't exist.
-func (a *ArchiveBuilder) ArchivePathsIfExist(ctx context.Context, paths []pathMapping) error {
+func (a *ArchiveBuilder) ArchivePathsIfExist(ctx context.Context, paths []PathMapping) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ArchivePathsIfExist")
 	defer span.Finish()
 	for _, p := range paths {
@@ -187,7 +187,7 @@ func (a *ArchiveBuilder) len() int {
 	return a.buf.Len()
 }
 
-func tarContextAndUpdateDf(ctx context.Context, df dockerfile.Dockerfile, paths []pathMapping, filter model.PathMatcher) (*bytes.Buffer, error) {
+func tarContextAndUpdateDf(ctx context.Context, df dockerfile.Dockerfile, paths []PathMapping, filter model.PathMatcher) (*bytes.Buffer, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-tarContextAndUpdateDf")
 	defer span.Finish()
 

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -43,12 +43,12 @@ func TestArchivePathsIfExists(t *testing.T) {
 
 	f.WriteFile("a", "a")
 
-	paths := []pathMapping{
-		pathMapping{
+	paths := []PathMapping{
+		PathMapping{
 			LocalPath:     f.JoinPath("a"),
 			ContainerPath: "/a",
 		},
-		pathMapping{
+		PathMapping{
 			LocalPath:     f.JoinPath("b"),
 			ContainerPath: "/b",
 		},
@@ -96,12 +96,12 @@ func TestDontArchiveTiltfile(t *testing.T) {
 	f.WriteFile("a", "a")
 	f.WriteFile("Tiltfile", "Tiltfile")
 
-	paths := []pathMapping{
-		pathMapping{
+	paths := []PathMapping{
+		PathMapping{
 			LocalPath:     f.JoinPath("a"),
 			ContainerPath: "/a",
 		},
-		pathMapping{
+		PathMapping{
 			LocalPath:     f.JoinPath("Tiltfile"),
 			ContainerPath: "/Tiltfile",
 		},


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/pathmapping:

667afc1dbcfa475bf8cdbc1c085ef6342ea9ad21 (2019-01-11 16:48:32 -0500)
build: make pathMapping public. it doesn't make sense to have public methods that take a non-public type