### PR TITLE
container: normalize all image names

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -22,7 +22,7 @@ func (id ID) ShortStr() string {
 func (n Name) String() string { return string(n) }
 
 func ParseNamedTagged(s string) (reference.NamedTagged, error) {
-	ref, err := reference.Parse(s)
+	ref, err := reference.ParseNormalizedNamed(s)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing %s", s)
 	}
@@ -43,7 +43,7 @@ func MustParseNamedTagged(s string) reference.NamedTagged {
 }
 
 func MustParseNamed(s string) reference.Named {
-	n, err := reference.ParseNamed(s)
+	n, err := reference.ParseNormalizedNamed(s)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/dockerfile/inject_test.go
+++ b/internal/dockerfile/inject_test.go
@@ -87,3 +87,21 @@ ADD . .
 `, string(newDf))
 	}
 }
+
+func TestInjectCopyNormalizedNames(t *testing.T) {
+	df := Dockerfile(`
+FROM golang:1.10
+COPY --from=vandelay/common /usr/src/common/package.json /usr/src/common/yarn.lock /usr/src/common/
+ADD . .
+`)
+	ref := container.MustParseNamedTagged("vandelay/common:deadbeef")
+	newDf, modified, err := InjectImageDigest(df, ref)
+	if assert.NoError(t, err) {
+		assert.True(t, modified)
+		assert.Equal(t, `
+FROM golang:1.10
+COPY --from="docker.io/vandelay/common:deadbeef" /usr/src/common/package.json /usr/src/common/yarn.lock /usr/src/common/
+ADD . .
+`, string(newDf))
+	}
+}

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -92,7 +92,15 @@ func podMap(podList *v1.PodList) map[string][]v1.Pod {
 	ip := make(map[string][]v1.Pod, 0)
 	for _, p := range podList.Items {
 		for _, c := range p.Spec.Containers {
-			ip[c.Image] = append(ip[c.Image], p)
+			imgRef := c.Image
+
+			// normalize the image name
+			ref, err := reference.ParseNormalizedNamed(imgRef)
+			if err == nil {
+				imgRef = ref.String()
+			}
+
+			ip[imgRef] = append(ip[imgRef], p)
 		}
 	}
 	return ip

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1239,6 +1239,29 @@ k8s_yaml('foo.yaml')
 	}, f.imageTargetNames(m))
 }
 
+func TestImageDependencyNormalization(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.gitInit("")
+	f.file("common.dockerfile", "FROM golang:1.10")
+	f.file("auth.dockerfile", "FROM vandelay/common")
+	f.yaml("auth.yaml", deployment("auth", image("vandelay/auth")))
+	f.file("Tiltfile", `
+docker_build('vandelay/common', '.', dockerfile='common.dockerfile')
+docker_build('vandelay/auth', '.', dockerfile='auth.dockerfile')
+k8s_yaml('auth.yaml')
+`)
+
+	f.load()
+
+	m := f.assertNextManifest("auth", deployment("auth"))
+	assert.Equal(t, []string{
+		"docker.io/vandelay/common",
+		"docker.io/vandelay/auth",
+	}, f.imageTargetNames(m))
+}
+
 func TestImageRefSuggestion(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/normalize:

f5fd5172aebf279d6675375172863bb925c2aae7 (2019-02-21 12:43:07 -0500)
container: normalize all image names