### PR TITLE
engine: skip images that have already been built and don't have updates

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -236,7 +236,9 @@ func TestIncrementalBuildKilled(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop)
 	defer f.TearDown()
 
-	bs := resultToStateSet(alreadyBuiltSet, nil, f.deployInfo())
+	changed := f.WriteFile("a.txt", "a")
+
+	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
 	f.docker.ExecErrorToThrow = docker.ExitError{ExitCode: build.TaskKillExitCode}
 
 	manifest := NewSanchoFastBuildManifest(f)
@@ -259,7 +261,8 @@ func TestFallBackToImageDeploy(t *testing.T) {
 
 	f.docker.ExecErrorToThrow = errors.New("some random error")
 
-	bs := resultToStateSet(alreadyBuiltSet, nil, f.deployInfo())
+	changed := f.WriteFile("a.txt", "a")
+	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
 
 	manifest := NewSanchoFastBuildManifest(f)
 	targets := buildTargets(manifest)
@@ -303,10 +306,8 @@ func TestIncrementalBuildTwice(t *testing.T) {
 
 	manifest := NewSanchoFastBuildManifest(f)
 	targets := buildTargets(manifest)
-	aPath := filepath.Join(f.Path(), "a.txt")
-	bPath := filepath.Join(f.Path(), "b.txt")
-	f.WriteFile("a.txt", "a")
-	f.WriteFile("b.txt", "b")
+	aPath := f.WriteFile("a.txt", "a")
+	bPath := f.WriteFile("b.txt", "b")
 
 	firstState := resultToStateSet(alreadyBuiltSet, []string{aPath}, f.deployInfo())
 	firstResult, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, firstState)
@@ -354,10 +355,8 @@ func TestIncrementalBuildTwiceDeadPod(t *testing.T) {
 
 	manifest := NewSanchoFastBuildManifest(f)
 	targets := buildTargets(manifest)
-	aPath := filepath.Join(f.Path(), "a.txt")
-	bPath := filepath.Join(f.Path(), "b.txt")
-	f.WriteFile("a.txt", "a")
-	f.WriteFile("b.txt", "b")
+	aPath := f.WriteFile("a.txt", "a")
+	bPath := f.WriteFile("b.txt", "b")
 
 	firstState := resultToStateSet(alreadyBuiltSet, []string{aPath}, f.deployInfo())
 	firstResult, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, firstState)

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -148,6 +148,14 @@ func (b BuildState) HasImage() bool {
 	return b.LastResult.HasImage()
 }
 
+// Whether the image represented by this state needs to be built.
+// If the image has already been built, and no files have been
+// changed since then, then we can re-use the previous result.
+func (b BuildState) NeedsImageBuild() bool {
+	alreadyBuilt := b.LastResult.HasImage()
+	return !alreadyBuilt || len(b.FilesChangedSet) > 0
+}
+
 type BuildStateSet map[model.TargetID]BuildState
 
 func (set BuildStateSet) Empty() bool {

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -60,7 +60,8 @@ func (f *TempDirFixture) JoinPaths(paths []string) []string {
 	return joined
 }
 
-func (f *TempDirFixture) WriteFile(path string, contents string) {
+// Returns the full path to the file written.
+func (f *TempDirFixture) WriteFile(path string, contents string) string {
 	fullPath := f.JoinPath(path)
 	base := filepath.Dir(fullPath)
 	err := os.MkdirAll(base, os.FileMode(0777))
@@ -71,6 +72,7 @@ func (f *TempDirFixture) WriteFile(path string, contents string) {
 	if err != nil {
 		f.t.Fatal(err)
 	}
+	return fullPath
 }
 
 func (f *TempDirFixture) WriteSymlink(linkContents, destPath string) {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/fastbuild:

e1961ac645e8381c1359fc81e7e093f7918ea4ed (2019-02-28 19:34:19 -0800)
engine: skip images that have already been built and don't have updates