### PR TITLE
cli: add a hidden flag to turn on klog traces, which logs all k8s api calls

### DIFF
--- a/cmd/tilt/main.go
+++ b/cmd/tilt/main.go
@@ -1,12 +1,7 @@
 package main
 
 import (
-	"flag"
-	"log"
-	"os"
-
 	"github.com/windmilleng/tilt/internal/cli"
-	"k8s.io/klog"
 )
 
 // Magic variables set by goreleaser
@@ -15,28 +10,9 @@ var commit string
 var date string
 
 func main() {
-	disableGlog()
-
 	cli.SetBuildInfo(cli.BuildInfo{
 		Version: version,
 		Date:    date,
 	})
 	cli.Execute()
-}
-
-// HACK(nick): The Kubernetes libs we use sometimes use klog to log things to
-// os.Stderr. There are no API hooks to configure this. And printing to Stderr
-// scrambles the HUD tty.
-//
-// Fortunately, klog does initialize itself from flags, so we can backdoor
-// configure it by setting our own flags. Don't do this at home!
-func disableGlog() {
-	var tmpFlagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	klog.InitFlags(tmpFlagSet)
-	err := tmpFlagSet.Parse([]string{
-		"--stderrthreshold", "FATAL",
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
 }

--- a/internal/cli/klog.go
+++ b/internal/cli/klog.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"k8s.io/klog"
+)
+
+var klogLevel = 0
+
+// HACK(nick): The Kubernetes libs we use sometimes use klog to log things to
+// os.Stderr. There are no API hooks to configure this. And printing to Stderr
+// scrambles the HUD tty.
+//
+// Fortunately, klog does initialize itself from flags, so we can backdoor
+// configure it by setting our own flags. Don't do this at home!
+func initKlog() {
+	var tmpFlagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(tmpFlagSet)
+
+	flags := []string{
+		"--stderrthreshold", "FATAL",
+	}
+
+	if klogLevel > 0 {
+		flags = append(flags, "-v", fmt.Sprintf("%d", klogLevel))
+	}
+
+	err := tmpFlagSet.Parse(flags)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -11,6 +11,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/klog"
 
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/engine"
@@ -95,6 +96,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	ctx = logger.WithLogger(ctx, l)
 
 	log.SetOutput(l.Writer(logger.InfoLvl))
+	klog.SetOutput(l.Writer(logger.InfoLvl))
 
 	logOutput(fmt.Sprintf("Starting Tilt (%s)…", buildStamp()))
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/klog:

c3f3e4fd1d69975bee019b4e18c0fabd3038d6a0 (2019-02-11 11:36:58 -0500)
cli: add a hidden flag to turn on klog traces, which logs all k8s api calls