### PR TITLE
engine: inject deployID on k8s deploy, use that to find pods [ch1544]

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -64,6 +64,31 @@ type LogAction struct {
 
 func (LogAction) Action() {}
 
+type DeployIDAction struct {
+	TargetID model.TargetID
+	DeployID model.DeployID
+}
+
+func (DeployIDAction) Action() {}
+
+func NewDeployIDAction(id model.TargetID, dID model.DeployID) DeployIDAction {
+	return DeployIDAction{
+		TargetID: id,
+		DeployID: dID,
+	}
+
+}
+func NewDeployIDActionsForTargets(ids []model.TargetID, dID model.DeployID) []DeployIDAction {
+	actions := make([]DeployIDAction, len(ids))
+	for i, id := range ids {
+		actions[i] = DeployIDAction{
+			TargetID: id,
+			DeployID: dID,
+		}
+	}
+	return actions
+}
+
 type BuildCompleteAction struct {
 	Result store.BuildResultSet
 	Error  error

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -17,7 +17,7 @@ type BuildAndDeployer interface {
 	//
 	// BuildResult can be used to construct a set of BuildStates, which contain
 	// the last successful builds of each target and the files changed since that build.
-	BuildAndDeploy(ctx context.Context, spects []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error)
+	BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error)
 }
 
 type BuildOrder []BuildAndDeployer
@@ -37,10 +37,10 @@ func NewCompositeBuildAndDeployer(builders BuildOrder) *CompositeBuildAndDeploye
 	return &CompositeBuildAndDeployer{builders: builders}
 }
 
-func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error) {
+func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error) {
 	var lastErr error
 	for _, builder := range composite.builders {
-		br, err := builder.BuildAndDeploy(ctx, specs, currentState)
+		br, err := builder.BuildAndDeploy(ctx, st, specs, currentState)
 		if err == nil {
 			return br, err
 		}

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -34,7 +34,7 @@ var imageTargetID = model.TargetID{
 }
 
 var alreadyBuilt = store.BuildResult{Image: testImageRef}
-var alreadyBuiltSet = store.BuildResultSet{Builds: map[model.TargetID]store.BuildResult{imageTargetID: alreadyBuilt}}
+var alreadyBuiltSet = store.BuildResultSet{imageTargetID: alreadyBuilt}
 
 type expectedFile = testutils.ExpectedFile
 
@@ -149,7 +149,7 @@ func TestContainerBuildLocal(t *testing.T) {
 	f.assertContainerRestarts(1)
 
 	id := manifest.ImageTargetAt(0).ID()
-	assert.Equal(t, k8s.MagicTestContainerID, result.Builds[id].ContainerID.String())
+	assert.Equal(t, k8s.MagicTestContainerID, result[id].ContainerID.String())
 }
 
 func TestContainerBuildSynclet(t *testing.T) {
@@ -175,7 +175,7 @@ func TestContainerBuildSynclet(t *testing.T) {
 	}
 
 	id := manifest.ImageTargetAt(0).ID()
-	assert.Equal(t, k8s.MagicTestContainerID, result.Builds[id].ContainerID.String())
+	assert.Equal(t, k8s.MagicTestContainerID, result[id].ContainerID.String())
 }
 
 func TestIncrementalBuildFailure(t *testing.T) {
@@ -292,7 +292,7 @@ func TestIncrementalBuildTwice(t *testing.T) {
 	}
 
 	id := manifest.ImageTargetAt(0).ID()
-	rSet := firstResult.Builds[id].FilesReplacedSet
+	rSet := firstResult[id].FilesReplacedSet
 	if len(rSet) != 1 || !rSet[aPath] {
 		t.Errorf("Expected replaced set with a.txt, actual: %v", rSet)
 	}
@@ -303,7 +303,7 @@ func TestIncrementalBuildTwice(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rSet = secondResult.Builds[id].FilesReplacedSet
+	rSet = secondResult[id].FilesReplacedSet
 	if len(rSet) != 2 || !rSet[aPath] || !rSet[bPath] {
 		t.Errorf("Expected replaced set with a.txt, b.txt, actual: %v", rSet)
 	}
@@ -343,7 +343,7 @@ func TestIncrementalBuildTwiceDeadPod(t *testing.T) {
 	}
 
 	id := manifest.ImageTargetAt(0).ID()
-	rSet := firstResult.Builds[id].FilesReplacedSet
+	rSet := firstResult[id].FilesReplacedSet
 	if len(rSet) != 1 || !rSet[aPath] {
 		t.Errorf("Expected replaced set with a.txt, actual: %v", rSet)
 	}
@@ -357,7 +357,7 @@ func TestIncrementalBuildTwiceDeadPod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rSet = secondResult.Builds[id].FilesReplacedSet
+	rSet = secondResult[id].FilesReplacedSet
 	if len(rSet) != 0 {
 		t.Errorf("Expected empty replaced set, actual: %v", rSet)
 	}
@@ -502,7 +502,7 @@ func (f *bdFixture) assertContainerRestarts(count int) {
 
 func resultToStateSet(resultSet store.BuildResultSet, files []string, deploy store.DeployInfo) store.BuildStateSet {
 	stateSet := store.BuildStateSet{}
-	for id, result := range resultSet.Builds {
+	for id, result := range resultSet {
 		state := store.NewBuildState(result, files).WithDeployTarget(deploy)
 		stateSet[id] = state
 	}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -149,12 +149,12 @@ func (c *BuildController) OnChange(ctx context.Context, st store.RStore) {
 		})
 		c.logBuildEntry(ctx, entry, filesChanged)
 
-		result, err := c.buildAndDeploy(ctx, entry)
+		result, err := c.buildAndDeploy(ctx, st, entry)
 		st.Dispatch(NewBuildCompleteAction(result, err))
 	}()
 }
 
-func (c *BuildController) buildAndDeploy(ctx context.Context, entry buildEntry) (store.BuildResultSet, error) {
+func (c *BuildController) buildAndDeploy(ctx context.Context, st store.RStore, entry buildEntry) (store.BuildResultSet, error) {
 	targets := entry.targets
 	for _, target := range targets {
 		err := target.Validate()
@@ -162,7 +162,7 @@ func (c *BuildController) buildAndDeploy(ctx context.Context, entry buildEntry) 
 			return store.BuildResultSet{}, err
 		}
 	}
-	return c.b.BuildAndDeploy(ctx, targets, entry.buildStateSet)
+	return c.b.BuildAndDeploy(ctx, st, targets, entry.buildStateSet)
 }
 
 func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry, changedFiles []string) {

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1,14 +1,13 @@
 package engine
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/model"
-	store "github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
@@ -35,7 +34,7 @@ func TestBuildControllerOnePod(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
-func TestBuildControllerTwoPods(t *testing.T) {
+func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
@@ -47,15 +46,17 @@ func TestBuildControllerTwoPods(t *testing.T) {
 	assert.Equal(t, manifest.ImageTargetAt(0), call.image())
 	assert.Equal(t, []string{}, call.oneState().FilesChanged())
 
+	// Associate the pods with the manifest state
 	podA := f.testPod("pod-a", "fe", "Running", testContainer, time.Now())
 	podB := f.testPod("pod-b", "fe", "Running", testContainer, time.Now())
-	image := fmt.Sprintf("%s:%s", f.imageNameForManifest("fe").String(), "now")
-	setImage(podA, image)
-	setImage(podB, image)
 	f.podEvent(podA)
 	f.podEvent(podB)
+
 	f.fsWatcher.events <- watch.FileEvent{Path: "main.go"}
 
+	// We expect two pods associated with this manifest. We don't want to container-build
+	// if there are multiple pods, so make sure we're not sending deploy info (i.e. that
+	// we're doing an image build)
 	call = f.nextCall()
 	assert.Equal(t, "", call.oneState().DeployInfo.PodID.String())
 

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -52,7 +52,7 @@ func (bd *DockerComposeBuildAndDeployer) extract(specs []model.TargetSpec) ([]mo
 	return iTargets, dcTargets
 }
 
-func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error) {
+func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error) {
 	iTargets, dcTargets := bd.extract(specs)
 	if len(dcTargets) != 1 {
 		return store.BuildResultSet{}, RedirectToNextBuilderf(

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -69,7 +69,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	span.SetTag("target", dcTargets[0].Name)
 	defer span.Finish()
 
-	results := store.NewBuildResultSet()
+	results := store.BuildResultSet{}
 
 	if haveImage {
 		var err error
@@ -93,7 +93,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 			return store.BuildResultSet{}, err
 		}
 
-		results.Builds[iTarget.ID()] = store.BuildResult{
+		results[iTarget.ID()] = store.BuildResult{
 			Image: ref,
 		}
 	}
@@ -112,7 +112,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		return store.BuildResultSet{}, err
 	}
 
-	results.Builds[dcTarget.ID()] = store.BuildResult{
+	results[dcTarget.ID()] = store.BuildResult{
 		ContainerID: cid,
 	}
 

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -69,7 +69,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, spe
 	span.SetTag("target", dcTargets[0].Name)
 	defer span.Finish()
 
-	results := store.BuildResultSet{}
+	results := store.NewBuildResultSet()
 
 	if haveImage {
 		var err error
@@ -93,7 +93,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, spe
 			return store.BuildResultSet{}, err
 		}
 
-		results[iTarget.ID()] = store.BuildResult{
+		results.Builds[iTarget.ID()] = store.BuildResult{
 			Image: ref,
 		}
 	}
@@ -112,7 +112,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, spe
 		return store.BuildResultSet{}, err
 	}
 
-	results[dcTarget.ID()] = store.BuildResult{
+	results.Builds[dcTarget.ID()] = store.BuildResult{
 		ContainerID: cid,
 	}
 

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -68,7 +68,7 @@ func TestTiltBuildsImage(t *testing.T) {
 		assert.False(t, call.ShouldBuild, "should call `up` without `--build` b/c Tilt is doing the building")
 	}
 
-	assert.Len(t, res.Builds, 2, "expect two results (one for each spec)")
+	assert.Len(t, res, 2, "expect two results (one for each spec)")
 }
 
 func TestTiltBuildsImageWithTag(t *testing.T) {

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -34,7 +34,7 @@ func TestDockerComposeTargetBuilt(t *testing.T) {
 	f := newDCBDFixture(t)
 	defer f.TearDown()
 
-	res, err := f.dcbad.BuildAndDeploy(f.ctx, []model.TargetSpec{dcTarg}, store.BuildStateSet{})
+	res, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, []model.TargetSpec{dcTarg}, store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestTiltBuildsImage(t *testing.T) {
 	f := newDCBDFixture(t)
 	defer f.TearDown()
 
-	res, err := f.dcbad.BuildAndDeploy(f.ctx, []model.TargetSpec{imgTarg, dcTarg}, store.BuildStateSet{})
+	res, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, []model.TargetSpec{imgTarg, dcTarg}, store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestTiltBuildsImageWithTag(t *testing.T) {
 		BuildDetails: model.StaticBuild{},
 	}
 
-	_, err := f.dcbad.BuildAndDeploy(f.ctx, []model.TargetSpec{iTarget, dcTarg}, store.BuildStateSet{})
+	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, []model.TargetSpec{iTarget, dcTarg}, store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,6 +106,7 @@ type dcbdFixture struct {
 	dcCli *dockercompose.FakeDCClient
 	dCli  *docker.FakeClient
 	dcbad *DockerComposeBuildAndDeployer
+	st    *store.Store
 }
 
 func newDCBDFixture(t *testing.T) *dcbdFixture {
@@ -127,5 +128,6 @@ func newDCBDFixture(t *testing.T) *dcbdFixture {
 		dcCli:          dcCli,
 		dCli:           dCli,
 		dcbad:          dcbad,
+		st:             store.NewStoreForTesting(),
 	}
 }

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -68,7 +68,7 @@ func TestTiltBuildsImage(t *testing.T) {
 		assert.False(t, call.ShouldBuild, "should call `up` without `--build` b/c Tilt is doing the building")
 	}
 
-	assert.Len(t, res, 2, "expect two results (one for each spec)")
+	assert.Len(t, res.Builds, 2, "expect two results (one for each spec)")
 }
 
 func TestTiltBuildsImageWithTag(t *testing.T) {

--- a/internal/engine/global_yaml_buildcontroller.go
+++ b/internal/engine/global_yaml_buildcontroller.go
@@ -55,7 +55,7 @@ func handleGlobalYamlChange(ctx context.Context, m model.Manifest, kCli k8s.Clie
 	newK8sEntities := []k8s.K8sEntity{}
 
 	for _, e := range entities {
-		e, err = k8s.InjectLabels(e, []model.LabelPair{TiltRunLabel(), {Key: ManifestNameLabel, Value: m.ManifestName().String()}})
+		e, err = k8s.InjectLabels(e, []model.LabelPair{k8s.TiltRunLabel(), {Key: k8s.ManifestNameLabel, Value: m.ManifestName().String()}})
 		if err != nil {
 			return errors.Wrap(err, "Error injecting labels in to k8s_yaml")
 		}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -52,7 +52,7 @@ func (ibd *ImageBuildAndDeployer) SetInjectSynclet(inject bool) {
 	ibd.injectSynclet = inject
 }
 
-func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []model.TargetSpec, stateSet store.BuildStateSet) (resultSet store.BuildResultSet, err error) {
+func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (resultSet store.BuildResultSet, err error) {
 	iTargets, kTargets := extractImageAndK8sTargets(specs)
 	if len(kTargets) == 0 || len(iTargets) == 0 {
 		return store.BuildResultSet{}, RedirectToNextBuilderf("ImageBuildAndDeployer does not support these specs")

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -82,7 +82,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []mo
 	ps := build.NewPipelineState(ctx, numStages, ibd.clock)
 	defer func() { ps.End(ctx, err) }()
 
-	results := store.BuildResultSet{}
+	results := store.NewBuildResultSet()
 
 	var refs []reference.NamedTagged
 	for _, iTarget := range iTargets {
@@ -90,7 +90,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []mo
 		if err != nil {
 			return store.BuildResultSet{}, err
 		}
-		results[iTarget.ID()] = store.BuildResult{
+		results.Builds[iTarget.ID()] = store.BuildResult{
 			Image: ref,
 		}
 		refs = append(refs, ref)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -96,16 +96,18 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []mo
 		refs = append(refs, ref)
 	}
 
-	err = ibd.deploy(ctx, ps, kTargets, refs)
+	deployID, err := ibd.deploy(ctx, ps, kTargets, refs)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
+
+	results = results.WithDeployID(deployID)
 
 	return results, nil
 }
 
 // Returns: the entities deployed and the namespace of the pod with the given image name/tag.
-func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.PipelineState, k8sTargets []model.K8sTarget, refs []reference.NamedTagged) error {
+func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.PipelineState, k8sTargets []model.K8sTarget, refs []reference.NamedTagged) (k8s.DeployID, error) {
 	ps.StartPipelineStep(ctx, "Deploying")
 	defer ps.EndPipelineStep(ctx)
 
@@ -114,18 +116,21 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.Pipeline
 	injectedRefs := map[string]bool{}
 	newK8sEntities := []k8s.K8sEntity{}
 
+	deployID := k8s.NewDeployID()
+	deployLabel := k8s.TiltDeployLabel(deployID)
+
 	for _, k8sTarget := range k8sTargets {
 		// TODO(nick): The parsed YAML should probably be a part of the model?
 		// It doesn't make much sense to re-parse it and inject labels on every deploy.
 		entities, err := k8s.ParseYAMLFromString(k8sTarget.YAML)
 		if err != nil {
-			return err
+			return deployID, err
 		}
 
 		for _, e := range entities {
-			e, err = k8s.InjectLabels(e, []model.LabelPair{TiltRunLabel(), {Key: ManifestNameLabel, Value: k8sTarget.Name.String()}})
+			e, err = k8s.InjectLabels(e, []model.LabelPair{k8s.TiltRunLabel(), {Key: k8s.ManifestNameLabel, Value: k8sTarget.Name.String()}, deployLabel})
 			if err != nil {
-				return errors.Wrap(err, "deploy")
+				return deployID, errors.Wrap(err, "deploy")
 			}
 
 			// For development, image pull policy should never be set to "Always",
@@ -133,7 +138,7 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.Pipeline
 			// set "Always" for development are shooting their own feet.
 			e, err = k8s.InjectImagePullPolicy(e, v1.PullIfNotPresent)
 			if err != nil {
-				return err
+				return deployID, err
 			}
 
 			// When working with a local k8s cluster, we set the pull policy to Never,
@@ -147,7 +152,7 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.Pipeline
 				var replaced bool
 				e, replaced, err = k8s.InjectImageDigest(e, ref, policy)
 				if err != nil {
-					return err
+					return deployID, err
 				}
 				if replaced {
 					injectedRefs[ref.String()] = true
@@ -156,10 +161,10 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.Pipeline
 						var sidecarInjected bool
 						e, sidecarInjected, err = sidecar.InjectSyncletSidecar(e, ref)
 						if err != nil {
-							return err
+							return deployID, err
 						}
 						if !sidecarInjected {
-							return fmt.Errorf("Could not inject synclet: %v", e)
+							return deployID, fmt.Errorf("Could not inject synclet: %v", e)
 						}
 					}
 				}
@@ -170,11 +175,11 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.Pipeline
 
 	for _, ref := range refs {
 		if !injectedRefs[ref.String()] {
-			return fmt.Errorf("Docker image missing from yaml: %s", ref)
+			return deployID, fmt.Errorf("Docker image missing from yaml: %s", ref)
 		}
 	}
 
-	return ibd.k8sClient.Upsert(ctx, newK8sEntities)
+	return deployID, ibd.k8sClient.Upsert(ctx, newK8sEntities)
 }
 
 // If we're using docker-for-desktop as our k8s backend,

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -107,7 +107,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []mo
 }
 
 // Returns: the entities deployed and the namespace of the pod with the given image name/tag.
-func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.PipelineState, k8sTargets []model.K8sTarget, refs []reference.NamedTagged) (k8s.DeployID, error) {
+func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.PipelineState, k8sTargets []model.K8sTarget, refs []reference.NamedTagged) (model.DeployID, error) {
 	ps.StartPipelineStep(ctx, "Deploying")
 	defer ps.EndPipelineStep(ctx)
 
@@ -116,7 +116,7 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, ps *build.Pipeline
 	injectedRefs := map[string]bool{}
 	newK8sEntities := []k8s.K8sEntity{}
 
-	deployID := k8s.NewDeployID()
+	deployID := model.NewDeployID()
 	deployLabel := k8s.TiltDeployLabel(deployID)
 
 	for _, k8sTarget := range k8sTargets {

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -27,7 +27,7 @@ func TestStaticDockerfileWithCache(t *testing.T) {
 	cache := "gcr.io/some-project-162817/sancho:tilt-cache-3de427a264f80719a58a9abd456487b3"
 	f.docker.Images[cache] = types.ImageInspect{}
 
-	_, err := f.ibd.BuildAndDeploy(f.ctx, buildTargets(manifest), store.BuildStateSet{})
+	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestBaseDockerfileWithCache(t *testing.T) {
 	cache := "gcr.io/some-project-162817/sancho:tilt-cache-3de427a264f80719a58a9abd456487b3"
 	f.docker.Images[cache] = types.ImageInspect{}
 
-	_, err := f.ibd.BuildAndDeploy(f.ctx, buildTargets(manifest), store.BuildStateSet{})
+	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestDeployTwinImages(t *testing.T) {
 
 	sancho := NewSanchoFastBuildManifest(f)
 	manifest := sancho.WithDeployTarget(sancho.K8sTarget().AppendYAML(SanchoTwinYAML))
-	result, err := f.ibd.BuildAndDeploy(f.ctx, buildTargets(manifest), store.BuildStateSet{})
+	result, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestDeployPodWithMultipleImages(t *testing.T) {
 	kTarget := model.K8sTarget{Name: "sancho", YAML: testyaml.SanchoSidecarYAML}
 	targets := []model.TargetSpec{iTarget1, iTarget2, kTarget}
 
-	result, err := f.ibd.BuildAndDeploy(f.ctx, targets, store.BuildStateSet{})
+	result, err := f.ibd.BuildAndDeploy(f.ctx, f.st, targets, store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,6 +120,7 @@ type ibdFixture struct {
 	docker *docker.FakeClient
 	k8s    *k8s.FakeK8sClient
 	ibd    *ImageBuildAndDeployer
+	st     *store.Store
 }
 
 func newIBDFixture(t *testing.T) *ibdFixture {
@@ -138,5 +139,6 @@ func newIBDFixture(t *testing.T) *ibdFixture {
 		docker:         docker,
 		k8s:            k8s,
 		ibd:            ibd,
+		st:             store.NewStoreForTesting(),
 	}
 }

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -82,7 +82,7 @@ func TestDeployTwinImages(t *testing.T) {
 
 	id := manifest.ImageTargetAt(0).ID()
 	expectedImage := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	assert.Equal(t, expectedImage, result.Builds[id].Image.String())
+	assert.Equal(t, expectedImage, result[id].Image.String())
 	assert.Equalf(t, 2, strings.Count(f.k8s.Yaml, expectedImage),
 		"Expected image to update twice in YAML: %s", f.k8s.Yaml)
 }
@@ -104,12 +104,12 @@ func TestDeployPodWithMultipleImages(t *testing.T) {
 	assert.Equal(t, 2, f.docker.BuildCount)
 
 	expectedSanchoRef := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	assert.Equal(t, expectedSanchoRef, result.Builds[iTarget1.ID()].Image.String())
+	assert.Equal(t, expectedSanchoRef, result[iTarget1.ID()].Image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSanchoRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
 
 	expectedSidecarRef := "gcr.io/some-project-162817/sancho-sidecar:tilt-11cd0b38bc3ceb95"
-	assert.Equal(t, expectedSidecarRef, result.Builds[iTarget2.ID()].Image.String())
+	assert.Equal(t, expectedSidecarRef, result[iTarget2.ID()].Image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSidecarRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
 }

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -82,7 +82,7 @@ func TestDeployTwinImages(t *testing.T) {
 
 	id := manifest.ImageTargetAt(0).ID()
 	expectedImage := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	assert.Equal(t, expectedImage, result[id].Image.String())
+	assert.Equal(t, expectedImage, result.Builds[id].Image.String())
 	assert.Equalf(t, 2, strings.Count(f.k8s.Yaml, expectedImage),
 		"Expected image to update twice in YAML: %s", f.k8s.Yaml)
 }
@@ -104,12 +104,12 @@ func TestDeployPodWithMultipleImages(t *testing.T) {
 	assert.Equal(t, 2, f.docker.BuildCount)
 
 	expectedSanchoRef := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	assert.Equal(t, expectedSanchoRef, result[iTarget1.ID()].Image.String())
+	assert.Equal(t, expectedSanchoRef, result.Builds[iTarget1.ID()].Image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSanchoRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
 
 	expectedSidecarRef := "gcr.io/some-project-162817/sancho-sidecar:tilt-11cd0b38bc3ceb95"
-	assert.Equal(t, expectedSidecarRef, result[iTarget2.ID()].Image.String())
+	assert.Equal(t, expectedSidecarRef, result.Builds[iTarget2.ID()].Image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSidecarRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
 }

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -29,7 +29,7 @@ func NewLocalContainerBuildAndDeployer(cu *build.ContainerUpdater,
 	}
 }
 
-func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
+func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
 	iTargets, kTargets := extractImageAndK8sTargets(specs)
 	if len(kTargets) != 1 || len(iTargets) != 1 {
 		return store.BuildResultSet{}, RedirectToNextBuilderf(

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -89,7 +89,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 	res := state.LastResult.ShallowCloneForContainerUpdate(state.FilesChangedSet)
 	res.ContainerID = deployInfo.ContainerID // the container we deployed on top of
 
-	resultSet := store.NewBuildResultSet()
-	resultSet.Builds[iTarget.ID()] = res
+	resultSet := store.BuildResultSet{}
+	resultSet[iTarget.ID()] = res
 	return resultSet, nil
 }

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -89,7 +89,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 	res := state.LastResult.ShallowCloneForContainerUpdate(state.FilesChangedSet)
 	res.ContainerID = deployInfo.ContainerID // the container we deployed on top of
 
-	resultSet := store.BuildResultSet{}
-	resultSet[iTarget.ID()] = res
+	resultSet := store.NewBuildResultSet()
+	resultSet.Builds[iTarget.ID()] = res
 	return resultSet, nil
 }

--- a/internal/engine/pod_watch.go
+++ b/internal/engine/pod_watch.go
@@ -65,7 +65,7 @@ func (w *PodWatcher) diff(ctx context.Context, st store.RStore) (setup []PodWatc
 		}
 	}
 	if atLeastOneK8S {
-		neededWatches = append(neededWatches, PodWatch{labels: TiltRunSelector()})
+		neededWatches = append(neededWatches, PodWatch{labels: k8s.TiltRunSelector()})
 	}
 
 	return subtract(neededWatches, w.watches), subtract(w.watches, neededWatches)

--- a/internal/engine/pod_watch_test.go
+++ b/internal/engine/pod_watch_test.go
@@ -26,7 +26,7 @@ func TestPodWatch(t *testing.T) {
 
 	f.pw.OnChange(f.ctx, f.store)
 
-	ls := TiltRunSelector()
+	ls := k8s.TiltRunSelector()
 	p := podNamed("hello")
 	f.kClient.EmitPod(ls, p)
 
@@ -39,7 +39,7 @@ func TestPodWatchExtraSelectors(t *testing.T) {
 	f := newPWFixture(t)
 	defer f.TearDown()
 
-	ls := TiltRunSelector()
+	ls := k8s.TiltRunSelector()
 	ls1 := labels.Set{"foo": "bar"}.AsSelector()
 	ls2 := labels.Set{"baz": "quu"}.AsSelector()
 	f.addManifestWithSelectors("server", ls1, ls2)
@@ -58,7 +58,7 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 	f := newPWFixture(t)
 	defer f.TearDown()
 
-	ls := TiltRunSelector()
+	ls := k8s.TiltRunSelector()
 	ls1 := labels.Set{"foo": "bar"}.AsSelector()
 	f.addManifestWithSelectors("server1", ls1)
 

--- a/internal/engine/service_watch.go
+++ b/internal/engine/service_watch.go
@@ -45,7 +45,7 @@ func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore) {
 	}
 	w.watching = true
 
-	ch, err := w.kCli.WatchServices(ctx, []model.LabelPair{TiltRunLabel()})
+	ch, err := w.kCli.WatchServices(ctx, []model.LabelPair{k8s.TiltRunLabel()})
 	if err != nil {
 		err = errors.Wrap(err, "Error watching services. Are you connected to kubernetes?\n")
 		st.Dispatch(NewErrorAction(err))

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -119,7 +119,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 	res := state.LastResult.ShallowCloneForContainerUpdate(state.FilesChangedSet)
 	res.ContainerID = deployInfo.ContainerID // the container we deployed on top of
 
-	resultSet := store.NewBuildResultSet()
-	resultSet.Builds[image.ID()] = res
+	resultSet := store.BuildResultSet{}
+	resultSet[image.ID()] = res
 	return resultSet, nil
 }

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -119,7 +119,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,
 	res := state.LastResult.ShallowCloneForContainerUpdate(state.FilesChangedSet)
 	res.ContainerID = deployInfo.ContainerID // the container we deployed on top of
 
-	resultSet := store.BuildResultSet{}
-	resultSet[image.ID()] = res
+	resultSet := store.NewBuildResultSet()
+	resultSet.Builds[image.ID()] = res
 	return resultSet, nil
 }

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -25,7 +25,7 @@ func NewSyncletBuildAndDeployer(sm SyncletManager) *SyncletBuildAndDeployer {
 	}
 }
 
-func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
+func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
 	iTargets, kTargets := extractImageAndK8sTargets(specs)
 	if len(kTargets) != 1 || len(iTargets) != 1 {
 		return store.BuildResultSet{}, RedirectToNextBuilderf(

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -293,7 +293,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 
 		ms.LastSuccessfulDeployTime = time.Now()
 
-		for id, result := range cb.Result {
+		for id, result := range cb.Result.Builds {
 			ms.MutableBuildStatus(id).LastSuccessfulResult = result
 		}
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -494,7 +494,7 @@ func handleConfigsReloaded(
 //
 // Intended as a helper for pod-mutating events.
 func ensureManifestTargetWithPod(state *store.EngineState, pod *v1.Pod) (*store.ManifestTarget, *store.Pod) {
-	manifestName := model.ManifestName(pod.ObjectMeta.Labels[ManifestNameLabel])
+	manifestName := model.ManifestName(pod.ObjectMeta.Labels[k8s.ManifestNameLabel])
 	if manifestName == "" {
 		// if there's no ManifestNameLabel, then maybe it matches some manifest's ExtraPodSelectors
 		for _, m := range state.Manifests() {
@@ -767,7 +767,7 @@ func handleLogAction(state *store.EngineState, action LogAction) {
 
 func handleServiceEvent(ctx context.Context, state *store.EngineState, action ServiceChangeAction) {
 	service := action.Service
-	manifestName := model.ManifestName(service.ObjectMeta.Labels[ManifestNameLabel])
+	manifestName := model.ManifestName(service.ObjectMeta.Labels[k8s.ManifestNameLabel])
 	if manifestName == "" || manifestName == model.GlobalYAMLManifestName {
 		return
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -934,7 +934,7 @@ func (f *testFixture) testPod(podID string, manifestName string, phase string, c
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              podID,
 			CreationTimestamp: metav1.Time{Time: creationTime},
-			Labels:            map[string]string{ManifestNameLabel: manifestName},
+			Labels:            map[string]string{k8s.ManifestNameLabel: manifestName},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
@@ -1529,7 +1529,7 @@ func testService(serviceName string, manifestName string, ip string, port int) *
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   serviceName,
-			Labels: map[string]string{ManifestNameLabel: manifestName},
+			Labels: map[string]string{k8s.ManifestNameLabel: manifestName},
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -176,8 +176,8 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []model
 		return store.BuildResultSet{}, err
 	}
 
-	result := store.BuildResultSet{}
-	result[buildID] = b.nextBuildResult(buildImageRef)
+	result := store.NewBuildResultSet()
+	result.Builds[buildID] = b.nextBuildResult(buildImageRef)
 	return result, nil
 }
 
@@ -2464,8 +2464,8 @@ func dcContainerEvtForManifest(m model.Manifest, action dockercompose.Action) do
 }
 
 func containerResultSet(manifest model.Manifest, id container.ID) store.BuildResultSet {
-	resultSet := store.BuildResultSet{}
-	resultSet[manifest.ImageTargetAt(0).ID()] = store.BuildResult{
+	resultSet := store.NewBuildResultSet()
+	resultSet.Builds[manifest.ImageTargetAt(0).ID()] = store.BuildResult{
 		ContainerID: id,
 	}
 	return resultSet

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -136,7 +136,7 @@ func (b *fakeBuildAndDeployer) nextBuildResult(ref reference.Named) store.BuildR
 	}
 }
 
-func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, specs []model.TargetSpec, state store.BuildStateSet) (store.BuildResultSet, error) {
+func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, state store.BuildStateSet) (store.BuildResultSet, error) {
 	b.buildCount++
 
 	call := buildAndDeployCall{count: b.buildCount, specs: specs, state: state}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -179,14 +179,9 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 		return store.BuildResultSet{}, err
 	}
 
-	result := store.NewBuildResultSet()
-	if b.nextDeployID != 0 {
-		result.DeployID = b.nextDeployID
-		b.nextDeployID = 0
-	} else {
-		result.DeployID = testDeployID
-	}
-	result.Builds[buildID] = b.nextBuildResult(buildImageRef)
+	result := store.BuildResultSet{}
+	result[buildID] = b.nextBuildResult(buildImageRef)
+
 	return result, nil
 }
 
@@ -1160,7 +1155,7 @@ func TestPodUnexpectedContainerStartsImageBuildOutOfOrderEvents(t *testing.T) {
 		StartTime:    time.Now(),
 	})
 	f.store.Dispatch(BuildCompleteAction{
-		Result: store.BuildResultSet{DeployID: testDeployID},
+		Result: store.BuildResultSet{},
 	})
 	f.WaitUntil("nothing waiting for build", func(st store.EngineState) bool {
 		return nextManifestNameToBuild(st) == ""
@@ -2497,9 +2492,8 @@ func dcContainerEvtForManifest(m model.Manifest, action dockercompose.Action) do
 }
 
 func containerResultSet(manifest model.Manifest, id container.ID) store.BuildResultSet {
-	resultSet := store.NewBuildResultSet()
-	resultSet.DeployID = testDeployID
-	resultSet.Builds[manifest.ImageTargetAt(0).ID()] = store.BuildResult{
+	resultSet := store.BuildResultSet{}
+	resultSet[manifest.ImageTargetAt(0).ID()] = store.BuildResult{
 		ContainerID: id,
 	}
 	return resultSet

--- a/internal/k8s/labels.go
+++ b/internal/k8s/labels.go
@@ -1,6 +1,9 @@
-package engine
+package k8s
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/windmilleng/tilt/internal/model"
 	"k8s.io/apimachinery/pkg/labels"
@@ -12,10 +15,25 @@ var TiltRunID = uuid.New().String()
 
 const ManifestNameLabel = "tilt-manifest"
 
+const TiltDeployIDLabel = "tilt-deployid"
+
+type DeployID int64 // Unix ns after epoch -- uniquely identify a deploy
+
 func TiltRunLabel() model.LabelPair {
 	return model.LabelPair{
 		Key:   TiltRunIDLabel,
 		Value: TiltRunID,
+	}
+}
+
+func NewDeployID() DeployID {
+	return DeployID(time.Now().UnixNano())
+}
+
+func TiltDeployLabel(dID DeployID) model.LabelPair {
+	return model.LabelPair{
+		Key:   TiltDeployIDLabel,
+		Value: strconv.Itoa(int(dID)),
 	}
 }
 

--- a/internal/k8s/labels.go
+++ b/internal/k8s/labels.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"strconv"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/windmilleng/tilt/internal/model"
@@ -17,8 +16,6 @@ const ManifestNameLabel = "tilt-manifest"
 
 const TiltDeployIDLabel = "tilt-deployid"
 
-type DeployID int64 // Unix ns after epoch -- uniquely identify a deploy
-
 func TiltRunLabel() model.LabelPair {
 	return model.LabelPair{
 		Key:   TiltRunIDLabel,
@@ -26,11 +23,7 @@ func TiltRunLabel() model.LabelPair {
 	}
 }
 
-func NewDeployID() DeployID {
-	return DeployID(time.Now().UnixNano())
-}
-
-func TiltDeployLabel(dID DeployID) model.LabelPair {
+func TiltDeployLabel(dID model.DeployID) model.LabelPair {
 	return model.LabelPair{
 		Key:   TiltDeployIDLabel,
 		Value: strconv.Itoa(int(dID)),

--- a/internal/model/build_status.go
+++ b/internal/model/build_status.go
@@ -12,6 +12,7 @@ type BuildRecord struct {
 	StartTime  time.Time
 	FinishTime time.Time // IsZero() == true for in-progress builds
 	Reason     BuildReason
+	DeployID   DeployID
 	Log        []byte `testdiff:"ignore"`
 }
 

--- a/internal/model/build_status.go
+++ b/internal/model/build_status.go
@@ -12,7 +12,6 @@ type BuildRecord struct {
 	StartTime  time.Time
 	FinishTime time.Time // IsZero() == true for in-progress builds
 	Reason     BuildReason
-	DeployID   DeployID
 	Log        Log `testdiff:"ignore"`
 }
 

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -15,6 +16,8 @@ type DeployID int64 // Unix ns after epoch -- uniquely identify a deploy
 func NewDeployID() DeployID {
 	return DeployID(time.Now().UnixNano())
 }
+
+func (dID DeployID) String() string { return strconv.Itoa(int(dID)) }
 
 type DockerComposeTarget struct {
 	Name       TargetName

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -2,12 +2,19 @@ package model
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/windmilleng/tilt/internal/sliceutils"
 	"github.com/windmilleng/tilt/internal/yaml"
 )
+
+type DeployID int64 // Unix ns after epoch -- uniquely identify a deploy
+
+func NewDeployID() DeployID {
+	return DeployID(time.Now().UnixNano())
+}
 
 type DockerComposeTarget struct {
 	Name       TargetName

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -17,6 +17,9 @@ type BuildResult struct {
 	// The tag is derived from a content-addressable digest.
 	Image reference.NamedTagged
 
+	// The ID we have assigned to this deployment.
+	DeployID k8s.DeployID
+
 	// If this build was a container build, containerID we built on top of
 	ContainerID container.ID
 
@@ -60,6 +63,13 @@ func (set BuildResultSet) AsOneResult() BuildResult {
 		}
 	}
 	return BuildResult{}
+}
+
+func (set BuildResultSet) WithDeployID(dID k8s.DeployID) BuildResultSet {
+	for _, res := range set {
+		res.DeployID = dID
+	}
+	return set
 }
 
 // The state of the system since the last successful build.

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -18,7 +18,7 @@ type BuildResult struct {
 	Image reference.NamedTagged
 
 	// The ID we have assigned to this deployment.
-	DeployID k8s.DeployID
+	DeployID model.DeployID
 
 	// If this build was a container build, containerID we built on top of
 	ContainerID container.ID
@@ -56,7 +56,7 @@ func (b BuildResult) ShallowCloneForContainerUpdate(filesReplacedSet map[string]
 
 type BuildResultSet struct {
 	Builds   map[model.TargetID]BuildResult
-	DeployID k8s.DeployID
+	DeployID model.DeployID
 }
 
 func NewBuildResultSet() BuildResultSet {
@@ -74,7 +74,7 @@ func (set BuildResultSet) AsOneResult() BuildResult {
 	return BuildResult{DeployID: set.DeployID}
 }
 
-func (set BuildResultSet) WithDeployID(dID k8s.DeployID) BuildResultSet {
+func (set BuildResultSet) WithDeployID(dID model.DeployID) BuildResultSet {
 	set.DeployID = dID
 	return set
 }

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -54,21 +54,28 @@ func (b BuildResult) ShallowCloneForContainerUpdate(filesReplacedSet map[string]
 	return result
 }
 
-type BuildResultSet map[model.TargetID]BuildResult
+type BuildResultSet struct {
+	Builds   map[model.TargetID]BuildResult
+	DeployID k8s.DeployID
+}
+
+func NewBuildResultSet() BuildResultSet {
+	return BuildResultSet{
+		Builds: make(map[model.TargetID]BuildResult),
+	}
+}
 
 func (set BuildResultSet) AsOneResult() BuildResult {
-	if len(set) == 1 {
-		for _, result := range set {
+	if len(set.Builds) == 1 {
+		for _, result := range set.Builds {
 			return result
 		}
 	}
-	return BuildResult{}
+	return BuildResult{DeployID: set.DeployID}
 }
 
 func (set BuildResultSet) WithDeployID(dID k8s.DeployID) BuildResultSet {
-	for _, res := range set {
-		res.DeployID = dID
-	}
+	set.DeployID = dID
 	return set
 }
 

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -17,9 +17,6 @@ type BuildResult struct {
 	// The tag is derived from a content-addressable digest.
 	Image reference.NamedTagged
 
-	// The ID we have assigned to this deployment.
-	DeployID model.DeployID
-
 	// If this build was a container build, containerID we built on top of
 	ContainerID container.ID
 
@@ -71,7 +68,7 @@ func (set BuildResultSet) AsOneResult() BuildResult {
 			return result
 		}
 	}
-	return BuildResult{DeployID: set.DeployID}
+	return BuildResult{}
 }
 
 func (set BuildResultSet) WithDeployID(dID model.DeployID) BuildResultSet {

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -51,29 +51,15 @@ func (b BuildResult) ShallowCloneForContainerUpdate(filesReplacedSet map[string]
 	return result
 }
 
-type BuildResultSet struct {
-	Builds   map[model.TargetID]BuildResult
-	DeployID model.DeployID
-}
-
-func NewBuildResultSet() BuildResultSet {
-	return BuildResultSet{
-		Builds: make(map[model.TargetID]BuildResult),
-	}
-}
+type BuildResultSet map[model.TargetID]BuildResult
 
 func (set BuildResultSet) AsOneResult() BuildResult {
-	if len(set.Builds) == 1 {
-		for _, result := range set.Builds {
+	if len(set) == 1 {
+		for _, result := range set {
 			return result
 		}
 	}
 	return BuildResult{}
-}
-
-func (set BuildResultSet) WithDeployID(dID model.DeployID) BuildResultSet {
-	set.DeployID = dID
-	return set
 }
 
 // The state of the system since the last successful build.

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -8,14 +8,13 @@ import (
 	"sort"
 	"time"
 
-	"github.com/docker/distribution/reference"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/ospath"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 const emptyTiltfileMsg = "Looks like you don't have any docker builds or services defined in your Tiltfile! Check out https://docs.tilt.build/tutorial.html to get started."
@@ -412,8 +411,8 @@ func (s *YAMLManifestState) LastBuild() model.BuildRecord {
 var _ model.TargetStatus = &YAMLManifestState{}
 
 type PodSet struct {
-	Pods    map[k8s.PodID]*Pod
-	ImageID reference.NamedTagged
+	Pods     map[k8s.PodID]*Pod
+	DeployID model.DeployID // Deploy that these pods correspond to
 }
 
 func NewPodSet(pods ...Pod) PodSet {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -293,6 +293,10 @@ func (ms *ManifestState) LastBuild() model.BuildRecord {
 	return ms.BuildHistory[0]
 }
 
+func (ms *ManifestState) LastDeployID() model.DeployID {
+	return ms.LastBuild().DeployID
+}
+
 func (ms *ManifestState) AddCompletedBuild(bs model.BuildRecord) {
 	ms.BuildHistory = append([]model.BuildRecord{bs}, ms.BuildHistory...)
 	if len(ms.BuildHistory) > model.BuildHistoryLimit {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -206,8 +206,9 @@ type ManifestState struct {
 	Name model.ManifestName
 
 	// k8s-specific state
-	PodSet PodSet
-	LBs    map[k8s.ServiceName]*url.URL
+	PodSet   PodSet
+	LBs      map[k8s.ServiceName]*url.URL
+	DeployID model.DeployID // ID we have assigned to the current deploy (helps find expected k8s objects)
 
 	BuildStatuses map[model.TargetID]*BuildStatus
 
@@ -293,10 +294,6 @@ func (ms *ManifestState) LastBuild() model.BuildRecord {
 		return model.BuildRecord{}
 	}
 	return ms.BuildHistory[0]
-}
-
-func (ms *ManifestState) LastDeployID() model.DeployID {
-	return ms.LastBuild().DeployID
 }
 
 func (ms *ManifestState) AddCompletedBuild(bs model.BuildRecord) {

--- a/internal/store/testing_store.go
+++ b/internal/store/testing_store.go
@@ -2,6 +2,8 @@ package store
 
 import "sync"
 
+var _ RStore = &TestingStore{}
+
 type TestingStore struct {
 	state   *EngineState
 	stateMu sync.RWMutex


### PR DESCRIPTION
This lets us simplify the logic to match pods to image, and will let us more easily match pods that were deployed by tilt but don't have tilt-built images.