### PR TITLE
engine: clear docker compose 'current log' when we deploy

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -205,7 +205,7 @@ func handleBuildStarted(ctx context.Context, state *store.EngineState, action Bu
 	}
 
 	if dcState, ok := ms.ResourceState.(dockercompose.State); ok {
-		ms.ResourceState = dcState.WithCurrentLog(dcState.CurrentLog)
+		ms.ResourceState = dcState.WithCurrentLog([]byte{})
 	}
 
 	// Keep the crash log around until we have a rebuild


### PR DESCRIPTION
We weren't clearing the old log when we did a new deploy, which led
to fun stuff like this:

![screen shot 2019-01-14 at 4 57 15 pm](https://user-images.githubusercontent.com/6332648/51146967-858dd700-1826-11e9-9f2a-0871d6e83bb8.png)
