### PR TITLE
tiltfile: roll back Yaml type, make blob constructor instead

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -304,7 +304,7 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 		s.recordConfigFile(d)
 	}
 
-	return newYAMLValue(yaml), nil
+	return newBlob(yaml), nil
 }
 
 func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -326,54 +326,17 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 
 	s.recordConfigFile(localPath.path)
 
-	return newYAMLValue(yaml), nil
+	return newBlob(string(yaml)), nil
 }
 
-func (s *tiltfileState) yaml(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var inputValue starlark.Value
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "input", &inputValue)
+func (s *tiltfileState) blob(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var input starlark.String
+	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "input", &input)
 	if err != nil {
 		return nil, err
 	}
-	var input string
-	switch v := inputValue.(type) {
-	case *blob:
-		input = v.text
-	case starlark.String:
-		input = v.GoString()
-	default:
-		return nil, fmt.Errorf("invalid type: got %s, want string or Blob", inputValue.Type())
-	}
 
-	return newYAMLValue(input), nil
-}
-
-type yamlValue struct {
-	contents string
-}
-
-var _ starlark.Value = &yamlValue{}
-
-func newYAMLValue(contents string) *yamlValue {
-	return &yamlValue{contents: contents}
-}
-
-func (y *yamlValue) String() string {
-	return y.contents
-}
-
-func (y *yamlValue) Type() string {
-	return "yaml"
-}
-
-func (y *yamlValue) Freeze() {}
-
-func (y *yamlValue) Truth() starlark.Bool {
-	return len(y.contents) > 0
-}
-
-func (y *yamlValue) Hash() (uint32, error) {
-	return 0, fmt.Errorf("unhashable type: yaml")
+	return newBlob(input.GoString()), nil
 }
 
 func (s *tiltfileState) listdir(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -154,7 +154,7 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 	}
 
 	return starlark.Tuple{
-		newYAMLValue(matchingStr), newYAMLValue(restStr),
+		newBlob(matchingStr), newBlob(restStr),
 	}, nil
 }
 
@@ -328,9 +328,6 @@ func (s *tiltfileState) yamlEntitiesFromSkylarkValue(v starlark.Value) ([]k8s.K8
 	case nil:
 		return nil, nil
 	case *blob:
-		// NOTE(Maia): return a specific err b/c this is a recent compatibility change (Feb. 20th 2019)
-		return nil, fmt.Errorf("`Blob` is no longer a valid YAML format: please wrap with `yaml(my_blob)`")
-	case *yamlValue:
 		return k8s.ParseYAMLFromString(v.String())
 	default:
 		yamlPath, err := s.localPathFromSkylarkValue(v)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -99,11 +99,11 @@ const (
 	readFileN     = "read_file"
 	kustomizeN    = "kustomize"
 	helmN         = "helm"
-	yamlN         = "yaml"
 	listdirN      = "listdir"
 
 	// other functions
 	failN = "fail"
+	blobN = "blob"
 )
 
 func (s *tiltfileState) builtins() starlark.StringDict {
@@ -132,7 +132,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	addBuiltin(r, kustomizeN, s.kustomize)
 	addBuiltin(r, helmN, s.helm)
 	addBuiltin(r, failN, s.fail)
-	addBuiltin(r, yamlN, s.yaml)
+	addBuiltin(r, blobN, s.blob)
 	addBuiltin(r, listdirN, s.listdir)
 
 	s.builtinsMap = r

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -297,7 +297,7 @@ func TestLocal(t *testing.T) {
 
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo')
-yaml = yaml(local('cat foo.yaml'))
+yaml = local('cat foo.yaml')
 k8s_resource('foo', yaml)
 `)
 
@@ -308,21 +308,6 @@ k8s_resource('foo', yaml)
 		deployment("foo"))
 }
 
-func TestBlobAsYamlErr(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupFoo()
-
-	f.file("Tiltfile", `
-docker_build('gcr.io/foo', 'foo')
-yaml = local('cat foo.yaml')
-k8s_resource('foo', yaml)
-`)
-
-	f.loadErrString("no longer a valid YAML format")
-}
-
 func TestReadFile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -331,7 +316,7 @@ func TestReadFile(t *testing.T) {
 
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo')
-yaml = yaml(read_file('foo.yaml'))
+yaml = read_file('foo.yaml')
 k8s_resource('foo', yaml)
 `)
 
@@ -1182,7 +1167,7 @@ func TestBlob(t *testing.T) {
 
 	f.file(
 		"Tiltfile",
-		fmt.Sprintf(`k8s_yaml(yaml('''%s'''))`, testyaml.SnackYaml),
+		fmt.Sprintf(`k8s_yaml(blob('''%s'''))`, testyaml.SnackYaml),
 	)
 
 	f.load()
@@ -1196,10 +1181,10 @@ func TestBlobErr(t *testing.T) {
 
 	f.file(
 		"Tiltfile",
-		`k8s_yaml(yaml(42))`,
+		`blob(42)`,
 	)
 
-	f.loadErrString("got int, want string or Blob")
+	f.loadErrString("for parameter 1: got int, want string")
 }
 
 func TestImageDependency(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan, @dbentley,

Please review the following commits I made in branch maiamcc/no-yaml-constructor:

b670d072c7348ca3a5b36543e04d964d947fbd9b (2019-02-22 14:19:59 -0500)
tiltfile: roll back Yaml type, make blob constructor instead

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics