### PR TITLE
watch: add watch function that traverses up directory structure recursively

### DIFF
--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -325,7 +326,11 @@ func TestWatchNonexistantDirectory(t *testing.T) {
 	f.fsync()
 	f.events = nil
 	f.WriteFile(file, "hello")
-	f.assertEvents(parent, file)
+	if runtime.GOOS == "darwin" {
+		f.assertEvents(file)
+	} else {
+		f.assertEvents(parent, file)
+	}
 }
 
 type notifyFixture struct {

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -309,6 +309,25 @@ func TestWatchBothDirAndFile(t *testing.T) {
 	f.assertEvents(fileB)
 }
 
+func TestWatchNonexistantDirectory(t *testing.T) {
+	f := newNotifyFixture(t)
+	defer f.tearDown()
+
+	root := f.JoinPath("root")
+	err := os.Mkdir(root, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := f.JoinPath("root", "parent")
+	file := f.JoinPath("root", "parent", "a")
+
+	f.watch(file)
+	f.fsync()
+	f.events = nil
+	f.WriteFile(file, "hello")
+	f.assertEvents(parent, file)
+}
+
 type notifyFixture struct {
 	*tempdir.TempDirFixture
 	notify  Notify

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -310,7 +310,7 @@ func TestWatchBothDirAndFile(t *testing.T) {
 	f.assertEvents(fileB)
 }
 
-func TestWatchNonexistantDirectory(t *testing.T) {
+func TestWatchNonexistentDirectory(t *testing.T) {
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 


### PR DESCRIPTION
to find appropriate parent to watch and wait for the specified path to exist.

I added a constraint that says not to watch root but I'm not sure if that's necessary, or if it's Windows compatible. Thoughts?