### PR TITLE
tiltfile: make use of Yaml type instead of blob

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -281,7 +281,8 @@ func (s *tiltfileState) yamlEntitiesFromSkylarkValue(v starlark.Value) ([]k8s.K8
 	case nil:
 		return nil, nil
 	case *blob:
-		return k8s.ParseYAMLFromString(v.String())
+		// NOTE(Maia): return a specific err b/c this is a recent compatibility change (Feb. 20th 2019)
+		return nil, fmt.Errorf("`Blob` is no longer a valid YAML format: please wrap with `yaml(my_blob)`")
 	case *yamlValue:
 		return k8s.ParseYAMLFromString(v.String())
 	default:

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -296,7 +296,7 @@ func TestLocal(t *testing.T) {
 
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo')
-yaml = local('cat foo.yaml')
+yaml = yaml(local('cat foo.yaml'))
 k8s_resource('foo', yaml)
 `)
 
@@ -307,6 +307,21 @@ k8s_resource('foo', yaml)
 		deployment("foo"))
 }
 
+func TestBlobAsYamlErr(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+
+	f.file("Tiltfile", `
+docker_build('gcr.io/foo', 'foo')
+yaml = local('cat foo.yaml')
+k8s_resource('foo', yaml)
+`)
+
+	f.loadErrString("no longer a valid YAML format")
+}
+
 func TestReadFile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -315,7 +330,7 @@ func TestReadFile(t *testing.T) {
 
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo')
-yaml = read_file('foo.yaml')
+yaml = yaml(read_file('foo.yaml'))
 k8s_resource('foo', yaml)
 `)
 
@@ -1168,7 +1183,7 @@ func TestBlobErr(t *testing.T) {
 		`k8s_yaml(yaml(42))`,
 	)
 
-	f.loadErrString("for parameter 1: got int, want string")
+	f.loadErrString("got int, want string or Blob")
 }
 
 func TestImageDependency(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan, @nicks,

Please review the following commits I made in branch maiamcc/return-yaml:

1e79b0d02d81ee7da65eeef36c4a18e81cc9dbf7 (2019-02-20 18:09:38 -0500)
tiltfile: make use of Yaml type instead of blob

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics