### PR TITLE
dockerfile: add a printer, to make it easy to make changes to the AST and then re-print it

### DIFF
--- a/internal/dockerfile/ast.go
+++ b/internal/dockerfile/ast.go
@@ -2,7 +2,11 @@ package dockerfile
 
 import (
 	"bytes"
+	"fmt"
+	"io"
+	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/pkg/errors"
 )
@@ -36,4 +40,113 @@ func (a AST) traverseNode(node *parser.Node, visit func(*parser.Node) error) err
 		}
 	}
 	return visit(node)
+}
+
+func (a AST) Print() (Dockerfile, error) {
+	buf := bytes.NewBuffer(nil)
+	currentLine := 1
+	for _, node := range a.result.AST.Children {
+		for currentLine < node.StartLine {
+			_, err := buf.Write([]byte("\n"))
+			if err != nil {
+				return "", err
+			}
+			currentLine++
+		}
+
+		err := a.printNode(node, buf)
+		if err != nil {
+			return "", err
+		}
+
+		currentLine = node.StartLine + 1
+		if node.Next != nil && node.Next.StartLine != 0 {
+			currentLine = node.Next.StartLine + 1
+		}
+	}
+	return Dockerfile(buf.String()), nil
+}
+
+// Loosely adapted from
+// https://github.com/jessfraz/dockfmt/blob/master/format.go
+func (a AST) printNode(node *parser.Node, writer io.Writer) error {
+	cmd := node.Value
+
+	var err error
+	var v string
+	if node.Next != nil {
+		v = node.Next.Value
+	}
+
+	// format per directive
+	switch node.Value {
+	// all the commands that use parseMaybeJSON
+	// https://github.com/moby/buildkit/blob/2ec7d53b00f24624cda0adfbdceed982623a93b3/frontend/dockerfile/parser/parser.go#L152
+	case command.Cmd, command.Entrypoint, command.Run, command.Shell:
+		v, err = fmtCmd(node.Next, node)
+		if err != nil {
+			return err
+		}
+	case command.Label:
+		v = fmtLabel(node.Next)
+	default:
+		v = fmtDefault(node.Next)
+	}
+
+	_, err = fmt.Fprintf(writer, "%s %s\n", strings.ToUpper(cmd), v)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getCmd(n *parser.Node) []string {
+	if n == nil {
+		return nil
+	}
+	cmd := []string{n.Value}
+	if len(n.Flags) > 0 {
+		cmd = append(cmd, n.Flags...)
+	}
+
+	for node := n.Next; node != nil; node = node.Next {
+		cmd = append(cmd, node.Value)
+		if len(node.Flags) > 0 {
+			cmd = append(cmd, node.Flags...)
+		}
+	}
+
+	return cmd
+}
+
+func fmtCmd(node *parser.Node, prevSibling *parser.Node) (string, error) {
+	cmd := getCmd(node)
+
+	if prevSibling.Attributes["json"] {
+		encoded := []string{}
+		for _, c := range cmd {
+			encoded = append(encoded, fmt.Sprintf("%q", c))
+		}
+		return fmt.Sprintf("[%s]", strings.Join(encoded, ", ")), nil
+	}
+
+	return strings.Join(cmd, " "), nil
+}
+
+func fmtDefault(node *parser.Node) string {
+	cmd := getCmd(node)
+	return strings.Join(cmd, " ")
+}
+
+func fmtLabel(node *parser.Node) string {
+	cmd := getCmd(node)
+	assignments := []string{}
+	for i := 0; i < len(cmd); i += 2 {
+		if i+1 < len(cmd) {
+			assignments = append(assignments, fmt.Sprintf("%s=%s", cmd[i], cmd[i+1]))
+		} else {
+			assignments = append(assignments, fmt.Sprintf("%s", cmd[i]))
+		}
+	}
+	return strings.Join(assignments, " ")
 }

--- a/internal/dockerfile/ast_test.go
+++ b/internal/dockerfile/ast_test.go
@@ -1,0 +1,88 @@
+package dockerfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintBasicAST(t *testing.T) {
+	assertPrintSame(t, `
+
+FROM golang:10
+RUN echo hi
+
+
+ADD . .
+
+RUN echo bye
+`)
+}
+
+func TestPrintASTRemovesComments(t *testing.T) {
+	assertPrint(t, `
+# comment
+FROM golang:10
+RUN echo bye
+`, `
+
+FROM golang:10
+RUN echo bye
+`)
+}
+
+func TestPrintCmd(t *testing.T) {
+	assertPrintSame(t, `
+FROM golang:10
+CMD echo bye
+`)
+}
+
+func TestPrintCmdJSON(t *testing.T) {
+	assertPrintSame(t, `
+FROM golang:10
+CMD ["sh", "-c", "echo bye"]
+`)
+}
+
+func TestPrintLabel(t *testing.T) {
+	// Examples taken from
+	// https://docs.docker.com/engine/reference/builder/#label
+	assertPrint(t, `
+LABEL key1=val1 key2=val2
+LABEL "com.example.vendor"="ACME Incorporated"
+LABEL com.example.label-with-value="foo"
+LABEL version="1.0"
+LABEL description="This text illustrates \
+that label-values can span multiple lines."
+`, `
+LABEL key1=val1 key2=val2
+LABEL "com.example.vendor"="ACME Incorporated"
+LABEL com.example.label-with-value="foo"
+LABEL version="1.0"
+LABEL description="This text illustrates that label-values can span multiple lines."
+`)
+}
+
+// Convert the dockerfile into an AST, print it, and then
+// assert that the result is the same as the original.
+func assertPrintSame(t *testing.T, original string) {
+	assertPrint(t, original, original)
+}
+
+// Convert the dockerfile into an AST, print it, and then
+// assert that the result is as expected.
+func assertPrint(t *testing.T, original, expected string) {
+	df := Dockerfile(original)
+	ast, err := ParseAST(df)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := ast.Print()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected, string(actual))
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/dockerfileprinter2:

cb4f86ec57d6ef7f22cc1454fa7976e495e50044 (2019-02-14 17:25:44 -0500)
dockerfile: add a printer, to make it easy to make changes to the AST and then re-print it

8284661cce48abf8a97ae52076955f91c021546a (2019-02-14 17:25:44 -0500)
dockerfile: refactor into AST type