### PR TITLE
tiltfile: logline for finished tiltfile exec

### DIFF
--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -70,6 +70,9 @@ func (s *tiltfileState) exec() error {
 
 	s.logger.Printf("Beginning Tiltfile execution")
 	_, err := starlark.ExecFile(thread, s.filename.path, nil, s.builtins())
+	if err == nil {
+		s.logger.Printf("Successfully executed Tiltfile")
+	}
 	return err
 }
 


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch end-tiltfile-exec-log:

4f5cc2278fa13bf0fb09f821d867c9eb56725242 (2019-02-21 15:20:20 -0500)
tiltfile: logline for finished tiltfile exec

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics