### PR TITLE
tar: handle relative symlinks correctly

### DIFF
--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -155,7 +155,16 @@ func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string
 			return nil
 		}
 
-		header, err := tar.FileInfoHeader(info, path)
+		linkname := ""
+		if info.Mode()&os.ModeSymlink != 0 {
+			var err error
+			linkname, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		header, err := tar.FileInfoHeader(info, linkname)
 		clearUIDAndGID(header)
 		if err != nil {
 			return errors.Wrapf(err, "%s: making header", path)

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -73,14 +73,13 @@ func (f *TempDirFixture) WriteFile(path string, contents string) {
 	}
 }
 
-func (f *TempDirFixture) WriteSymlink(srcPath, destPath string) {
-	fullSrcPath := f.JoinPath(srcPath)
+func (f *TempDirFixture) WriteSymlink(linkContents, destPath string) {
 	fullDestPath := f.JoinPath(destPath)
 	err := os.MkdirAll(filepath.Dir(fullDestPath), os.FileMode(0777))
 	if err != nil {
 		f.t.Fatal(err)
 	}
-	err = os.Symlink(fullSrcPath, fullDestPath)
+	err = os.Symlink(linkContents, fullDestPath)
 	if err != nil {
 		f.t.Fatal(err)
 	}


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/symlink:

ceff3c77f1e9fcdab49c9bcddab8adc7e96cd802 (2019-02-07 13:26:37 -0500)
tar: handle relative symlinks correctly