### PR TITLE
engine: change WatchManager to watch targets instead of manifests

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -141,7 +141,7 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		err = action.Error
 	case hud.ExitAction:
 		handleExitAction(state, action)
-	case manifestFilesChangedAction:
+	case targetFilesChangedAction:
 		handleFSEvent(ctx, state, action)
 	case PodChangeAction:
 		handlePodEvent(ctx, state, action.Pod)
@@ -343,16 +343,21 @@ func handleStartProfilingAction(state *store.EngineState) {
 func handleFSEvent(
 	ctx context.Context,
 	state *store.EngineState,
-	event manifestFilesChangedAction) {
+	event targetFilesChangedAction) {
 
-	if event.manifestName == ConfigsManifestName {
+	if event.targetID.Type == model.TargetTypeConfigs {
 		for _, f := range event.files {
 			state.PendingConfigFileChanges[f] = true
 		}
 		return
 	}
 
-	ms, ok := state.ManifestState(event.manifestName)
+	mn := state.ManifestNameForTargetID(event.targetID)
+	if mn == "" {
+		return
+	}
+
+	ms, ok := state.ManifestState(mn)
 	if !ok {
 		return
 	}

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -19,14 +19,14 @@ func (fcf fileChangeFilter) Matches(f string, isDir bool) (bool, error) {
 	return fcf.ignoreMatchers.Matches(f, isDir)
 }
 
-type repoManifest interface {
+type repoTarget interface {
 	LocalRepos() []model.LocalGitRepo
 	Dockerignores() []model.Dockerignore
 	TiltFilename() string
 }
 
 // Filter out files that should not be included in the build context.
-func CreateBuildContextFilter(m repoManifest) model.PathMatcher {
+func CreateBuildContextFilter(m repoTarget) model.PathMatcher {
 	matchers := []model.PathMatcher{}
 	if m.TiltFilename() != "" {
 		m, err := model.NewSimpleFileMatcher(m.TiltFilename())
@@ -50,7 +50,7 @@ func CreateBuildContextFilter(m repoManifest) model.PathMatcher {
 	return model.NewCompositeMatcher(matchers)
 }
 
-type IgnorableManifest interface {
+type IgnorableTarget interface {
 	LocalRepos() []model.LocalGitRepo
 	Dockerignores() []model.Dockerignore
 
@@ -59,7 +59,7 @@ type IgnorableManifest interface {
 }
 
 // Filter out files that should not trigger new builds.
-func CreateFileChangeFilter(m IgnorableManifest) (model.PathMatcher, error) {
+func CreateFileChangeFilter(m IgnorableTarget) (model.PathMatcher, error) {
 	matchers := []model.PathMatcher{}
 	for _, r := range m.LocalRepos() {
 		gim, err := git.NewRepoIgnoreTester(context.Background(), r.LocalPath, r.GitignoreContents)

--- a/internal/model/target.go
+++ b/internal/model/target.go
@@ -28,6 +28,9 @@ const (
 	// TODO(nick): Currenly used as the type for both Manifest and YAMLManifest, though
 	// we expect YAMLManifest to go away.
 	TargetTypeManifest TargetType = "manifest"
+
+	// Changes that affect all targets, rebuilding the target graph.
+	TargetTypeConfigs TargetType = "configs"
 )
 
 type TargetID struct {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -71,6 +71,22 @@ type EngineState struct {
 	IsProfiling bool
 }
 
+func (e *EngineState) ManifestNameForTargetID(id model.TargetID) model.ManifestName {
+	for mn, state := range e.ManifestTargets {
+		manifest := state.Manifest
+		if manifest.ImageTarget.ID() == id {
+			return mn
+		}
+		if manifest.K8sTarget().ID() == id {
+			return mn
+		}
+		if manifest.DockerComposeTarget().ID() == id {
+			return mn
+		}
+	}
+	return ""
+}
+
 func (e *EngineState) UpsertManifestTarget(mt *ManifestTarget) {
 	mn := mt.Manifest.Name
 	_, ok := e.ManifestTargets[mn]


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/watch:

41984a1b074181c63f9a552f7ed3d5d466b644c5 (2019-01-15 20:20:14 -0500)
engine: change WatchManager to watch targets instead of manifests
in preparation for multiple image builds per pod, where each image
may watch different things