### PR TITLE
engine: prefix logs with container name where appropriate

### DIFF
--- a/internal/engine/podlogmanager_test.go
+++ b/internal/engine/podlogmanager_test.go
@@ -41,10 +41,7 @@ func TestLogs(t *testing.T) {
 	f.store.UnlockMutableState()
 
 	f.plm.OnChange(f.ctx, f.store)
-	err := f.out.WaitUntilContains("hello world!", time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	f.AssertOutputContains("hello world!")
 }
 
 func TestLogActions(t *testing.T) {
@@ -88,10 +85,7 @@ func TestLogsFailed(t *testing.T) {
 	f.store.UnlockMutableState()
 
 	f.plm.OnChange(f.ctx, f.store)
-	err := f.out.WaitUntilContains("Error streaming server logs", time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	f.AssertOutputContains("Error streaming server logs")
 	assert.Contains(t, f.out.String(), "my-error")
 }
 
@@ -114,19 +108,13 @@ func TestLogsCanceledUnexpectedly(t *testing.T) {
 	f.store.UnlockMutableState()
 
 	f.plm.OnChange(f.ctx, f.store)
-	err := f.out.WaitUntilContains("hello world!\n", time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	f.AssertOutputContains("hello world!\n")
 
 	// Previous log stream has finished, so the first pod watch has been canceled,
 	// but not cleaned up; check that we start a new watch .OnChange
 	f.kClient.SetLogsForPodContainer(podID, cName, "goodbye world!\n")
 	f.plm.OnChange(f.ctx, f.store)
-	err = f.out.WaitUntilContains("goodbye world!\n", time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	f.AssertOutputContains("goodbye world!\n")
 }
 
 func TestMultiContainerLogs(t *testing.T) {
@@ -153,14 +141,8 @@ func TestMultiContainerLogs(t *testing.T) {
 	f.store.UnlockMutableState()
 
 	f.plm.OnChange(f.ctx, f.store)
-	err := f.out.WaitUntilContains("hello world!", time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = f.out.WaitUntilContains("goodbye world!", time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	f.AssertOutputContains("hello world!")
+	f.AssertOutputContains("goodbye world!")
 }
 
 func TestContainerPrefixes(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/container-prefixes-ch1738:

f733c3ef544ec22f122d77397aa766bffabd150c (2019-03-07 11:37:21 -0500)
clean up tests with better assert funcs

410d4abd99f66ff06efebd399f8c0377124050e1 (2019-03-07 11:36:05 -0500)
engine: prefix logs with container name where appropriate

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics