### PR TITLE
k8s: don't try to get k8s rest api etc if no k8s configured [ch1433]

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -20,11 +20,11 @@ import (
 )
 
 var K8sWireSet = wire.NewSet(
-	k8s.DetectEnv,
+	k8s.ProvideEnvOrError,
+	k8s.ProideEnv,
 	k8s.DetectNodeIP,
 
-	k8s.ProvideK8sClient,
-	wire.Bind(new(k8s.Client), k8s.K8sClient{}))
+	k8s.ProvideK8sClient)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -20,14 +20,10 @@ import (
 )
 
 var K8sWireSet = wire.NewSet(
-	k8s.DetectKubeContext,
 	k8s.DetectEnv,
 	k8s.DetectNodeIP,
 
-	k8s.ProvidePortForwarder,
-	k8s.ProvideRESTClient,
-	k8s.ProvideRESTConfig,
-	k8s.NewK8sClient,
+	k8s.ProvideK8sClient,
 	wire.Bind(new(k8s.Client), k8s.K8sClient{}))
 
 var BaseWireSet = wire.NewSet(

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -30,26 +30,27 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	if err != nil {
 		return demo.Script{}, err
 	}
-	env := k8s.DetectEnv(ctx)
-	k8sClient, err := k8s.ProvideK8sClient(ctx, env)
+	envOrError := k8s.ProvideEnvOrError(ctx)
+	client, err := k8s.ProvideK8sClient(ctx, envOrError)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	podWatcher := engine.NewPodWatcher(k8sClient)
+	podWatcher := engine.NewPodWatcher(client)
+	env := k8s.ProideEnv(envOrError)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
+	serviceWatcher := engine.NewServiceWatcher(client, nodeIP)
 	reducer := _wireReducerValue
 	storeLogActionsFlag := provideLogActions()
 	storeStore := store.NewStore(reducer, storeLogActionsFlag)
-	podLogManager := engine.NewPodLogManager(k8sClient)
-	portForwardController := engine.NewPortForwardController(k8sClient)
+	podLogManager := engine.NewPodLogManager(client)
+	portForwardController := engine.NewPortForwardController(client)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
 	timerMaker := engine.ProvideTimerMaker()
 	watchManager := engine.NewWatchManager(fsWatcherMaker, timerMaker)
-	syncletManager := engine.NewSyncletManager(k8sClient)
+	syncletManager := engine.NewSyncletManager(client)
 	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(syncletManager)
 	cli, err := docker.DefaultClient(ctx, env)
 	if err != nil {
@@ -73,7 +74,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 		return demo.Script{}, err
 	}
 	clock := build.ProvideClock()
-	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8sClient, env, analytics, updateMode, clock)
+	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, client, env, analytics, updateMode, clock)
 	dockerComposeClient := dockercompose.NewDockerComposeClient()
 	imageAndCacheBuilder := engine.NewImageAndCacheBuilder(imageBuilder, cacheBuilder, updateMode)
 	dockerComposeBuildAndDeployer := engine.NewDockerComposeBuildAndDeployer(dockerComposeClient, cli, imageAndCacheBuilder, clock)
@@ -82,13 +83,13 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
-	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
+	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(client)
 	configsController := engine.NewConfigsController()
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
 	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager)
-	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, storeStore, branch)
+	script := demo.NewScript(upper, headsUpDisplay, client, env, storeStore, branch)
 	return script, nil
 }
 
@@ -104,26 +105,27 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	if err != nil {
 		return Threads{}, err
 	}
-	env := k8s.DetectEnv(ctx)
-	k8sClient, err := k8s.ProvideK8sClient(ctx, env)
+	envOrError := k8s.ProvideEnvOrError(ctx)
+	client, err := k8s.ProvideK8sClient(ctx, envOrError)
 	if err != nil {
 		return Threads{}, err
 	}
-	podWatcher := engine.NewPodWatcher(k8sClient)
+	podWatcher := engine.NewPodWatcher(client)
+	env := k8s.ProideEnv(envOrError)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
 		return Threads{}, err
 	}
-	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
+	serviceWatcher := engine.NewServiceWatcher(client, nodeIP)
 	reducer := _wireReducerValue
 	storeLogActionsFlag := provideLogActions()
 	storeStore := store.NewStore(reducer, storeLogActionsFlag)
-	podLogManager := engine.NewPodLogManager(k8sClient)
-	portForwardController := engine.NewPortForwardController(k8sClient)
+	podLogManager := engine.NewPodLogManager(client)
+	portForwardController := engine.NewPortForwardController(client)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
 	timerMaker := engine.ProvideTimerMaker()
 	watchManager := engine.NewWatchManager(fsWatcherMaker, timerMaker)
-	syncletManager := engine.NewSyncletManager(k8sClient)
+	syncletManager := engine.NewSyncletManager(client)
 	syncletBuildAndDeployer := engine.NewSyncletBuildAndDeployer(syncletManager)
 	cli, err := docker.DefaultClient(ctx, env)
 	if err != nil {
@@ -147,7 +149,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 		return Threads{}, err
 	}
 	clock := build.ProvideClock()
-	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, k8sClient, env, analytics, updateMode, clock)
+	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, client, env, analytics, updateMode, clock)
 	dockerComposeClient := dockercompose.NewDockerComposeClient()
 	imageAndCacheBuilder := engine.NewImageAndCacheBuilder(imageBuilder, cacheBuilder, updateMode)
 	dockerComposeBuildAndDeployer := engine.NewDockerComposeBuildAndDeployer(dockerComposeClient, cli, imageAndCacheBuilder, clock)
@@ -156,7 +158,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
-	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(k8sClient)
+	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(client)
 	configsController := engine.NewConfigsController()
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
@@ -168,17 +170,17 @@ func wireThreads(ctx context.Context) (Threads, error) {
 }
 
 func wireK8sClient(ctx context.Context) (k8s.Client, error) {
-	env := k8s.DetectEnv(ctx)
-	k8sClient, err := k8s.ProvideK8sClient(ctx, env)
+	envOrError := k8s.ProvideEnvOrError(ctx)
+	client, err := k8s.ProvideK8sClient(ctx, envOrError)
 	if err != nil {
 		return nil, err
 	}
-	return k8sClient, nil
+	return client, nil
 }
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.DetectEnv, k8s.DetectNodeIP, k8s.ProvideK8sClient, wire.Bind(new(k8s.Client), k8s.K8sClient{}))
+var K8sWireSet = wire.NewSet(k8s.ProvideEnvOrError, k8s.ProideEnv, k8s.DetectNodeIP, k8s.ProvideK8sClient)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -30,21 +30,11 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	if err != nil {
 		return demo.Script{}, err
 	}
-	kubeContext := k8s.DetectKubeContext(ctx)
-	env, err := k8s.DetectEnv(kubeContext)
+	env := k8s.DetectEnv(ctx)
+	k8sClient, err := k8s.ProvideK8sClient(ctx, env)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	config, err := k8s.ProvideRESTConfig()
-	if err != nil {
-		return demo.Script{}, err
-	}
-	coreV1Interface, err := k8s.ProvideRESTClient(config)
-	if err != nil {
-		return demo.Script{}, err
-	}
-	portForwarder := k8s.ProvidePortForwarder()
-	k8sClient := k8s.NewK8sClient(ctx, env, coreV1Interface, config, portForwarder, kubeContext)
 	podWatcher := engine.NewPodWatcher(k8sClient)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
@@ -114,21 +104,11 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	if err != nil {
 		return Threads{}, err
 	}
-	kubeContext := k8s.DetectKubeContext(ctx)
-	env, err := k8s.DetectEnv(kubeContext)
+	env := k8s.DetectEnv(ctx)
+	k8sClient, err := k8s.ProvideK8sClient(ctx, env)
 	if err != nil {
 		return Threads{}, err
 	}
-	config, err := k8s.ProvideRESTConfig()
-	if err != nil {
-		return Threads{}, err
-	}
-	coreV1Interface, err := k8s.ProvideRESTClient(config)
-	if err != nil {
-		return Threads{}, err
-	}
-	portForwarder := k8s.ProvidePortForwarder()
-	k8sClient := k8s.NewK8sClient(ctx, env, coreV1Interface, config, portForwarder, kubeContext)
 	podWatcher := engine.NewPodWatcher(k8sClient)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
@@ -188,27 +168,17 @@ func wireThreads(ctx context.Context) (Threads, error) {
 }
 
 func wireK8sClient(ctx context.Context) (k8s.Client, error) {
-	kubeContext := k8s.DetectKubeContext(ctx)
-	env, err := k8s.DetectEnv(kubeContext)
+	env := k8s.DetectEnv(ctx)
+	k8sClient, err := k8s.ProvideK8sClient(ctx, env)
 	if err != nil {
 		return nil, err
 	}
-	config, err := k8s.ProvideRESTConfig()
-	if err != nil {
-		return nil, err
-	}
-	coreV1Interface, err := k8s.ProvideRESTClient(config)
-	if err != nil {
-		return nil, err
-	}
-	portForwarder := k8s.ProvidePortForwarder()
-	k8sClient := k8s.NewK8sClient(ctx, env, coreV1Interface, config, portForwarder, kubeContext)
 	return k8sClient, nil
 }
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.DetectKubeContext, k8s.DetectEnv, k8s.DetectNodeIP, k8s.ProvidePortForwarder, k8s.ProvideRESTClient, k8s.ProvideRESTConfig, k8s.NewK8sClient, wire.Bind(new(k8s.Client), k8s.K8sClient{}))
+var K8sWireSet = wire.NewSet(k8s.DetectEnv, k8s.DetectNodeIP, k8s.ProvideK8sClient, wire.Bind(new(k8s.Client), k8s.K8sClient{}))
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics,

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -35,7 +35,6 @@ type ServiceName string
 type KubeContext string
 
 const DefaultNamespace = Namespace("default")
-const KubeContextNone = KubeContext(EnvNone) // stand-in for when k8s not running
 
 func (pID PodID) Empty() bool    { return pID.String() == "" }
 func (pID PodID) String() string { return string(pID) }
@@ -107,13 +106,31 @@ var _ Client = K8sClient{}
 
 type PortForwarder func(ctx context.Context, restConfig *rest.Config, core apiv1.CoreV1Interface, namespace string, podID PodID, localPort int, remotePort int) (closer func(), err error)
 
+func ProvideK8sClient(ctx context.Context, env Env) (K8sClient, error) {
+	if env == EnvNone {
+		// No k8s, so no need to get any further configs
+		return K8sClient{env: env}, nil
+	}
+
+	config, err := ProvideRESTConfig()
+	if err != nil {
+		return K8sClient{}, err
+	}
+	coreV1Interface, err := ProvideRESTClient(config)
+	if err != nil {
+		return K8sClient{}, err
+	}
+	portForwarder := ProvidePortForwarder()
+	k8sClient := NewK8sClient(ctx, env, coreV1Interface, config, portForwarder)
+	return k8sClient, nil
+}
+
 func NewK8sClient(
 	ctx context.Context,
 	env Env,
 	core apiv1.CoreV1Interface,
 	restConfig *rest.Config,
-	pf PortForwarder,
-	kubeContext KubeContext) K8sClient {
+	pf PortForwarder) K8sClient {
 
 	// TODO(nick): I'm not happy about the way that pkg/browser uses global writers.
 	writer := logger.Get(ctx).Writer(logger.DebugLvl)
@@ -126,7 +143,6 @@ func NewK8sClient(
 		core:          core,
 		restConfig:    restConfig,
 		portForwarder: pf,
-		kubeContext:   kubeContext,
 	}
 }
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -106,10 +106,11 @@ var _ Client = K8sClient{}
 
 type PortForwarder func(ctx context.Context, restConfig *rest.Config, core apiv1.CoreV1Interface, namespace string, podID PodID, localPort int, remotePort int) (closer func(), err error)
 
-func ProvideK8sClient(ctx context.Context, env Env) (Client, error) {
+func ProvideK8sClient(ctx context.Context, envOrErr EnvOrError) (Client, error) {
+	env := envOrErr.Env
 	if env == EnvNone {
 		// No k8s, so no need to get any further configs
-		return &explodingClient{}, nil
+		return &explodingClient{err: envOrErr.Err}, nil
 	}
 
 	config, err := ProvideRESTConfig()

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -106,10 +106,10 @@ var _ Client = K8sClient{}
 
 type PortForwarder func(ctx context.Context, restConfig *rest.Config, core apiv1.CoreV1Interface, namespace string, podID PodID, localPort int, remotePort int) (closer func(), err error)
 
-func ProvideK8sClient(ctx context.Context, env Env) (K8sClient, error) {
+func ProvideK8sClient(ctx context.Context, env Env) (Client, error) {
 	if env == EnvNone {
 		// No k8s, so no need to get any further configs
-		return K8sClient{env: env}, nil
+		return &explodingClient{}, nil
 	}
 
 	config, err := ProvideRESTConfig()

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -2,11 +2,11 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
 
 	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -14,56 +14,58 @@ import (
 
 var _ Client = &explodingClient{}
 
-type explodingClient struct{}
+type explodingClient struct {
+	err error
+}
 
 func (ec *explodingClient) Upsert(ctx context.Context, entities []K8sEntity) error {
-	return fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity) error {
-	return fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) PodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, labels []LabelPair) ([]v1.Pod, error) {
-	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) PollForPodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, labels []LabelPair, timeout time.Duration) ([]v1.Pod, error) {
-	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) PodByID(ctx context.Context, podID PodID, n Namespace) (*v1.Pod, error) {
-	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, error) {
-	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) ContainerLogs(ctx context.Context, podID PodID, cName container.Name, n Namespace, startTime time.Time) (io.ReadCloser, error) {
-	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error) {
-	return NodeID(""), fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return NodeID(""), errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) FindAppByNode(ctx context.Context, nodeID NodeID, appName string, options FindAppByNodeOptions) (PodID, error) {
-	return PodID(""), fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return PodID(""), errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) ForwardPort(ctx context.Context, namespace Namespace, podID PodID, optionalLocalPort, remotePort int) (localPort int, closer func(), err error) {
-	return 0, nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return 0, nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) WatchPods(ctx context.Context, lps []LabelPair) (<-chan *v1.Pod, error) {
-	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) WatchServices(ctx context.Context, lps []LabelPair) (<-chan *v1.Service, error) {
-	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) ConnectedToCluster(ctx context.Context) error {
-	return fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+	return errors.Wrap(ec.err, "could not set up k8s client")
 }

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -1,0 +1,69 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/container"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+var _ Client = &explodingClient{}
+
+type explodingClient struct{}
+
+func (ec *explodingClient) Upsert(ctx context.Context, entities []K8sEntity) error {
+	return fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity) error {
+	return fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) PodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, labels []LabelPair) ([]v1.Pod, error) {
+	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) PollForPodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, labels []LabelPair, timeout time.Duration) ([]v1.Pod, error) {
+	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) PodByID(ctx context.Context, podID PodID, n Namespace) (*v1.Pod, error) {
+	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, error) {
+	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) ContainerLogs(ctx context.Context, podID PodID, cName container.Name, n Namespace, startTime time.Time) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) GetNodeForPod(ctx context.Context, podID PodID) (NodeID, error) {
+	return NodeID(""), fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) FindAppByNode(ctx context.Context, nodeID NodeID, appName string, options FindAppByNodeOptions) (PodID, error) {
+	return PodID(""), fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) ForwardPort(ctx context.Context, namespace Namespace, podID PodID, optionalLocalPort, remotePort int) (localPort int, closer func(), err error) {
+	return 0, nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) WatchPods(ctx context.Context, lps []LabelPair) (<-chan *v1.Pod, error) {
+	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) WatchServices(ctx context.Context, lps []LabelPair) (<-chan *v1.Service, error) {
+	return nil, fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}
+
+func (ec *explodingClient) ConnectedToCluster(ctx context.Context) error {
+	return fmt.Errorf("ERROR: no k8s client. Make sure you have kubectl installed and accessible from $PATH")
+}


### PR DESCRIPTION
Friend w/o kubectl was trying to run k8s and got error:

> Error: could not get config for context ({"" "" "" "" map[]}): invalid configuration: no configuration has been provided

This PR checks whether user has kubectl present at all before trying to get REST API/other k8s-relevant configs.