### PR TITLE
engine: rm dead code in podLogManager

### DIFF
--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -20,15 +20,13 @@ import (
 type PodLogManager struct {
 	kClient k8s.Client
 
-	watches      map[podLogKey]PodLogWatch
-	watchesByPod map[k8s.PodID]PodLogWatch
+	watches map[podLogKey]PodLogWatch
 }
 
 func NewPodLogManager(kClient k8s.Client) *PodLogManager {
 	return &PodLogManager{
-		kClient:      kClient,
-		watches:      make(map[podLogKey]PodLogWatch),
-		watchesByPod: make(map[k8s.PodID]PodLogWatch),
+		kClient: kClient,
+		watches: make(map[podLogKey]PodLogWatch),
 	}
 }
 
@@ -49,12 +47,6 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 		for _, pod := range ms.PodSet.PodList() {
 			if pod.PodID == "" {
 				continue
-			}
-
-			watchByPod, ok := m.watchesByPod[pod.PodID]
-			if ok && watchByPod.cID != pod.ContainerID {
-				watchByPod.cancel()
-				delete(m.watchesByPod, pod.PodID)
 			}
 
 			if pod.ContainerName == "" || pod.ContainerID == "" {
@@ -103,7 +95,6 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 				terminationTime: make(chan time.Time, 1),
 			}
 			m.watches[key] = w
-			m.watchesByPod[pod.PodID] = w
 			setup = append(setup, w)
 		}
 	}
@@ -112,12 +103,6 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 		_, inState := stateWatches[key]
 		if !inState {
 			delete(m.watches, key)
-
-			byPod, ok := m.watchesByPod[key.podID]
-			if ok && byPod.cID != key.cID {
-				delete(m.watchesByPod, key.podID)
-			}
-
 			teardown = append(teardown, value)
 		}
 	}

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -88,7 +88,6 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 				cancel:          cancel,
 				name:            ms.Name,
 				podID:           pod.PodID,
-				cID:             pod.ContainerID,
 				cName:           pod.ContainerName,
 				namespace:       pod.Namespace,
 				startWatchTime:  startWatchTime,
@@ -176,7 +175,6 @@ type PodLogWatch struct {
 	name            model.ManifestName
 	podID           k8s.PodID
 	namespace       k8s.Namespace
-	cID             container.ID
 	cName           container.Name
 	startWatchTime  time.Time
 	terminationTime chan time.Time


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/clean-up-pod-log-watch:

c2fc560669dd3211c118f87897947bc926099d90 (2019-03-05 17:52:39 -0500)
engine: rm dead code in podLogManager

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics