### PR TITLE
engine: allow explicit k8s_resource with just yaml, no image, to appear in hud, get logs, etc. [ch1457]

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -54,7 +54,7 @@ func (ibd *ImageBuildAndDeployer) SetInjectSynclet(inject bool) {
 
 func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (resultSet store.BuildResultSet, err error) {
 	iTargets, kTargets := extractImageAndK8sTargets(specs)
-	if len(kTargets) == 0 || len(iTargets) == 0 {
+	if len(kTargets) == 0 && len(iTargets) == 0 {
 		return store.BuildResultSet{}, RedirectToNextBuilderf("ImageBuildAndDeployer does not support these specs")
 	}
 
@@ -85,6 +85,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 	results := store.BuildResultSet{}
 
 	var refs []reference.NamedTagged
+
 	var anyFastBuild bool
 	for _, iTarget := range iTargets {
 		ref, err := ibd.icb.Build(ctx, iTarget, stateSet[iTarget.ID()], ps, ibd.canSkipPush())
@@ -98,6 +99,8 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		anyFastBuild = anyFastBuild || iTarget.IsFastBuild()
 	}
 
+	// (If we pass an empty list of refs here (as we will do if only deploying
+	// yaml), we just don't inject any image refs into the yaml, nbd.
 	err = ibd.deploy(ctx, st, ps, kTargets, refs, anyFastBuild)
 	if err != nil {
 		return store.BuildResultSet{}, err

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -151,8 +151,6 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 		buildID = call.image().ID()
 		buildImageRef = call.image().Ref
 
-	} else {
-		b.t.Fatalf("Invalid call: %+v", call)
 	}
 
 	ids := []model.TargetID{}
@@ -191,7 +189,9 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 	}
 
 	result := store.BuildResultSet{}
-	result[buildID] = b.nextBuildResult(buildImageRef)
+	if !buildID.Empty() {
+		result[buildID] = b.nextBuildResult(buildImageRef)
+	}
 
 	return result, nil
 }
@@ -1110,6 +1110,64 @@ func TestPodEventContainerStatus(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestPodEventContainerStatusWithoutImage(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+	manifest := model.Manifest{
+		Name: model.ManifestName("foobar"),
+	}.WithDeployTarget(model.K8sTarget{
+		YAML: "fake-yaml",
+	})
+	deployID := model.DeployID(123)
+	f.b.nextDeployID = deployID
+	ref := container.MustParseNamedTagged("dockerhub/we-didnt-build-this:foo")
+	f.Start([]model.Manifest{manifest}, true)
+
+	f.WaitUntilManifestState("first build complete", "foobar", func(ms store.ManifestState) bool {
+		return len(ms.BuildHistory) > 0
+	})
+
+	pod := f.testPodWithDeployID("my-pod", "foobar", "Running", testContainer, time.Now(), deployID)
+	pod.Status = k8s.FakePodStatus(ref, "Running")
+
+	// If we have no image target to match container status by image ref,
+	// we should just take the first one, i.e. this one
+	pod.Status.ContainerStatuses[0].Name = "first-container"
+	pod.Status.ContainerStatuses[0].ContainerID = "docker://great-container-id"
+
+	pod.Spec = v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "second-container",
+				Image: "gcr.io/windmill-public-containers/tilt-synclet:latest",
+				Ports: []v1.ContainerPort{{ContainerPort: 9999}},
+			},
+			// we match container spec by NAME, so we'll get this one even tho it comes second.
+			{
+				Name:  "first-container",
+				Image: ref.Name(),
+				Ports: []v1.ContainerPort{{ContainerPort: 8080}},
+			},
+		},
+	}
+
+	f.podEvent(pod)
+
+	podState := store.Pod{}
+	f.WaitUntilManifestState("container status", "foobar", func(ms store.ManifestState) bool {
+		podState = ms.MostRecentPod()
+		return podState.PodID == "my-pod"
+	})
+
+	// If we have no image target to match container by image ref, we just take the first one
+	assert.Equal(t, "great-container-id", string(podState.ContainerID))
+	assert.Equal(t, "first-container", string(podState.ContainerName))
+	assert.Equal(t, []int32{8080}, podState.ContainerPorts)
+
+	err := f.Stop()
+	assert.Nil(t, err)
+}
+
 func TestPodUnexpectedContainerStartsImageBuild(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
@@ -1737,7 +1795,7 @@ func TestNewMountsAreWatched(t *testing.T) {
 		return len(mt.Manifest.ImageTargetAt(0).FastBuildInfo().Mounts) == 2
 	})
 
-	f.PollUntil("watches setup", func() bool {
+	f.PollUntil("watches set up", func() bool {
 		watches, ok := f.fwm.targetWatches[m2.ImageTargetAt(0).ID()]
 		if !ok {
 			return false
@@ -2162,8 +2220,8 @@ func (f *testFixture) Init(action InitAction) {
 		return len(st.ManifestTargets) == len(manifests) && st.WatchMounts == watchMounts
 	})
 
-	f.PollUntil("watches setup", func() bool {
-		return !watchMounts || len(f.fwm.targetWatches) == len(manifests)
+	f.PollUntil("watches set up", func() bool {
+		return !watchMounts || len(f.fwm.targetWatches) == len(watchableTargetsForManifests(manifests))
 	})
 }
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -150,7 +150,8 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 	} else if !call.image().ID().Empty() {
 		buildID = call.image().ID()
 		buildImageRef = call.image().Ref
-
+	} else if call.k8s().Empty() {
+		b.t.Fatalf("Invalid call: %+v", call)
 	}
 
 	ids := []model.TargetID{}

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -232,7 +232,10 @@ func bestLogs(res view.Resource) string {
 		}
 
 		// The last build finished, but the pod hasn't started yet.
-		if res.LastBuild().StartTime.After(k8sInfo.PodCreationTime) {
+		// NOTE(maia): we truncate build state time down to the second b/c
+		// pod creation time is only precise to the second.
+		// TODO(maia): can compare expected/actual DeployID for more accuracy.
+		if res.LastBuild().StartTime.Truncate(time.Second).After(k8sInfo.PodCreationTime) {
 			return res.LastBuild().Log.String()
 		}
 	}

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -115,6 +116,8 @@ type K8sTarget struct {
 	ExtraPodSelectors []labels.Selector
 	ResourceNames     []string
 }
+
+func (k8s K8sTarget) Empty() bool { return reflect.DeepEqual(k8s, K8sTarget{}) }
 
 func (k8s K8sTarget) Validate() error {
 	if k8s.ID().Empty() {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -534,6 +534,17 @@ k8s_resource('explicit_a', image='gcr.io/a', port_forwards=8000)
 	f.assertNextManifest("d", db(image("gcr.io/d")), deployment("d"))
 }
 
+func TestK8sResourceWithoutDockerBuild(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.setupFoo()
+	f.file("Tiltfile", `
+k8s_resource('foo', yaml='foo.yaml', port_forwards=8000)
+`)
+	f.load()
+	f.assertNextManifest("foo", []model.PortForward{{LocalPort: 8000}})
+}
+
 func TestExpandTwoDeploymentsWithSameImage(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @nicks, @dbentley,

Please review the following commits I made in branch maiamcc/explicit-resource-without-build:

9f0a81cb93dd44fe0abd9f1afdddc3f78c6acd36 (2019-02-12 18:28:27 -0500)
make sure logs get into log modal for resource even if redeploy is really fast

9336cf7f783305620846159132d417cf243fad44 (2019-02-12 17:44:58 -0500)
test container matching

43a94866c2121f7eab823d326ad896671a074d49 (2019-02-12 16:49:51 -0500)
port forwarding

d54847b886d33d67ae12b35ae357e1d43e87a653 (2019-02-12 14:57:04 -0500)
ImageBuildAndDeployer can handle calls with only deploy targets, no build targets (i.e. only k8s yaml, no image builds)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics