### PR TITLE
hud: colors for ErrImagePull and ImagePullBackOff

### DIFF
--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -54,6 +54,8 @@ var statusColors = map[string]tcell.Color{
 	"Pending":                          cPending,
 	"Error":                            cBad,
 	"CrashLoopBackOff":                 cBad,
+	"ErrImagePull":                     cBad,
+	"ImagePullBackOff":                 cBad,
 	string(dockercompose.StatusInProg): cPending,
 	string(dockercompose.StatusUp):     cGood,
 	string(dockercompose.StatusDown):   cBad,


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/more-k8s-statuses:

7d55bae04e3e4d148d24c67835902c2dab15ed04 (2019-02-19 15:15:51 -0500)
hud: colors for ErrImagePull and ImagePullBackOff

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics