### PR TITLE
analytics: count number of unbuilt resources [ch1651]

### DIFF
--- a/internal/engine/analytics_reporter.go
+++ b/internal/engine/analytics_reporter.go
@@ -52,10 +52,13 @@ func ProvideAnalyticsReporter(a analytics.Analytics, st *store.Store) *Analytics
 func (ar *AnalyticsReporter) report() {
 	st := ar.store.RLockState()
 	defer ar.store.RUnlockState()
-	var dcCount, k8sCount, fastbuildCount int
+	var dcCount, k8sCount, fastbuildCount, unbuiltCount int
 	for _, m := range st.Manifests() {
 		if m.IsK8s() {
 			k8sCount++
+			if len(m.ImageTargets) == 0 {
+				unbuiltCount++
+			}
 		}
 		if m.IsDC() {
 			dcCount++
@@ -82,6 +85,7 @@ func (ar *AnalyticsReporter) report() {
 		stats["resource.dockercompose.count"] = strconv.Itoa(dcCount)
 		stats["resource.k8s.count"] = strconv.Itoa(k8sCount)
 		stats["resource.fastbuild.count"] = strconv.Itoa(fastbuildCount)
+		stats["resource.unbuiltresources.count"] = strconv.Itoa(unbuiltCount)
 	}
 
 	stats["tiltfile.error"] = tiltfileIsInError

--- a/internal/engine/analytics_reporter_test.go
+++ b/internal/engine/analytics_reporter_test.go
@@ -17,15 +17,15 @@ import (
 func TestAnalyticsReporter_Everything(t *testing.T) {
 	tf := newAnalyticsReporterTestFixture()
 
-	tf.addManifest(tf.nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.FastBuild{}}))
-	tf.addManifest(tf.nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.StaticBuild{}}))
-	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))
-	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))
-	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))
-	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))
-	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))
-	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))
-	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))
+	tf.addManifest(tf.nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.FastBuild{}}))   // k8s, fastbuild
+	tf.addManifest(tf.nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.StaticBuild{}})) // k8s
+	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))                                   // k8s, unbuilt
+	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))                                   // k8s, unbuilt
+	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))                                   // k8s, unbuilt
+	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))                         // dc
+	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))                         // dc
+	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))                         // dc
+	tf.addManifest(tf.nextManifest().WithDeployTarget(model.DockerComposeTarget{}))                         // dc
 
 	state := tf.ar.store.LockMutableStateForTesting()
 	state.TiltStartTime = time.Now()
@@ -37,13 +37,14 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 	tf.run()
 
 	expectedTags := map[string]string{
-		"builds.completed_count":       "3",
-		"resource.count":               "9",
-		"resource.dockercompose.count": "4",
-		"resource.fastbuild.count":     "1",
-		"resource.k8s.count":           "3",
-		"tiltfile.error":               "false",
-		"up.starttime":                 state.TiltStartTime.Format(time.RFC3339),
+		"builds.completed_count":          "3",
+		"resource.count":                  "9",
+		"resource.dockercompose.count":    "4",
+		"resource.unbuiltresources.count": "3",
+		"resource.fastbuild.count":        "1",
+		"resource.k8s.count":              "3",
+		"tiltfile.error":                  "false",
+		"up.starttime":                    state.TiltStartTime.Format(time.RFC3339),
 	}
 
 	tf.assertStats(t, expectedTags)


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/unbuilt-resources-stats:

73b3be842c24558de140867f39b3afdcbf9e2add (2019-02-21 15:55:19 -0500)
analytics: count number of unbuilt resources (k8s resources w/o image targets)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics