### PR TITLE
tiltfile: store normalized image name on dc_resource for matching against imagesByName

### DIFF
--- a/internal/docker/image.go
+++ b/internal/docker/image.go
@@ -19,3 +19,19 @@ func ToImgNameAndTag(nt reference.NamedTagged) ImgNameAndTag {
 		Tag:  nt.Tag(),
 	}
 }
+
+func NormalizeRefName(ref string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return "", err
+	}
+	return named.String(), nil
+}
+
+func MustNormalizeRefName(ref string) string {
+	normalized, err := NormalizeRefName(ref)
+	if err != nil {
+		panic(err)
+	}
+	return normalized
+}

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/model"
@@ -94,7 +95,11 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 	if err != nil {
 		return nil, err
 	}
-	svc.ImageRef = imageRef
+	normalized, err := docker.NormalizeRefName(imageRef)
+	if err != nil {
+		return nil, err
+	}
+	svc.ImageRef = normalized
 
 	return starlark.None, nil
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -184,11 +184,13 @@ func (s *tiltfileState) assembleK8s() (map[string]bool, error) {
 
 func (s *tiltfileState) validateK8s(r *k8sResource, assembledImages map[string]bool) error {
 	if len(r.entities) == 0 {
-		if len(r.providedImageRefs) == 0 {
-			return fmt.Errorf("resource %q: no matching resource", r.name)
-		}
+		if len(r.providedImageRefs) > 0 {
 
-		return fmt.Errorf("resource %q: could not find images %q; perhaps there's a typo?", r.name, r.providedImageRefList())
+			return fmt.Errorf("resource %q: could not find k8s entities matching "+
+				"image(s) %q; perhaps there's a typo?",
+				r.name, strings.Join(r.providedImageRefList(), "; "))
+		}
+		return fmt.Errorf("resource %q: you never associated any image refs with this resource", r.name)
 	}
 
 	for ref := range r.imageRefs {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/tiltfile-err-messaging:

2f4f105ad55f4721499d3ccf612a2be2053ee1d2 (2019-01-25 15:20:52 -0500)
tiltfile: store normalized image name on dc_resource for matching against imagesByName

4c791725e180bd4e9140a0dc7627aacd89d517b0 (2019-01-25 11:37:38 -0500)
tiltfile: better err messaging for k8s validation

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics