### PR TITLE
dockerfile: add a helper function for injecting an image digest into a dockerfile

### DIFF
--- a/internal/dockerfile/inject.go
+++ b/internal/dockerfile/inject.go
@@ -1,0 +1,46 @@
+package dockerfile
+
+import (
+	"github.com/docker/distribution/reference"
+	"github.com/moby/buildkit/frontend/dockerfile/command"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+func InjectImageDigest(df Dockerfile, ref reference.NamedTagged) (Dockerfile, bool, error) {
+	ast, err := ParseAST(df)
+	if err != nil {
+		return "", false, err
+	}
+
+	modified := false
+	err = ast.Traverse(func(node *parser.Node) error {
+		if node.Value != command.From || node.Next == nil {
+			return nil
+		}
+
+		val := node.Next.Value
+		fromRef, err := reference.ParseNormalizedNamed(val)
+		if err != nil {
+			// ignore the error
+			return nil
+		}
+
+		if fromRef.Name() == ref.Name() {
+			node.Next.Value = ref.String()
+			modified = true
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", false, err
+	}
+
+	if !modified {
+		return df, false, nil
+	}
+
+	newDf, err := ast.Print()
+	return newDf, true, err
+}

--- a/internal/dockerfile/inject_test.go
+++ b/internal/dockerfile/inject_test.go
@@ -1,0 +1,53 @@
+package dockerfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/container"
+)
+
+func TestInjectUntagged(t *testing.T) {
+	df := Dockerfile(`
+FROM gcr.io/windmill/foo
+ADD . .
+`)
+	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
+	newDf, modified, err := InjectImageDigest(df, ref)
+	if assert.NoError(t, err) {
+		assert.True(t, modified)
+		assert.Equal(t, `
+FROM gcr.io/windmill/foo:deadbeef
+ADD . .
+`, string(newDf))
+	}
+}
+
+func TestInjectTagged(t *testing.T) {
+	df := Dockerfile(`
+FROM gcr.io/windmill/foo:v1
+ADD . .
+`)
+	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
+	newDf, modified, err := InjectImageDigest(df, ref)
+	if assert.NoError(t, err) {
+		assert.True(t, modified)
+		assert.Equal(t, `
+FROM gcr.io/windmill/foo:deadbeef
+ADD . .
+`, string(newDf))
+	}
+}
+
+func TestInjectNoMatch(t *testing.T) {
+	df := Dockerfile(`
+FROM gcr.io/windmill/bar:v1
+ADD . .
+`)
+	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
+	newDf, modified, err := InjectImageDigest(df, ref)
+	if assert.NoError(t, err) {
+		assert.False(t, modified)
+		assert.Equal(t, df, newDf)
+	}
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/inject:

3af357ede2e318c494cb29b22e0e9130f9b493dd (2019-02-14 18:21:03 -0500)
dockerfile: add a helper function for injecting an image digest into a dockerfile