### PR TITLE
dockerfile: inject into COPY --from

### DIFF
--- a/internal/dockerfile/dockerfile_test.go
+++ b/internal/dockerfile/dockerfile_test.go
@@ -159,3 +159,12 @@ func TestFindImagesWeirdSyntax(t *testing.T) {
 		assert.Equal(t, "docker.io/library/a", images[0].String())
 	}
 }
+
+func TestFindImagesCopyFrom(t *testing.T) {
+	df := Dockerfile(`COPY --from=gcr.io/image-a /srcA/package.json /srcB/package.json`)
+	images, err := df.FindImages()
+	assert.NoError(t, err)
+	if assert.Equal(t, 1, len(images)) {
+		assert.Equal(t, "gcr.io/image-a", images[0].String())
+	}
+}


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/copyfrom:

d7cd67abc3d66439988afb0c5da58c5a9457f080 (2019-02-18 15:23:45 -0500)
dockerfile: inject into COPY --from

324ce6fd5201b030c358ee6d576df48eb6456ac5 (2019-02-18 13:37:00 -0500)
vendor: buildkit instruction parser (#1174)

734db2dd537e25d7ce9ad37c72bb51b48d56acf3 (2019-02-18 13:28:32 -0500)
dockerfile: fix a bug in the ast printer when the command has flags