### PR TITLE
globalyaml: apply namespaces first

### DIFF
--- a/internal/engine/global_yaml_buildcontroller_test.go
+++ b/internal/engine/global_yaml_buildcontroller_test.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"testing"
 
+	"github.com/windmilleng/tilt/internal/yaml"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
@@ -93,8 +95,8 @@ func TestGlobalYamlFailUpsert(t *testing.T) {
 }
 
 func TestGlobalYamlNamespacesFirst(t *testing.T) {
-	yaml := testyaml.ConcatYAML(testyaml.DoggosDeploymentYaml, testyaml.MyNamespaceYAML)
-	st := newTestingStoreWithGlobalYAML(yaml)
+	y := yaml.ConcatYAML(testyaml.DoggosDeploymentYaml, testyaml.MyNamespaceYAML)
+	st := newTestingStoreWithGlobalYAML(y)
 	bc := newGlobalYamlBuildControllerForTest(testyaml.SecretYaml)
 
 	bc.OnChange(output.CtxForTest(), st)
@@ -103,8 +105,13 @@ func TestGlobalYamlNamespacesFirst(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, "mynamespace", entities[0].Name())
-	assert.Equal(t, "doggos", entities[1].Name())
+
+	var observedNames []string
+	for _, e := range entities {
+		observedNames = append(observedNames, e.Name())
+	}
+	expectedNames := []string{"mynamespace", "doggos"}
+	assert.Equal(t, expectedNames, observedNames)
 }
 
 func newTestingStoreWithGlobalYAML(yaml string) *store.TestingStore {

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1,6 +1,9 @@
 package testyaml
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const BlorgBackendYAML = `
 apiVersion: v1
@@ -1111,6 +1114,16 @@ metadata:
 spec:
   replicas: 1
 `
+
+const MyNamespaceYAML = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: mynamespace
+`
+
+func ConcatYAML(y1, y2 string) string {
+	return fmt.Sprintf("%s\n---\n%s", y1, y2)
+}
 
 func Deployment(name string, imageName string) string {
 	result := `

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1,7 +1,6 @@
 package testyaml
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -1120,10 +1119,6 @@ kind: Namespace
 metadata:
   name: mynamespace
 `
-
-func ConcatYAML(y1, y2 string) string {
-	return fmt.Sprintf("%s\n---\n%s", y1, y2)
-}
 
 func Deployment(name string, imageName string) string {
 	result := `


### PR DESCRIPTION
Problem:
If the yaml contains both namespaces and objects in those namespaces, trying to apply the objects in the namespaces before the namespaces themselves will result in failure (because the namespaces don't exist)

Solution:
sort namespaces to the front of global yaml
This doesn't fully solve the problem, since global yaml gets applied in parallel with resourced entities, and those resourced entities could be in a namespace specified in global yaml, but that's a problem to tackle separately.