### PR TITLE
container: Add a concept of image selectors in place of image refs.

### DIFF
--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -1,0 +1,51 @@
+package container
+
+import "github.com/docker/distribution/reference"
+
+type RefSelector struct {
+	ref reference.Named
+}
+
+func NewRefSelector(ref reference.Named) RefSelector {
+	return RefSelector{ref: ref}
+}
+
+func MustParseSelector(s string) RefSelector {
+	return NewRefSelector(MustParseNamed(s))
+}
+
+func MustParseTaggedSelector(s string) RefSelector {
+	return NewRefSelector(MustParseNamedTagged(s))
+}
+
+func (s RefSelector) Matches(toMatch reference.Named) bool {
+	if s.ref == nil {
+		return false
+	}
+	return toMatch.Name() == s.ref.Name()
+}
+
+func (s RefSelector) Empty() bool {
+	return s.ref == nil
+}
+
+func (s RefSelector) Name() string {
+	return s.ref.Name()
+}
+
+func (s RefSelector) AsNamedOnly() reference.Named {
+	return reference.TrimNamed(s.ref)
+}
+
+// TODO(nick): This method is only provided for legacy compatibility.
+// All uses of this really should not be using the full ref.
+func (s RefSelector) AsRef() reference.Named {
+	return s.ref
+}
+
+func (s RefSelector) String() string {
+	if s.ref == nil {
+		return ""
+	}
+	return s.ref.String()
+}

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -123,7 +123,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 }
 
 func (bd *DockerComposeBuildAndDeployer) tagWithExpected(ctx context.Context, ref reference.NamedTagged,
-	expected reference.Named) (reference.NamedTagged, error) {
+	expected container.RefSelector) (reference.NamedTagged, error) {
 	var tagAs reference.NamedTagged
 	expectedNt, err := container.ParseNamedTagged(expected.String())
 	if err == nil {

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -24,7 +24,7 @@ var dcTarg = model.DockerComposeTarget{Name: dcName, ConfigPath: confPath}
 
 var imgRef = "gcr.io/some/image"
 var imgTarg = model.ImageTarget{
-	Ref: container.MustParseNamed(imgRef),
+	Ref: container.MustParseSelector(imgRef),
 	BuildDetails: model.StaticBuild{
 		Dockerfile: "Dockerfile.whales",
 		BuildPath:  "/whales/are/big",
@@ -78,7 +78,7 @@ func TestTiltBuildsImageWithTag(t *testing.T) {
 
 	refWithTag := "gcr.io/foo:bar"
 	iTarget := model.ImageTarget{
-		Ref:          container.MustParseNamed(refWithTag),
+		Ref:          container.MustParseSelector(refWithTag),
 		BuildDetails: model.StaticBuild{},
 	}
 

--- a/internal/engine/image_and_cache_builder.go
+++ b/internal/engine/image_and_cache_builder.go
@@ -46,7 +46,7 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 		defer ps.EndPipelineStep(ctx)
 
 		df := icb.staticDockerfile(iTarget, cacheRef)
-		ref, err := icb.ib.BuildDockerfile(ctx, ps, ref, df, bd.BuildPath, ignore.CreateBuildContextFilter(iTarget), bd.BuildArgs)
+		ref, err := icb.ib.BuildDockerfile(ctx, ps, ref.AsNamedOnly(), df, bd.BuildPath, ignore.CreateBuildContextFilter(iTarget), bd.BuildArgs)
 
 		if err != nil {
 			return nil, err
@@ -62,7 +62,7 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 
 			df := icb.baseDockerfile(bd, cacheRef, iTarget.CachePaths())
 			steps := bd.Steps
-			ref, err := icb.ib.BuildImageFromScratch(ctx, ps, ref, df, bd.Mounts, ignore.CreateBuildContextFilter(iTarget), steps, bd.Entrypoint)
+			ref, err := icb.ib.BuildImageFromScratch(ctx, ps, ref.AsNamedOnly(), df, bd.Mounts, ignore.CreateBuildContextFilter(iTarget), steps, bd.Entrypoint)
 
 			if err != nil {
 				return nil, err
@@ -95,7 +95,7 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 	case model.CustomBuild:
 		ps.StartPipelineStep(ctx, "Building Dockerfile: [%s]", ref)
 		defer ps.EndPipelineStep(ctx)
-		ref, err := icb.custb.Build(ctx, ref, bd.Command)
+		ref, err := icb.custb.Build(ctx, ref.AsNamedOnly(), bd.Command)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +166,7 @@ func (icb *imageAndCacheBuilder) createCacheInputs(iTarget model.ImageTarget) bu
 	}
 
 	return build.CacheInputs{
-		Ref:            iTarget.Ref,
+		Ref:            iTarget.Ref.AsNamedOnly(),
 		CachePaths:     iTarget.CachePaths(),
 		BaseDockerfile: baseDockerfile,
 	}

--- a/internal/engine/imagecontroller.go
+++ b/internal/engine/imagecontroller.go
@@ -40,7 +40,7 @@ func (c *ImageController) refsToReap(st store.RStore) []reference.Named {
 	refs := []reference.Named{}
 	for _, manifest := range state.Manifests() {
 		for _, iTarget := range manifest.ImageTargets {
-			refs = append(refs, iTarget.Ref)
+			refs = append(refs, iTarget.Ref.AsNamedOnly())
 		}
 	}
 	return refs

--- a/internal/engine/synclet_manager.go
+++ b/internal/engine/synclet_manager.go
@@ -7,6 +7,7 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/options"
 	"github.com/windmilleng/tilt/internal/store"
@@ -190,7 +191,7 @@ func newSyncletClient(ctx context.Context, kCli k8s.Client, podID k8s.PodID, ns 
 	}
 
 	// Make sure that the synclet container is ready and not crashlooping.
-	_, err = k8s.WaitForContainerReady(ctx, kCli, pod, sidecar.SyncletImageRef)
+	_, err = k8s.WaitForContainerReady(ctx, kCli, pod, container.NewRefSelector(sidecar.SyncletImageRef))
 	if err != nil {
 		return nil, errors.Wrap(err, "newSyncletClient")
 	}

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -27,9 +27,9 @@ type pather interface {
 	MkdirAll(p string)
 }
 
-var SanchoRef = container.MustParseNamed("gcr.io/some-project-162817/sancho")
-var SanchoBaseRef = container.MustParseNamed("sancho-base")
-var SanchoSidecarRef = container.MustParseNamed("gcr.io/some-project-162817/sancho-sidecar")
+var SanchoRef = container.MustParseSelector("gcr.io/some-project-162817/sancho")
+var SanchoBaseRef = container.MustParseSelector("sancho-base")
+var SanchoSidecarRef = container.MustParseSelector("gcr.io/some-project-162817/sancho-sidecar")
 
 func NewSanchoFastBuild(fixture pather) model.FastBuild {
 	return model.FastBuild{
@@ -165,9 +165,9 @@ func NewSanchoFastMultiStageManifest(fixture pather) model.Manifest {
 }
 
 func NewManifestsWithCommonAncestor(fixture pather) (model.Manifest, model.Manifest) {
-	refCommon := container.MustParseNamed("gcr.io/common")
-	ref1 := container.MustParseNamed("gcr.io/image-1")
-	ref2 := container.MustParseNamed("gcr.io/image-2")
+	refCommon := container.MustParseSelector("gcr.io/common")
+	ref1 := container.MustParseSelector("gcr.io/image-1")
+	ref2 := container.MustParseSelector("gcr.io/image-2")
 
 	fixture.MkdirAll("common")
 	fixture.MkdirAll("image-1")

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2468,7 +2468,7 @@ func (f *testFixture) imageNameForManifest(manifestName string) reference.Named 
 }
 
 func (f *testFixture) newManifest(name string, mounts []model.Mount) model.Manifest {
-	ref := f.imageNameForManifest(name)
+	ref := container.NewRefSelector(f.imageNameForManifest(name))
 	return assembleK8sManifest(
 		model.Manifest{Name: model.ManifestName(name)},
 		model.K8sTarget{YAML: "fake-yaml"},

--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -15,7 +15,7 @@ import (
 func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	f := newClientTestFixture(t)
 
-	nt := container.MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseSelector(blorgDevImgStr)
 	podData := fakePod(expectedPod, blorgDevImgStr)
 	podData.Status = v1.PodStatus{
 		ContainerStatuses: []v1.ContainerStatus{
@@ -53,7 +53,7 @@ func TestWaitForContainerSuccess(t *testing.T) {
 	f := newClientTestFixture(t)
 	f.addObject(&fakePodList)
 
-	nt := container.MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseTaggedSelector(blorgDevImgStr)
 	pod, err := f.client.core.Pods("").Get(expectedPod.String(), metav1.GetOptions{})
 	if err != nil {
 		f.t.Fatal(err)
@@ -91,7 +91,7 @@ func TestWaitForContainerFailure(t *testing.T) {
 	f := newClientTestFixture(t)
 	f.addObject(&fakePodList)
 
-	nt := container.MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseTaggedSelector(blorgDevImgStr)
 	pod, err := f.client.core.Pods("").Get(expectedPod.String(), metav1.GetOptions{})
 	if err != nil {
 		f.t.Fatal(err)
@@ -132,7 +132,7 @@ func TestWaitForContainerUnschedulable(t *testing.T) {
 	f := newClientTestFixture(t)
 	f.addObject(&fakePodList)
 
-	nt := container.MustParseNamedTagged(blorgDevImgStr)
+	nt := container.MustParseTaggedSelector(blorgDevImgStr)
 	pod, err := f.client.core.Pods("").Get(expectedPod.String(), metav1.GetOptions{})
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -192,7 +192,7 @@ func Filter(entities []K8sEntity, test func(e K8sEntity) (bool, error)) (passing
 	return passing, rest, nil
 }
 
-func FilterByImage(entities []K8sEntity, img reference.Named, k8sImageJsonPathsByKind map[string][]string) (passing, rest []K8sEntity, err error) {
+func FilterByImage(entities []K8sEntity, img container.RefSelector, k8sImageJsonPathsByKind map[string][]string) (passing, rest []K8sEntity, err error) {
 	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img, k8sImageJsonPathsByKind) })
 }
 

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -178,7 +178,7 @@ func injectImageDigestInUnstructured(entity K8sEntity, injectRef reference.Named
 }
 
 // HasImage indicates whether the given entity is tagged with the given image.
-func (e K8sEntity) HasImage(image reference.Named, k8sImageJsonPathsByKind map[string][]string) (bool, error) {
+func (e K8sEntity) HasImage(image container.RefSelector, k8sImageJsonPathsByKind map[string][]string) (bool, error) {
 	images, err := e.FindImages(k8sImageJsonPathsByKind)
 	if err != nil {
 		fmt.Printf("error in FindImages: %+v\n", err)
@@ -186,7 +186,7 @@ func (e K8sEntity) HasImage(image reference.Named, k8sImageJsonPathsByKind map[s
 	}
 
 	for _, existingRef := range images {
-		if existingRef.Name() == image.Name() {
+		if image.Matches(existingRef) {
 			return true, nil
 		}
 	}

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -240,8 +240,8 @@ func TestEntityHasImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	img := container.MustParseNamed("gcr.io/blorg-dev/blorg-backend:devel-nick")
-	wrongImg := container.MustParseNamed("gcr.io/blorg-dev/wrong-app-whoops:devel-nick")
+	img := container.MustParseSelector("gcr.io/blorg-dev/blorg-backend:devel-nick")
+	wrongImg := container.MustParseSelector("gcr.io/blorg-dev/wrong-app-whoops:devel-nick")
 
 	match, err := entities[0].HasImage(img, nil)
 	if err != nil {
@@ -253,25 +253,25 @@ func TestEntityHasImage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.True(t, match, "deployment yaml should match image %s", img.Name())
+	assert.True(t, match, "deployment yaml should match image %s", img.String())
 
 	match, err = entities[1].HasImage(wrongImg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.False(t, match, "deployment yaml should not match image %s", img.Name())
+	assert.False(t, match, "deployment yaml should not match image %s", img.String())
 
 	entities, err = ParseYAMLFromString(testyaml.CRDYAML)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	img = container.MustParseNamed("docker.io/bitnami/minideb:latest")
+	img = container.MustParseTaggedSelector("docker.io/bitnami/minideb:latest")
 	match, err = entities[0].HasImage(img, map[string][]string{"CustomResourceDefinition": {"{.spec.validation.openAPIV3Schema.properties.spec.properties.image}"}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.True(t, match, "CRD yaml should match image %s", img.Name())
+	assert.True(t, match, "CRD yaml should match image %s", img.String())
 }
 
 func TestInjectDigestEnvVar(t *testing.T) {

--- a/internal/model/custom_build_test.go
+++ b/internal/model/custom_build_test.go
@@ -42,7 +42,7 @@ func TestValidate(t *testing.T) {
 		Deps:    []string{"foo", "bar"},
 	}
 	it := ImageTarget{
-		Ref:          container.MustParseNamed("gcr.io/foo/bar"),
+		Ref:          container.MustParseSelector("gcr.io/foo/bar"),
 		BuildDetails: cb,
 	}
 
@@ -55,7 +55,7 @@ func TestDoesNotValidate(t *testing.T) {
 		Deps:    []string{"foo", "bar"},
 	}
 	it := ImageTarget{
-		Ref:          container.MustParseNamed("gcr.io/foo/bar"),
+		Ref:          container.MustParseSelector("gcr.io/foo/bar"),
 		BuildDetails: cb,
 	}
 

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -5,12 +5,12 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/sliceutils"
 )
 
 type ImageTarget struct {
-	Ref          reference.Named
+	Ref          container.RefSelector
 	BuildDetails BuildDetails
 
 	cachePaths []string
@@ -24,10 +24,10 @@ type ImageTarget struct {
 	dependencyIDs []TargetID
 }
 
-func ImageID(ref reference.Named) TargetID {
+func ImageID(ref container.RefSelector) TargetID {
 	name := TargetName("")
-	if ref != nil {
-		name = TargetName(ref.Name())
+	if !ref.Empty() {
+		name = TargetName(ref.String())
 	}
 	return TargetID{
 		Type: TargetTypeImage,
@@ -49,7 +49,7 @@ func (i ImageTarget) WithDependencyIDs(ids []TargetID) ImageTarget {
 }
 
 func (i ImageTarget) Validate() error {
-	if i.Ref == nil {
+	if i.Ref.Empty() {
 		return fmt.Errorf("[Validate] Image target missing image ref: %+v", i.BuildDetails)
 	}
 

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -12,8 +12,8 @@ import (
 var portFwd8000 = []PortForward{{LocalPort: 8080}}
 var portFwd8001 = []PortForward{{LocalPort: 8081}}
 
-var img1 = container.MustParseNamed("blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f")
-var img2 = container.MustParseNamed("blorg.io/blorgdev/blorg-backend:tilt-361d98a2d335373f")
+var img1 = container.MustParseSelector("blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f")
+var img2 = container.MustParseSelector("blorg.io/blorgdev/blorg-backend:tilt-361d98a2d335373f")
 
 var buildArgs1 = DockerBuildArgs{
 	"foo": "bar",

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -203,7 +203,7 @@ func NewDeployInfo(iTarget model.ImageTarget, podSet PodSet) DeployInfo {
 	}
 
 	// Only return the pod if it matches our image.
-	if pod.ContainerImageRef == nil || pod.ContainerImageRef.Name() != iTarget.Ref.Name() {
+	if pod.ContainerImageRef == nil || !iTarget.Ref.Matches(pod.ContainerImageRef) {
 		return DeployInfo{}
 	}
 

--- a/internal/tiltfile/build_index.go
+++ b/internal/tiltfile/build_index.go
@@ -32,7 +32,9 @@ func newBuildIndex() *buildIndex {
 }
 
 func (idx *buildIndex) addImage(img *dockerImage) error {
-	ref := img.ref
+	// TODO(nick): Rewrite this index to allow multiple selectors with the
+	// same name but different tags.
+	ref := img.ref.AsRef()
 	refTagged, hasTag := ref.(reference.NamedTagged)
 	if hasTag {
 		key := fmt.Sprintf("%s:%s", ref.Name(), refTagged.Tag())

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -18,7 +18,7 @@ import (
 type dockerImage struct {
 	baseDockerfilePath localPath
 	baseDockerfile     dockerfile.Dockerfile
-	ref                reference.Named
+	ref                container.RefSelector
 	mounts             []mount
 	steps              []model.Step
 	entrypoint         string
@@ -125,7 +125,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		staticDockerfilePath: dockerfilePath,
 		staticDockerfile:     dockerfile.Dockerfile(dockerfileContents),
 		staticBuildPath:      context,
-		ref:                  ref,
+		ref:                  container.NewRefSelector(ref),
 		staticBuildArgs:      sba,
 		cachePaths:           cachePaths,
 	}
@@ -177,7 +177,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 	}
 
 	img := &dockerImage{
-		ref:           ref,
+		ref:           container.NewRefSelector(ref),
 		customCommand: command,
 		customDeps:    localDeps,
 	}
@@ -198,7 +198,7 @@ type customBuild struct {
 var _ starlark.Value = &customBuild{}
 
 func (b *customBuild) String() string {
-	return fmt.Sprintf("custom_build(%q)", b.img.ref.Name())
+	return fmt.Sprintf("custom_build(%q)", b.img.ref.String())
 }
 
 func (b *customBuild) Type() string {
@@ -279,7 +279,7 @@ func (s *tiltfileState) fastBuild(thread *starlark.Thread, fn *starlark.Builtin,
 	r := &dockerImage{
 		baseDockerfilePath: baseDockerfilePath,
 		baseDockerfile:     df,
-		ref:                ref,
+		ref:                container.NewRefSelector(ref),
 		entrypoint:         entrypoint,
 		cachePaths:         cachePaths,
 	}
@@ -317,7 +317,7 @@ type fastBuild struct {
 var _ starlark.Value = &fastBuild{}
 
 func (b *fastBuild) String() string {
-	return fmt.Sprintf("fast_build(%q)", b.img.ref.Name())
+	return fmt.Sprintf("fast_build(%q)", b.img.ref.String())
 }
 
 func (b *fastBuild) Type() string {
@@ -369,7 +369,7 @@ func (b *fastBuild) hotReload(thread *starlark.Thread, fn *starlark.Builtin, arg
 
 func (b *fastBuild) add(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(b.img.steps) > 0 {
-		return nil, fmt.Errorf("fast_build(%q).add() called after .run(); must add all code before runs", b.img.ref.Name())
+		return nil, fmt.Errorf("fast_build(%q).add() called after .run(); must add all code before runs", b.img.ref.String())
 	}
 
 	var src starlark.Value

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1978,7 +1978,7 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 			image := nextImageTarget()
 			caches := image.CachePaths()
 			ref := image.Ref
-			if ref == nil {
+			if ref.Empty() {
 				f.t.Fatalf("manifest %v has no image ref; expected %q", m.Name, opt.image.ref)
 			}
 			if ref.Name() != opt.image.ref {


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/ch1654/selector:

56c33aa0ad99d8afdcdb432ee942df95c94fac8b (2019-03-07 11:57:18 -0500)
container: Add a concept of image selectors in place of image refs.
This is in service of https://github.com/windmilleng/tilt/issues/1259, but
currenlty changes no functionality