### PR TITLE
store: track pending files per-image instead of per-manifest

### DIFF
--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -76,6 +76,10 @@ func (m *podMonitor) OnChange(ctx context.Context, st store.RStore) {
 		m.healthy = false
 	}
 
+	if state.CurrentlyBuilding != "" {
+		m.healthy = false
+	}
+
 	for _, ms := range state.ManifestStates() {
 		pod := ms.MostRecentPod()
 		if pod.Phase != v1.PodRunning {
@@ -92,8 +96,10 @@ func (m *podMonitor) OnChange(ctx context.Context, st store.RStore) {
 			m.healthy = false
 		}
 
-		if state.CurrentlyBuilding != "" || len(ms.PendingFileChanges) > 0 {
-			m.healthy = false
+		for _, status := range ms.BuildStatuses {
+			if len(status.PendingFileChanges) > 0 {
+				m.healthy = false
+			}
 		}
 	}
 

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -123,7 +123,7 @@ func TestBuildControllerManualTrigger(t *testing.T) {
 	f.fsWatcher.events <- watch.FileEvent{Path: "main.go"}
 
 	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
-		return len(st.ManifestTargets["fe"].State.PendingFileChanges) > 0
+		return len(st.BuildStatus(manifest.ImageTarget.ID()).PendingFileChanges) > 0
 	})
 
 	// We don't expect a call because the trigger happened before the file event

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1069,7 +1069,7 @@ func TestPodEventContainerStatus(t *testing.T) {
 
 	var ref reference.NamedTagged
 	f.WaitUntilManifestState("image appears", "foobar", func(ms store.ManifestState) bool {
-		ref = ms.LastSuccessfulResult.Image
+		ref = ms.BuildStatus(manifest.ImageTarget.ID()).LastSuccessfulResult.Image
 		return ref != nil
 	})
 
@@ -1330,7 +1330,7 @@ func TestPodContainerStatus(t *testing.T) {
 
 	var ref reference.NamedTagged
 	f.WaitUntilManifestState("image appears", "fe", func(ms store.ManifestState) bool {
-		ref = ms.LastSuccessfulResult.Image
+		ref = ms.BuildStatus(manifest.ImageTarget.ID()).LastSuccessfulResult.Image
 		return ref != nil
 	})
 

--- a/internal/hud/renderer_test.go
+++ b/internal/hud/renderer_test.go
@@ -41,7 +41,7 @@ func TestRender(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name: "a-a-a-aaaaabe vigoda",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					FinishTime: time.Now(),
 					Error:      fmt.Errorf("oh no the build failed"),
 					Log:        []byte("1\n2\n3\nthe compiler did not understand!\n5\n6\n7\n8\n"),
@@ -56,7 +56,7 @@ func TestRender(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name: "a-a-a-aaaaabe vigoda",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					FinishTime: time.Now(),
 					Error:      fmt.Errorf("oh no the build failed"),
 					Log: []byte(`STEP 1/2 — Building Dockerfile: [gcr.io/windmill-public-containers/servantes/snack]
@@ -82,7 +82,7 @@ ERROR: ImageBuild: executor failed running [/bin/sh -c go install github.com/win
 		Resources: []view.Resource{
 			{
 				Name: "a-a-a-aaaaabe vigoda",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Error: fmt.Errorf("oh no the build failed"),
 					Log:   []byte("1\n2\n3\nthe compiler wasn't smart enough to figure out what you meant!\n5\n6\n7\n8\n"),
 				}},
@@ -117,7 +117,7 @@ ERROR: ImageBuild: executor failed running [/bin/sh -c go install github.com/win
 		Resources: []view.Resource{
 			{
 				Name: "a-a-a-aaaaabe vigoda",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Error: fmt.Errorf("broken go code!"),
 					Log:   []byte("mashing keys is not a good way to generate code"),
 				}},
@@ -134,7 +134,7 @@ ERROR: ImageBuild: executor failed running [/bin/sh -c go install github.com/win
 				Name:               "a-a-a-aaaaabe vigoda",
 				DirectoriesWatched: []string{"foo", "bar"},
 				LastDeployTime:     ts,
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Edits:      []string{"main.go", "cli.go"},
 					Error:      fmt.Errorf("the build failed!"),
 					FinishTime: ts,
@@ -142,7 +142,7 @@ ERROR: ImageBuild: executor failed running [/bin/sh -c go install github.com/win
 				}},
 				PendingBuildEdits: []string{"main.go", "cli.go", "vigoda.go"},
 				PendingBuildSince: ts,
-				CurrentBuild: model.BuildStatus{
+				CurrentBuild: model.BuildRecord{
 					Edits:     []string{"main.go"},
 					StartTime: ts,
 				},
@@ -167,11 +167,11 @@ ERROR: ImageBuild: executor failed running [/bin/sh -c go install github.com/win
 				Name:               "abe vigoda",
 				DirectoriesWatched: []string{"foo", "bar"},
 				LastDeployTime:     ts,
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Edits: []string{"main.go"},
 				}},
 				PendingBuildSince: ts,
-				CurrentBuild: model.BuildStatus{
+				CurrentBuild: model.BuildRecord{
 					StartTime: ts,
 					Reason:    model.BuildReasonFlagCrash,
 				},
@@ -194,7 +194,7 @@ ERROR: ImageBuild: executor failed running [/bin/sh -c go install github.com/win
 				Name:               "vigoda",
 				DirectoriesWatched: []string{"foo", "bar"},
 				LastDeployTime:     ts,
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Edits:      []string{"main.go", "cli.go"},
 					FinishTime: ts,
 					StartTime:  ts.Add(-1400 * time.Millisecond),
@@ -221,7 +221,7 @@ oh noooooooooooooooooo nooooooooooo noooooooooooo nooooooooooo`,
 		Resources: []view.Resource{
 			{
 				Name: "GlobalYAML",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					FinishTime: ts,
 					StartTime:  ts.Add(-1400 * time.Millisecond),
 				}},
@@ -240,7 +240,7 @@ oh noooooooooooooooooo nooooooooooo noooooooooooo nooooooooooo`,
 		Resources: []view.Resource{
 			{
 				Name: "vigoda",
-				CurrentBuild: model.BuildStatus{
+				CurrentBuild: model.BuildRecord{
 					StartTime: ts.Add(-5 * time.Second),
 					Edits:     []string{"main.go"},
 				},
@@ -267,7 +267,7 @@ oh noooooooooooooooooo nooooooooooo noooooooooooo nooooooooooo`,
 			{
 				Name:           "vigoda",
 				LastDeployTime: ts.Add(-5 * time.Second),
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Edits: []string{"abbot.go", "costello.go", "harold.go"},
 				}},
 				ResourceInfo: view.K8SResourceInfo{},
@@ -305,7 +305,7 @@ func TestRenderLogModal(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name: "vigoda",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					StartTime:  now.Add(-time.Minute),
 					FinishTime: now,
 					Log: []byte(`STEP 1/2 — Building Dockerfile: [gcr.io/windmill-public-containers/servantes/snack]
@@ -331,10 +331,10 @@ func TestRenderLogModal(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name: "vigoda",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					FinishTime: now.Add(-time.Minute),
 				}},
-				CurrentBuild: model.BuildStatus{
+				CurrentBuild: model.BuildRecord{
 					StartTime: now,
 					Log:       []byte("building!"),
 					Reason:    model.BuildReasonFlagCrash,
@@ -360,8 +360,8 @@ func TestRenderLogModal(t *testing.T) {
 					"Hi hello I'm a docker compose log",
 					time.Now().Add(time.Second*-12),
 				),
-				BuildHistory: []model.BuildStatus{
-					model.BuildStatus{
+				BuildHistory: []model.BuildRecord{
+					model.BuildRecord{
 						Log: []byte("Hi hello I'm a docker compose build log"),
 					},
 				},
@@ -411,7 +411,7 @@ func TestAutoCollapseModes(t *testing.T) {
 			{
 				Name:               "vigoda",
 				DirectoriesWatched: []string{"bar"},
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					FinishTime: time.Now(),
 					Error:      fmt.Errorf("oh no the build failed"),
 					Log:        []byte("1\n2\n3\nthe compiler did not understand!\n5\n6\n7\n8\n"),
@@ -438,7 +438,7 @@ func TestPodPending(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name: "vigoda",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					StartTime:  ts,
 					FinishTime: ts,
 					Log: []byte(`STEP 1/2 — Building Dockerfile: [gcr.io/windmill-public-containers/servantes/snack]
@@ -479,7 +479,7 @@ func TestPodLogContainerUpdate(t *testing.T) {
 			{
 				Name:      "vigoda",
 				Endpoints: []string{"1.2.3.4:8080"},
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Log:        []byte("Building (1/2)\nBuilding (2/2)\n"),
 					StartTime:  ts,
 					FinishTime: ts,
@@ -510,7 +510,7 @@ func TestCrashingPodInlineCrashLog(t *testing.T) {
 				Name:      "vigoda",
 				Endpoints: []string{"1.2.3.4:8080"},
 				CrashLog:  "Definitely borken",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Log:        []byte("Building (1/2)\nBuilding (2/2)\n"),
 					StartTime:  ts,
 					FinishTime: ts,
@@ -540,7 +540,7 @@ func TestCrashingPodInlinePodLogIfNoCrashLog(t *testing.T) {
 			{
 				Name:      "vigoda",
 				Endpoints: []string{"1.2.3.4:8080"},
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Log:        []byte("Building (1/2)\nBuilding (2/2)\n"),
 					StartTime:  ts,
 					FinishTime: ts,
@@ -571,7 +571,7 @@ func TestNonCrashingPodNoInlineCrashLog(t *testing.T) {
 				Name:      "vigoda",
 				Endpoints: []string{"1.2.3.4:8080"},
 				CrashLog:  "Definitely borken",
-				BuildHistory: []model.BuildStatus{{
+				BuildHistory: []model.BuildRecord{{
 					Log:        []byte("Building (1/2)\nBuilding (2/2)\n"),
 					StartTime:  ts,
 					FinishTime: ts,
@@ -617,7 +617,7 @@ func TestBuildHistory(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name: "vigoda",
-				BuildHistory: []model.BuildStatus{
+				BuildHistory: []model.BuildRecord{
 					{
 						Edits:      []string{"main.go"},
 						StartTime:  ts.Add(-10 * time.Second),
@@ -652,7 +652,7 @@ func TestStatusBarDCRebuild(t *testing.T) {
 			{
 				Name:         "snack",
 				ResourceInfo: view.NewDCResourceInfo("foo", dockercompose.StatusDown, testCID, "hellllo", now.Add(-5*time.Second)),
-				CurrentBuild: model.BuildStatus{
+				CurrentBuild: model.BuildRecord{
 					StartTime: now.Add(-5 * time.Second),
 					Reason:    model.BuildReasonFlagMountFiles,
 				},

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -69,8 +69,8 @@ type Resource struct {
 	PathsWatched       []string
 	LastDeployTime     time.Time
 
-	BuildHistory []model.BuildStatus
-	CurrentBuild model.BuildStatus
+	BuildHistory []model.BuildRecord
+	CurrentBuild model.BuildRecord
 
 	PendingBuildReason model.BuildReason
 	PendingBuildEdits  []string
@@ -124,9 +124,9 @@ func (r Resource) IsYAML() bool {
 	return ok
 }
 
-func (r Resource) LastBuild() model.BuildStatus {
+func (r Resource) LastBuild() model.BuildRecord {
 	if len(r.BuildHistory) == 0 {
-		return model.BuildStatus{}
+		return model.BuildRecord{}
 	}
 	return r.BuildHistory[0]
 }

--- a/internal/model/build_status.go
+++ b/internal/model/build_status.go
@@ -6,7 +6,7 @@ import (
 
 const BuildHistoryLimit = 2
 
-type BuildStatus struct {
+type BuildRecord struct {
 	Edits      []string
 	Error      error
 	StartTime  time.Time
@@ -15,11 +15,11 @@ type BuildStatus struct {
 	Log        []byte `testdiff:"ignore"`
 }
 
-func (bs BuildStatus) Empty() bool {
+func (bs BuildRecord) Empty() bool {
 	return bs.StartTime.IsZero()
 }
 
-func (bs BuildStatus) Duration() time.Duration {
+func (bs BuildRecord) Duration() time.Duration {
 	if bs.StartTime.IsZero() {
 		return time.Duration(0)
 	}

--- a/internal/model/target.go
+++ b/internal/model/target.go
@@ -61,8 +61,8 @@ type TargetSpec interface {
 
 type TargetStatus interface {
 	TargetID() TargetID
-	ActiveBuild() BuildStatus
-	LastBuild() BuildStatus
+	ActiveBuild() BuildRecord
+	LastBuild() BuildRecord
 }
 
 type Target interface {

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -53,6 +53,15 @@ func (b BuildResult) ShallowCloneForContainerUpdate(filesReplacedSet map[string]
 
 type BuildResultSet map[model.TargetID]BuildResult
 
+func (set BuildResultSet) AsOneResult() BuildResult {
+	if len(set) == 1 {
+		for _, result := range set {
+			return result
+		}
+	}
+	return BuildResult{}
+}
+
 // The state of the system since the last successful build.
 // This data structure should be considered immutable.
 // All methods that return a new BuildState should first clone the existing build state.

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -26,10 +26,11 @@ func TestStateToViewMultipleMounts(t *testing.T) {
 	state := newState([]model.Manifest{m}, model.YAMLManifest{})
 	ms := state.ManifestTargets[m.Name].State
 	ms.CurrentBuild.Edits = []string{"/a/b/d", "/a/b/c/d/e"}
-	ms.BuildHistory = []model.BuildStatus{
+	ms.BuildHistory = []model.BuildRecord{
 		{Edits: []string{"/a/b/d", "/a/b/c/d/e"}},
 	}
-	ms.PendingFileChanges = map[string]time.Time{"/a/b/d": time.Now(), "/a/b/c/d/e": time.Now()}
+	ms.MutableBuildStatus(m.ImageTarget.ID()).PendingFileChanges =
+		map[string]time.Time{"/a/b/d": time.Now(), "/a/b/c/d/e": time.Now()}
 	v := StateToView(*state)
 
 	if !assert.Equal(t, 1, len(v.Resources)) {
@@ -95,7 +96,7 @@ func TestEmptyState(t *testing.T) {
 	v := StateToView(*es)
 	assert.Equal(t, "", v.TiltfileErrorMessage)
 
-	es.LastTiltfileBuild = model.BuildStatus{
+	es.LastTiltfileBuild = model.BuildRecord{
 		StartTime:  time.Now(),
 		FinishTime: time.Now(),
 	}


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/pending:

fe4b3290ebb93ef151418793b77d16b3efe93804 (2019-01-16 10:40:17 -0500)
store: track pending files per-image instead of per-manifest
in preparation for multiple images per manifest