### PR TITLE
dont set empty string as dockercompose status [ch1321]

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -760,7 +760,10 @@ func handleDockerComposeEvent(ctx context.Context, engineState *store.EngineStat
 	state = state.WithContainerID(container.ID(evt.ID))
 
 	// For now, just guess at state.
-	state = state.WithStatus(evt.GuessStatus())
+	status := evt.GuessStatus()
+	if status != "" {
+		state = state.WithStatus(status)
+	}
 
 	if evt.IsStartupEvent() {
 		state = state.WithStartTime(time.Now())


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/handle-unknown-evts:

060d6bb056955a45781e543972664a13a136c682 (2019-01-14 12:24:42 -0500)
dont set empty string as dockercompose status [ch1321]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics