### PR TITLE
tiltfile: fix tests to reflect preference for fb.add(src: str...) [ch1716]

### DIFF
--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -172,9 +172,8 @@ func TestFastBuildSimple(t *testing.T) {
 
 	f.setupFoo()
 	f.file("Tiltfile", `
-repo = local_git_repo('.')
 fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
+  .add('foo', 'src/') \
   .run("echo hi")
 k8s_resource('foo', 'foo.yaml')
 `)
@@ -192,9 +191,8 @@ func TestFastBuildHotReload(t *testing.T) {
 
 	f.setupFoo()
 	f.file("Tiltfile", `
-repo = local_git_repo('.')
 fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
+  .add('foo', 'src/') \
   .run("echo hi") \
   .hot_reload()
 k8s_resource('foo', 'foo.yaml')
@@ -213,9 +211,8 @@ func TestFastBuildPassedToResource(t *testing.T) {
 
 	f.setupFoo()
 	f.file("Tiltfile", `
-repo = local_git_repo('.')
 fb = fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
+  .add('foo', 'src/') \
   .run("echo hi")
 k8s_resource('foo', 'foo.yaml', image=fb)
 `)
@@ -236,9 +233,8 @@ func TestFastBuildValidates(t *testing.T) {
 from golang:1.10
 ADD . .`)
 	f.file("Tiltfile", `
-repo = local_git_repo('.')
 fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
+  .add('foo', 'src/') \
   .run("echo hi")
 k8s_resource('foo', 'foo.yaml')
 `)
@@ -251,10 +247,9 @@ func TestFastBuildRunBeforeAdd(t *testing.T) {
 
 	f.setupFoo()
 	f.file("Tiltfile", `
-repo = local_git_repo('.')
 fast_build('gcr.io/foo', 'foo/Dockerfile') \
   .run("echo hi") \
-  .add(repo.path('foo'), 'src/')
+  .add('foo', 'src/')
 k8s_resource('foo', 'foo.yaml')
 `)
 	f.loadErrString("fast_build(\"gcr.io/foo\").add() called after .run()")
@@ -266,9 +261,8 @@ func TestFastBuildTriggers(t *testing.T) {
 
 	f.setupFoo()
 	f.file("Tiltfile", `
-repo = local_git_repo('.')
 fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
+  .add('foo', 'src/') \
   .run("echo hi", trigger=['a', 'b']) \
   .run("echo again", trigger='c')
 k8s_resource('foo', 'foo.yaml')
@@ -975,9 +969,8 @@ func TestFastBuildDockerignoreSubdir(t *testing.T) {
 	f.setupFoo()
 	f.file("foo/.dockerignore", "*.txt")
 	f.file("Tiltfile", `
-repo = local_git_repo('.')
 fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
+  .add('foo', 'src/') \
   .run("echo hi")
 k8s_resource('foo', 'foo.yaml')
 `)
@@ -1678,14 +1671,13 @@ func TestCustomBuild(t *testing.T) {
 	f := newFixture(t)
 	fmt.Println(f.TempDirFixture.Path())
 
-	tiltfile := `repo = local_git_repo('.')
-k8s_yaml('foo.yaml')
+	tiltfile := `k8s_yaml('foo.yaml')
 hfb = custom_build(
   'gcr.io/foo',
   'docker build -t $TAG foo',
   ['foo']
 ).add_fast_build()
-hfb.add(repo.path('foo'), '/app')
+hfb.add('foo', '/app')
 hfb.run('cd /app && pip install -r requirements.txt')
 hfb.hot_reload()`
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -436,6 +436,38 @@ fast_build('gcr.io/bar', 'foo/Dockerfile').add('%s', '/bar')
 	f.assertNextManifest("bar", fb(image("gcr.io/bar"), add("bar", "/bar")))
 }
 
+func TestFastBuildAddLocalPath(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+	f.file("Tiltfile", `
+repo = local_git_repo('.')
+k8s_yaml('foo.yaml')
+fast_build('gcr.io/foo', 'foo/Dockerfile').add(repo.path('foo'), '/foo')
+`)
+
+	f.load()
+	f.assertNextManifest("foo", fb(image("gcr.io/foo"), add("foo", "/foo")))
+}
+
+func TestFastBuildAddGitRepo(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+	f.file("Tiltfile", `
+repo = local_git_repo('.')
+k8s_yaml('foo.yaml')
+
+# add the whole repo
+fast_build('gcr.io/foo', 'foo/Dockerfile').add(repo, '/whole_repo')
+`)
+
+	f.load()
+	f.assertNextManifest("foo", fb(image("gcr.io/foo"), add(".", "/whole_repo")))
+}
+
 type portForwardCase struct {
 	name     string
 	expr     string


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/dont-need-git-repo:

257c6df2c605e0c03b65a736a5f3f04715b6fa78 (2019-02-28 18:13:16 -0500)
default case for tests is to pass a string to fb.add

198d6b2698b19b03cd56fb7021e3d5f1cc702b59 (2019-02-28 18:05:28 -0500)
more gitignore tests

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics