### PR TITLE
engine: add ConfigsController test

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/k8s"
@@ -36,7 +37,7 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 	})
 	defer analyticsService.Flush(time.Second)
 
-	manifests, globalYaml, _, _, err := tiltfile.Load(ctx, c.fileName, nil, os.Stdout)
+	manifests, globalYaml, _, _, err := tiltfile.NewTiltfileLoader().Load(ctx, c.fileName, nil, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/tiltfile"
+
 	"github.com/docker/docker/api/types"
 	"github.com/google/wire"
 	"k8s.io/apimachinery/pkg/version"
@@ -49,6 +51,8 @@ var BaseWireSet = wire.NewSet(
 	dockercompose.NewDockerComposeClient,
 
 	build.NewImageReaper,
+
+	tiltfile.NewTiltfileLoader,
 
 	engine.DeployerWireSet,
 	engine.NewPodLogManager,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -20,6 +20,7 @@ import (
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/tiltfile"
 	"k8s.io/apimachinery/pkg/version"
 	"time"
 )
@@ -104,7 +105,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(client)
-	configsController := engine.NewConfigsController()
+	tiltfileLoader := tiltfile.NewTiltfileLoader()
+	configsController := engine.NewConfigsController(tiltfileLoader)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
@@ -197,7 +199,8 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
 	globalYAMLBuildController := engine.NewGlobalYAMLBuildController(client)
-	configsController := engine.NewConfigsController()
+	tiltfileLoader := tiltfile.NewTiltfileLoader()
+	configsController := engine.NewConfigsController(tiltfileLoader)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
@@ -330,7 +333,7 @@ func wireDockerEnv(ctx context.Context) (docker.DockerEnv, error) {
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideKubeContext, k8s.ProvideClientConfig, k8s.ProvideClientSet, k8s.ProvideRESTConfig, k8s.ProvidePortForwarder, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, docker.ProvideDockerEnv, docker.ProvideDockerClient, docker.ProvideDockerVersion, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, server.ProvideHeadsUpServer, provideThreads,
+	K8sWireSet, docker.ProvideDockerEnv, docker.ProvideDockerClient, docker.ProvideDockerVersion, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, tiltfile.NewTiltfileLoader, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, server.ProvideHeadsUpServer, provideThreads,
 )
 
 type Threads struct {

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/hud"
@@ -20,8 +23,6 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/tiltfile"
-	"golang.org/x/sync/errgroup"
-	v1 "k8s.io/api/core/v1"
 )
 
 type RepoBranch string
@@ -182,7 +183,7 @@ func (s Script) Run(ctx context.Context) error {
 
 		tfPath := filepath.Join(dir, tiltfile.FileName)
 		// TODO(dmiller): not this?
-		manifests, _, _, warnings, err := tiltfile.Load(ctx, tfPath, nil, os.Stdout)
+		manifests, _, _, warnings, err := tiltfile.NewTiltfileLoader().Load(ctx, tfPath, nil, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/internal/engine/analytics_reporter_test.go
+++ b/internal/engine/analytics_reporter_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -89,10 +88,10 @@ type analyticsReporterTestFixture struct {
 }
 
 func newAnalyticsReporterTestFixture() *analyticsReporterTestFixture {
-	reducer := func(ctx context.Context, engineState *store.EngineState, action store.Action) {}
+	st, _ := store.NewStoreForTesting()
 	ar := AnalyticsReporter{
 		a:       analytics.NewMemoryAnalytics(),
-		store:   store.NewStore(reducer, store.LogActionsFlag(false)),
+		store:   st,
 		started: false,
 	}
 

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/wmclient/pkg/dirs"
+
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
@@ -24,7 +26,6 @@ import (
 	"github.com/windmilleng/tilt/internal/testutils"
 	"github.com/windmilleng/tilt/internal/testutils/output"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
-	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 var testImageRef = container.MustParseNamedTagged("gcr.io/some-project-162817/sancho:deadbeef")
@@ -491,6 +492,8 @@ func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
 		t.Fatal(err)
 	}
 
+	st, _ := store.NewStoreForTesting()
+
 	return &bdFixture{
 		TempDirFixture: f,
 		ctx:            ctx,
@@ -498,7 +501,7 @@ func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
 		k8s:            k8s,
 		sCli:           sCli,
 		bd:             bd,
-		st:             store.NewStoreForTesting(),
+		st:             st,
 	}
 }
 

--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -41,18 +41,17 @@ func TestConfigsController(t *testing.T) {
 
 func (f *ccFixture) run() ConfigsReloadedAction {
 	// configs_controller uses state.RelativeTiltfilePath, which is relative to wd
-	origDir, err := os.Getwd()
-	if err != nil {
-		f.T().Fatalf("error getting wd: %v", err)
-	}
-	err = os.Chdir(f.Path())
+	// sometimes the original directory was invalid (e.g., it was another test's temp dir, which was deleted,
+	// but not changed out of), and if it was already invalid, then let's not worry about it.
+	origDir, _ := os.Getwd()
+	err := os.Chdir(f.Path())
 	if err != nil {
 		f.T().Fatalf("error changing dir: %v", err)
 	}
 	defer func() {
-		// sometimes the original directory was invalid (e.g., it was another test's temp dir, which was deleted,
-		// but not changed out of), so changing back to the original directory will fail, and we probably don't care.
-		_ = os.Chdir(origDir)
+		if origDir != "" {
+			_ = os.Chdir(origDir)
+		}
 	}()
 
 	f.tfl.Manifests = []model.Manifest{{Name: "bar"}}

--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -1,0 +1,100 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+	"github.com/windmilleng/tilt/internal/tiltfile"
+)
+
+func TestConfigsController(t *testing.T) {
+	f := newCCFixture(t)
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{Name: "foo"}
+	mt := store.NewManifestTarget(m)
+	state.UpsertManifestTarget(mt)
+	state.PendingConfigFileChanges["Tiltfile"] = true
+	state.TiltfilePath = f.JoinPath("Tiltfile")
+	f.st.UnlockMutableState()
+
+	a := f.run()
+
+	expected := ConfigsReloadedAction{
+		Manifests:  []model.Manifest{{Name: "bar"}},
+		StartTime:  f.fc.Times[0],
+		FinishTime: f.fc.Times[1],
+	}
+
+	assert.Equal(t, expected, a)
+}
+
+func (f *ccFixture) run() ConfigsReloadedAction {
+	// configs_controller uses state.RelativeTiltfilePath, which is relative to wd
+	origDir, err := os.Getwd()
+	if err != nil {
+		f.T().Fatalf("error getting wd: %v", err)
+	}
+	err = os.Chdir(f.Path())
+	if err != nil {
+		f.T().Fatalf("error changing dir: %v", err)
+	}
+	defer func() {
+		// sometimes the original directory was invalid (e.g., it was another test's temp dir, which was deleted,
+		// but not changed out of), so changing back to the original directory will fail, and we probably don't care.
+		_ = os.Chdir(origDir)
+	}()
+
+	f.tfl.Manifests = []model.Manifest{{Name: "bar"}}
+
+	f.st.NotifySubscribers(f.ctx)
+
+	a := waitForAction(f.T(), reflect.TypeOf(ConfigsReloadedAction{}), f.actions)
+	cra, ok := a.(ConfigsReloadedAction)
+	if !ok {
+		f.T().Fatalf("didn't get an action of type %T", ConfigsReloadedAction{})
+	}
+
+	return cra
+}
+
+type ccFixture struct {
+	*tempdir.TempDirFixture
+	ctx     context.Context
+	cc      *ConfigsController
+	st      *store.Store
+	actions <-chan store.Action
+	tfl     *tiltfile.FakeTiltfileLoader
+	fc      *testutils.FakeClock
+}
+
+func newCCFixture(t *testing.T) *ccFixture {
+	f := tempdir.NewTempDirFixture(t)
+	st, actions := store.NewStoreForTesting()
+	tfl := tiltfile.NewFakeTiltfileLoader()
+	cc := NewConfigsController(tfl)
+	fc := testutils.NewRandomFakeClock()
+	cc.clock = fc.Clock()
+	ctx := output.CtxForTest()
+	st.AddSubscriber(cc)
+	go st.Loop(ctx)
+	return &ccFixture{
+		TempDirFixture: f,
+		ctx:            ctx,
+		cc:             cc,
+		st:             st,
+		actions:        actions,
+		tfl:            tfl,
+		fc:             fc,
+	}
+}

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/wmclient/pkg/dirs"
+
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockercompose"
@@ -13,7 +15,6 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/testutils/output"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
-	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
 var expectedContainer = container.ID("dc-cont")
@@ -122,12 +123,13 @@ func newDCBDFixture(t *testing.T) *dcbdFixture {
 	if err != nil {
 		t.Fatal(err)
 	}
+	st, _ := store.NewStoreForTesting()
 	return &dcbdFixture{
 		TempDirFixture: f,
 		ctx:            ctx,
 		dcCli:          dcCli,
 		dCli:           dCli,
 		dcbad:          dcbad,
-		st:             store.NewStoreForTesting(),
+		st:             st,
 	}
 }

--- a/internal/engine/portforwardcontroller_test.go
+++ b/internal/engine/portforwardcontroller_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
-	"k8s.io/api/core/v1"
 )
 
 func TestPortForward(t *testing.T) {
@@ -99,7 +100,7 @@ type plcFixture struct {
 
 func newPLCFixture(t *testing.T) *plcFixture {
 	f := tempdir.NewTempDirFixture(t)
-	st := store.NewStoreForTesting()
+	st, _ := store.NewStoreForTesting()
 	kCli := k8s.NewFakeK8sClient()
 	plc := NewPortForwardController(kCli)
 	return &plcFixture{

--- a/internal/engine/store_testutil.go
+++ b/internal/engine/store_testutil.go
@@ -1,0 +1,32 @@
+package engine
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+// for use by tests, to wait until an action of the specified type comes out of the given chan
+func waitForAction(t testing.TB, typ reflect.Type, actions <-chan store.Action) store.Action {
+	timeout := time.After(300 * time.Millisecond)
+	var seenActions []store.Action
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("timed out waiting for action of type %s. Saw the following actions while waiting: %+v",
+				typ.Name(),
+				seenActions)
+		case a := <-actions:
+			if reflect.TypeOf(a) == typ {
+				return a
+			} else if la, ok := a.(LogAction); ok {
+				fmt.Println(string(la.Log))
+			} else {
+				seenActions = append(seenActions, a)
+			}
+		}
+	}
+}

--- a/internal/engine/synclet_manager_test.go
+++ b/internal/engine/synclet_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
@@ -59,7 +60,7 @@ func newSMFixture(t *testing.T) *smFixture {
 	kCli := k8s.NewFakeK8sClient()
 	sCli := synclet.NewFakeSyncletClient()
 	sm := NewSyncletManagerForTests(kCli, sCli)
-	st := store.NewStoreForTesting()
+	st, _ := store.NewStoreForTesting()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	l := logger.NewLogger(logger.DebugLvl, os.Stdout)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2141,7 +2141,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	pfc := NewPortForwardController(k8s)
 	ic := NewImageController(reaper)
 	gybc := NewGlobalYAMLBuildController(k8s)
-	cc := NewConfigsController()
+	cc := NewConfigsController(tiltfile.NewTiltfileLoader())
 	dcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	dcw := NewDockerComposeEventWatcher(dcc)
 	dclm := NewDockerComposeLogManager(dcc)
@@ -2493,7 +2493,7 @@ func (f *testFixture) assertAllBuildsConsumed() {
 }
 
 func (f *testFixture) loadAndStart() {
-	manifests, _, _, _, err := tiltfile.Load(f.ctx, f.JoinPath(tiltfile.FileName), nil, os.Stdout)
+	manifests, _, _, _, err := tiltfile.NewTiltfileLoader().Load(f.ctx, f.JoinPath(tiltfile.FileName), nil, os.Stdout)
 	if err != nil {
 		f.T().Fatal(err)
 	}
@@ -2530,7 +2530,7 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 
 	f.WriteFile("Tiltfile", `docker_compose('docker-compose.yml')`)
 
-	manifests, _, _, _, err := tiltfile.Load(f.ctx, f.JoinPath("Tiltfile"), nil, os.Stdout)
+	manifests, _, _, _, err := tiltfile.NewTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), nil, os.Stdout)
 	if err != nil {
 		f.T().Fatal(err)
 	}

--- a/internal/store/subscriber_test.go
+++ b/internal/store/subscriber_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSubscriber(t *testing.T) {
-	st := NewStore(EmptyReducer, LogActionsFlag(false))
+	st, _ := NewStoreForTesting()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(s)
@@ -20,7 +20,7 @@ func TestSubscriber(t *testing.T) {
 }
 
 func TestSubscriberInterleavedCalls(t *testing.T) {
-	st := NewStore(EmptyReducer, LogActionsFlag(false))
+	st, _ := NewStoreForTesting()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(s)
@@ -44,7 +44,7 @@ func TestSubscriberInterleavedCalls(t *testing.T) {
 }
 
 func TestRemoveSubscriber(t *testing.T) {
-	st := NewStore(EmptyReducer, LogActionsFlag(false))
+	st, _ := NewStoreForTesting()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 
@@ -59,7 +59,7 @@ func TestRemoveSubscriber(t *testing.T) {
 }
 
 func TestRemoveSubscriberNotFound(t *testing.T) {
-	st := NewStore(EmptyReducer, LogActionsFlag(false))
+	st, _ := NewStoreForTesting()
 	s := newFakeSubscriber()
 	err := st.RemoveSubscriber(s)
 	if assert.Error(t, err) {

--- a/internal/testutils/fake_clock.go
+++ b/internal/testutils/fake_clock.go
@@ -1,0 +1,33 @@
+package testutils
+
+import (
+	"math/rand"
+	"time"
+)
+
+type Clock func() time.Time
+
+type FakeClock struct {
+	Times    []time.Time
+	nextTime Clock
+}
+
+func (fc *FakeClock) next() time.Time {
+	ret := fc.nextTime()
+	fc.Times = append(fc.Times, ret)
+	return ret
+}
+
+func (fc *FakeClock) Clock() Clock {
+	return fc.next
+}
+
+func NewRandomFakeClock() *FakeClock {
+	return &FakeClock{
+		nextTime: func() time.Time {
+			d := rand.Int()
+			h := rand.Int()
+			return time.Date(2019, 1, d, h, 0, 0, 0, time.UTC)
+		},
+	}
+}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/yaml"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/yaml"
 
 	"github.com/windmilleng/tilt/internal/ignore"
 	"github.com/windmilleng/tilt/internal/k8s"
@@ -730,7 +731,7 @@ docker_build('gcr.io/bar', 'bar')
 k8s_resource('bar', 'bar.yaml')
 `)
 
-	_, _, _, _, err := Load(f.ctx, f.JoinPath("Tiltfile"), matchMap("baz"), os.Stdout)
+	_, _, _, _, err := NewTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), matchMap("baz"), os.Stdout)
 	if assert.Error(t, err) {
 		assert.Equal(t, "Could not find resources: baz. Existing resources in Tiltfile: foo, bar", err.Error())
 	}
@@ -1442,7 +1443,7 @@ func matchMap(names ...string) map[string]bool {
 }
 
 func (f *fixture) load(names ...string) {
-	manifests, yamlManifest, configFiles, warnings, err := Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...), os.Stdout)
+	manifests, yamlManifest, configFiles, warnings, err := NewTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...), os.Stdout)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -1453,7 +1454,7 @@ func (f *fixture) load(names ...string) {
 }
 
 func (f *fixture) loadErrString(msgs ...string) {
-	manifests, _, configFiles, _, err := Load(f.ctx, f.JoinPath("Tiltfile"), nil, os.Stdout)
+	manifests, _, configFiles, _, err := NewTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), nil, os.Stdout)
 	if err == nil {
 		f.t.Fatalf("expected error but got nil")
 	}


### PR DESCRIPTION
also:
1. Make `FakeStore` a little more useful for testing subscribers (exposing dispatched actions)
2. Add a `FakeClock` class for the obvious
3. Add a `FakeTiltfileLoader` to avoid having to generate actual tilt configs in `Tiltfile.Load`'s callers (I'm not super excited about all the result `NewTiltfileLoader`s - open to suggestions)
