### PR TITLE
tiltfile: better err messaging for k8s validation

### DIFF
--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -184,11 +184,13 @@ func (s *tiltfileState) assembleK8s() (map[string]bool, error) {
 
 func (s *tiltfileState) validateK8s(r *k8sResource, assembledImages map[string]bool) error {
 	if len(r.entities) == 0 {
-		if len(r.providedImageRefs) == 0 {
-			return fmt.Errorf("resource %q: no matching resource", r.name)
-		}
+		if len(r.providedImageRefs) > 0 {
 
-		return fmt.Errorf("resource %q: could not find images %q; perhaps there's a typo?", r.name, r.providedImageRefList())
+			return fmt.Errorf("resource %q: could not find k8s entities matching "+
+				"image(s) %q; perhaps there's a typo?",
+				r.name, strings.Join(r.providedImageRefList(), "; "))
+		}
+		return fmt.Errorf("resource %q: you never associated any image refs with this resource", r.name)
 	}
 
 	for ref := range r.imageRefs {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/tiltfile-err-messaging:

4c791725e180bd4e9140a0dc7627aacd89d517b0 (2019-01-25 11:37:38 -0500)
tiltfile: better err messaging for k8s validation

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics