### PR TITLE
model: manifest.ImageTarget -> manifest.ImageTargets

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -147,7 +147,7 @@ func TestContainerBuildLocal(t *testing.T) {
 	}
 	f.assertContainerRestarts(1)
 
-	id := manifest.ImageTarget.ID()
+	id := manifest.ImageTargetAt(0).ID()
 	assert.Equal(t, k8s.MagicTestContainerID, result[id].ContainerID.String())
 }
 
@@ -173,7 +173,7 @@ func TestContainerBuildSynclet(t *testing.T) {
 		t.Errorf("Expected 1 synclet containerUpdate, actual: %d", f.sCli.UpdateContainerCount)
 	}
 
-	id := manifest.ImageTarget.ID()
+	id := manifest.ImageTargetAt(0).ID()
 	assert.Equal(t, k8s.MagicTestContainerID, result[id].ContainerID.String())
 }
 
@@ -272,7 +272,7 @@ func TestIncrementalBuildTwice(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := manifest.ImageTarget.ID()
+	id := manifest.ImageTargetAt(0).ID()
 	rSet := firstResult[id].FilesReplacedSet
 	if len(rSet) != 1 || !rSet[aPath] {
 		t.Errorf("Expected replaced set with a.txt, actual: %v", rSet)
@@ -324,7 +324,7 @@ func TestIncrementalBuildTwiceDeadPod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := manifest.ImageTarget.ID()
+	id := manifest.ImageTargetAt(0).ID()
 	rSet := firstResult[id].FilesReplacedSet
 	if len(rSet) != 1 || !rSet[aPath] {
 		t.Errorf("Expected replaced set with a.txt, actual: %v", rSet)
@@ -387,7 +387,7 @@ func TestIgnoredFiles(t *testing.T) {
 	manifest := NewSanchoFastBuildManifest(f)
 
 	tiltfile := filepath.Join(f.Path(), "Tiltfile")
-	manifest = manifest.WithImageTarget(manifest.ImageTarget.WithRepos([]model.LocalGitRepo{
+	manifest = manifest.WithImageTarget(manifest.ImageTargetAt(0).WithRepos([]model.LocalGitRepo{
 		model.LocalGitRepo{
 			LocalPath: f.Path(),
 		},

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -214,7 +214,12 @@ func buildTargets(manifest model.Manifest) []model.TargetSpec {
 	}
 
 	if manifest.IsK8s() {
-		return []model.TargetSpec{manifest.ImageTarget, manifest.K8sTarget()}
+		result := []model.TargetSpec{}
+		for _, iTarget := range manifest.ImageTargets {
+			result = append(result, iTarget)
+		}
+		result = append(result, manifest.K8sTarget())
+		return result
 	}
 
 	return nil

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -21,7 +21,7 @@ func TestBuildControllerOnePod(t *testing.T) {
 	f.Start([]model.Manifest{manifest}, true)
 
 	call := f.nextCall()
-	assert.Equal(t, manifest.ImageTarget, call.image())
+	assert.Equal(t, manifest.ImageTargetAt(0), call.image())
 	assert.Equal(t, []string{}, call.oneState().FilesChanged())
 
 	f.podEvent(f.testPod("pod-id", "fe", "Running", testContainer, time.Now()))
@@ -44,7 +44,7 @@ func TestBuildControllerTwoPods(t *testing.T) {
 	f.Start([]model.Manifest{manifest}, true)
 
 	call := f.nextCall()
-	assert.Equal(t, manifest.ImageTarget, call.image())
+	assert.Equal(t, manifest.ImageTargetAt(0), call.image())
 	assert.Equal(t, []string{}, call.oneState().FilesChanged())
 
 	podA := f.testPod("pod-a", "fe", "Running", testContainer, time.Now())
@@ -73,7 +73,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.Start([]model.Manifest{manifest}, true)
 
 	call := f.nextCall()
-	assert.Equal(t, manifest.ImageTarget, call.image())
+	assert.Equal(t, manifest.ImageTargetAt(0), call.image())
 	assert.Equal(t, []string{}, call.oneState().FilesChanged())
 	f.waitForCompletedBuildCount(1)
 
@@ -123,7 +123,7 @@ func TestBuildControllerManualTrigger(t *testing.T) {
 	f.fsWatcher.events <- watch.FileEvent{Path: "main.go"}
 
 	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
-		return len(st.BuildStatus(manifest.ImageTarget.ID()).PendingFileChanges) > 0
+		return len(st.BuildStatus(manifest.ImageTargetAt(0).ID()).PendingFileChanges) > 0
 	})
 
 	// We don't expect a call because the trigger happened before the file event

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -80,7 +80,7 @@ func TestDeployTwinImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := manifest.ImageTarget.ID()
+	id := manifest.ImageTargetAt(0).ID()
 	expectedImage := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
 	assert.Equal(t, expectedImage, result[id].Image.String())
 	assert.Equalf(t, 2, strings.Count(f.k8s.Yaml, expectedImage),

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -55,7 +55,7 @@ func NewSanchoFastBuildManifest(fixture pather) model.Manifest {
 
 func NewSanchoFastBuildManifestWithCache(fixture pather, paths []string) model.Manifest {
 	manifest := NewSanchoFastBuildManifest(fixture)
-	manifest = manifest.WithImageTarget(manifest.ImageTarget.WithCachePaths(paths))
+	manifest = manifest.WithImageTarget(manifest.ImageTargetAt(0).WithCachePaths(paths))
 	return manifest
 }
 
@@ -89,6 +89,6 @@ func NewSanchoStaticManifest() model.Manifest {
 
 func NewSanchoStaticManifestWithCache(paths []string) model.Manifest {
 	manifest := NewSanchoStaticManifest()
-	manifest = manifest.WithImageTarget(manifest.ImageTarget.WithCachePaths(paths))
+	manifest = manifest.WithImageTarget(manifest.ImageTargetAt(0).WithCachePaths(paths))
 	return manifest
 }

--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -93,8 +93,9 @@ func (w *WatchManager) diff(ctx context.Context, st store.RStore) (setup []Watch
 		if m.IsDC() {
 			dcTarget := m.DockerComposeTarget()
 			targetsToProcess[dcTarget.ID()] = dcTarget
-		} else {
-			iTarget := m.ImageTarget
+		}
+
+		for _, iTarget := range m.ImageTargets {
 			targetsToProcess[iTarget.ID()] = iTarget
 		}
 	}

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/windmilleng/tilt/internal/sliceutils"
 	"github.com/windmilleng/tilt/internal/yaml"
@@ -85,19 +84,7 @@ func (t DockerComposeTarget) WithIgnoredLocalDirectories(dirs []string) DockerCo
 // TODO(nick): This method should be deleted. We should just de-dupe and sort LocalPaths once
 // when we create it, rather than have a duplicate method that does the "right" thing.
 func (t DockerComposeTarget) Dependencies() []string {
-	// TODO(dmiller) we can know the length of this slice
-	deps := []string{}
-
-	for _, p := range t.LocalPaths() {
-		deps = append(deps, p)
-	}
-
-	deduped := sliceutils.DedupeStringSlice(deps)
-
-	// Sort so that any nested paths come after their parents
-	sort.Strings(deduped)
-
-	return deduped
+	return sliceutils.DedupedAndSorted(t.LocalPaths())
 }
 
 func (dc DockerComposeTarget) Validate() error {

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -150,19 +150,7 @@ func (i ImageTarget) WithTiltFilename(f string) ImageTarget {
 // TODO(nick): This method should be deleted. We should just de-dupe and sort LocalPaths once
 // when we create it, rather than have a duplicate method that does the "right" thing.
 func (i ImageTarget) Dependencies() []string {
-	// TODO(dmiller) we can know the length of this slice
-	deps := []string{}
-
-	for _, p := range i.LocalPaths() {
-		deps = append(deps, p)
-	}
-
-	deduped := sliceutils.DedupeStringSlice(deps)
-
-	// Sort so that any nested paths come after their parents
-	sort.Strings(deduped)
-
-	return deduped
+	return sliceutils.DedupedAndSorted(i.LocalPaths())
 }
 
 type StaticBuild struct {

--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -1,6 +1,9 @@
 package sliceutils
 
-func DedupeStringSlice(slice []string) (result []string) {
+import "sort"
+
+// Deduplicate and sort a slice of strings.
+func DedupedAndSorted(slice []string) (result []string) {
 	seen := map[string]bool{}
 
 	for _, s := range slice {
@@ -9,5 +12,6 @@ func DedupeStringSlice(slice []string) (result []string) {
 			result = append(result, s)
 		}
 	}
+	sort.Strings(result)
 	return result
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -74,8 +74,10 @@ type EngineState struct {
 func (e *EngineState) ManifestNameForTargetID(id model.TargetID) model.ManifestName {
 	for mn, state := range e.ManifestTargets {
 		manifest := state.Manifest
-		if manifest.ImageTarget.ID() == id {
-			return mn
+		for _, iTarget := range manifest.ImageTargets {
+			if iTarget.ID() == id {
+				return mn
+			}
 		}
 		if manifest.K8sTarget().ID() == id {
 			return mn

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -29,7 +29,7 @@ func TestStateToViewMultipleMounts(t *testing.T) {
 	ms.BuildHistory = []model.BuildRecord{
 		{Edits: []string{"/a/b/d", "/a/b/c/d/e"}},
 	}
-	ms.MutableBuildStatus(m.ImageTarget.ID()).PendingFileChanges =
+	ms.MutableBuildStatus(m.ImageTargets[0].ID()).PendingFileChanges =
 		map[string]time.Time{"/a/b/d": time.Now(), "/a/b/c/d/e": time.Now()}
 	v := StateToView(*state)
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -369,10 +369,10 @@ func (s *tiltfileState) translateDC(dc dcResource) ([]model.Manifest, error) {
 			return nil, err
 		}
 		result = append(result, m)
-		s.configFiles = sliceutils.DedupeStringSlice(append(s.configFiles, configFiles...))
+		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configFiles...))
 	}
 	if dc.configPath != "" {
-		s.configFiles = sliceutils.DedupeStringSlice(append(s.configFiles, dc.configPath))
+		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, dc.configPath))
 	}
 	return result, nil
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -810,8 +810,8 @@ k8s_resource('foo', 'foo.yaml')
 `)
 	f.load()
 	m := f.assertManifest("foo", db(image("gcr.io/foo")))
-	assert.True(t, m.ImageTarget.IsStaticBuild())
-	assert.False(t, m.ImageTarget.IsFastBuild())
+	assert.True(t, m.ImageTargetAt(0).IsStaticBuild())
+	assert.False(t, m.ImageTargetAt(0).IsFastBuild())
 }
 
 func TestEmptyDockerfileFastBuild(t *testing.T) {
@@ -825,8 +825,8 @@ k8s_resource('foo', 'foo.yaml')
 `)
 	f.load()
 	m := f.assertManifest("foo", db(image("gcr.io/foo")))
-	assert.False(t, m.ImageTarget.IsStaticBuild())
-	assert.True(t, m.ImageTarget.IsFastBuild())
+	assert.False(t, m.ImageTargetAt(0).IsStaticBuild())
+	assert.True(t, m.ImageTargetAt(0).IsFastBuild())
 }
 
 type fixture struct {
@@ -970,8 +970,8 @@ func (f *fixture) assertManifest(name string, opts ...interface{}) model.Manifes
 	for _, opt := range opts {
 		switch opt := opt.(type) {
 		case dbHelper:
-			caches := m.ImageTarget.CachePaths()
-			ref := m.ImageTarget.Ref
+			caches := m.ImageTargetAt(0).CachePaths()
+			ref := m.ImageTargetAt(0).Ref
 			if ref == nil {
 				f.t.Fatalf("manifest %v has no image ref; expected %q", m.Name, opt.image.ref)
 			}
@@ -991,7 +991,7 @@ func (f *fixture) assertManifest(name string, opts ...interface{}) model.Manifes
 				}
 			}
 		case fbHelper:
-			image := m.ImageTarget
+			image := m.ImageTargetAt(0)
 			ref := image.Ref
 			if ref.Name() != opt.image.ref {
 				f.t.Fatalf("manifest %v image ref: %q; expected %q", m.Name, ref.Name(), opt.image.ref)
@@ -1056,7 +1056,7 @@ func (f *fixture) assertManifest(name string, opts ...interface{}) model.Manifes
 			}
 
 			expectedFilter := opt.missing
-			filter := ignore.CreateBuildContextFilter(m.ImageTarget)
+			filter := ignore.CreateBuildContextFilter(m.ImageTargetAt(0))
 			if m.IsDC() {
 				filter = ignore.CreateBuildContextFilter(m.DockerComposeTarget())
 			}
@@ -1066,7 +1066,7 @@ func (f *fixture) assertManifest(name string, opts ...interface{}) model.Manifes
 				if m.IsDC() {
 					filter, err = ignore.CreateFileChangeFilter(m.DockerComposeTarget())
 				} else {
-					filter, err = ignore.CreateFileChangeFilter(m.ImageTarget)
+					filter, err = ignore.CreateFileChangeFilter(m.ImageTargetAt(0))
 				}
 				if err != nil {
 					f.t.Fatalf("Error creating file change filter: %v", err)


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/model:

4e47b56d1fccaaa5e38697f327b6ab46fae3c73d (2019-01-16 12:38:18 -0500)
model: manifest.ImageTarget -> manifest.ImageTargets
there's currently no way to use this functionality from a tiltfile but it will work ok