### PR TITLE
tilt: fix klog printing to stderr

### DIFF
--- a/cmd/tilt/main.go
+++ b/cmd/tilt/main.go
@@ -34,7 +34,7 @@ func disableGlog() {
 	var tmpFlagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(tmpFlagSet)
 	err := tmpFlagSet.Parse([]string{
-		"--stderrthreshold", "ERROR",
+		"--stderrthreshold", "FATAL",
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/error:

5d8d1cba1e36732c7a6a0fcb7694ee56e3362eda (2019-02-05 18:29:43 -0500)
tilt: fix klog printing to stderr