### PR TITLE
engine: record and display Tiltfile logs separately

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -35,7 +36,7 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 	})
 	defer analyticsService.Flush(time.Second)
 
-	manifests, globalYaml, _, err := tiltfile.Load(ctx, c.fileName, nil)
+	manifests, globalYaml, _, err := tiltfile.Load(ctx, c.fileName, nil, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -20,7 +20,7 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type RepoBranch string
@@ -174,7 +174,8 @@ func (s Script) Run(ctx context.Context) error {
 		}
 
 		tfPath := filepath.Join(dir, tiltfile.FileName)
-		manifests, _, _, err := tiltfile.Load(ctx, tfPath, nil)
+		// TODO(dmiller): not this?
+		manifests, _, _, err := tiltfile.Load(ctx, tfPath, nil, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type ErrorAction struct {
@@ -161,3 +161,9 @@ type DockerComposeLogAction struct {
 }
 
 func (DockerComposeLogAction) Action() {}
+
+type TiltfileLogAction struct {
+	Log []byte
+}
+
+func (TiltfileLogAction) Action() {}

--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -51,7 +51,9 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
 			return
 		}
 
-		manifests, globalYAML, configFiles, err := tiltfile.Load(ctx, tiltfilePath, matching)
+		tlw := NewTiltfileLogWriter(st)
+
+		manifests, globalYAML, configFiles, err := tiltfile.Load(ctx, tiltfilePath, matching, tlw)
 		st.Dispatch(ConfigsReloadedAction{
 			Manifests:   manifests,
 			GlobalYAML:  globalYAML,

--- a/internal/engine/tiltfile_log_writer.go
+++ b/internal/engine/tiltfile_log_writer.go
@@ -1,0 +1,18 @@
+package engine
+
+import "github.com/windmilleng/tilt/internal/store"
+
+type tiltfileLogWriter struct {
+	store store.RStore
+}
+
+func NewTiltfileLogWriter(s store.RStore) *tiltfileLogWriter {
+	return &tiltfileLogWriter{s}
+}
+
+func (w *tiltfileLogWriter) Write(p []byte) (n int, err error) {
+	w.store.Dispatch(TiltfileLogAction{
+		Log: append([]byte{}, p...),
+	})
+	return len(p), nil
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -786,7 +786,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 
 func setLastTiltfileBuild(state *store.EngineState, status model.BuildRecord) {
 	if status.Error != nil {
-		log := []byte(fmt.Sprintf("Tiltfile error:\n%v\n", status.Error))
+		log := []byte(fmt.Sprintf("%v\n", status.Error))
 		handleTiltfileLogAction(state, TiltfileLogAction{log})
 	}
 	state.LastTiltfileBuild = status

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -427,7 +427,7 @@ func handleConfigsReloadStarted(
 	state *store.EngineState,
 	event ConfigsReloadStartedAction,
 ) {
-	state.TiltfileLog = []byte{}
+	state.CurrentTiltfileBuild = model.BuildRecord{}
 	state.PendingConfigFileChanges = make(map[string]bool)
 }
 
@@ -855,5 +855,5 @@ func handleDockerComposeLogAction(state *store.EngineState, action DockerCompose
 }
 
 func handleTiltfileLogAction(state *store.EngineState, action TiltfileLogAction) {
-	state.TiltfileLog = append(state.TiltfileLog, action.Log...)
+	state.CurrentTiltfileBuild.Log = append(state.CurrentTiltfileBuild.Log, action.Log...)
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -908,7 +908,7 @@ func TestHudUpdated(t *testing.T) {
 	err = f.Stop()
 	assert.Equal(t, nil, err)
 
-	assert.Equal(t, 1, len(f.hud.LastView.Resources))
+	assert.Equal(t, 2, len(f.hud.LastView.Resources))
 	rv := f.hud.LastView.Resources[0]
 	assert.Equal(t, manifest.Name, model.ManifestName(rv.Name))
 	assert.Equal(t, ".", rv.DirectoriesWatched[0])
@@ -2382,7 +2382,7 @@ func (f *testFixture) assertAllBuildsConsumed() {
 }
 
 func (f *testFixture) loadAndStart() {
-	manifests, _, _, err := tiltfile.Load(f.ctx, f.JoinPath(tiltfile.FileName), nil)
+	manifests, _, _, err := tiltfile.Load(f.ctx, f.JoinPath(tiltfile.FileName), nil, os.Stdout)
 	if err != nil {
 		f.T().Fatal(err)
 	}
@@ -2419,7 +2419,7 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 
 	f.WriteFile("Tiltfile", `docker_compose('docker-compose.yml')`)
 
-	manifests, _, _, err := tiltfile.Load(f.ctx, f.JoinPath("Tiltfile"), nil)
+	manifests, _, _, err := tiltfile.Load(f.ctx, f.JoinPath("Tiltfile"), nil, os.Stdout)
 	if err != nil {
 		f.T().Fatal(err)
 	}

--- a/internal/hud/buildstatus.go
+++ b/internal/hud/buildstatus.go
@@ -32,6 +32,12 @@ func makeBuildStatus(res view.Resource, triggerMode model.TriggerMode) buildStat
 	deployTime := time.Time{}
 	reason := model.BuildReason(0)
 
+	if res.IsTiltfile {
+		return buildStatus{
+			status: "OK",
+		}
+	}
+
 	if !res.CurrentBuild.Empty() && !res.CurrentBuild.Reason.IsCrashOnly() {
 		status = "Building"
 		duration = time.Since(res.CurrentBuild.StartTime)

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -65,7 +65,6 @@ func (r *Renderer) layout(v view.View, vs view.ViewState) rty.Component {
 		l.Add(rty.NewLine())
 	}
 
-	l.Add(r.renderTiltfileError(v))
 	l.Add(r.renderResourceHeader(v))
 	l.Add(r.renderResources(v, vs))
 	l.Add(r.renderPaneHeader(vs))
@@ -202,6 +201,12 @@ func isCrashing(res view.Resource) bool {
 }
 
 func bestLogs(res view.Resource) string {
+	if res.IsTiltfile && res.CrashLog != "" {
+		return string(res.CrashLog)
+	}
+	if res.IsTiltfile {
+		return string(res.CurrentBuild.Log)
+	}
 	// A build is in progress, triggered by an explicit edit.
 	if res.CurrentBuild.StartTime.After(res.LastBuild().FinishTime) &&
 		!res.CurrentBuild.Reason.IsCrashOnly() {
@@ -325,18 +330,6 @@ func (r *Renderer) renderResources(v view.View, vs view.ViewState) rty.Component
 
 func (r *Renderer) renderResource(res view.Resource, rv view.ResourceViewState, triggerMode model.TriggerMode, selected bool) rty.Component {
 	return NewResourceView(res, rv, triggerMode, selected, r.clock).Build()
-}
-
-func (r *Renderer) renderTiltfileError(v view.View) rty.Component {
-	if v.TiltfileErrorMessage != "" {
-		c := rty.NewConcatLayout(rty.DirVert)
-		c.Add(rty.TextString("Tiltfile error: "))
-		c.Add(rty.TextString(v.TiltfileErrorMessage))
-		c.Add(rty.NewFillerString('─'))
-		return c
-	}
-
-	return rty.NewLines()
 }
 
 func (r *Renderer) SetUp() (chan tcell.Event, error) {

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -201,12 +201,6 @@ func isCrashing(res view.Resource) bool {
 }
 
 func bestLogs(res view.Resource) string {
-	if res.IsTiltfile && res.CrashLog != "" {
-		return string(res.CrashLog)
-	}
-	if res.IsTiltfile {
-		return string(res.CurrentBuild.Log)
-	}
 	// A build is in progress, triggered by an explicit edit.
 	if res.CurrentBuild.StartTime.After(res.LastBuild().FinishTime) &&
 		!res.CurrentBuild.Reason.IsCrashOnly() {
@@ -239,6 +233,10 @@ func bestLogs(res view.Resource) string {
 		if res.LastBuild().StartTime.After(k8sInfo.PodCreationTime) {
 			return string(res.LastBuild().Log)
 		}
+	}
+
+	if res.IsTiltfile {
+		return string(res.CurrentBuild.Log)
 	}
 
 	return string(res.LastBuild().Log) + "\n" + res.ResourceInfo.RuntimeLog()

--- a/internal/hud/renderer_test.go
+++ b/internal/hud/renderer_test.go
@@ -383,17 +383,6 @@ func TestRenderNarrationMessage(t *testing.T) {
 	rtf.run("narration message", 60, 20, v, vs)
 }
 
-func TestRenderTiltfileError(t *testing.T) {
-	rtf := newRendererTestFixture(t)
-	v := view.View{
-		TiltfileErrorMessage: "Tiltfile error!",
-	}
-
-	vs := view.ViewState{}
-
-	rtf.run("tiltfile error", 60, 20, v, vs)
-}
-
 func TestAutoCollapseModes(t *testing.T) {
 	rtf := newRendererTestFixture(t)
 

--- a/internal/hud/resourceview.go
+++ b/internal/hud/resourceview.go
@@ -109,7 +109,7 @@ func (v *ResourceView) titleTextName() rty.Component {
 	sb.Fg(color).Textf(" ● ")
 
 	name := v.res.Name.String()
-	if color == cPending {
+	if color == cPending && !v.res.IsTiltfile {
 		name = fmt.Sprintf("%s %s", v.res.Name, v.spinner())
 	}
 	sb.Fg(tcell.ColorDefault).Text(name)

--- a/internal/hud/resourceview.go
+++ b/internal/hud/resourceview.go
@@ -66,8 +66,10 @@ func (v *ResourceView) resourceTitle() rty.Component {
 }
 
 func statusColor(res view.Resource, triggerMode model.TriggerMode) tcell.Color {
-	if res.IsTiltfile {
+	if res.IsTiltfile && res.CrashLog == "" {
 		return cGood
+	} else if res.IsTiltfile && res.CrashLog != "" {
+		return cBad
 	}
 	if !res.CurrentBuild.Empty() && !res.CurrentBuild.Reason.IsCrashOnly() {
 		return cPending

--- a/internal/hud/resourceview.go
+++ b/internal/hud/resourceview.go
@@ -66,6 +66,9 @@ func (v *ResourceView) resourceTitle() rty.Component {
 }
 
 func statusColor(res view.Resource, triggerMode model.TriggerMode) tcell.Color {
+	if res.IsTiltfile {
+		return cGood
+	}
 	if !res.CurrentBuild.Empty() && !res.CurrentBuild.Reason.IsCrashOnly() {
 		return cPending
 	} else if !res.PendingBuildSince.IsZero() && !res.PendingBuildReason.IsCrashOnly() {

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -83,6 +83,8 @@ type Resource struct {
 	// If a pod had to be killed because it was crashing, we keep the old log around
 	// for a little while.
 	CrashLog string
+
+	IsTiltfile bool
 }
 
 func (r Resource) DockerComposeTarget() DCResourceInfo {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -70,7 +70,7 @@ type EngineState struct {
 
 	IsProfiling bool
 
-	TiltfileLog []byte `testdiff:"ignore"`
+	CurrentTiltfileBuild model.BuildRecord
 }
 
 func (e *EngineState) ManifestNameForTargetID(id model.TargetID) model.ManifestName {
@@ -664,9 +664,8 @@ func StateToView(s EngineState) view.View {
 		ret.Resources = append(ret.Resources, r)
 	}
 
-	// TODO(dmiller): we might not want to grab this build
 	tfb := s.LastTiltfileBuild
-	tfb.Log = s.TiltfileLog
+	tfb.Log = s.CurrentTiltfileBuild.Log
 	tr := view.Resource{
 		Name:         "(Tiltfile)",
 		IsTiltfile:   true,

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -34,7 +34,7 @@ func TestStateToViewMultipleMounts(t *testing.T) {
 		map[string]time.Time{"/a/b/d": time.Now(), "/a/b/c/d/e": time.Now()}
 	v := StateToView(*state)
 
-	if !assert.Equal(t, 1, len(v.Resources)) {
+	if !assert.Equal(t, 2, len(v.Resources)) {
 		return
 	}
 
@@ -67,7 +67,7 @@ func TestStateViewYAMLManifestNoYAML(t *testing.T) {
 	state := newState([]model.Manifest{}, m)
 	v := StateToView(*state)
 
-	assert.Equal(t, 0, len(v.Resources))
+	assert.Equal(t, 1, len(v.Resources))
 }
 
 func TestStateViewYAMLManifestWithYAML(t *testing.T) {
@@ -76,7 +76,7 @@ func TestStateViewYAMLManifestWithYAML(t *testing.T) {
 	state.ConfigFiles = []string{"global.yaml"}
 	v := StateToView(*state)
 
-	assert.Equal(t, 1, len(v.Resources))
+	assert.Equal(t, 2, len(v.Resources))
 
 	r := v.Resources[0]
 	assert.Equal(t, nil, r.LastBuild().Error)

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -3,6 +3,8 @@ package tiltfile
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -24,7 +26,8 @@ func init() {
 }
 
 // Load loads the Tiltfile in `filename`, and returns the manifests matching `matching`.
-func Load(ctx context.Context, filename string, matching map[string]bool) (manifests []model.Manifest, global model.Manifest, configFiles []string, err error) {
+func Load(ctx context.Context, filename string, matching map[string]bool, logs io.Writer) (manifests []model.Manifest, global model.Manifest, configFiles []string, err error) {
+	l := log.New(logs, "", log.LstdFlags)
 	absFilename, err := ospath.RealAbs(filename)
 	if err != nil {
 		absFilename, _ = filepath.Abs(filename)
@@ -33,7 +36,7 @@ func Load(ctx context.Context, filename string, matching map[string]bool) (manif
 
 	tfRoot, _ := filepath.Split(absFilename)
 
-	s := newTiltfileState(ctx, absFilename, tfRoot)
+	s := newTiltfileState(ctx, absFilename, tfRoot, l)
 	defer func() {
 		configFiles = s.configFiles
 	}()

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -30,6 +31,9 @@ func Load(ctx context.Context, filename string, matching map[string]bool, logs i
 	l := log.New(logs, "", log.LstdFlags)
 	absFilename, err := ospath.RealAbs(filename)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, model.Manifest{}, nil, fmt.Errorf("No Tiltfile found at %s. Check out https://docs.tilt.build/write_your_tiltfile.html", filename)
+		}
 		absFilename, _ = filepath.Abs(filename)
 		return nil, model.Manifest{}, []string{absFilename}, err
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -570,7 +570,7 @@ docker_build('gcr.io/bar', 'bar')
 k8s_resource('bar', 'bar.yaml')
 `)
 
-	_, _, _, err := Load(f.ctx, f.JoinPath("Tiltfile"), matchMap("baz"))
+	_, _, _, err := Load(f.ctx, f.JoinPath("Tiltfile"), matchMap("baz"), os.Stdout)
 	if assert.Error(t, err) {
 		assert.Equal(t, "Could not find resources: baz. Existing resources in Tiltfile: foo, bar", err.Error())
 	}
@@ -967,7 +967,7 @@ func matchMap(names ...string) map[string]bool {
 }
 
 func (f *fixture) load(names ...string) {
-	manifests, yamlManifest, configFiles, err := Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...))
+	manifests, yamlManifest, configFiles, err := Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...), os.Stdout)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -977,7 +977,7 @@ func (f *fixture) load(names ...string) {
 }
 
 func (f *fixture) loadErrString(msgs ...string) {
-	manifests, _, configFiles, err := Load(f.ctx, f.JoinPath("Tiltfile"), nil)
+	manifests, _, configFiles, err := Load(f.ctx, f.JoinPath("Tiltfile"), nil, os.Stdout)
 	if err == nil {
 		f.t.Fatalf("expected error but got nil")
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -27,7 +27,7 @@ func TestNoTiltfile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	f.loadErrString("no such file")
+	f.loadErrString("No Tiltfile found at")
 }
 
 func TestEmpty(t *testing.T) {


### PR DESCRIPTION
Regular (good) view:

![regular view](https://user-images.githubusercontent.com/452453/51406548-7c9f4d00-1b27-11e9-8ea3-b88c402bd57a.png)

There's a Tiltfile and an error:

![screen shot 2019-01-18 at 1 46 01 pm](https://user-images.githubusercontent.com/452453/51406567-89bc3c00-1b27-11e9-95c5-5198f177fd5b.png)

There's no Tiltfile:

![screen shot 2019-01-18 at 1 46 29 pm](https://user-images.githubusercontent.com/452453/51406599-9b054880-1b27-11e9-952d-acec37c4880a.png)
