### PR TITLE
tiltfile: add k8s_kind

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -192,8 +192,8 @@ func Filter(entities []K8sEntity, test func(e K8sEntity) (bool, error)) (passing
 	return passing, rest, nil
 }
 
-func FilterByImage(entities []K8sEntity, img reference.Named) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img) })
+func FilterByImage(entities []K8sEntity, img reference.Named, k8sImageJsonPathsByKind map[string][]string) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img, k8sImageJsonPathsByKind) })
 }
 
 func FilterBySelectorMatchesLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1095,6 +1095,7 @@ spec:
       properties:
         spec:
           properties:
+            image: docker.io/bitnami/minideb:latest
             replicas:
               minimum: 1
               type: integer

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -296,25 +296,17 @@ func (s *tiltfileState) cachePathsFromSkylarkValue(val starlark.Value) ([]string
 	if val == nil {
 		return nil, nil
 	}
-	if val, ok := val.(starlark.Sequence); ok {
-		var result []string
-		it := val.Iterate()
-		defer it.Done()
-		var i starlark.Value
-		for it.Next(&i) {
-			str, ok := i.(starlark.String)
-			if !ok {
-				return nil, fmt.Errorf("cache param %v is a %T; must be a string", i, i)
-			}
-			result = append(result, string(str))
+	cachePaths := starlarkValueOrSequenceToSlice(val)
+
+	var ret []string
+	for _, v := range cachePaths {
+		str, ok := v.(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("cache param %v is a %T; must be a string", v, v)
 		}
-		return result, nil
+		ret = append(ret, string(str))
 	}
-	str, ok := val.(starlark.String)
-	if !ok {
-		return nil, fmt.Errorf("cache param %v is a %T; must be a string or a sequence of strings", val, val)
-	}
-	return []string{string(str)}, nil
+	return ret, nil
 }
 
 type fastBuild struct {

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -334,35 +334,32 @@ func podLabelsFromStarlarkValue(v starlark.Value) ([]labels.Selector, error) {
 	}
 }
 
-func (s *tiltfileState) k8sExtraImageLocation(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (s *tiltfileState) k8sKind(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var kind string
-	var jsonPath starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := starlark.UnpackArgs(fn.Name(), args, nil,
 		"kind", &kind,
-		"json_path", &jsonPath,
 	); err != nil {
 		return nil, err
 	}
 
-	switch x := jsonPath.(type) {
-	case starlark.String:
-		s.k8sImageJsonPathsByKind[kind] = []string{jsonPath.String()}
-	case *starlark.List:
-		var paths []string
-		it := x.Iterate()
-		defer it.Done()
-		var i starlark.Value
-		for it.Next(&i) {
-			s, ok := i.(starlark.String)
-			if !ok {
-				return nil, fmt.Errorf("json_path must be a string or list of strings, found a list containing value '%+v' of type '%T'", i, i)
-			}
-			paths = append(paths, s.String())
-		}
-		s.k8sImageJsonPathsByKind[kind] = paths
-	default:
-		return nil, fmt.Errorf("json_path must be a string or list of strings. Found a %T", jsonPath)
+	// unpacked separately so that this is a keyword-only arg
+	var imageJSONPath starlark.Value
+	if err := starlark.UnpackArgs(fn.Name(), nil, kwargs,
+		"image_json_path", &imageJSONPath,
+	); err != nil {
+		return nil, err
 	}
+
+	values := starlarkValueOrSequenceToSlice(imageJSONPath)
+	var paths []string
+	for _, v := range values {
+		s, ok := v.(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("image_json_path must be a string or list of strings, found a list containing value '%+v' of type '%T'", v, v)
+		}
+		paths = append(paths, s.String())
+	}
+	s.k8sImageJsonPathsByKind[kind] = paths
 
 	return starlark.None, nil
 }
@@ -383,21 +380,17 @@ func (s *tiltfileState) makeK8sResource(name string) (*k8sResource, error) {
 }
 
 func (s *tiltfileState) yamlEntitiesFromSkylarkValueOrList(v starlark.Value) ([]k8s.K8sEntity, error) {
-	if v, ok := v.(starlark.Sequence); ok {
-		var result []k8s.K8sEntity
-		it := v.Iterate()
-		defer it.Done()
-		var i starlark.Value
-		for it.Next(&i) {
-			entities, err := s.yamlEntitiesFromSkylarkValue(i)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, entities...)
+	values := starlarkValueOrSequenceToSlice(v)
+	var ret []k8s.K8sEntity
+	for _, value := range values {
+		entities, err := s.yamlEntitiesFromSkylarkValue(value)
+		if err != nil {
+			return nil, err
 		}
-		return result, nil
+		ret = append(ret, entities...)
 	}
-	return s.yamlEntitiesFromSkylarkValue(v)
+
+	return ret, nil
 }
 
 func parseYAMLFromBlob(blob blob) ([]k8s.K8sEntity, error) {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -148,6 +148,23 @@ func skylarkStringDictToGoMap(d *starlark.Dict) (map[string]string, error) {
 	return r, nil
 }
 
+// If `v` is a `starlark.Sequence`, return a slice of its elements
+// Otherwise, return it as a single-element slice
+// For functions that take `Union[List[T], T]`
+func starlarkValueOrSequenceToSlice(v starlark.Value) []starlark.Value {
+	if v, ok := v.(starlark.Sequence); ok {
+		var ret []starlark.Value
+		it := v.Iterate()
+		defer it.Done()
+		var i starlark.Value
+		for it.Next(&i) {
+			ret = append(ret, i)
+		}
+		return ret
+	}
+	return []starlark.Value{v}
+}
+
 func (tfl *tiltfileLoader) reportTiltfileLoaded(counts map[string]int) {
 	tags := make(map[string]string)
 	for builtinName, count := range counts {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -30,12 +30,13 @@ type tiltfileState struct {
 	dcCli    dockercompose.DockerComposeClient
 
 	// added to during execution
-	configFiles    []string
-	buildIndex     *buildIndex
-	k8s            []*k8sResource
-	k8sByName      map[string]*k8sResource
-	k8sUnresourced []k8s.K8sEntity
-	dc             dcResourceSet // currently only support one d-c.yml
+	configFiles             []string
+	buildIndex              *buildIndex
+	k8s                     []*k8sResource
+	k8sByName               map[string]*k8sResource
+	k8sUnresourced          []k8s.K8sEntity
+	dc                      dcResourceSet // currently only support one d-c.yml
+	k8sImageJsonPathsByKind map[string][]string
 
 	// for assembly
 	usedImages map[string]bool
@@ -51,15 +52,16 @@ type tiltfileState struct {
 func newTiltfileState(ctx context.Context, filename string, tfRoot string, l *log.Logger) *tiltfileState {
 	lp := localPath{path: filename}
 	s := &tiltfileState{
-		ctx:               ctx,
-		filename:          localPath{path: filename},
-		dcCli:             dockercompose.NewDockerComposeClient(),
-		buildIndex:        newBuildIndex(),
-		k8sByName:         make(map[string]*k8sResource),
-		configFiles:       []string{filename},
-		usedImages:        make(map[string]bool),
-		logger:            l,
-		builtinCallCounts: make(map[string]int),
+		ctx:                     ctx,
+		filename:                localPath{path: filename},
+		dcCli:                   dockercompose.NewDockerComposeClient(),
+		buildIndex:              newBuildIndex(),
+		k8sByName:               make(map[string]*k8sResource),
+		k8sImageJsonPathsByKind: make(map[string][]string),
+		configFiles:             []string{filename},
+		usedImages:              make(map[string]bool),
+		logger:                  l,
+		builtinCallCounts:       make(map[string]int),
 	}
 	s.filename = s.maybeAttachGitRepo(lp, filepath.Dir(lp.path))
 	return s
@@ -93,10 +95,11 @@ const (
 	dcResourceN    = "dc_resource"
 
 	// k8s functions
-	k8sYamlN     = "k8s_yaml"
-	filterYamlN  = "filter_yaml"
-	k8sResourceN = "k8s_resource"
-	portForwardN = "port_forward"
+	k8sYamlN              = "k8s_yaml"
+	filterYamlN           = "filter_yaml"
+	k8sResourceN          = "k8s_resource"
+	portForwardN          = "port_forward"
+	k8sExtraImageLocation = "k8s_extra_image_location"
 
 	// file functions
 	localGitRepoN = "local_git_repo"
@@ -142,6 +145,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	addBuiltin(r, filterYamlN, s.filterYaml)
 	addBuiltin(r, k8sResourceN, s.k8sResource)
 	addBuiltin(r, portForwardN, s.portForward)
+	addBuiltin(r, k8sExtraImageLocation, s.k8sExtraImageLocation)
 	addBuiltin(r, localGitRepoN, s.localGitRepo)
 	addBuiltin(r, kustomizeN, s.kustomize)
 	addBuiltin(r, helmN, s.helm)
@@ -251,6 +255,7 @@ func (s *tiltfileState) assembleK8sWithImages() error {
 	if err != nil {
 		return err
 	}
+
 	for _, k8sRef := range k8sRefs {
 		image := s.buildIndex.findBuilderForConsumedImage(k8sRef)
 		if image == nil {
@@ -355,7 +360,7 @@ func (s *tiltfileState) findUnresourcedImages() ([]reference.Named, error) {
 	seen := make(map[string]bool)
 
 	for _, e := range s.k8sUnresourced {
-		images, err := e.FindImages()
+		images, err := e.FindImages(s.k8sImageJsonPathsByKind)
 		if err != nil {
 			return nil, err
 		}
@@ -371,12 +376,12 @@ func (s *tiltfileState) findUnresourcedImages() ([]reference.Named, error) {
 
 // extractEntities extracts k8s entities matching the image ref and stores them on the dest k8sResource
 func (s *tiltfileState) extractEntities(dest *k8sResource, imageRef reference.Named) error {
-	extracted, remaining, err := k8s.FilterByImage(s.k8sUnresourced, imageRef)
+	extracted, remaining, err := k8s.FilterByImage(s.k8sUnresourced, imageRef, s.k8sImageJsonPathsByKind)
 	if err != nil {
 		return err
 	}
 
-	err = dest.addEntities(extracted)
+	err = dest.addEntities(extracted, s.k8sImageJsonPathsByKind)
 	if err != nil {
 		return err
 	}
@@ -389,7 +394,7 @@ func (s *tiltfileState) extractEntities(dest *k8sResource, imageRef reference.Na
 			return err
 		}
 
-		err = dest.addEntities(match)
+		err = dest.addEntities(match, s.k8sImageJsonPathsByKind)
 		if err != nil {
 			return err
 		}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -95,11 +95,11 @@ const (
 	dcResourceN    = "dc_resource"
 
 	// k8s functions
-	k8sYamlN              = "k8s_yaml"
-	filterYamlN           = "filter_yaml"
-	k8sResourceN          = "k8s_resource"
-	portForwardN          = "port_forward"
-	k8sExtraImageLocation = "k8s_extra_image_location"
+	k8sYamlN     = "k8s_yaml"
+	filterYamlN  = "filter_yaml"
+	k8sResourceN = "k8s_resource"
+	portForwardN = "port_forward"
+	k8sKindN     = "k8s_kind"
 
 	// file functions
 	localGitRepoN = "local_git_repo"
@@ -145,7 +145,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	addBuiltin(r, filterYamlN, s.filterYaml)
 	addBuiltin(r, k8sResourceN, s.k8sResource)
 	addBuiltin(r, portForwardN, s.portForward)
-	addBuiltin(r, k8sExtraImageLocation, s.k8sExtraImageLocation)
+	addBuiltin(r, k8sKindN, s.k8sKind)
 	addBuiltin(r, localGitRepoN, s.localGitRepo)
 	addBuiltin(r, kustomizeN, s.kustomize)
 	addBuiltin(r, helmN, s.helm)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1706,7 +1706,7 @@ func TestExtraImageLocationOneImage(t *testing.T) {
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
 	f.file("Tiltfile", `k8s_yaml('crd.yaml')
-k8s_extra_image_location('Environment', '{.spec.runtime.image}')
+k8s_kind('Environment', image_json_path='{.spec.runtime.image}')
 docker_build('test/mycrd-env', 'env')
 `)
 
@@ -1725,7 +1725,7 @@ func TestExtraImageLocationTwoImages(t *testing.T) {
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
 	f.file("Tiltfile", `k8s_yaml('crd.yaml')
-k8s_extra_image_location('Environment', ['{.spec.runtime.image}', '{.spec.builder.image}'])
+k8s_kind('Environment', image_json_path=['{.spec.runtime.image}', '{.spec.builder.image}'])
 docker_build('test/mycrd-builder', 'builder')
 docker_build('test/mycrd-env', 'env')
 `)
@@ -1748,7 +1748,7 @@ func TestExtraImageLocationNoMatch(t *testing.T) {
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
 	f.file("Tiltfile", `k8s_yaml('crd.yaml')
-k8s_extra_image_location('Environment', '{.foobar}')
+k8s_kind('Environment', image_json_path='{.foobar}')
 docker_build('test/mycrd-env', 'env')
 `)
 
@@ -1761,7 +1761,7 @@ func TestExtraImageLocationInvalidJsonPath(t *testing.T) {
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
 	f.file("Tiltfile", `k8s_yaml('crd.yaml')
-k8s_extra_image_location('Environment', '{foobar()}')
+k8s_kind('Environment', image_json_path='{foobar()}')
 docker_build('test/mycrd-env', 'env')
 `)
 
@@ -1770,19 +1770,19 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationNoPaths(t *testing.T) {
 	f := newFixture(t)
-	f.file("Tiltfile", `k8s_extra_image_location('MyType')`)
-	f.loadErrString("missing argument for json_path")
+	f.file("Tiltfile", `k8s_kind('MyType')`)
+	f.loadErrString("missing argument for image_json_path")
 }
 
 func TestExtraImageLocationNotListOrString(t *testing.T) {
 	f := newFixture(t)
-	f.file("Tiltfile", `k8s_extra_image_location('MyType', 8)`)
+	f.file("Tiltfile", `k8s_kind('MyType', image_json_path=8)`)
 	f.loadErrString("json_path must be a string or list of strings", "Int")
 }
 
 func TestExtraImageLocationListContainsNonString(t *testing.T) {
 	f := newFixture(t)
-	f.file("Tiltfile", `k8s_extra_image_location('MyType', ["foo", 8])`)
+	f.file("Tiltfile", `k8s_kind('MyType', image_json_path=["foo", 8])`)
 	f.loadErrString("json_path must be a string or list of strings", "8", "Int")
 }
 


### PR DESCRIPTION
Problems:
1. In order to use CRDs, users had to manually join images with k8s entities by passing them all together to `k8s_resource`, which felt kind of clunky.
2. `k8s_resource` only takes one image, which meant this didn't work with CRDs with multiple images.

Solution:
Add `k8s_extra_image_location` method, which says where to find the image definitions for a given k8s object type, so now CRDs can have multiple images and don't need a call to `k8s_resource`, but can just use the normal tiltfile joining logic.