### PR TITLE
k8s: pull context from the k8s api instead of from the cli, and capture namespace in kubectlRunner

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -21,9 +21,15 @@ import (
 )
 
 var K8sWireSet = wire.NewSet(
-	k8s.ProvideEnvOrError,
-	k8s.ProideEnv,
+	k8s.ProvideEnv,
 	k8s.DetectNodeIP,
+	k8s.ProvideKubeContext,
+	k8s.ProvideClientConfig,
+	k8s.ProvideRESTConfig,
+	k8s.ProvideCoreInterface,
+	k8s.ProvidePortForwarder,
+	k8s.ProvideConfigNamespace,
+	k8s.ProvideKubectlRunner,
 
 	k8s.ProvideK8sClient)
 

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -30,13 +30,17 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	if err != nil {
 		return demo.Script{}, err
 	}
-	envOrError := k8s.ProvideEnvOrError(ctx)
-	client, err := k8s.ProvideK8sClient(ctx, envOrError)
+	clientConfig := k8s.ProvideClientConfig()
+	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return demo.Script{}, err
 	}
+	env := k8s.ProvideEnv(kubeContext)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
+	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	podWatcher := engine.NewPodWatcher(client)
-	env := k8s.ProideEnv(envOrError)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
 		return demo.Script{}, err
@@ -106,13 +110,17 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	if err != nil {
 		return Threads{}, err
 	}
-	envOrError := k8s.ProvideEnvOrError(ctx)
-	client, err := k8s.ProvideK8sClient(ctx, envOrError)
+	clientConfig := k8s.ProvideClientConfig()
+	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return Threads{}, err
 	}
+	env := k8s.ProvideEnv(kubeContext)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
+	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	podWatcher := engine.NewPodWatcher(client)
-	env := k8s.ProideEnv(envOrError)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
 		return Threads{}, err
@@ -172,17 +180,22 @@ func wireThreads(ctx context.Context) (Threads, error) {
 }
 
 func wireK8sClient(ctx context.Context) (k8s.Client, error) {
-	envOrError := k8s.ProvideEnvOrError(ctx)
-	client, err := k8s.ProvideK8sClient(ctx, envOrError)
+	clientConfig := k8s.ProvideClientConfig()
+	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return nil, err
 	}
+	env := k8s.ProvideEnv(kubeContext)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
+	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	return client, nil
 }
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.ProvideEnvOrError, k8s.ProideEnv, k8s.DetectNodeIP, k8s.ProvideK8sClient)
+var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideKubeContext, k8s.ProvideClientConfig, k8s.ProvideRESTConfig, k8s.ProvideCoreInterface, k8s.ProvidePortForwarder, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideK8sClient)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, server.ProvideHeadsUpServer, provideThreads,

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -103,38 +103,27 @@ var _ Client = K8sClient{}
 
 type PortForwarder func(ctx context.Context, restConfig *rest.Config, core apiv1.CoreV1Interface, namespace string, podID PodID, localPort int, remotePort int) (closer func(), err error)
 
-func ProvideK8sClient(ctx context.Context, envOrErr EnvOrError) (Client, error) {
-	env := envOrErr.Env
-	if env == EnvNone {
-		// No k8s, so no need to get any further configs
-		return &explodingClient{err: envOrErr.Err}, nil
-	}
-
-	loader := ProvideClientConfig()
-	config, err := ProvideRESTConfig(loader)
-	if err != nil {
-		return K8sClient{}, err
-	}
-	namespace, err := ProvideConfigNamespace(loader)
-	if err != nil {
-		return K8sClient{}, err
-	}
-	coreV1Interface, err := ProvideRESTClient(config)
-	if err != nil {
-		return K8sClient{}, err
-	}
-	portForwarder := ProvidePortForwarder()
-	k8sClient := NewK8sClient(ctx, env, coreV1Interface, config, portForwarder, namespace)
-	return k8sClient, nil
-}
-
-func NewK8sClient(
+func ProvideK8sClient(
 	ctx context.Context,
 	env Env,
-	core apiv1.CoreV1Interface,
-	restConfig *rest.Config,
 	pf PortForwarder,
-	configNamespace Namespace) K8sClient {
+	configNamespace Namespace,
+	runner kubectlRunner,
+	clientLoader clientcmd.ClientConfig) Client {
+	if env == EnvNone {
+		// No k8s, so no need to get any further configs
+		return &explodingClient{err: fmt.Errorf("Kubernetes context not set")}
+	}
+
+	restConfig, err := ProvideRESTConfig(clientLoader)
+	if err != nil {
+		return &explodingClient{err: err}
+	}
+
+	core, err := ProvideCoreInterface(restConfig)
+	if err != nil {
+		return &explodingClient{err: err}
+	}
 
 	// TODO(nick): I'm not happy about the way that pkg/browser uses global writers.
 	writer := logger.Get(ctx).Writer(logger.DebugLvl)
@@ -143,7 +132,7 @@ func NewK8sClient(
 
 	return K8sClient{
 		env:             env,
-		kubectlRunner:   realKubectlRunner{},
+		kubectlRunner:   runner,
 		core:            core,
 		restConfig:      restConfig,
 		portForwarder:   pf,
@@ -240,7 +229,7 @@ func (k K8sClient) Upsert(ctx context.Context, entities []K8sEntity) error {
 }
 
 func (k K8sClient) ConnectedToCluster(ctx context.Context) error {
-	stdout, stderr, err := k.kubectlRunner.exec(ctx, k.kubeContext, []string{"cluster-info"})
+	stdout, stderr, err := k.kubectlRunner.exec(ctx, []string{"cluster-info"})
 	if err != nil {
 		return errors.Wrapf(err, "Unable to connect to cluster via `kubectl cluster-info`:\nstdout: %s\nstderr: %s", stdout, stderr)
 	}
@@ -286,19 +275,10 @@ func (k K8sClient) actOnEntities(ctx context.Context, cmdArgs []string, entities
 	}
 	stdin := bytes.NewReader([]byte(rawYAML))
 
-	return k.kubectlRunner.execWithStdin(ctx, k.kubeContext, args, stdin)
+	return k.kubectlRunner.execWithStdin(ctx, args, stdin)
 }
 
 func ProvideCoreInterface(cfg *rest.Config) (apiv1.CoreV1Interface, error) {
-	clientSet, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientSet.CoreV1(), nil
-}
-
-func ProvideRESTClient(cfg *rest.Config) (apiv1.CoreV1Interface, error) {
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -320,23 +300,25 @@ func ProvideClientConfig() clientcmd.ClientConfig {
 // The namespace in the kubeconfig.
 // Used as a default namespace in some (but not all) client commands.
 // https://godoc.org/k8s.io/client-go/tools/clientcmd/api/v1#Context
-func ProvideConfigNamespace(clientLoader clientcmd.ClientConfig) (Namespace, error) {
+func ProvideConfigNamespace(clientLoader clientcmd.ClientConfig) Namespace {
 	namespace, explicit, err := clientLoader.Namespace()
 	if err != nil {
-		return "", errors.Wrap(err, "could not get namespace")
+		// If we can't get a namespace from the config, just fail gracefully to the default.
+		// If this error indicates a more serious problem, it will get handled downstream.
+		return ""
 	}
 
 	// TODO(nick): Right now, tilt doesn't provide a namespace flag. If we ever did,
 	// we would need to handle explicit namespaces different than implicit ones.
 	_ = explicit
 
-	return Namespace(namespace), nil
+	return Namespace(namespace)
 }
 
 func ProvideRESTConfig(clientLoader clientcmd.ClientConfig) (*rest.Config, error) {
 	config, err := clientLoader.ClientConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get config")
+		return nil, err
 	}
 	return config, nil
 }

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -30,7 +30,7 @@ func TestUpsert(t *testing.T) {
 	err = f.client.Upsert(f.ctx, postgres)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(f.runner.calls))
-	assert.Equal(t, []string{"--context=unknown", "apply", "-f", "-"}, f.runner.calls[0].argv)
+	assert.Equal(t, []string{"apply", "-f", "-"}, f.runner.calls[0].argv)
 }
 
 func TestUpsertStatefulsetForbidden(t *testing.T) {
@@ -42,8 +42,8 @@ func TestUpsertStatefulsetForbidden(t *testing.T) {
 	err = f.client.Upsert(f.ctx, postgres)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(f.runner.calls))
-	assert.Equal(t, []string{"--context=unknown", "apply", "-f", "-"}, f.runner.calls[0].argv)
-	assert.Equal(t, []string{"--context=unknown", "replace", "--force", "-f", "-"}, f.runner.calls[1].argv)
+	assert.Equal(t, []string{"apply", "-f", "-"}, f.runner.calls[0].argv)
+	assert.Equal(t, []string{"replace", "--force", "-f", "-"}, f.runner.calls[1].argv)
 }
 
 type call struct {
@@ -59,12 +59,11 @@ type fakeKubectlRunner struct {
 	calls []call
 }
 
-func (f *fakeKubectlRunner) execWithStdin(ctx context.Context, kubeContext KubeContext, args []string, stdin io.Reader) (stdout string, stderr string, err error) {
+func (f *fakeKubectlRunner) execWithStdin(ctx context.Context, args []string, stdin io.Reader) (stdout string, stderr string, err error) {
 	b, err := ioutil.ReadAll(stdin)
 	if err != nil {
 		return "", "", errors.Wrap(err, "reading stdin")
 	}
-	args = prependKubeContext(kubeContext, args)
 	f.calls = append(f.calls, call{argv: args, stdin: string(b)})
 
 	defer func() {
@@ -75,8 +74,7 @@ func (f *fakeKubectlRunner) execWithStdin(ctx context.Context, kubeContext KubeC
 	return f.stdout, f.stderr, f.err
 }
 
-func (f *fakeKubectlRunner) exec(ctx context.Context, kubeContext KubeContext, args []string) (stdout string, stderr string, err error) {
-	args = prependKubeContext(kubeContext, args)
+func (f *fakeKubectlRunner) exec(ctx context.Context, args []string) (stdout string, stderr string, err error) {
 	f.calls = append(f.calls, call{argv: args})
 	defer func() {
 		f.stdout = ""

--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -1,13 +1,10 @@
 package k8s
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/windmilleng/tilt/internal/logger"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type Env string
@@ -25,40 +22,17 @@ func (e Env) IsLocalCluster() bool {
 	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s
 }
 
-// If something goes wrong getting k8s Env, we want to hold onto err in case we need to
-// surface for debugging, but it might be an expected case so we don't want to stop wiring.
-type EnvOrError struct {
-	Env Env
-	Err error
+func ProvideEnv(kubeContext KubeContext) Env {
+	return EnvFromString(string(kubeContext))
 }
 
-func ProvideEnvOrError(ctx context.Context) EnvOrError {
-	kubeContext, err := detectKubeContext()
+func ProvideKubeContext(clientLoader clientcmd.ClientConfig) (KubeContext, error) {
+	access := clientLoader.ConfigAccess()
+	config, err := access.GetStartingConfig()
 	if err != nil {
-		logger.Get(ctx).Debugf(err.Error())
-		return EnvOrError{
-			Env: EnvNone,
-			Err: err,
-		}
+		return "", errors.Wrap(err, "Loading Kubernetes current-context")
 	}
-	return EnvOrError{Env: EnvFromString(string(kubeContext))}
-}
-
-func detectKubeContext() (KubeContext, error) {
-	cmd := exec.Command("kubectl", "config", "current-context")
-	outputBytes, err := cmd.Output()
-
-	if err != nil {
-		exitErr, isExit := err.(*exec.ExitError)
-		if isExit {
-			return KubeContext(""), fmt.Errorf("DetectKubeContext failed. Output:\n%s", string(exitErr.Stderr))
-		} else {
-			return KubeContext(""), errors.Wrap(err, "DetectKubeContext failed")
-		}
-	}
-
-	output := strings.TrimSpace(string(outputBytes))
-	return KubeContext(output), nil
+	return KubeContext(config.CurrentContext), nil
 }
 
 func EnvFromString(s string) Env {
@@ -76,8 +50,4 @@ func EnvFromString(s string) Env {
 		return EnvGKE
 	}
 	return EnvUnknown
-}
-
-func ProideEnv(envOrErr EnvOrError) Env {
-	return envOrErr.Env
 }


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/kubecontext:

7d4b489451493b89e2a667adafd97ac40d4850ff (2019-02-11 16:27:14 -0500)
k8s: pull context from the k8s api instead of from the cli, and capture namespace in kubectlRunner