### PR TITLE
integration: add back filewatching to dc integration test

### DIFF
--- a/integration/dc_fixture_test.go
+++ b/integration/dc_fixture_test.go
@@ -1,0 +1,84 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+type dcFixture struct {
+	*fixture
+}
+
+func newDCFixture(t *testing.T, dir string) *dcFixture {
+	f := newFixture(t, dir)
+	return &dcFixture{fixture: f}
+}
+
+func (f *dcFixture) dockerCmd(args []string, outWriter io.Writer) *exec.Cmd {
+	outWriter = io.MultiWriter(f.logs, outWriter)
+	cmd := exec.CommandContext(f.ctx, "docker", args...)
+	cmd.Stdout = outWriter
+	cmd.Stderr = outWriter
+	return cmd
+}
+
+func (f *dcFixture) dockerContainerID(name string) (string, error) {
+	out := &bytes.Buffer{}
+	cmd := f.dockerCmd([]string{
+		"ps", "-q", "-f", fmt.Sprintf("name=%s", name),
+	}, out)
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	cID := strings.TrimSpace(out.String())
+	if cID == "" {
+		return "", fmt.Errorf("No container found for %s", name)
+	}
+	return cID, nil
+}
+
+func (f *dcFixture) dockerKillAll(name string) {
+	out := &bytes.Buffer{}
+	cmd := f.dockerCmd([]string{
+		"ps", "-q", "-f", fmt.Sprintf("name=%s", name),
+	}, out)
+	err := cmd.Run()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	cIDs := strings.Split(strings.TrimSpace(out.String()), " ")
+	if len(cIDs) == 0 || (len(cIDs) == 1 && cIDs[0] == "") {
+		return
+	}
+
+	cmd = f.dockerCmd(append([]string{
+		"kill",
+	}, cIDs...), ioutil.Discard)
+	err = cmd.Run()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *dcFixture) CurlUntil(ctx context.Context, service string, url string, expectedContents string) {
+	f.WaitUntil(ctx, fmt.Sprintf("curl(%s)", url), func() (string, error) {
+		out := &bytes.Buffer{}
+		cID, err := f.dockerContainerID(service)
+		if err != nil {
+			return "", err
+		}
+
+		cmd := f.dockerCmd([]string{
+			"exec", cID, "curl", "-s", url,
+		}, out)
+		err = cmd.Run()
+		return out.String(), err
+	}, expectedContents)
+}

--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -1,0 +1,162 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type k8sFixture struct {
+	*fixture
+}
+
+func newK8sFixture(t *testing.T, dir string) *k8sFixture {
+	f := newFixture(t, dir)
+
+	kf := &k8sFixture{fixture: f}
+	kf.CreateNamespaceIfNecessary()
+	kf.ClearNamespace()
+	return kf
+}
+
+func (f *k8sFixture) Curl(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", errors.Wrap(err, "Curl")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		f.t.Errorf("Error fetching %s: %s", url, resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "Curl")
+	}
+	return string(body), nil
+}
+
+func (f *k8sFixture) CurlUntil(ctx context.Context, url string, expectedContents string) {
+	f.WaitUntil(ctx, fmt.Sprintf("curl(%s)", url), func() (string, error) {
+		return f.Curl(url)
+	}, expectedContents)
+}
+
+// Waits until all pods matching the selector are ready.
+// At least one pod must match.
+// Returns the names of the ready pods.
+func (f *k8sFixture) WaitForAllPodsReady(ctx context.Context, selector string) []string {
+	for {
+		allPodsReady, output, podNames := f.AllPodsReady(ctx, selector)
+		if allPodsReady {
+			return podNames
+		}
+
+		select {
+		case <-ctx.Done():
+			f.t.Fatalf("Timed out waiting for pods to be ready. Selector: %s. Output:\n:%s\n", selector, output)
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+// Returns the output (for diagnostics) and the name of the ready pods.
+func (f *k8sFixture) AllPodsReady(ctx context.Context, selector string) (bool, string, []string) {
+	cmd := exec.Command("kubectl", "get", "pods",
+		namespaceFlag, "--selector="+selector, "-o=template",
+		"--template", "{{range .items}}{{.metadata.name}} {{.status.phase}}{{println}}{{end}}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+
+	outStr := string(out)
+	lines := strings.Split(outStr, "\n")
+	podNames := []string{}
+	hasOneRunningPod := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		elements := strings.Split(line, " ")
+		if len(elements) < 2 {
+			f.t.Fatalf("Unexpected output of kubect get pods: %s", outStr)
+		}
+
+		name, phase := elements[0], elements[1]
+		if phase == "Running" {
+			hasOneRunningPod = true
+		} else {
+			return false, outStr, nil
+		}
+
+		podNames = append(podNames, name)
+	}
+	return hasOneRunningPod, outStr, podNames
+}
+
+func (f *k8sFixture) ForwardPort(name string, portMap string) {
+	outWriter := os.Stdout
+
+	cmd := exec.CommandContext(f.ctx, "kubectl", "port-forward", namespaceFlag, name, portMap)
+	cmd.Stdout = outWriter
+	cmd.Stderr = outWriter
+	err := cmd.Start()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+
+	f.cmds = append(f.cmds, cmd)
+	go func() {
+		err := cmd.Wait()
+		if err != nil && !f.tearingDown {
+			fmt.Printf("port forward failed: %v\n", err)
+		}
+	}()
+}
+
+func (f *k8sFixture) ClearResource(name string) {
+	outWriter := bytes.NewBuffer(nil)
+	cmd := exec.CommandContext(f.ctx, "kubectl", "delete", name, namespaceFlag, "--all")
+	cmd.Stdout = outWriter
+	cmd.Stderr = outWriter
+	err := cmd.Run()
+	if err != nil {
+		f.t.Fatalf("Error deleting deployments: %v. Logs:\n%s", err, outWriter.String())
+	}
+}
+
+func (f *k8sFixture) CreateNamespaceIfNecessary() {
+	outWriter := bytes.NewBuffer(nil)
+	cmd := exec.CommandContext(f.ctx, "kubectl", "apply", "-f", "namespace.yaml")
+	cmd.Stdout = outWriter
+	cmd.Stderr = outWriter
+	cmd.Dir = packageDir
+	err := cmd.Run()
+	if err != nil {
+		f.t.Fatalf("Error creating namespace: %v. Logs:\n%s", err, outWriter.String())
+	}
+}
+
+func (f *k8sFixture) ClearNamespace() {
+	f.ClearResource("deployments")
+	f.ClearResource("services")
+}
+
+func (f *k8sFixture) TearDown() {
+	f.tearingDown = true
+	f.ClearNamespace()
+	f.fixture.TearDown()
+}

--- a/integration/onedc_test.go
+++ b/integration/onedc_test.go
@@ -5,13 +5,12 @@ package integration
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"testing"
 	"time"
 )
 
 func TestOneDockerCompose(t *testing.T) {
-	f := newFixture(t, "onedc")
+	f := newDCFixture(t, "onedc")
 	defer f.TearDown()
 
 	f.dockerKillAll("onedc_web")
@@ -29,21 +28,11 @@ func TestOneDockerCompose(t *testing.T) {
 		return out.String(), err
 	}, "onedc_web")
 
-	cID := f.dockerContainerID("onedc_web")
+	f.CurlUntil(ctx, "onedc_web", "localhost:8000", "🍄 One-Up! 🍄")
 
-	f.WaitUntil(ctx, fmt.Sprintf("onedc_web curl(%s)", cID), func() (string, error) {
-		out := &bytes.Buffer{}
-		cmd := f.dockerCmd([]string{
-			"exec", cID, "curl", "-s", "localhost:8000",
-		}, out)
-		err := cmd.Run()
-		return out.String(), err
-	}, "🍄 One-Up! 🍄")
+	f.ReplaceContents("main.go", "One-Up", "Two-Up")
 
-	// TODO(nick): uncomment when file-watching works
-	// f.ReplaceContents("main.go", "One-Up", "Two-Up")
-
-	// ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
-	// defer cancel()
-	// f.CurlUntil(ctx, "http://localhost:31235", "🍄 Two-Up! 🍄")
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "onedc_web", "localhost:8000", "🍄 Two-Up! 🍄")
 }

--- a/integration/oneup_custom_test.go
+++ b/integration/oneup_custom_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOneUpCustom(t *testing.T) {
-	f := newFixture(t, "oneup_custom")
+	f := newK8sFixture(t, "oneup_custom")
 	defer f.TearDown()
 
 	f.TiltUp("oneup-custom")

--- a/integration/oneup_test.go
+++ b/integration/oneup_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOneUp(t *testing.T) {
-	f := newFixture(t, "oneup")
+	f := newK8sFixture(t, "oneup")
 	defer f.TearDown()
 
 	f.TiltUp("oneup")

--- a/integration/onewatch_test.go
+++ b/integration/onewatch_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestOneWatch(t *testing.T) {
-	f := newFixture(t, "onewatch")
+	f := newK8sFixture(t, "onewatch")
 	defer f.TearDown()
 
 	f.TiltWatch("onewatch")


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/dc-integ-filewatch:

4231e11b1db277e4021fbe061063df65cbfcdcd9 (2019-03-07 14:15:15 -0500)
integration: add back filewatching to dc integration test

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics