### PR TITLE
tiltfile: fast_build.add may take a string (in addition to localpath, gitrepo) [ch1716]

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -128,7 +128,7 @@ func (s *tiltfileState) localPathFromSkylarkValue(v starlark.Value) (localPath, 
 	case starlark.String:
 		return s.localPathFromString(string(v)), nil
 	default:
-		return localPath{}, fmt.Errorf("Expected local path. Actual type: %T", v)
+		return localPath{}, fmt.Errorf("expected localPath | gitRepo | string. Actual type: %T", v)
 	}
 }
 


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/add-takes-string:

708fb6b6f3395dadc5534a23d63e82179ca14f75 (2019-02-28 14:43:46 -0500)
tiltfile: fast_build.add may take a string (in addition to localpath, gitrepo)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics