### PR TITLE
tiltfile: when building manifests, de-dupe dependencies

### DIFF
--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -65,7 +65,7 @@ func (t DockerComposeTarget) LocalPaths() []string {
 }
 
 func (t DockerComposeTarget) WithDependencyIDs(ids []TargetID) DockerComposeTarget {
-	t.dependencyIDs = ids
+	t.dependencyIDs = DedupeTargetIDs(ids)
 	return t
 }
 
@@ -156,7 +156,7 @@ func (k8s K8sTarget) ID() TargetID {
 }
 
 func (k8s K8sTarget) WithDependencyIDs(ids []TargetID) K8sTarget {
-	k8s.dependencyIDs = ids
+	k8s.dependencyIDs = DedupeTargetIDs(ids)
 	return k8s
 }
 

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -44,7 +44,7 @@ func (i ImageTarget) DependencyIDs() []TargetID {
 }
 
 func (i ImageTarget) WithDependencyIDs(ids []TargetID) ImageTarget {
-	i.dependencyIDs = ids
+	i.dependencyIDs = DedupeTargetIDs(ids)
 	return i
 }
 

--- a/internal/model/target.go
+++ b/internal/model/target.go
@@ -69,3 +69,16 @@ type Target interface {
 	Spec() TargetSpec
 	Status() TargetStatus
 }
+
+// De-duplicate target ids, maintaining the same order.
+func DedupeTargetIDs(ids []TargetID) []TargetID {
+	result := make([]TargetID, 0, len(ids))
+	dupes := make(map[TargetID]bool, len(ids))
+	for _, id := range ids {
+		if !dupes[id] {
+			dupes[id] = true
+			result = append(result, id)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/doubledeps:

0627bd991f5a176e71e198ce7312dc717023240a (2019-02-21 17:40:52 -0500)
tiltfile: when building manifests, de-dupe dependencies