### PR TITLE
dockerfile: fix a minor bug in how images were injected into the AST

### DIFF
--- a/internal/dockerfile/ast.go
+++ b/internal/dockerfile/ast.go
@@ -70,7 +70,7 @@ func (a AST) traverseImageRefs(visitor func(node *parser.Node, ref reference.Nam
 			if newRef != nil {
 				for i, flag := range node.Flags {
 					if strings.HasPrefix(flag, "--from=") {
-						node.Flags[i] = fmt.Sprintf("--from=%q", newRef.String())
+						node.Flags[i] = fmt.Sprintf("--from=%s", newRef.String())
 					}
 				}
 			}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/twice:

6628e1baa695f36afea0bb6bacdc9df184cb292b (2019-02-21 15:36:51 -0500)
dockerfile: fix a minor bug in how images were injected into the AST
quoting happens at AST-parsing time, not Instruction-parsing time

There's a separate bug here of "why are we trying to inject this image twice" that i also need to look into