### PR TITLE
dockercompose: use a channel to more accurately simulate streaming output

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -447,8 +447,8 @@ func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
 	k8s := k8s.NewFakeK8sClient()
 	sCli := synclet.NewFakeSyncletClient()
 	mode := UpdateModeFlag(UpdateModeAuto)
-	dcc := dockercompose.NewFakeDockerComposeClient(t)
-	bd, err := provideBuildAndDeployer(output.CtxForTest(), docker, k8s, dir, env, mode, sCli, dcc)
+	dcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
+	bd, err := provideBuildAndDeployer(ctx, docker, k8s, dir, env, mode, sCli, dcc)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/flakey:

becc6dde8f702853d2de7f7f5c3dfed3e1a3aac8 (2019-01-16 13:21:41 -0500)
dockercompose: use a channel to more accurately simulate streaming output