### PR TITLE
engine: tiltfile logs also written to global logs

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -9,6 +9,7 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/tiltfile"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -877,5 +878,5 @@ func handleDockerComposeLogAction(state *store.EngineState, action DockerCompose
 
 func handleTiltfileLogAction(ctx context.Context, state *store.EngineState, action TiltfileLogAction) {
 	state.CurrentTiltfileBuild.Log = model.AppendLog(state.CurrentTiltfileBuild.Log, action.Log)
-	logger.Get(ctx).Infof("[TILTFILE] " + string(action.Log))
+	logger.Get(ctx).Infof("[%s] %s", tiltfile.FileName, string(action.Log))
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -178,7 +178,7 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 	case hud.StopProfilingAction:
 		handleStopProfilingAction(state)
 	case TiltfileLogAction:
-		handleTiltfileLogAction(state, action)
+		handleTiltfileLogAction(ctx, state, action)
 	default:
 		err = fmt.Errorf("unrecognized action: %T", action)
 	}
@@ -875,6 +875,7 @@ func handleDockerComposeLogAction(state *store.EngineState, action DockerCompose
 	ms.ResourceState = dcState.WithCurrentLog(append(dcState.CurrentLog, action.Log...))
 }
 
-func handleTiltfileLogAction(state *store.EngineState, action TiltfileLogAction) {
+func handleTiltfileLogAction(ctx context.Context, state *store.EngineState, action TiltfileLogAction) {
 	state.CurrentTiltfileBuild.Log = model.AppendLog(state.CurrentTiltfileBuild.Log, action.Log)
+	logger.Get(ctx).Infof("[TILTFILE] " + string(action.Log))
 }


### PR DESCRIPTION
I remember it was originally an intitional design choice to not have the
Tiltfile log to the global log pane, but it confuses me every damn time,
and [some users too](https://kubernetes.slack.com/archives/CESBL84MV/p1551395345022900).

I propose that until Tiltfile output gets unweildy, we display it in the global
log with everything else -- how do y'all feel about that?