### PR TITLE
tiltfile: don't pull dockerignores for repo root

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -513,6 +513,16 @@ func (s *tiltfileState) dockerignoresForImage(image *dockerImage) []model.Docker
 
 	for _, m := range image.mounts {
 		paths = append(paths, m.src.path)
+
+		// NOTE(maia): this doesn't reflect the behavior of Docker, which only
+		// looks in the build context for the .dockerignore file. Leaving it
+		// for now, though, for fastbuild cases where .dockerignore doesn't
+		// live in the user's mount(s) (e.g. user only mounts several specific
+		// files, not a directory containing the .dockerignore).
+		repo := m.src.repo
+		if repo != nil {
+			paths = append(paths, repo.basePath)
+		}
 	}
 	paths = append(paths, image.staticBuildPath.path)
 

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -513,11 +513,6 @@ func (s *tiltfileState) dockerignoresForImage(image *dockerImage) []model.Docker
 
 	for _, m := range image.mounts {
 		paths = append(paths, m.src.path)
-
-		repo := m.src.repo
-		if repo != nil {
-			paths = append(paths, repo.basePath)
-		}
 	}
 	paths = append(paths, image.staticBuildPath.path)
 

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -35,7 +35,7 @@ func (s *tiltfileState) newGitRepo(path string) (*gitRepo, error) {
 		return nil, err
 	}
 
-	return &gitRepo{absPath, string(gitignoreContents)}, nil
+	return &gitRepo{basePath: absPath, gitignoreContents: string(gitignoreContents)}, nil
 }
 
 func (s *tiltfileState) localGitRepo(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -837,6 +837,26 @@ k8s_yaml('foo.yaml')
 	)
 }
 
+func TestFastBuildDockerignoreRoot(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+	f.file(".dockerignore", "foo/*.txt")
+	f.file("Tiltfile", `
+repo = local_git_repo('.')
+fast_build('gcr.io/foo', 'foo/Dockerfile') \
+  .add(repo.path('foo'), 'src/') \
+  .run("echo hi")
+k8s_resource('foo', 'foo.yaml')
+`)
+	f.load("foo")
+	f.assertNextManifest("foo",
+		buildFilters("foo/a.txt"),
+		fileChangeFilters("foo/a.txt"),
+	)
+}
+
 func TestFastBuildDockerignoreSubdir(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -837,26 +837,6 @@ k8s_yaml('foo.yaml')
 	)
 }
 
-func TestFastBuildDockerignoreRoot(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupFoo()
-	f.file(".dockerignore", "foo/*.txt")
-	f.file("Tiltfile", `
-repo = local_git_repo('.')
-fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
-  .run("echo hi")
-k8s_resource('foo', 'foo.yaml')
-`)
-	f.load("foo")
-	f.assertNextManifest("foo",
-		buildFilters("foo/a.txt"),
-		fileChangeFilters("foo/a.txt"),
-	)
-}
-
 func TestFastBuildDockerignoreSubdir(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/correct-dockerignore-behavior:

1e63990a5e36cec9ae624c5b4bd384fe5a3acd89 (2019-02-28 16:47:48 -0500)
tiltfile: don't pull dockerignores for repo root
from Docker docs:
> Before the docker CLI sends the context to the docker daemon, it looks for a file named .dockerignore **in the root directory of the context**.

we should not check the repo root for .dockerignores, it's different from the behavior of docker

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics