### PR TITLE
tiltfile: include sources in k8s yaml parse errors

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -200,17 +200,18 @@ func (s *tiltfileState) skylarkReadFile(thread *starlark.Thread, fn *starlark.Bu
 		return nil, err
 	}
 
-	return newBlob(string(bs)), nil
+	return newBlob(string(bs), fmt.Sprintf("file: %s", path)), nil
 }
 
 type blob struct {
-	text string
+	text   string
+	source string
 }
 
 var _ starlark.Value = &blob{}
 
-func newBlob(text string) *blob {
-	return &blob{text: text}
+func newBlob(text string, source string) *blob {
+	return &blob{text: text, source: source}
 }
 
 func (b *blob) String() string {
@@ -244,7 +245,7 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 		return nil, err
 	}
 
-	return newBlob(out), nil
+	return newBlob(out, fmt.Sprintf("cmd: '%s'", command)), nil
 }
 
 func (s *tiltfileState) execLocalCmd(cmd string) (string, error) {
@@ -304,7 +305,7 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 		s.recordConfigFile(d)
 	}
 
-	return newBlob(yaml), nil
+	return newBlob(yaml, fmt.Sprintf("kustomize: %s", kustomizePath.String())), nil
 }
 
 func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -326,7 +327,7 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 
 	s.recordConfigFile(localPath.path)
 
-	return newBlob(string(yaml)), nil
+	return newBlob(string(yaml), fmt.Sprintf("helm: %s", localPath.path)), nil
 }
 
 func (s *tiltfileState) blob(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -336,7 +337,7 @@ func (s *tiltfileState) blob(thread *starlark.Thread, fn *starlark.Builtin, args
 		return nil, err
 	}
 
-	return newBlob(input.GoString()), nil
+	return newBlob(input.GoString(), "Tiltfile blob() call"), nil
 }
 
 func (s *tiltfileState) listdir(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -200,7 +200,7 @@ func (s *tiltfileState) skylarkReadFile(thread *starlark.Thread, fn *starlark.Bu
 		return nil, err
 	}
 
-	return newBlob(string(bs), fmt.Sprintf("file: %s", path)), nil
+	return newBlob(string(bs), fmt.Sprintf("file: %s", p.path)), nil
 }
 
 type blob struct {

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -6,13 +6,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"k8s.io/apimachinery/pkg/labels"
-
-	"go.starlark.net/starlark"
-
 	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
+	"go.starlark.net/starlark"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1508,7 +1508,7 @@ func TestYamlErrorFromReadFile(t *testing.T) {
 	f.file("Tiltfile", `
 k8s_yaml(read_file('foo.yaml'))
 `)
-	f.loadErrString("file: \"foo.yaml\"")
+	f.loadErrString(fmt.Sprintf("file: %s", f.JoinPath("foo.yaml")))
 }
 
 func TestYamlErrorFromHelm(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1493,6 +1493,42 @@ k8s_yaml('foo.yaml')
 	assert.Equal(t, expected, f.an.Counts)
 }
 
+func TestYamlErrorFromLocal(t *testing.T) {
+	f := newFixture(t)
+	f.file("Tiltfile", `
+yaml = local('echo hi')
+k8s_yaml(yaml)
+`)
+	f.loadErrString("cmd: 'echo hi'")
+}
+
+func TestYamlErrorFromReadFile(t *testing.T) {
+	f := newFixture(t)
+	f.file("foo.yaml", "hi")
+	f.file("Tiltfile", `
+k8s_yaml(read_file('foo.yaml'))
+`)
+	f.loadErrString("file: \"foo.yaml\"")
+}
+
+func TestYamlErrorFromHelm(t *testing.T) {
+	f := newFixture(t)
+	f.setupHelm()
+	f.file("helm/templates/foo.yaml", "hi")
+	f.file("Tiltfile", `
+k8s_yaml(helm('helm'))
+`)
+	f.loadErrString("from helm")
+}
+
+func TestYamlErrorFromBlob(t *testing.T) {
+	f := newFixture(t)
+	f.file("Tiltfile", `
+k8s_yaml(blob('hi'))
+`)
+	f.loadErrString("from Tiltfile blob() call")
+}
+
 type fixture struct {
 	ctx context.Context
 	t   *testing.T


### PR DESCRIPTION
before:
```
       Error: error converting YAML to JSON: yaml: line 3:
       could not find expected ':'
```

after:
```
       Error: Error reading yaml from cmd: 'm4 -Dvarowner="matt"
       -Dvarimgname="gcr.io/windmill-public-containers/servantes/doggos"
       "deploy/doggos.yaml"': error converting YAML to JSON: yaml: line 3:
       could not find expected ':'
```