### PR TITLE
tiltfile: speed up load for DC manifests [ch1201]

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -21,7 +21,6 @@ type DockerComposeClient interface {
 	StreamLogs(ctx context.Context, configPath string, serviceName model.TargetName) (io.ReadCloser, error)
 	StreamEvents(ctx context.Context, configPath string) (<-chan string, error)
 	Config(ctx context.Context, configPath string) (string, error)
-	Services(ctx context.Context, configPath string) (string, error)
 	ContainerID(ctx context.Context, configPath string, serviceName model.TargetName) (container.ID, error)
 }
 
@@ -131,10 +130,6 @@ func (c *cmdDCClient) StreamEvents(ctx context.Context, configPath string) (<-ch
 
 func (c *cmdDCClient) Config(ctx context.Context, configPath string) (string, error) {
 	return dcOutput(ctx, configPath, "config")
-}
-
-func (c *cmdDCClient) Services(ctx context.Context, configPath string) (string, error) {
-	return dcOutput(ctx, configPath, "config", "--services")
 }
 
 func (c *cmdDCClient) ContainerID(ctx context.Context, configPath string, serviceName model.TargetName) (container.ID, error) {

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -17,6 +17,7 @@ type FakeDCClient struct {
 	RunLogOutput      map[model.TargetName]<-chan string
 	ContainerIdOutput container.ID
 	eventJson         chan string
+	ConfigOutput      string
 
 	UpCalls []UpCall
 }
@@ -100,11 +101,7 @@ func (c *FakeDCClient) SendEvent(evt Event) error {
 }
 
 func (c *FakeDCClient) Config(ctx context.Context, pathToConfig string) (string, error) {
-	return "", nil
-}
-
-func (c *FakeDCClient) Services(ctx context.Context, pathToConfig string) (string, error) {
-	return "", nil
+	return c.ConfigOutput, nil
 }
 
 func (c *FakeDCClient) ContainerID(ctx context.Context, pathToConfig string, serviceName model.TargetName) (container.ID, error) {

--- a/internal/tiltfile/docker_compose_test.go
+++ b/internal/tiltfile/docker_compose_test.go
@@ -1,0 +1,40 @@
+package tiltfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/dockercompose"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+)
+
+var dcYamlManyServices = `version: '3'
+services:
+  a:
+    image: imga
+  b:
+    image: imgb
+  c:
+    image: imgc
+  d:
+    image: imgd
+  e:
+    image: imge
+  f:
+    image: imgf`
+
+// ParseConfig must return services topologically sorted wrt dependencies.
+func TestParseConfigPreservesServiceOrder(t *testing.T) {
+	ctx := output.CtxForTest()
+	dcCli := dockercompose.NewFakeDockerComposeClient(t, ctx)
+	dcCli.ConfigOutput = dcYamlManyServices
+
+	services, err := parseDCConfig(ctx, dcCli, "doesn't-matter.yml")
+	if assert.NoError(t, err) {
+		if assert.Len(t, services, 6) {
+			for i, name := range []string{"a", "b", "c", "d", "e", "f"} {
+				assert.Equal(t, name, services[i].Name)
+			}
+		}
+	}
+}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -91,7 +91,7 @@ services:
 
 	f.load("bar")
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	f.assertDcManifest("foo",
+	f.assertDcManifest("bar",
 		dcConfigPath(configPath),
 		dcYAMLRaw("image: redis:alpine"),
 		dcDfRaw(""),
@@ -361,7 +361,7 @@ dc_resource('bar', 'gcr.io/bar')
 	assert.True(t, foo.ImageTargetAt(0).IsStaticBuild())
 	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
-	bar := f.assertManifest("foo", db(image("gcr.io/bar")))
+	bar := f.assertManifest("bar", db(image("gcr.io/bar")))
 	assert.True(t, foo.ImageTargetAt(0).IsStaticBuild())
 	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/sliceutils"
 	"go.starlark.net/starlark"
 
@@ -25,6 +26,7 @@ type tiltfileState struct {
 	// set at creation
 	ctx      context.Context
 	filename localPath
+	dcCli    dockercompose.DockerComposeClient
 
 	// added to during execution
 	configFiles    []string
@@ -48,6 +50,7 @@ func newTiltfileState(ctx context.Context, filename string, tfRoot string, l *lo
 	s := &tiltfileState{
 		ctx:          ctx,
 		filename:     localPath{path: filename},
+		dcCli:        dockercompose.NewDockerComposeClient(),
 		imagesByName: make(map[string]*dockerImage),
 		k8sByName:    make(map[string]*k8sResource),
 		configFiles:  []string{filename},

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1040,9 +1040,23 @@ func (f *fixture) assertManifest(name string, opts ...interface{}) model.Manifes
 	if len(f.manifests) == 0 {
 		f.t.Fatalf("no more manifests; trying to find %q", name)
 	}
-
-	m := f.manifests[0]
-	f.manifests = f.manifests[1:]
+	var m model.Manifest
+	var found bool
+	for i, man := range f.manifests {
+		if man.Name == model.ManifestName(name) {
+			m = man
+			found = true
+			remaining := append([]model.Manifest{}, f.manifests[:i]...)
+			if len(f.manifests) > i+i {
+				remaining = append(remaining, f.manifests[i+1:]...)
+			}
+			f.manifests = remaining
+			break
+		}
+	}
+	if !found {
+		f.t.Fatalf("could not find manifest %q", name)
+	}
 
 	for _, opt := range opts {
 		switch opt := opt.(type) {


### PR DESCRIPTION
loading dc manifests can take c. 0.8s b/c we were making two calls to
`docker-compose config` (one with `--services` to get services in
topologically sorted order). this pr removes the second call (with
`--services`) in favor of making sure to preserve service order when
we unmarshal the results of `docker-compose config`.