### PR TITLE
engine: keep trying to watch for Docker Compose events if we didn't actually start watching the first time

### DIFF
--- a/internal/engine/docker_compose_event_watcher.go
+++ b/internal/engine/docker_compose_event_watcher.go
@@ -30,7 +30,6 @@ func (w *DockerComposeEventWatcher) OnChange(ctx context.Context, st store.RStor
 	if !w.needsWatch(st) {
 		return
 	}
-	w.watching = true
 
 	state := st.RLockState()
 	configPath := state.DockerComposeConfigPath()
@@ -41,6 +40,7 @@ func (w *DockerComposeEventWatcher) OnChange(ctx context.Context, st store.RStor
 		return
 	}
 
+	w.watching = true
 	ch, err := w.startWatch(ctx, configPath)
 	if err != nil {
 		err = errors.Wrap(err, "Subscribing to docker-compose events")


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/fix-dc-event-watch:

e902d4be932125238e28e5bce01559cdebb03510 (2019-03-06 17:12:22 -0500)
engine: keep trying to watch for Docker Compose events if we didn't actually start watching the first time

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics