### PR TITLE
fast_build: fix add error message

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -284,7 +284,7 @@ func (b *fastBuild) add(thread *starlark.Thread, fn *starlark.Builtin, args star
 	case *gitRepo:
 		m.src = p.makeLocalPath("")
 	default:
-		return nil, fmt.Errorf("fast_build(%q).add(): invalid type for src. Got %s want gitRepo OR localPath", fn.Name(), src.Type())
+		return nil, fmt.Errorf("%s.%s(): invalid type for src. Got %s, want gitRepo OR localPath", b.String(), fn.Name(), src.Type())
 	}
 
 	m.mountPoint = mountPoint

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -412,7 +412,7 @@ docker_build("ceci n'est pas une valid image ref", 'a')
 	f.loadErrString("invalid reference format")
 }
 
-func TestFastBuildAddStringFailes(t *testing.T) {
+func TestFastBuildAddStringFails(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -423,7 +423,7 @@ fast_build('gcr.io/foo', 'foo/Dockerfile').add('/foo', '/foo')
 `)
 
 	f.loadErrString("invalid type for src. Got string, want gitRepo OR localPath",
-		"fast_build(\"docker.io/library/my_picnic_image\").add()")
+		"fast_build(\"gcr.io/foo\").add()")
 }
 
 type portForwardCase struct {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -422,7 +422,8 @@ k8s_yaml('foo.yaml')
 fast_build('gcr.io/foo', 'foo/Dockerfile').add('/foo', '/foo')
 `)
 
-	f.loadErrString("invalid type for src. Got string want gitRepo OR localPath")
+	f.loadErrString("invalid type for src. Got string, want gitRepo OR localPath",
+		"fast_build(\"docker.io/library/my_picnic_image\").add()")
 }
 
 type portForwardCase struct {


### PR DESCRIPTION
This was generating errors like
```
Error: fast_build("add").add(): invalid type for src. Got string want gitRepo OR localPath
```
the `"add"` there is super weird

now we get:
```
Error: fast_build("docker.io/library/my_picnic_image").add(): invalid type for src. Got string, want gitRepo
        OR localPath
```