### PR TITLE
tiltfile: don't print 'Successfully executed' prematurely

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -80,6 +80,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		configFiles = s.configFiles
 	}()
 
+	s.logger.Printf("Beginning Tiltfile execution")
 	if err := s.exec(); err != nil {
 		if err, ok := err.(*starlark.EvalError); ok {
 			return nil, model.Manifest{}, nil, s.warnings, errors.New(err.Backtrace())
@@ -115,6 +116,10 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		if err != nil {
 			return nil, model.Manifest{}, nil, s.warnings, err
 		}
+	}
+
+	if err == nil {
+		s.logger.Printf("Successfully loaded Tiltfile")
 	}
 
 	tfl.reportTiltfileLoaded(s.builtinCallCounts)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -74,11 +74,7 @@ func (s *tiltfileState) exec() error {
 		},
 	}
 
-	s.logger.Printf("Beginning Tiltfile execution")
 	_, err := starlark.ExecFile(thread, s.filename.path, nil, s.builtins())
-	if err == nil {
-		s.logger.Printf("Successfully executed Tiltfile")
-	}
 	return err
 }
 


### PR DESCRIPTION
to avoid, e.g.:
```
2019/03/04 15:55:04 Running `"m4 -Dvarowner=\"matt\" \"deploy/fission.yaml\""`
2019/03/04 15:55:04 Successfully executed Tiltfile
resource "go-env": could not find k8s entities matching image(s)
"gcr.io/windmill-public-containers/servantes/go-env"; perhaps there's
a typo?
```