### PR TITLE
engine: hack to allow us to watch all containers of a pod for logs [ch1737]

### DIFF
--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -86,7 +86,7 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 			containerInfos := pod.ContainerInfos
 			if len(containerInfos) == 0 {
 				containerInfos = []store.ContainerInfo{
-					store.ContainerInfo{Name: pod.ContainerName, ID: pod.ContainerID},
+					store.ContainerInfo{ID: pod.ContainerID, Name: pod.ContainerName},
 				}
 			}
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -609,8 +609,8 @@ func populateContainerStatus(ctx context.Context, manifest model.Manifest, podIn
 			return
 		}
 		cInfos = append(cInfos, store.ContainerInfo{
-			Name: k8s.ContainerNameFromContainerStatus(cStat),
 			ID:   cID,
+			Name: k8s.ContainerNameFromContainerStatus(cStat),
 		})
 	}
 	podInfo.ContainerInfos = cInfos

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/tiltfile"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/windmilleng/tilt/internal/container"
@@ -600,6 +600,11 @@ func populateContainerStatus(ctx context.Context, manifest model.Manifest, podIn
 	// to stream logs from them.
 	var cInfos []store.ContainerInfo
 	for _, cStat := range pod.Status.ContainerStatuses {
+		if cStat.Name == sidecar.SyncletContainerName {
+			// We don't want logs for the Tilt synclet.
+			continue
+		}
+
 		cID, err := k8s.ContainerIDFromContainerStatus(cStat)
 		if err != nil {
 			logger.Get(ctx).Debugf("Error parsing container ID: %v", err)

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -488,6 +488,8 @@ type Pod struct {
 	// until it actually gets removed.
 	Deleting bool
 
+	HasSynclet bool
+
 	// The log for the previously active pod, if any
 	PreRestartLog model.Log `testdiff:"ignore"`
 	// The log for the currently active pod, if any
@@ -504,7 +506,17 @@ type Pod struct {
 	ContainerRestarts int
 	OldRestarts       int // # times the pod restarted when it was running old code
 
-	HasSynclet bool
+	// HACK(maia): eventually we'll want our model of the world to handle pods with
+	// multiple containers (for logs, restart counts, port forwards, etc.). For now,
+	// we need to ship log visibility into multiple containers. Here's the minimum
+	// of info we need for that.
+	ContainerInfos []ContainerInfo
+}
+
+// The minimum info we need to retrieve logs for a container.
+type ContainerInfo struct {
+	container.Name
+	ID container.ID
 }
 
 func (p Pod) Empty() bool {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -515,8 +515,8 @@ type Pod struct {
 
 // The minimum info we need to retrieve logs for a container.
 type ContainerInfo struct {
-	container.Name
 	ID container.ID
+	container.Name
 }
 
 func (p Pod) Empty() bool {


### PR DESCRIPTION
This is the quickest way to support multi-container logs.

It doesn't actually improve our model in any useful way -- that's
for a separate PR.