### PR TITLE
wire: upgrade version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -545,14 +545,6 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
-  branch = "master"
-  digest = "1:dcc626804fa1b81a7714906f44d4b6b21773f995d044f96030744e557348cbd2"
-  name = "github.com/google/go-cloud"
-  packages = ["wire"]
-  pruneopts = "UT"
-  revision = "1e2867e5b7c01e3766e577e9ac9dae28769512c8"
-
-[[projects]]
   digest = "1:d2754cafcab0d22c13541618a8029a70a8959eb3525ff201fe971637e2274cd0"
   name = "github.com/google/go-cmp"
   packages = [
@@ -581,6 +573,14 @@
   pruneopts = "UT"
   revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:3c4df6e0ec96b9dec76f15e0bcad888fa268ee6404d1cdcaf90d7567e32a8f73"
+  name = "github.com/google/wire"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a7ae3ba6b734d831e88c75966fd5e9c0abdeace"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
@@ -1555,10 +1555,10 @@
     "github.com/gdamore/tcell",
     "github.com/gobwas/glob",
     "github.com/golang/protobuf/proto",
-    "github.com/google/go-cloud/wire",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/google/uuid",
+    "github.com/google/wire",
     "github.com/gorilla/mux",
     "github.com/gorilla/websocket",
     "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,10 +34,6 @@
   branch = "master"
 
 [[constraint]]
-  name = "github.com/google/go-cloud"
-  branch = "master"
-
-[[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.3"
 

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/go-cloud/wire"
+	"github.com/google/wire"
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/demo"
 	"github.com/windmilleng/tilt/internal/docker"

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -7,7 +7,7 @@ package cli
 
 import (
 	"context"
-	"github.com/google/go-cloud/wire"
+	"github.com/google/wire"
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/demo"
 	"github.com/windmilleng/tilt/internal/docker"

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -6,7 +6,7 @@ package engine
 import (
 	"context"
 
-	"github.com/google/go-cloud/wire"
+	"github.com/google/wire"
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockercompose"

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -7,7 +7,7 @@ package engine
 
 import (
 	"context"
-	"github.com/google/go-cloud/wire"
+	"github.com/google/wire"
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockercompose"

--- a/internal/synclet/wire.go
+++ b/internal/synclet/wire.go
@@ -6,7 +6,7 @@ package synclet
 import (
 	"context"
 
-	"github.com/google/go-cloud/wire"
+	"github.com/google/wire"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 )

--- a/vendor/github.com/google/wire/.contributebot
+++ b/vendor/github.com/google/wire/.contributebot
@@ -1,0 +1,3 @@
+{
+  "issue_title_pattern": "^.*$"
+}

--- a/vendor/github.com/google/wire/.travis.yml
+++ b/vendor/github.com/google/wire/.travis.yml
@@ -1,0 +1,49 @@
+# Copyright 2018 The Wire Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+os:
+  - linux
+  - osx
+  - windows
+
+language: go
+go_import_path: github.com/google/go-cloud
+go: "1.11.x"
+
+before_install:
+  # The Bash that comes with OS X is ancient.
+  # grep is similar: it's not GNU grep, which means commands aren't portable.
+  # Homebrew installs grep as ggrep if you don't build from source, so it needs
+  # moving so it takes precedence in the PATH.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      HOMEBREW_NO_AUTO_UPDATE=1 brew install bash grep;
+      mv $(brew --prefix)/bin/ggrep $(brew --prefix)/bin/grep;
+    fi
+
+install:
+  # Re-checkout files preserving line feeds. This prevents Windows builds from
+  # converting \n to \r\n.
+  - "git config --global core.autocrlf input"
+  - "git checkout -- ."
+  - "go install ./cmd/wire"
+  - "go install github.com/mattn/goveralls"
+
+script:
+  - 'go test -race -coverpkg=./... -coverprofile=coverage.out ./...'
+  - 'goveralls -coverprofile=coverage.out -service=travis-ci'
+
+env:
+  global:
+  - GOPROXY=https://storage.googleapis.com/wire-modules/
+  - GO111MODULE=on

--- a/vendor/github.com/google/wire/AUTHORS
+++ b/vendor/github.com/google/wire/AUTHORS
@@ -1,0 +1,18 @@
+# This is the official list of Wire authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as one of
+#     Organization's name
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+# See CONTRIBUTORS for the meaning of multiple email addresses.
+
+# Please keep the list sorted.
+
+Google LLC
+ktr <ktr@syfm.me>
+Kumbirai Tanekha <kumbirai.tanekha@gmail.com>
+Oleg Kovalov <iamolegkovalov@gmail.com>
+Yoichiro Shimizu <budougumi0617@gmail.com>
+Zachary Romero <zacromero3@gmail.com>

--- a/vendor/github.com/google/wire/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/google/wire/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Code of Conduct
+
+This project is covered under the [Go Code of Conduct][]. In summary:
+
+-   Treat everyone with respect and kindness.
+-   Be thoughtful in how you communicate.
+-   Don’t be destructive or inflammatory.
+-   If you encounter an issue, please mail conduct@golang.org.
+
+[Go Code of Conduct]: https://golang.org/conduct

--- a/vendor/github.com/google/wire/CONTRIBUTING.md
+++ b/vendor/github.com/google/wire/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# How to Contribute
+
+We would love to accept your patches and contributions to this project. Here is
+how you can help.
+
+## Filing issues
+
+Filing issues is an important way you can contribute to the Wire Project. We
+want your feedback on things like bugs, desired API changes, or just anything
+that isn't working for you.
+
+### Bugs
+
+If your issue is a bug, open one
+[here](https://github.com/google/wire/issues/new). The easiest way to file an
+issue with all the right information is to run `go bug`. `go bug` will print out
+a handy template of questions and system information that will help us get to
+the root of the issue quicker.
+
+### Changes
+
+Unlike the core Go project, we do not have a formal proposal process for
+changes. If you have a change you would like to see in Wire, please file an
+issue with the necessary details.
+
+### Triaging
+
+The Go Cloud team triages issues at least every two weeks, but usually within
+two business days. Bugs or feature requests are either placed into a **Sprint**
+milestone which means the issue is intended to be worked on. Issues that we
+would like to address but do not have time for are placed into the [Unplanned][]
+milestone.
+
+[Unplanned]: https://github.com/google/wire/milestone/1
+
+## Contributing Code
+
+We love accepting contributions! If your change is minor, please feel free
+submit a [pull request](https://help.github.com/articles/about-pull-requests/).
+If your change is larger, or adds a feature, please file an issue beforehand so
+that we can discuss the change. You're welcome to file an implementation pull
+request immediately as well, although we generally lean towards discussing the
+change and then reviewing the implementation separately.
+
+### Finding something to work on
+
+If you want to write some code, but don't know where to start or what you might
+want to do, take a look at our [Unplanned][] milestone. This is where you can
+find issues we would like to address but can't currently find time for. See if
+any of the latest ones look interesting! If you need help before you can start
+work, you can comment on the issue and we will try to help as best we can.
+
+### Contributor License Agreement
+
+Contributions to this project can only be made by those who have signed Google's
+Contributor License Agreement. You (or your employer) retain the copyright to
+your contribution, this simply gives us permission to use and redistribute your
+contributions as part of the project. Head over to
+<https://cla.developers.google.com/> to see your current agreements on file or
+to sign a new one.
+
+As a personal contributor, you only need to sign the Google CLA once across all
+Google projects. If you've already signed the CLA, there is no need to do it
+again. If you are submitting code on behalf of your employer, there's
+[a separate corporate CLA that your employer manages for you](https://opensource.google.com/docs/cla/#external-contributors).
+
+## Making a pull request
+
+*   Follow the normal
+    [pull request flow](https://help.github.com/articles/creating-a-pull-request/)
+*   Build your changes using Go 1.11 with Go modules enabled. Wire's continuous
+    integration uses Go modules in order to ensure
+    [reproducible builds](https://research.swtch.com/vgo-repro).
+*   Test your changes using `go test ./...`. Please add tests that show the
+    change does what it says it does, even if there wasn't a test in the first
+    place.
+*   Feel free to make as many commits as you want; we will squash them all into
+    a single commit before merging your change.
+*   Check the diffs, write a useful description (including something like
+    `Fixes #123` if it's fixing a bug) and send the PR out.
+*   [Travis CI](http://travis-ci.com) will run tests against the PR. This should
+    happen within 10 minutes or so. If a test fails, go back to the coding stage
+    and try to fix the test and push the same branch again. You won't need to
+    make a new pull request, the changes will be rolled directly into the PR you
+    already opened. Wait for Travis again. There is no need to assign a reviewer
+    to the PR, the project team will assign someone for review during the
+    standard [triage](#triaging) process.
+
+## Code review
+
+All submissions, including submissions by project members, require review. It is
+almost never the case that a pull request is accepted without some changes
+requested, so please do not be offended!
+
+When you have finished making requested changes to your pull request, please
+make a comment containing "PTAL" (Please Take Another Look) on your pull
+request. GitHub notifications can be noisy, and it is unfortunately easy for
+things to be lost in the shuffle.
+
+Once your PR is approved (hooray!) the reviewer will squash your commits into a
+single commit, and then merge the commit onto the Wire master branch. Thank you!
+
+## Github code review workflow conventions
+
+(For project members and frequent contributors.)
+
+As a contributor:
+
+-   Try hard to make each Pull Request as small and focused as possible. In
+    particular, this means that if a reviewer asks you to do something that is
+    beyond the scope of the Pull Request, the best practice is to file another
+    issue and reference it from the Pull Request rather than just adding more
+    commits to the existing PR.
+-   Adding someone as a Reviewer means "please feel free to look and comment";
+    the review is optional. Choose as many Reviewers as you'd like.
+-   Adding someone as an Assignee means that the Pull Request should not be
+    submitted until they approve. If you choose multiple Assignees, wait until
+    all of them approve. It is fine to ask someone if they are OK with being
+    removed as an Assignee.
+    -   Note that if you don't select any assignees, ContributeBot will turn all
+        of your Reviewers into Assignees.
+-   Make as many commits as you want locally, but try not to push them to Github
+    until you've addressed comments; this allows the email notification about
+    the push to be a signal to reviewers that the PR is ready to be looked at
+    again.
+-   When there may be confusion about what should happen next for a PR, be
+    explicit; add a "PTAL" comment if it is ready for review again, or a "Please
+    hold off on reviewing for now" if you are still working on addressing
+    comments.
+-   "Resolve" comments that you are sure you've addressed; let your reviewers
+    resolve ones that you're not sure about.
+-   Do not use `git push --force`; this can cause comments from your reviewers
+    that are associated with a specific commit to be lost. This implies that
+    once you've sent a Pull Request, you should use `git merge` instead of `git
+    rebase` to incorporate commits from the master branch.
+
+As a reviewer:
+
+-   Be timely in your review process, especially if you are an Assignee.
+-   Try to use `Start a Review` instead of single comments, to reduce email
+    spam.
+-   "Resolve" your own comments if they have been addressed.
+-   If you want your review to be blocking, and are not currently an Assignee,
+    add yourself as an Assignee.
+
+When squashing-and-merging:
+
+-   Ensure that **all** of the Assignees have approved.
+-   Do a final review of the one-line PR summary, ensuring that it accurately
+    describes the change.
+-   Delete the automatically added commit lines; these are generally not
+    interesting and make commit history harder to read.

--- a/vendor/github.com/google/wire/CONTRIBUTORS
+++ b/vendor/github.com/google/wire/CONTRIBUTORS
@@ -1,0 +1,43 @@
+# This is the official list of people who can contribute
+# (and typically have contributed) code to the Wire repository.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# Names should be added to this file only after verifying that
+# the individual or the individual's organization has agreed to
+# the appropriate Contributor License Agreement, found here:
+#
+#     http://code.google.com/legal/individual-cla-v1.0.html
+#     http://code.google.com/legal/corporate-cla-v1.0.html
+#
+# The agreement for individuals can be filled out on the web.
+#
+# When adding J Random Contributor's name to this file,
+# either J's name or J's organization's name should be
+# added to the AUTHORS file, depending on whether the
+# individual or corporate CLA was used.
+
+# Names should be added to this file like so:
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+#
+# An entry with multiple email addresses specifies that the
+# first address should be used in the submit logs and
+# that the other addresses should be recognized as the
+# same person when interacting with Git.
+
+# Please keep the list sorted.
+
+Chris Lewis <cflewis@google.com> <cflewis@golang.org> <c@chris.to>
+Christina Austin <4240737+clausti@users.noreply.github.com>
+Eno Compton <enocom@google.com>
+Issac Trotts <issactrotts@google.com> <issac.trotts@gmail.com>
+ktr <ktr@syfm.me>
+Kumbirai Tanekha <kumbirai.tanekha@gmail.com>
+Oleg Kovalov <iamolegkovalov@gmail.com>
+Robert van Gent <rvangent@google.com> <vangent@gmail.com>
+Ross Light <light@google.com> <ross@zombiezen.com>
+Tuo Shan <shantuo@google.com> <sturbo89@gmail.com>
+Yoichiro Shimizu <budougumi0617@gmail.com>
+Zachary Romero <zacromero3@gmail.com>

--- a/vendor/github.com/google/wire/LICENSE
+++ b/vendor/github.com/google/wire/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/wire/README.md
+++ b/vendor/github.com/google/wire/README.md
@@ -1,0 +1,56 @@
+# Wire: Automated Initialization in Go
+
+[![Build Status](https://travis-ci.com/google/wire.svg?branch=master)][travis]
+[![godoc](https://godoc.org/github.com/google/wire?status.svg)][godoc]
+[![Coverage Status](https://coveralls.io/repos/github/google/wire/badge.svg?branch=master)](https://coveralls.io/github/google/wire?branch=master)
+
+Wire is a code generation tool that automates connecting components using
+[dependency injection][]. Dependencies between components are represented in
+Wire as function parameters, encouraging explicit initialization instead of
+global variables. Because Wire operates without runtime state or reflection,
+code written to be used with Wire is useful even for hand-written
+initialization.
+
+For an overview, see the [introductory blog post][].
+
+[dependency injection]: https://en.wikipedia.org/wiki/Dependency_injection
+[introductory blog post]: https://blog.golang.org/wire
+[godoc]: https://godoc.org/github.com/google/wire
+[travis]: https://travis-ci.com/google/wire
+
+## Installing
+
+Install Wire by running:
+
+```shell
+go get github.com/google/wire/cmd/wire
+```
+
+and ensuring that `$GOPATH/bin` is added to your `$PATH`.
+
+## Documentation
+
+- [Tutorial][]
+- [User Guide][]
+- [Best Practices][]
+- [FAQ][]
+
+[Tutorial]: ./_tutorial/README.md
+[Best Practices]: ./docs/best-practices.md
+[FAQ]: ./docs/faq.md
+[User Guide]: ./docs/guide.md
+
+## Project status
+
+**This project is in alpha and is not yet suitable for production.**
+
+While in alpha, the API is subject to breaking changes.
+
+## Community
+
+You can contact us on the [go-cloud mailing list][].
+
+This project is covered by the Go [Code of Conduct][].
+
+[Code of Conduct]: ./CODE_OF_CONDUCT.md
+[go-cloud mailing list]: https://groups.google.com/forum/#!forum/go-cloud

--- a/vendor/github.com/google/wire/go.mod
+++ b/vendor/github.com/google/wire/go.mod
@@ -1,0 +1,7 @@
+module github.com/google/wire
+
+require (
+	github.com/google/go-cmp v0.2.0
+	github.com/pmezard/go-difflib v1.0.0
+	golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28
+)

--- a/vendor/github.com/google/wire/go.sum
+++ b/vendor/github.com/google/wire/go.sum
@@ -1,0 +1,6 @@
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28 h1:vnbqcYKfOxPnXXUlBo7t+R4pVIh0wInyOSNxih1S9Dc=
+golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/vendor/github.com/google/wire/wire.go
+++ b/vendor/github.com/google/wire/wire.go
@@ -1,0 +1,134 @@
+// Copyright 2018 The Wire Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wire contains directives for Wire code generation.
+// For an overview of working with Wire, see the user guide at
+// https://github.com/google/wire/blob/master/docs/guide.md
+//
+// The directives in this package are used as input to the Wire code generation
+// tool. The entry point of Wire's analysis are injector functions: function
+// templates denoted by only containing a call to Build. The arguments to Build
+// describes a set of providers and the Wire code generation tool builds a
+// directed acylic graph of the providers' output types. The generated code will
+// fill in the function template by using the providers from the provider set to
+// instantiate any needed types.
+package wire
+
+// ProviderSet is a marker type that collects a group of providers.
+type ProviderSet struct{}
+
+// NewSet creates a new provider set that includes the providers in its
+// arguments. Each argument is a function value, a struct (zero) value, a
+// provider set, a call to Bind, a call to Value, or a call to InterfaceValue.
+//
+// Passing a function value to NewSet declares that the function's first
+// return value type will be provided by calling the function. The arguments
+// to the function will come from the providers for their types. As such, all
+// the parameters must be of non-identical types. The function may optionally
+// return an error as its last return value and a cleanup function as the
+// second return value. A cleanup function must be of type func() and is
+// guaranteed to be called before the cleanup function of any of the
+// provider's inputs. If any provider returns an error, the injector function
+// will call all the appropriate cleanup functions and return the error from
+// the injector function.
+//
+// Passing a struct value of type S to NewSet declares that both S and *S will
+// be provided by creating a new value of the appropriate type by filling in
+// each field of S using the provider of the field's type.
+//
+// Passing a ProviderSet to NewSet is the same as if the set's contents
+// were passed as arguments to NewSet directly.
+//
+// The behavior of passing the result of a call to other functions in this
+// package are described in their respective doc comments.
+func NewSet(...interface{}) ProviderSet {
+	return ProviderSet{}
+}
+
+// Build is placed in the body of an injector function template to declare the
+// providers to use. The Wire code generation tool will fill in an
+// implementation of the function. The arguments to Build are interpreted the
+// same as NewSet: they determine the provider set presented to Wire's
+// dependency graph. Build returns an error message that can be sent to a call
+// to panic().
+//
+// The parameters of the injector function are used as inputs in the dependency
+// graph.
+//
+// Similar to provider functions passed into NewSet, the first return value is
+// the output of the injector function, the optional second return value is a
+// cleanup function, and the optional last return value is an error. If any of
+// the provider functions in the injector function's provider set return errors
+// or cleanup functions, the corresponding return value must be present in the
+// injector function template.
+//
+// Examples:
+//
+//	func injector(ctx context.Context) (*sql.DB, error) {
+//		wire.Build(otherpkg.FooSet, myProviderFunc)
+//		return nil, nil
+//	}
+//
+//	func injector(ctx context.Context) (*sql.DB, error) {
+//		panic(wire.Build(otherpkg.FooSet, myProviderFunc))
+//	}
+func Build(...interface{}) string {
+	return "implementation not generated, run wire"
+}
+
+// A Binding maps an interface to a concrete type.
+type Binding struct{}
+
+// Bind declares that a concrete type should be used to satisfy a
+// dependency on the type of iface, which must be a pointer to an
+// interface type.
+//
+// Example:
+//
+//	type Fooer interface {
+//		Foo()
+//	}
+//
+//	type MyFoo struct{}
+//
+//	func (MyFoo) Foo() {}
+//
+//	var MySet = wire.NewSet(
+//		MyFoo{},
+//		wire.Bind(new(Fooer), new(MyFoo)))
+func Bind(iface, to interface{}) Binding {
+	return Binding{}
+}
+
+// A ProvidedValue is an expression that is copied to the generated injector.
+type ProvidedValue struct{}
+
+// Value binds an expression to provide the type of the expression.
+// The expression may not be an interface value; use InterfaceValue for that.
+//
+// Example:
+//
+//	var MySet = wire.NewSet(wire.Value([]string(nil)))
+func Value(interface{}) ProvidedValue {
+	return ProvidedValue{}
+}
+
+// InterfaceValue binds an expression to provide a specific interface type.
+//
+// Example:
+//
+//	var MySet = wire.NewSet(wire.InterfaceValue(new(io.Reader), os.Stdin))
+func InterfaceValue(typ interface{}, x interface{}) ProvidedValue {
+	return ProvidedValue{}
+}


### PR DESCRIPTION
notes:
1. wire has moved to a new repo (out of go-cloud), so this comes with a package name change.
2. This will silently break everyone's `make wire` until they switch to the new repo. The behavior with a `wire` from the old repo is that it just no-ops.
3. CI is already using the new repo (which means that its `wire check` was a no-op)
4. Maybe we wanna dockerize `make wire` so that we're not depending on what versions we have on our laptops? I'm leaning against that being a good use of time at the moment.