### PR TITLE
tiltfile: filter_yaml also supports name, namespace, kind [ch1626]

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -203,6 +203,14 @@ func FilterByMetadataLabels(entities []K8sEntity, labels map[string]string) (pas
 	return Filter(entities, func(e K8sEntity) (bool, error) { return e.MatchesMetadataLabels(labels) })
 }
 
+func FilterByName(entities []K8sEntity, name string) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return true, nil })
+}
+
+func FilterByKind(entities []K8sEntity, kind string) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return true, nil })
+}
+
 func FilterByHasPodTemplateSpec(entities []K8sEntity) (passing, rest []K8sEntity, err error) {
 	return Filter(entities, func(e K8sEntity) (bool, error) {
 		templateSpecs, err := ExtractPodTemplateSpec(&e)

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -204,11 +205,15 @@ func FilterByMetadataLabels(entities []K8sEntity, labels map[string]string) (pas
 }
 
 func FilterByName(entities []K8sEntity, name string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return true, nil })
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasName(name) })
+}
+
+func FilterByNamespace(entities []K8sEntity, ns string) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasNamespace(ns), nil })
 }
 
 func FilterByKind(entities []K8sEntity, kind string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return true, nil })
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasKind(kind), nil })
 }
 
 func FilterByHasPodTemplateSpec(entities []K8sEntity) (passing, rest []K8sEntity, err error) {
@@ -246,4 +251,30 @@ func FilterByMatchesPodTemplateSpec(withPodSpec K8sEntity, entities []K8sEntity)
 
 func (e K8sEntity) ResourceName() string {
 	return fmt.Sprintf("k8s%s-%s", e.Kind.Kind, e.Name())
+}
+
+func (e K8sEntity) HasName(name string) (bool, error) {
+	metas, err := extractObjectMetas(&e)
+	if err != nil {
+		return false, err
+	}
+	for _, m := range metas {
+		if m.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (e K8sEntity) HasNamespace(ns string) bool {
+	realNs := e.Namespace()
+	if ns == "" {
+		return realNs == DefaultNamespace
+	}
+	return realNs.String() == ns
+}
+
+func (e K8sEntity) HasKind(kind string) bool {
+	// TODO(maia): support kind aliases (e.g. "po" for "pod")
+	return strings.ToLower(e.Kind.Kind) == strings.ToLower(kind)
 }

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -205,7 +205,7 @@ func FilterByMetadataLabels(entities []K8sEntity, labels map[string]string) (pas
 }
 
 func FilterByName(entities []K8sEntity, name string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasName(name) })
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasName(name), nil })
 }
 
 func FilterByNamespace(entities []K8sEntity, ns string) (passing, rest []K8sEntity, err error) {
@@ -253,17 +253,8 @@ func (e K8sEntity) ResourceName() string {
 	return fmt.Sprintf("k8s%s-%s", e.Kind.Kind, e.Name())
 }
 
-func (e K8sEntity) HasName(name string) (bool, error) {
-	metas, err := extractObjectMetas(&e)
-	if err != nil {
-		return false, err
-	}
-	for _, m := range metas {
-		if m.Name == name {
-			return true, nil
-		}
-	}
-	return false, nil
+func (e K8sEntity) HasName(name string) bool {
+	return e.Name() == name
 }
 
 func (e K8sEntity) HasNamespace(ns string) bool {

--- a/internal/k8s/entity_test.go
+++ b/internal/k8s/entity_test.go
@@ -122,6 +122,62 @@ func TestFilter(t *testing.T) {
 	}
 }
 
+func TestHasName(t *testing.T) {
+	entities, err := parseYAMLFromStrings(testyaml.DoggosDeploymentYaml, testyaml.SnackYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entities) != 2 {
+		t.Fatalf("expected 2 entites, got %d: %v", len(entities), entities)
+	}
+
+	// Doggos
+	hasName, err := entities[0].HasName(testyaml.DoggosName)
+	if assert.NoError(t, err) {
+		assert.True(t, hasName)
+	}
+
+	// Snack
+	hasName, err = entities[1].HasName(testyaml.DoggosName)
+	if assert.NoError(t, err) {
+		assert.False(t, hasName)
+	}
+}
+
+func TestHasNamespace(t *testing.T) {
+	entities, err := parseYAMLFromStrings(testyaml.DoggosDeploymentYaml, testyaml.SnackYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entities) != 2 {
+		t.Fatalf("expected 2 entites, got %d: %v", len(entities), entities)
+	}
+
+	doggos := entities[0]
+	assert.True(t, doggos.HasNamespace(testyaml.DoggosNamespace))
+
+	snack := entities[0]
+	assert.True(t, snack.HasNamespace(testyaml.DoggosNamespace))
+}
+
+func TestHasKind(t *testing.T) {
+	entities, err := parseYAMLFromStrings(testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entities) != 2 {
+		t.Fatalf("expected 2 entites, got %d: %v", len(entities), entities)
+	}
+
+	depl := entities[0]
+	assert.True(t, depl.HasKind("deployment"))
+	assert.False(t, depl.HasKind("service"))
+
+	svc := entities[1]
+	assert.False(t, svc.HasKind("deployment"))
+	assert.True(t, svc.HasKind("service"))
+}
+
 func parseYAMLFromStrings(yaml ...string) ([]K8sEntity, error) {
 	var res []K8sEntity
 	for _, s := range yaml {

--- a/internal/k8s/entity_test.go
+++ b/internal/k8s/entity_test.go
@@ -131,17 +131,11 @@ func TestHasName(t *testing.T) {
 		t.Fatalf("expected 2 entites, got %d: %v", len(entities), entities)
 	}
 
-	// Doggos
-	hasName, err := entities[0].HasName(testyaml.DoggosName)
-	if assert.NoError(t, err) {
-		assert.True(t, hasName)
-	}
+	doggos := entities[0]
+	assert.True(t, doggos.HasName(testyaml.DoggosName))
 
-	// Snack
-	hasName, err = entities[1].HasName(testyaml.DoggosName)
-	if assert.NoError(t, err) {
-		assert.False(t, hasName)
-	}
+	snack := entities[1]
+	assert.False(t, snack.HasName(testyaml.DoggosName))
 }
 
 func TestHasNamespace(t *testing.T) {
@@ -156,8 +150,8 @@ func TestHasNamespace(t *testing.T) {
 	doggos := entities[0]
 	assert.True(t, doggos.HasNamespace(testyaml.DoggosNamespace))
 
-	snack := entities[0]
-	assert.True(t, snack.HasNamespace(testyaml.DoggosNamespace))
+	snack := entities[1]
+	assert.False(t, snack.HasNamespace(testyaml.DoggosNamespace))
 }
 
 func TestHasKind(t *testing.T) {

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -558,6 +558,7 @@ metadata:
     app: doggos
     breed: corgi
     whosAGoodBoy: imAGoodBoy
+  namespace: the-dog-zone
 spec:
   selector:
     matchLabels:
@@ -595,7 +596,8 @@ spec:
     app: doggos
 `
 const (
-	DoggosName = "doggos"
+	DoggosName      = "doggos"
+	DoggosNamespace = "the-dog-zone"
 )
 
 const SnackYaml = `

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -112,11 +112,14 @@ func (s *tiltfileState) k8sYaml(thread *starlark.Thread, fn *starlark.Builtin, a
 }
 
 func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var yamlValue starlark.Value
-	var labelsValue starlark.Value
+	var yamlValue, labelsValue starlark.Value
+	var name, kind string
 	err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"yaml", &yamlValue,
-		"labels?", &labelsValue)
+		"labels?", &labelsValue,
+		"name?", &name,
+		"kind?", &kind,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -139,16 +142,44 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		return nil, err
 	}
 
-	match, rest, err := k8s.FilterByMetadataLabels(entities, metaLabels)
-	if err != nil {
-		return nil, err
+	var match, allRest []k8s.K8sEntity
+	match = append(match, entities...)
+	if len(metaLabels) > 0 {
+		match, allRest, err = k8s.FilterByMetadataLabels(match, metaLabels)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if name != "" {
+		var rest []k8s.K8sEntity
+		match, rest, err = k8s.FilterByName(match, name)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(rest) > 0 {
+			allRest = append(allRest, rest...)
+		}
+	}
+
+	if kind != "" {
+		var rest []k8s.K8sEntity
+		match, rest, err = k8s.FilterByKind(match, kind)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(rest) > 0 {
+			allRest = append(allRest, rest...)
+		}
 	}
 
 	matchingStr, err := k8s.SerializeYAML(match)
 	if err != nil {
 		return nil, err
 	}
-	restStr, err := k8s.SerializeYAML(rest)
+	restStr, err := k8s.SerializeYAML(allRest)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -113,11 +113,12 @@ func (s *tiltfileState) k8sYaml(thread *starlark.Thread, fn *starlark.Builtin, a
 
 func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var yamlValue, labelsValue starlark.Value
-	var name, kind string
+	var name, namespace, kind string
 	err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"yaml", &yamlValue,
 		"labels?", &labelsValue,
 		"name?", &name,
+		"namespace?", &namespace,
 		"kind?", &kind,
 	)
 	if err != nil {
@@ -154,6 +155,18 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 	if name != "" {
 		var rest []k8s.K8sEntity
 		match, rest, err = k8s.FilterByName(match, name)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(rest) > 0 {
+			allRest = append(allRest, rest...)
+		}
+	}
+
+	if namespace != "" {
+		var rest []k8s.K8sEntity
+		match, rest, err = k8s.FilterByNamespace(match, namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -143,8 +143,8 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		return nil, err
 	}
 
-	var match, allRest []k8s.K8sEntity
-	match = append(match, entities...)
+	var allRest []k8s.K8sEntity
+	match := entities
 	if len(metaLabels) > 0 {
 		match, allRest, err = k8s.FilterByMetadataLabels(match, metaLabels)
 		if err != nil {
@@ -158,10 +158,8 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		if err != nil {
 			return nil, err
 		}
+		allRest = append(allRest, rest...)
 
-		if len(rest) > 0 {
-			allRest = append(allRest, rest...)
-		}
 	}
 
 	if namespace != "" {
@@ -170,10 +168,7 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		if err != nil {
 			return nil, err
 		}
-
-		if len(rest) > 0 {
-			allRest = append(allRest, rest...)
-		}
+		allRest = append(allRest, rest...)
 	}
 
 	if kind != "" {
@@ -182,10 +177,7 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		if err != nil {
 			return nil, err
 		}
-
-		if len(rest) > 0 {
-			allRest = append(allRest, rest...)
-		}
+		allRest = append(allRest, rest...)
 	}
 
 	matchingStr, err := k8s.SerializeYAML(match)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -897,10 +897,12 @@ docker_build("gcr.io/foo", "foo", cache='/path/to/cache')
 	f.loadErrString("no such file or directory")
 }
 
-func TestFilterYaml(t *testing.T) {
+func TestFilterYamlByLabel(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
-	f.file("k8s.yaml", yaml.ConcatYAML(testyaml.DoggosDeploymentYaml, testyaml.SnackYaml, testyaml.SanchoYAML))
+	f.file("k8s.yaml", yaml.ConcatYAML(
+		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
+		testyaml.SnackYaml, testyaml.SanchoYAML))
 	f.file("Tiltfile", `labels = {'app': 'doggos'}
 doggos, rest = filter_yaml('k8s.yaml', labels=labels)
 k8s_resource('doggos', yaml=doggos)
@@ -908,8 +910,67 @@ k8s_resource('rest', yaml=rest)
 `)
 	f.load()
 
-	f.assertNextManifest("doggos", deployment("doggos"))
+	f.assertNextManifest("doggos", deployment("doggos"), service("doggos"))
 	f.assertNextManifest("rest", deployment("snack"), deployment("sancho"))
+}
+
+func TestFilterYamlByName(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.file("k8s.yaml", yaml.ConcatYAML(
+		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
+		testyaml.SnackYaml, testyaml.SanchoYAML))
+	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', name='doggos')
+k8s_resource('doggos', yaml=doggos)
+k8s_resource('rest', yaml=rest)
+`)
+	f.load()
+
+	f.assertNextManifest("doggos", deployment("doggos"), service("doggos"))
+	f.assertNextManifest("rest", deployment("snack"), deployment("sancho"))
+}
+
+func TestFilterYamlByNameKind(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.file("k8s.yaml", yaml.ConcatYAML(
+		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
+		testyaml.SnackYaml, testyaml.SanchoYAML))
+	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', name='doggos', kind='deployment')
+k8s_resource('doggos', yaml=doggos)
+k8s_resource('rest', yaml=rest)
+`)
+	f.load()
+
+	f.assertNextManifest("doggos", deployment("doggos"))
+	f.assertNextManifest("rest", service("doggos"), deployment("snack"), deployment("sancho"))
+}
+
+func TestFilterYamlByNamespace(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.file("k8s.yaml", yaml.ConcatYAML(
+		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
+		testyaml.SnackYaml, testyaml.SanchoYAML))
+	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', namespace='the-dog-zone')
+k8s_resource('doggos', yaml=doggos)
+k8s_resource('rest', yaml=rest)
+`)
+	f.load()
+
+	f.assertNextManifest("doggos", deployment("doggos"))
+	f.assertNextManifest("rest", service("doggos"), deployment("snack"), deployment("sancho"))
+}
+
+func TestFilterYamlNoMatch(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.file("k8s.yaml", yaml.ConcatYAML(testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml))
+	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', namespace='dne', kind='deployment')
+k8s_resource('doggos', yaml=doggos)
+k8s_resource('rest', yaml=rest)
+`)
+	f.loadErrString("could not associate any k8s YAML with this resource")
 }
 
 func TestTopLevelIfStatement(t *testing.T) {


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/filter-yaml-name-kind:

0867c1ef7fa83025f3eb41fb6aeb551de9d3532b (2019-02-22 17:41:58 -0500)
implement, tests

c08611729845979378bafaabd70a1bf6dae6f8d9 (2019-02-22 15:49:54 -0500)
stub out func

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics