### PR TITLE
tiltfile func to filter yaml by label(s) [ch1626]

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -195,8 +195,12 @@ func FilterByImage(entities []K8sEntity, img reference.Named) (passing, rest []K
 	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img) })
 }
 
-func FilterByLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.MatchesLabels(labels), nil })
+func FilterBySelectorMatchesLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.SelectorMatchesLabels(labels), nil })
+}
+
+func FilterByMetadataLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.MatchesMetadataLabels(labels) })
 }
 
 func FilterByHasPodTemplateSpec(entities []K8sEntity) (passing, rest []K8sEntity, err error) {
@@ -222,7 +226,7 @@ func FilterByMatchesPodTemplateSpec(withPodSpec K8sEntity, entities []K8sEntity)
 	var allMatches []K8sEntity
 	remaining := append([]K8sEntity{}, entities...)
 	for _, template := range podTemplates {
-		match, rest, err := FilterByLabels(remaining, template.Labels)
+		match, rest, err := FilterBySelectorMatchesLabels(remaining, template.Labels)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "filtering entities by label")
 		}

--- a/internal/k8s/entity_benchmark_test.go
+++ b/internal/k8s/entity_benchmark_test.go
@@ -1,0 +1,67 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+	"github.com/windmilleng/tilt/internal/yaml"
+)
+
+func BenchmarkParseUnparseSingle(b *testing.B) {
+	run := func() {
+		entities, err := ParseYAMLFromString(testyaml.PodYAML)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = SerializeYAML(entities)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		run()
+	}
+}
+
+func BenchmarkParseUnparseLonger(b *testing.B) {
+	bigYaml := makeBigYaml(25)
+	run := func() {
+		entities, err := ParseYAMLFromString(bigYaml)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = SerializeYAML(entities)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		run()
+	}
+}
+
+func BenchmarkParseUnparseLongest(b *testing.B) {
+	bigYaml := makeBigYaml(100)
+
+	run := func() {
+		entities, err := ParseYAMLFromString(bigYaml)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = SerializeYAML(entities)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		run()
+	}
+}
+
+func makeBigYaml(n int) string {
+	strs := make([]string, n)
+	for i := 0; i < n; i++ {
+		strs[i] = testyaml.PodYAML
+	}
+	return yaml.ConcatYAML(strs...)
+}

--- a/internal/k8s/label.go
+++ b/internal/k8s/label.go
@@ -129,10 +129,10 @@ func allowLabelChangesInExtDeploymentBeta1(dep *extv1beta1.Deployment) {
 	dep.Spec.Selector.MatchLabels = matchLabels
 }
 
-// MatchesLevel indicates whether the selector of the given entity matches the given label(s).
+// SelectorMatchesLabels indicates whether the pod selector of the given entity matches the given label(s).
 // Currently only supports Services, but may be expanded to support other types that
 // match pods via selectors.
-func (e K8sEntity) MatchesLabels(labels map[string]string) bool {
+func (e K8sEntity) SelectorMatchesLabels(labels map[string]string) bool {
 	svc, ok := e.Obj.(*v1.Service)
 	if !ok {
 		return false
@@ -145,5 +145,26 @@ func (e K8sEntity) MatchesLabels(labels map[string]string) bool {
 		}
 	}
 	return true
+
+}
+
+// MatchesMetadataLabels indicates whether the given label(s) are a subset
+// of metadata labels for the given entity.
+func (e K8sEntity) MatchesMetadataLabels(labels map[string]string) (bool, error) {
+	metas, err := extractObjectMetas(&e)
+	if err != nil {
+		return false, err
+	}
+
+	for _, meta := range metas {
+		for k, v := range labels {
+			realVal, ok := meta.Labels[k]
+			if !ok || realVal != v {
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
 
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -86,6 +86,7 @@ const (
 
 	// k8s functions
 	k8sYamlN     = "k8s_yaml"
+	filterYamlN  = "filter_yaml"
 	k8sResourceN = "k8s_resource"
 	portForwardN = "port_forward"
 
@@ -121,6 +122,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	addBuiltin(r, dockerComposeN, s.dockerCompose)
 	addBuiltin(r, dcResourceN, s.dcResource)
 	addBuiltin(r, k8sYamlN, s.k8sYaml)
+	addBuiltin(r, filterYamlN, s.filterYaml)
 	addBuiltin(r, k8sResourceN, s.k8sResource)
 	addBuiltin(r, portForwardN, s.portForward)
 	addBuiltin(r, localGitRepoN, s.localGitRepo)


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/split-out-yaml:

55b701d6041bc2dda17c6e10349aecf5c6a3dc53 (2019-02-20 16:38:02 -0500)
tiltfile func to filter yaml by label

2c69e3cbe075ea0c76669842604ef4a2522d3702 (2019-02-20 16:28:03 -0500)
metadata label match funcs

a0f31ff53c0063a1c51f0ed9a23f4b6001c44616 (2019-02-20 14:51:58 -0500)
benchmark parse/unparse yaml

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics