### PR TITLE
dockerfile: fix a bug in the ast printer when the command has flags

### DIFF
--- a/internal/dockerfile/ast_test.go
+++ b/internal/dockerfile/ast_test.go
@@ -64,6 +64,22 @@ LABEL description="This text illustrates that label-values can span multiple lin
 `)
 }
 
+func TestPrintCopyFlags(t *testing.T) {
+	assertPrintSame(t, `
+FROM golang:10
+COPY --from=gcr.io/windmill/image-a /src /src
+RUN echo bye
+`)
+}
+
+func TestPrintCopyFlagsLabel(t *testing.T) {
+	assertPrintSame(t, `
+FROM golang:10
+COPY --from=gcr.io/windmill/image-a:latest /src /src
+RUN echo bye
+`)
+}
+
 // Convert the dockerfile into an AST, print it, and then
 // assert that the result is the same as the original.
 func assertPrintSame(t *testing.T, original string) {


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/astprint:

a40052f2158ac4ccd4c094c9516b8f889bbd7c8e (2019-02-18 13:24:08 -0500)
dockerfile: fix a bug in the ast printer when the command has flags