### PR TITLE
k8s: more robust watches and error handling

### DIFF
--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -124,7 +124,7 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 	ret.tracker = tracker
 
 	core := cs.CoreV1()
-	ret.client = K8sClient{EnvUnknown, ret.runner, core, nil, fakePortForwarder, KubeContext("unknown")}
+	ret.client = K8sClient{EnvUnknown, ret.runner, core, nil, fakePortForwarder, KubeContext("unknown"), ""}
 	return ret
 }
 


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/namespaces:

44e8b7306fa92e1a3534a6cc65bc7284901c7ae2 (2019-02-08 17:54:21 -0500)
k8s: more robust watches and error handling
fixes https://github.com/windmilleng/tilt/issues/1139