### PR TITLE
Track images added by docker_build and fast_build by ref

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -101,7 +101,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		dockerfileContents = string(bs)
 	}
 
-	if s.imagesByName[ref.Name()] != nil {
+	if s.imagesByRef[ref.String()] != nil {
 		return nil, fmt.Errorf("Image for ref %q has already been defined", ref.Name())
 	}
 
@@ -118,7 +118,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		staticBuildArgs:      sba,
 		cachePaths:           cachePaths,
 	}
-	s.imagesByName[ref.Name()] = r
+	s.imagesByRef[ref.String()] = r
 	s.images = append(s.images, r)
 
 	return starlark.None, nil
@@ -149,7 +149,7 @@ func (s *tiltfileState) fastBuild(thread *starlark.Thread, fn *starlark.Builtin,
 		return nil, fmt.Errorf("Parsing %q: %v", dockerRef, err)
 	}
 
-	if s.imagesByName[ref.Name()] != nil {
+	if s.imagesByRef[ref.String()] != nil {
 		return nil, fmt.Errorf("Image for ref %q has already been defined", ref.Name())
 	}
 
@@ -175,7 +175,7 @@ func (s *tiltfileState) fastBuild(thread *starlark.Thread, fn *starlark.Builtin,
 		entrypoint:         entrypoint,
 		cachePaths:         cachePaths,
 	}
-	s.imagesByName[ref.Name()] = r
+	s.imagesByRef[ref.String()] = r
 	s.images = append(s.images, r)
 
 	fb := &fastBuild{s: s, img: r}

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -102,7 +102,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 	}
 
 	if s.imagesByRef[ref.String()] != nil {
-		return nil, fmt.Errorf("Image for ref %q has already been defined", ref.Name())
+		return nil, fmt.Errorf("Image for ref %q has already been defined", ref.String())
 	}
 
 	cachePaths, err := s.cachePathsFromSkylarkValue(cacheVal)


### PR DESCRIPTION
Hey, was having some trouble with Tilt 0.5.1 and decided to dig into this one myself. Basically Tilt was complaining that an image added by `docker_build` wasn't being used by any resource. In my case this wasn't right as I had a `k8s_resource` whose YAML file declared a container using that very same image.

So it turns out `docker_build` and `fast_build` were parsing the image attribute to get the _name_, while `k8s_resource` and friends were using the _ref_. Meanwhile, I was specifying a name plus tag in my `docker_build`, which caused Tilt's confusion.

This PR aims to reconcile the two by using refs everywhere. I could also see this going the other way for usability purposes by simply comparing names everywhere with no regard to tags. But then this can create an unpleasant situation where your manifests and published images might work fine in Tilt but not "in production" when you push the image, apply the manifest, etc.

Anyway, I don't think the PR is entirely done (I have some failing tests that I haven't dug into yet), but I was hoping it could be a platform for discussion so I know if this is going in the right direction, etc.