### PR TITLE
k8s: if can't get kubecontext (e.g. no kubectl), return EnvNone instead of throwing error [ch1443]

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -30,10 +30,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	if err != nil {
 		return demo.Script{}, err
 	}
-	kubeContext, err := k8s.DetectKubeContext()
-	if err != nil {
-		return demo.Script{}, err
-	}
+	kubeContext := k8s.DetectKubeContext(ctx)
 	env, err := k8s.DetectEnv(kubeContext)
 	if err != nil {
 		return demo.Script{}, err
@@ -117,10 +114,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	if err != nil {
 		return Threads{}, err
 	}
-	kubeContext, err := k8s.DetectKubeContext()
-	if err != nil {
-		return Threads{}, err
-	}
+	kubeContext := k8s.DetectKubeContext(ctx)
 	env, err := k8s.DetectEnv(kubeContext)
 	if err != nil {
 		return Threads{}, err
@@ -194,10 +188,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 }
 
 func wireK8sClient(ctx context.Context) (k8s.Client, error) {
-	kubeContext, err := k8s.DetectKubeContext()
-	if err != nil {
-		return nil, err
-	}
+	kubeContext := k8s.DetectKubeContext(ctx)
 	env, err := k8s.DetectEnv(kubeContext)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -32,6 +32,7 @@ type ServiceName string
 type KubeContext string
 
 const DefaultNamespace = Namespace("default")
+const KubeContextNone = KubeContext("none") // stand-in for when k8s not running
 
 func (pID PodID) Empty() bool    { return pID.String() == "" }
 func (pID PodID) String() string { return string(pID) }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -32,7 +32,7 @@ type ServiceName string
 type KubeContext string
 
 const DefaultNamespace = Namespace("default")
-const KubeContextNone = KubeContext("none") // stand-in for when k8s not running
+const KubeContextNone = KubeContext(EnvNone) // stand-in for when k8s not running
 
 func (pID PodID) Empty() bool    { return pID.String() == "" }
 func (pID PodID) String() string { return string(pID) }

--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -52,7 +52,7 @@ func EnvFromString(s string) Env {
 		return EnvDockerDesktop
 	} else if s == EnvMicroK8s {
 		return EnvMicroK8s
-	} else if s == string(KubeContextNone) {
+	} else if s == EnvNone {
 		return EnvNone
 	} else if strings.HasPrefix(s, EnvGKE) {
 		// GKE context strings look like:

--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -1,11 +1,11 @@
 package k8s
 
 import (
-	"fmt"
+	"context"
 	"os/exec"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/logger"
 )
 
 type Env string
@@ -16,6 +16,7 @@ const (
 	EnvMinikube          = "minikube"
 	EnvDockerDesktop     = "docker-for-desktop"
 	EnvMicroK8s          = "microk8s"
+	EnvNone              = "none" // k8s not running (not neces. a problem, e.g. if using Tilt x Docker Compose)
 )
 
 func (e Env) IsLocalCluster() bool {
@@ -26,20 +27,22 @@ func DetectEnv(kubeContext KubeContext) (Env, error) {
 	return EnvFromString(string(kubeContext)), nil
 }
 
-func DetectKubeContext() (KubeContext, error) {
+func DetectKubeContext(ctx context.Context) KubeContext {
 	cmd := exec.Command("kubectl", "config", "current-context")
 	outputBytes, err := cmd.Output()
 
 	if err != nil {
 		exitErr, isExit := err.(*exec.ExitError)
 		if isExit {
-			return KubeContext(""), fmt.Errorf("DetectKubeContext failed. Output:\n%s", string(exitErr.Stderr))
+			logger.Get(ctx).Debugf("DetectKubeContext failed. Output:\n%s", string(exitErr.Stderr))
+		} else {
+			logger.Get(ctx).Debugf("DetectKubeContext failed: %v", err)
 		}
-		return KubeContext(""), errors.Wrap(err, "DetectKubeContext")
+		return KubeContextNone
 	}
 
 	output := strings.TrimSpace(string(outputBytes))
-	return KubeContext(output), nil
+	return KubeContext(output)
 }
 
 func EnvFromString(s string) Env {
@@ -49,6 +52,8 @@ func EnvFromString(s string) Env {
 		return EnvDockerDesktop
 	} else if s == EnvMicroK8s {
 		return EnvMicroK8s
+	} else if s == string(KubeContextNone) {
+		return EnvNone
 	} else if strings.HasPrefix(s, EnvGKE) {
 		// GKE context strings look like:
 		// gke_blorg-dev_us-central1-b_blorg


### PR DESCRIPTION
running w/o k8s/kubectl is now a possible use-case that we shouldn't crash
for (e.g. someone is running tilt x DC and doesn't need k8s at all).