### PR TITLE
tiltfile: support multiple images per manifest

### DIFF
--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -235,6 +235,37 @@ spec:
         image: gcr.io/some-project-162817/sancho-sidecar
 `
 
+const SanchoRedisSidecarYAML = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sancho
+  namespace: sancho-ns
+  labels:
+    app: sancho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sancho
+  template:
+    metadata:
+      labels:
+        app: sancho
+    spec:
+      containers:
+      - name: sancho
+        image: gcr.io/some-project-162817/sancho
+        env:
+          - name: token
+            valueFrom:
+              secretKeyRef:
+                name: slacktoken
+                key: token
+      - name: redis-sidecar
+        image: redis:latest
+`
+
 const TracerYAML = `
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -42,6 +42,11 @@ func (m Manifest) WithImageTarget(iTarget ImageTarget) Manifest {
 	return m
 }
 
+func (m Manifest) WithImageTargets(iTargets []ImageTarget) Manifest {
+	m.ImageTargets = append([]ImageTarget{}, iTargets...)
+	return m
+}
+
 func (m Manifest) ImageTargetAt(i int) ImageTarget {
 	if i < len(m.ImageTargets) {
 		return m.ImageTargets[i]


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch1202/sidecars:

204293830dfe051d59aa1fc5074fa36e3343064f (2019-01-16 16:02:25 -0500)
tiltfile: support multiple images per manifest