### PR TITLE
engine: remove manifest from buildAndDeployCall, in preparation for removing manifest from BuildAndDeployer

### DIFF
--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -14,7 +14,7 @@ import (
 type FakeDCClient struct {
 	t *testing.T
 
-	RunLogOutput map[model.ManifestName]string
+	RunLogOutput map[model.TargetName]string
 	eventJson    chan string
 }
 
@@ -22,11 +22,11 @@ func NewFakeDockerComposeClient(t *testing.T) *FakeDCClient {
 	return &FakeDCClient{
 		t:            t,
 		eventJson:    make(chan string, 100),
-		RunLogOutput: make(map[model.ManifestName]string),
+		RunLogOutput: make(map[model.TargetName]string),
 	}
 }
 
-func (c *FakeDCClient) Up(ctx context.Context, pathToConfig, serviceName string, stdout, stderr io.Writer) error {
+func (c *FakeDCClient) Up(ctx context.Context, pathToConfig string, serviceName model.TargetName, stdout, stderr io.Writer) error {
 	return nil
 }
 
@@ -34,8 +34,8 @@ func (c *FakeDCClient) Down(ctx context.Context, pathToConfig string, stdout, st
 	return nil
 }
 
-func (c *FakeDCClient) StreamLogs(ctx context.Context, pathToConfig, serviceName string) (io.ReadCloser, error) {
-	output := c.RunLogOutput[model.ManifestName(serviceName)]
+func (c *FakeDCClient) StreamLogs(ctx context.Context, pathToConfig string, serviceName model.TargetName) (io.ReadCloser, error) {
+	output := c.RunLogOutput[serviceName]
 	return ioutil.NopCloser(bytes.NewReader([]byte(output))), nil
 }
 

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -103,7 +103,7 @@ type ManifestReloadedAction struct {
 func (ManifestReloadedAction) Action() {}
 
 type BuildStartedAction struct {
-	Manifest     model.Manifest
+	ManifestName model.ManifestName
 	StartTime    time.Time
 	FilesChanged []string
 	Reason       model.BuildReason

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
-var imageID = container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef")
-var alreadyBuilt = store.BuildResult{Image: imageID}
+var testImageRef = container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef")
+var alreadyBuilt = store.BuildResult{Image: testImageRef}
 
 type expectedFile = testutils.ExpectedFile
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -153,7 +153,7 @@ func (c *BuildController) OnChange(ctx context.Context, st store.RStore) {
 
 	go func() {
 		st.Dispatch(BuildStartedAction{
-			Manifest:     entry.manifest,
+			ManifestName: entry.manifest.Name,
 			StartTime:    time.Now(),
 			FilesChanged: entry.filesChanged,
 			Reason:       entry.buildReason,

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -21,7 +21,7 @@ func TestBuildControllerOnePod(t *testing.T) {
 	f.Start([]model.Manifest{manifest}, true)
 
 	call := f.nextCall()
-	assert.Equal(t, manifest, call.manifest)
+	assert.Equal(t, manifest.ImageTarget, call.image())
 	assert.Equal(t, []string{}, call.state.FilesChanged())
 
 	f.podEvent(f.testPod("pod-id", "fe", "Running", testContainer, time.Now()))
@@ -44,7 +44,7 @@ func TestBuildControllerTwoPods(t *testing.T) {
 	f.Start([]model.Manifest{manifest}, true)
 
 	call := f.nextCall()
-	assert.Equal(t, manifest, call.manifest)
+	assert.Equal(t, manifest.ImageTarget, call.image())
 	assert.Equal(t, []string{}, call.state.FilesChanged())
 
 	podA := f.testPod("pod-a", "fe", "Running", testContainer, time.Now())
@@ -73,7 +73,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.Start([]model.Manifest{manifest}, true)
 
 	call := f.nextCall()
-	assert.Equal(t, manifest, call.manifest)
+	assert.Equal(t, manifest.ImageTarget, call.image())
 	assert.Equal(t, []string{}, call.state.FilesChanged())
 	f.waitForCompletedBuildCount(1)
 

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -29,10 +29,10 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, man
 	if !manifest.IsDC() {
 		return store.BuildResult{}, RedirectToNextBuilderf("not a docker compose manifest")
 	}
-	dcInfo := manifest.DockerComposeTarget()
+	dc := manifest.DockerComposeTarget()
 	stdout := logger.Get(ctx).Writer(logger.InfoLvl)
 	stderr := logger.Get(ctx).Writer(logger.InfoLvl)
 
-	err = bd.dcc.Up(ctx, dcInfo.ConfigPath, manifest.Name.String(), stdout, stderr)
+	err = bd.dcc.Up(ctx, dc.ConfigPath, dc.Name, stdout, stderr)
 	return store.BuildResult{}, err
 }

--- a/internal/engine/docker_compose_log_manager.go
+++ b/internal/engine/docker_compose_log_manager.go
@@ -61,7 +61,7 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 			ctx:             ctx,
 			cancel:          cancel,
 			name:            manifest.Name,
-			dcConfigPath:    manifest.DockerComposeTarget().ConfigPath,
+			dc:              manifest.DockerComposeTarget(),
 			startWatchTime:  startWatchTime,
 			terminationTime: make(chan time.Time, 1),
 		}
@@ -98,7 +98,7 @@ func (m *DockerComposeLogManager) consumeLogs(watch dockerComposeLogWatch, st st
 	}()
 
 	name := watch.name
-	readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dcConfigPath, watch.name.String())
+	readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPath, watch.dc.Name)
 	if err != nil {
 		logger.Get(watch.ctx).Debugf("Error streaming %s logs: %v", name, err)
 		return
@@ -129,7 +129,7 @@ type dockerComposeLogWatch struct {
 	ctx             context.Context
 	cancel          func()
 	name            model.ManifestName
-	dcConfigPath    string
+	dc              model.DockerComposeTarget
 	startWatchTime  time.Time
 	terminationTime chan time.Time
 

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -25,9 +25,13 @@ type ImageTarget struct {
 }
 
 func (i ImageTarget) ID() TargetID {
+	name := TargetName("")
+	if i.Ref != nil {
+		name = TargetName(i.Ref.String())
+	}
 	return TargetID{
 		Type: TargetTypeImage,
-		Name: TargetName(i.Ref.String()),
+		Name: name,
 	}
 }
 


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/targets3:

00025b7ed3c2a57448d8305d7974ab1ed7ba4062 (2019-01-14 17:24:08 -0500)
engine: remove manifest from buildAndDeployCall, in preparation for removing manifest from BuildAndDeployer