### PR TITLE
analytics: periodically report some tilt usage information

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1060,7 +1060,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7e986d1e9856d450aa04f836edd4ffc6c7311e5edf1a13022ebbb9d21fcdf953"
+  digest = "1:ed39a6c301e5d16c82cafc73fe605cc1ea2555ecdf908f070c52b58e3cb7b63c"
   name = "github.com/windmilleng/wmclient"
   packages = [
     "pkg/analytics",
@@ -1069,7 +1069,7 @@
     "pkg/os/temp",
   ]
   pruneopts = "UT"
-  revision = "1ae9d14ff820ee5bf828577042af23faab7e208a"
+  revision = "7ee652d5293faba12e5416c032c223610a851848"
 
 [[projects]]
   digest = "1:2ae8314c44cd413cfdb5b1df082b350116dd8d2fff973e62c01b285b7affd89e"

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/wire"
+
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/demo"
 	"github.com/windmilleng/tilt/internal/docker"
@@ -58,6 +59,7 @@ var BaseWireSet = wire.NewSet(
 
 	engine.NewUpper,
 	provideAnalytics,
+	engine.ProvideAnalyticsReporter,
 	provideUpdateModeFlag,
 	engine.NewWatchManager,
 	engine.ProvideFsWatcherMaker,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -88,7 +88,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
-	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager)
+	analyticsReporter := engine.ProvideAnalyticsReporter(analytics, storeStore)
+	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter)
 	script := demo.NewScript(upper, headsUpDisplay, client, env, storeStore, branch)
 	return script, nil
 }
@@ -163,7 +164,8 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
-	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager)
+	analyticsReporter := engine.ProvideAnalyticsReporter(analytics, storeStore)
+	upper := engine.NewUpper(ctx, headsUpDisplay, podWatcher, serviceWatcher, storeStore, podLogManager, portForwardController, watchManager, buildController, imageController, globalYAMLBuildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter)
 	headsUpServer := server.ProvideHeadsUpServer(storeStore)
 	threads := provideThreads(headsUpDisplay, upper, headsUpServer)
 	return threads, nil
@@ -183,8 +185,7 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 var K8sWireSet = wire.NewSet(k8s.ProvideEnvOrError, k8s.ProideEnv, k8s.DetectNodeIP, k8s.ProvideK8sClient)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics,
-	provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, server.ProvideHeadsUpServer, provideThreads,
+	K8sWireSet, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, server.ProvideHeadsUpServer, provideThreads,
 )
 
 type Threads struct {

--- a/internal/engine/analytics_reporter.go
+++ b/internal/engine/analytics_reporter.go
@@ -1,0 +1,73 @@
+package engine
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/windmilleng/wmclient/pkg/analytics"
+
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+// How often to perodically report data for analytics while Tilt is running
+const analyticsReportingInterval = time.Hour * 4
+
+type AnalyticsReporter struct {
+	a       analytics.Analytics
+	store   *store.Store
+	started bool
+}
+
+func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore) {
+	if ar.started {
+		return
+	}
+
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	// wait until state has been kinda initialized
+	if !state.TiltStartTime.IsZero() {
+		ar.started = true
+		go func() {
+			ar.report()
+			time.Sleep(analyticsReportingInterval)
+		}()
+	}
+}
+
+var _ store.Subscriber = &AnalyticsReporter{}
+
+func ProvideAnalyticsReporter(a analytics.Analytics, st *store.Store) *AnalyticsReporter {
+	return &AnalyticsReporter{a, st, false}
+}
+
+func (ar *AnalyticsReporter) report() {
+	st := ar.store.RLockState()
+	defer ar.store.RUnlockState()
+	var dcCount, k8sCount, fastbuildCount int
+	for _, m := range st.Manifests() {
+		if m.IsK8s() {
+			k8sCount++
+		}
+		if m.IsDC() {
+			dcCount++
+		}
+		for _, it := range m.ImageTargets {
+			if it.IsFastBuild() {
+				fastbuildCount++
+				break
+			}
+		}
+	}
+
+	ar.a.Incr("up.running", map[string]string{
+		"up.starttime":                 st.TiltStartTime.Format(time.RFC3339),
+		"builds.completed_count":       strconv.Itoa(st.CompletedBuildCount),
+		"resource.count":               strconv.Itoa(len(st.ManifestDefinitionOrder)),
+		"resource.dockercompose.count": strconv.Itoa(dcCount),
+		"resource.k8s.count":           strconv.Itoa(k8sCount),
+		"resource.fastbuild.count":     strconv.Itoa(fastbuildCount),
+	})
+}

--- a/internal/engine/analytics_reporter_test.go
+++ b/internal/engine/analytics_reporter_test.go
@@ -61,6 +61,7 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 		"resource.dockercompose.count": "4",
 		"resource.fastbuild.count":     "1",
 		"resource.k8s.count":           "3",
+		"tiltfile.error":               "false",
 		"up.starttime":                 state.TiltStartTime.Format(time.RFC3339),
 	}
 

--- a/internal/engine/analytics_reporter_test.go
+++ b/internal/engine/analytics_reporter_test.go
@@ -1,0 +1,72 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/wmclient/pkg/analytics"
+
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+func TestAnalyticsReporter_Everything(t *testing.T) {
+	reducer := func(ctx context.Context, engineState *store.EngineState, action store.Action) {}
+	ar := AnalyticsReporter{
+		a:       analytics.NewMemoryAnalytics(),
+		store:   store.NewStore(reducer, store.LogActionsFlag(false)),
+		started: false,
+	}
+
+	manifestCount := 0
+	nextManifest := func() model.Manifest {
+		manifestCount++
+		return model.Manifest{Name: model.ManifestName(fmt.Sprintf("manifest%d", manifestCount))}
+	}
+
+	manifests := []model.Manifest{
+		nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.FastBuild{}}),
+		nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.StaticBuild{}}),
+		nextManifest().WithDeployTarget(model.K8sTarget{}),
+		nextManifest().WithDeployTarget(model.K8sTarget{}),
+		nextManifest().WithDeployTarget(model.K8sTarget{}),
+		nextManifest().WithDeployTarget(model.DockerComposeTarget{}),
+		nextManifest().WithDeployTarget(model.DockerComposeTarget{}),
+		nextManifest().WithDeployTarget(model.DockerComposeTarget{}),
+		nextManifest().WithDeployTarget(model.DockerComposeTarget{}),
+	}
+
+	state := ar.store.LockMutableStateForTesting()
+	for _, m := range manifests {
+		state.UpsertManifestTarget(store.NewManifestTarget(m))
+	}
+	state.TiltStartTime = time.Now()
+
+	state.CompletedBuildCount = 3
+
+	ar.store.UnlockMutableState()
+
+	ar.report()
+
+	ar.a.Flush(500 * time.Second)
+
+	ma := ar.a.(*analytics.MemoryAnalytics)
+
+	expectedTags := map[string]string{
+		"builds.completed_count":       "3",
+		"resource.count":               "9",
+		"resource.dockercompose.count": "4",
+		"resource.fastbuild.count":     "1",
+		"resource.k8s.count":           "3",
+		"up.starttime":                 state.TiltStartTime.Format(time.RFC3339),
+	}
+
+	assert.Equal(t, []analytics.CountEvent{{
+		Name: "up.running",
+		Tags: expectedTags,
+		N:    1,
+	}}, ma.Counts)
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -7,22 +7,21 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/docker/distribution/reference"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/docker/distribution/reference"
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
-	"github.com/windmilleng/tilt/internal/synclet/sidecar"
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/synclet/sidecar"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 	"github.com/windmilleng/tilt/internal/watch"
 )
@@ -71,7 +70,7 @@ func NewUpper(ctx context.Context, hud hud.HeadsUpDisplay, pw *PodWatcher, sw *S
 	st *store.Store, plm *PodLogManager, pfc *PortForwardController, fwm *WatchManager, bc *BuildController,
 	ic *ImageController, gybc *GlobalYAMLBuildController, cc *ConfigsController,
 	dcw *DockerComposeEventWatcher, dclm *DockerComposeLogManager, pm *ProfilerManager,
-	sm SyncletManager) Upper {
+	sm SyncletManager, ar *AnalyticsReporter) Upper {
 
 	st.AddSubscriber(bc)
 	st.AddSubscriber(hud)
@@ -87,6 +86,7 @@ func NewUpper(ctx context.Context, hud hud.HeadsUpDisplay, pw *PodWatcher, sw *S
 	st.AddSubscriber(dclm)
 	st.AddSubscriber(pm)
 	st.AddSubscriber(sm)
+	st.AddSubscriber(ar)
 
 	return Upper{
 		store: st,
@@ -783,6 +783,7 @@ func handleServiceEvent(ctx context.Context, state *store.EngineState, action Se
 
 func handleInitAction(ctx context.Context, engineState *store.EngineState, action InitAction) error {
 	watchMounts := action.WatchMounts
+	engineState.TiltStartTime = action.StartTime
 	engineState.TiltfilePath = action.TiltfilePath
 	engineState.TriggerMode = action.TriggerMode
 	engineState.ConfigFiles = action.ConfigFiles

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -15,30 +15,29 @@ import (
 	"testing"
 	"time"
 
-	"github.com/windmilleng/tilt/internal/container"
-	"github.com/windmilleng/tilt/internal/dockercompose"
-	"github.com/windmilleng/tilt/internal/hud/view"
-	"github.com/windmilleng/tilt/internal/k8s/testyaml"
-	"github.com/windmilleng/tilt/internal/logger"
-	"github.com/windmilleng/tilt/internal/synclet"
-
-	"github.com/windmilleng/tilt/internal/testutils/bufsync"
-	"github.com/windmilleng/tilt/internal/tiltfile"
-
 	"github.com/docker/distribution/reference"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	"github.com/windmilleng/wmclient/pkg/analytics"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud"
+	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/synclet"
+	"github.com/windmilleng/tilt/internal/testutils/bufsync"
 	testoutput "github.com/windmilleng/tilt/internal/testutils/output"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+	"github.com/windmilleng/tilt/internal/tiltfile"
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
@@ -2055,7 +2054,9 @@ func newTestFixture(t *testing.T) *testFixture {
 	pm := NewProfilerManager()
 	sCli := synclet.NewFakeSyncletClient()
 	sm := NewSyncletManagerForTests(k8s, sCli)
-	upper := NewUpper(ctx, fakeHud, pw, sw, st, plm, pfc, fwm, bc, ic, gybc, cc, dcw, dclm, pm, sm)
+	an := analytics.NewMemoryAnalytics()
+	ar := ProvideAnalyticsReporter(an, st)
+	upper := NewUpper(ctx, fakeHud, pw, sw, st, plm, pfc, fwm, bc, ic, gybc, cc, dcw, dclm, pm, sm, ar)
 
 	go func() {
 		fakeHud.Run(ctx, upper.Dispatch, hud.DefaultRefreshInterval)

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -21,6 +21,8 @@ import (
 const emptyTiltfileMsg = "Looks like you don't have any docker builds or services defined in your Tiltfile! Check out https://docs.tilt.build/tutorial.html to get started."
 
 type EngineState struct {
+	TiltStartTime time.Time
+
 	// saved so that we can render in order
 	ManifestDefinitionOrder []model.ManifestName
 

--- a/vendor/github.com/windmilleng/wmclient/pkg/analytics/analytics.go
+++ b/vendor/github.com/windmilleng/wmclient/pkg/analytics/analytics.go
@@ -256,15 +256,15 @@ type MemoryAnalytics struct {
 }
 
 type CountEvent struct {
-	name string
-	tags map[string]string
-	n    int
+	Name string
+	Tags map[string]string
+	N    int
 }
 
 type TimeEvent struct {
-	name string
-	tags map[string]string
-	dur  time.Duration
+	Name string
+	Tags map[string]string
+	Dur  time.Duration
 }
 
 func NewMemoryAnalytics() *MemoryAnalytics {
@@ -272,7 +272,7 @@ func NewMemoryAnalytics() *MemoryAnalytics {
 }
 
 func (a *MemoryAnalytics) Count(name string, tags map[string]string, n int) {
-	a.Counts = append(a.Counts, CountEvent{name: name, tags: tags, n: n})
+	a.Counts = append(a.Counts, CountEvent{Name: name, Tags: tags, N: n})
 }
 
 func (a *MemoryAnalytics) Incr(name string, tags map[string]string) {
@@ -280,7 +280,7 @@ func (a *MemoryAnalytics) Incr(name string, tags map[string]string) {
 }
 
 func (a *MemoryAnalytics) Timer(name string, dur time.Duration, tags map[string]string) {
-	a.Timers = append(a.Timers, TimeEvent{name: name, dur: dur, tags: tags})
+	a.Timers = append(a.Timers, TimeEvent{Name: name, Dur: dur, Tags: tags})
 }
 
 func (a *MemoryAnalytics) Flush(timeout time.Duration) {}


### PR DESCRIPTION
1. Report an "up.running" event every 4 hours while tilt is running (theoretically we have a compelling use case that involves just leaving Tilt running all the time, and we want to count these users appropriately).
2. Count builds, resources, resources w/ DC, resources w/ k8s, resources w/ fast build.