### PR TITLE
tilt: fix misc lint errors

### DIFF
--- a/internal/build/buildkit_printer.go
+++ b/internal/build/buildkit_printer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	digest "github.com/opencontainers/go-digest"
+
 	"github.com/windmilleng/tilt/internal/logger"
 )
 
@@ -30,7 +31,7 @@ type vertex struct {
 const cmdPrefix = "/bin/sh -c "
 const buildPrefix = "    ╎ "
 
-var stepPattern = regexp.MustCompile("^\\[[0-9]+/[0-9]+\\]")
+var stepPattern = regexp.MustCompile(`^\[[0-9]+/[0-9]+\]`)
 
 func (v *vertex) isRun() bool {
 	return strings.HasPrefix(v.name, cmdPrefix)

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -482,7 +482,7 @@ func (d *dockerImageBuilder) getDigestFromDockerOutput(ctx context.Context, outp
 }
 
 func getDigestFromAux(aux json.RawMessage) (digest.Digest, error) {
-	digestMap := make(map[string]string, 0)
+	digestMap := make(map[string]string)
 	err := json.Unmarshal(aux, &digestMap)
 	if err != nil {
 		return "", errors.Wrap(err, "getDigestFromAux")
@@ -514,7 +514,7 @@ func digestMatchesRef(ref reference.NamedTagged, digest digest.Digest) bool {
 	return strings.HasPrefix(digestHash, tagHash)
 }
 
-var oldDigestRegexp = regexp.MustCompile("^Successfully built ([0-9a-f]+)\\s*$")
+var oldDigestRegexp = regexp.MustCompile(`^Successfully built ([0-9a-f]+)\s*$`)
 
 type dockerOutput struct {
 	aux         *json.RawMessage

--- a/internal/build/label.go
+++ b/internal/build/label.go
@@ -10,13 +10,13 @@ const (
 	BuildMode dockerfile.Label = "tilt.buildMode"
 
 	// Label when an image is created by a test.
-	TestImage = "tilt.test"
+	TestImage dockerfile.Label = "tilt.test"
 
 	// Label when an image is for path caching.
-	CacheImage = "tilt.cache"
+	CacheImage dockerfile.Label = "tilt.cache"
 )
 
 const (
 	BuildModeScratch  dockerfile.LabelValue = "scratch"
-	BuildModeExisting                       = "existing"
+	BuildModeExisting dockerfile.LabelValue = "existing"
 )

--- a/internal/build/options.go
+++ b/internal/build/options.go
@@ -18,10 +18,7 @@ func Options(archive io.Reader, args model.DockerBuildArgs) docker.BuildOptions 
 }
 
 func shouldRemoveImage() bool {
-	if flag.Lookup("test.v") == nil {
-		return false
-	}
-	return true
+	return flag.Lookup("test.v") != nil
 }
 
 func manifestBuildArgsToDockerBuildArgs(args model.DockerBuildArgs) map[string]*string {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/windmilleng/tilt/internal/tracer"
 
 	"github.com/spf13/cobra"
+
 	"github.com/windmilleng/tilt/internal/logger"
 )
 
@@ -87,7 +88,7 @@ func preCommand(ctx context.Context) (context.Context, func() error) {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		_ = <-sigs
+		<-sigs
 
 		cancel()
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -163,7 +163,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 
 func logOutput(s string) {
 	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
-	log.Printf(color.GreenString(s))
+	log.Print(color.GreenString(s))
 }
 
 func provideUpdateModeFlag() engine.UpdateModeFlag {

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
@@ -98,8 +99,6 @@ var _ Client = &Cli{}
 type Cli struct {
 	*client.Client
 	supportsBuildkit bool
-
-	env []string
 
 	creds     dockerCreds
 	initError error
@@ -411,7 +410,7 @@ func (c *Cli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.C
 		return errors.Wrap(err, "ExecInContainer#copy")
 	}
 
-	for true {
+	for {
 		inspected, err := c.ContainerExecInspect(ctx, execId.ID)
 		if err != nil {
 			return errors.Wrap(err, "ExecInContainer#inspect")
@@ -427,6 +426,4 @@ func (c *Cli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.C
 		}
 		return nil
 	}
-
-	return nil
 }

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -3,6 +3,7 @@ package dockercompose
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"testing"
 
@@ -80,8 +81,8 @@ func (c *FakeDCClient) StreamEvents(ctx context.Context, pathToConfig string) (<
 				select {
 				case events <- event: // send event to channel (unless it's full)
 				default:
-					c.t.Fatalf("no room on events channel to send event: '%s'. Something "+
-						"is wrong (or you need to increase the buffer).", event)
+					panic(fmt.Sprintf("no room on events channel to send event: '%s'. Something "+
+						"is wrong (or you need to increase the buffer).", event))
 				}
 			case <-ctx.Done():
 				return

--- a/internal/engine/build_errors.go
+++ b/internal/engine/build_errors.go
@@ -43,10 +43,7 @@ var _ error = DontFallBackError{}
 // It will never recover, even on subsequent rebuilds.
 func isPermanentError(err error) bool {
 	cause := errors.Cause(err)
-	if cause == context.Canceled {
-		return true
-	}
-	return false
+	return cause == context.Canceled
 }
 
 func shouldFallBackForErr(err error) bool {

--- a/internal/engine/docker_compose_log_manager.go
+++ b/internal/engine/docker_compose_log_manager.go
@@ -170,11 +170,7 @@ func (w DockerComposeLogActionWriter) Write(p []byte) (n int, err error) {
 var _ store.Subscriber = &DockerComposeLogManager{}
 
 func shouldFilterDCLog(p []byte) bool {
-	if bytes.HasPrefix(p, []byte("Attaching to ")) {
-		return true
-	}
-
-	return false
+	return bytes.HasPrefix(p, []byte("Attaching to "))
 }
 
 type DockerComposeGlobalLogWriter struct {

--- a/internal/engine/image_and_cache_builder.go
+++ b/internal/engine/image_and_cache_builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/docker/distribution/reference"
+
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/ignore"
@@ -157,7 +158,7 @@ func (icb *imageAndCacheBuilder) createCacheInputs(iTarget model.ImageTarget) bu
 	baseDockerfile := dockerfile.Dockerfile(iTarget.FastBuildInfo().BaseDockerfile)
 	if sbInfo, ok := iTarget.BuildDetails.(model.StaticBuild); ok {
 		staticDockerfile := dockerfile.Dockerfile(sbInfo.Dockerfile)
-		ok := true
+		var ok bool
 		baseDockerfile, _, ok = staticDockerfile.SplitIntoBaseDockerfile()
 		if !ok {
 			return build.CacheInputs{}

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/api/core/v1"
+
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
-	"k8s.io/api/core/v1"
 )
 
 // Collects logs from deployed containers.
@@ -43,7 +44,7 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 		return nil, nil
 	}
 
-	stateWatches := make(map[podLogKey]bool, 0)
+	stateWatches := make(map[podLogKey]bool)
 	for _, ms := range state.ManifestStates() {
 		for _, pod := range ms.PodSet.PodList() {
 			if pod.PodID == "" {

--- a/internal/engine/synclet_manager.go
+++ b/internal/engine/synclet_manager.go
@@ -6,15 +6,17 @@ import (
 	"sync"
 
 	opentracing "github.com/opentracing/opentracing-go"
+
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/options"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/synclet/sidecar"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/synclet"
-	"google.golang.org/grpc"
 )
 
 type newCliFn func(ctx context.Context, kCli k8s.Client, podID k8s.PodID, ns k8s.Namespace) (synclet.SyncletClient, error)
@@ -89,7 +91,7 @@ func (sm SyncletManager) diff(ctx context.Context, st store.RStore) (setup []syn
 		return
 	}
 
-	activePodIDs := make(map[k8s.PodID]bool, 0)
+	activePodIDs := make(map[k8s.PodID]bool)
 
 	// Look for all the pods that have synclets, and
 	// start warming the connection.

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -276,9 +276,7 @@ func (h *Hud) refresh(ctx context.Context) error {
 	}
 
 	vs := h.currentViewState
-	for _, r := range h.currentViewState.Resources {
-		vs.Resources = append(vs.Resources, r)
-	}
+	vs.Resources = append(vs.Resources, h.currentViewState.Resources...)
 
 	return h.Update(h.currentView, h.currentViewState)
 }

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -161,10 +161,7 @@ func (r *Renderer) renderStatusBar(v view.View) rty.Component {
 		}
 
 		if v.TiltfileErrorMessage != "" {
-			_, err := tiltfileError.WriteString(" • Tiltfile error")
-			if err != nil {
-				// This space intentionally left blank
-			}
+			_, _ = tiltfileError.WriteString(" • Tiltfile error")
 		}
 		sb.Fg(cBad).Text("✖").Fg(tcell.ColorDefault).Fg(cText).Textf("%s%s", errorCountMessage, tiltfileError.String()).Fg(tcell.ColorDefault)
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -100,7 +100,6 @@ type K8sClient struct {
 	core            apiv1.CoreV1Interface
 	restConfig      *rest.Config
 	portForwarder   PortForwarder
-	kubeContext     KubeContext
 	configNamespace Namespace
 	clientSet       kubernetes.Interface
 	runtimeAsync    *runtimeAsync

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -19,6 +19,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/testutils/output"
 )
@@ -123,7 +124,7 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 
 	core := cs.CoreV1()
 	runtimeAsync := newRuntimeAsync(core)
-	ret.client = K8sClient{EnvUnknown, ret.runner, core, nil, fakePortForwarder, KubeContext("unknown"), "", nil, runtimeAsync}
+	ret.client = K8sClient{EnvUnknown, ret.runner, core, nil, fakePortForwarder, "", nil, runtimeAsync}
 	return ret
 }
 

--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
+	"k8s.io/api/core/v1"
+
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/logger"
-	"k8s.io/api/core/v1"
 )
 
 const ContainerIDPrefix = "docker://"
@@ -28,7 +29,7 @@ func WaitForContainerReady(ctx context.Context, client Client, pod *v1.Pod, ref 
 	}
 	defer watch.Stop()
 
-	for true {
+	for {
 		select {
 		case <-ctx.Done():
 			return v1.ContainerStatus{}, errors.Wrap(ctx.Err(), "WaitForContainerReady")

--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -53,7 +53,6 @@ func WaitForContainerReady(ctx context.Context, client Client, pod *v1.Pod, ref 
 			}
 		}
 	}
-	panic("WaitForContainerReady") // should never reach this state
 }
 
 func waitForContainerReadyHelper(pod *v1.Pod, ref reference.Named) (v1.ContainerStatus, error) {

--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -11,11 +11,11 @@ type Env string
 
 const (
 	EnvUnknown       Env = "unknown"
-	EnvGKE               = "gke"
-	EnvMinikube          = "minikube"
-	EnvDockerDesktop     = "docker-for-desktop"
-	EnvMicroK8s          = "microk8s"
-	EnvNone              = "none" // k8s not running (not neces. a problem, e.g. if using Tilt x Docker Compose)
+	EnvGKE           Env = "gke"
+	EnvMinikube      Env = "minikube"
+	EnvDockerDesktop Env = "docker-for-desktop"
+	EnvMicroK8s      Env = "microk8s"
+	EnvNone          Env = "none" // k8s not running (not neces. a problem, e.g. if using Tilt x Docker Compose)
 )
 
 func (e Env) IsLocalCluster() bool {
@@ -36,15 +36,15 @@ func ProvideKubeContext(clientLoader clientcmd.ClientConfig) (KubeContext, error
 }
 
 func EnvFromString(s string) Env {
-	if s == EnvMinikube {
+	if Env(s) == EnvMinikube {
 		return EnvMinikube
-	} else if s == EnvDockerDesktop || s == "docker-desktop" {
+	} else if Env(s) == EnvDockerDesktop || s == "docker-desktop" {
 		return EnvDockerDesktop
-	} else if s == EnvMicroK8s {
+	} else if Env(s) == EnvMicroK8s {
 		return EnvMicroK8s
-	} else if s == EnvNone {
+	} else if Env(s) == EnvNone {
 		return EnvNone
-	} else if strings.HasPrefix(s, EnvGKE) {
+	} else if strings.HasPrefix(s, string(EnvGKE)) {
 		// GKE context strings look like:
 		// gke_blorg-dev_us-central1-b_blorg
 		return EnvGKE

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -11,10 +11,11 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/windmilleng/tilt/internal/container"
 )
 
 func (k K8sClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, error) {
@@ -89,7 +90,7 @@ func (k K8sClient) PodsWithImage(ctx context.Context, image reference.NamedTagge
 }
 
 func podMap(podList *v1.PodList) map[string][]v1.Pod {
-	ip := make(map[string][]v1.Pod, 0)
+	ip := make(map[string][]v1.Pod)
 	for _, p := range podList.Items {
 		for _, c := range p.Spec.Containers {
 			imgRef := c.Image

--- a/internal/minikube/docker.go
+++ b/internal/minikube/docker.go
@@ -32,7 +32,7 @@ func DockerEnv(ctx context.Context) (map[string]string, error) {
 }
 
 func dockerEnvFromOutput(output []byte) (map[string]string, error) {
-	result := make(map[string]string, 0)
+	result := make(map[string]string)
 	scanner := bufio.NewScanner(bytes.NewBuffer(output))
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/internal/ospath/ospath.go
+++ b/internal/ospath/ospath.go
@@ -16,7 +16,7 @@ func Child(dir string, file string) (string, bool) {
 
 	current := file
 	child := "."
-	for true {
+	for {
 		if dir == current {
 			return child, true
 		}
@@ -30,8 +30,6 @@ func Child(dir string, file string) (string, bool) {
 		child = filepath.Join(cBase, child)
 		current = cDir
 	}
-
-	return "", false
 }
 
 func RealChild(dir string, file string) (string, bool, error) {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -8,13 +8,14 @@ import (
 	"sort"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/ospath"
-	v1 "k8s.io/api/core/v1"
 )
 
 const emptyTiltfileMsg = "Looks like you don't have any docker builds or services defined in your Tiltfile! Check out https://docs.tilt.dev/tutorial.html to get started."
@@ -659,10 +660,7 @@ func StateToView(s EngineState) view.View {
 	}
 
 	if s.GlobalYAML.K8sTarget().YAML != "" {
-		var absWatches []string
-		for _, p := range s.ConfigFiles {
-			absWatches = append(absWatches, p)
-		}
+		absWatches := append([]string{}, s.ConfigFiles...)
 		relWatches := ospath.TryAsCwdChildren(absWatches)
 
 		r := view.Resource{

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -84,16 +84,6 @@ func (r k8sResource) providedImageRefNameList() []string {
 	return result
 }
 
-// Return the image refs in a deterministic order.
-func (r k8sResource) imageRefNameList() []string {
-	result := make([]string, 0, len(r.imageRefNames))
-	for ref := range r.imageRefNames {
-		result = append(result, ref)
-	}
-	sort.Strings(result)
-	return result
-}
-
 func (s *tiltfileState) k8sYaml(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var yamlValue starlark.Value
 	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -288,6 +288,9 @@ func (s *tiltfileState) assembleK8sUnresourced() error {
 		target.entities = append(target.entities, e)
 
 		match, rest, err := k8s.FilterByMatchesPodTemplateSpec(e, allRest)
+		if err != nil {
+			return err
+		}
 		target.entities = append(target.entities, match...)
 		allRest = rest
 	}


### PR DESCRIPTION
Changing some things that golangci-lint complained about.

I think in general the only things that are really interesting are ineffectual assignment [here](https://github.com/windmilleng/tilt/compare/matt/fix_lint?expand=1#diff-187cac6214111b4c1831b65825c135f8R291) and `t.Fatal` from a go routine [here](https://github.com/windmilleng/tilt/compare/matt/fix_lint?expand=1#diff-d505e8f7d9a2cc3ff33cb6041e787e9dR84). I mostly just changing the others to make it cheaper to read the output of golangci-lint in the future.