### PR TITLE
 store: fix a bug in the results api when there are multiple images

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -156,7 +156,7 @@ func TestContainerBuildLocal(t *testing.T) {
 	id := manifest.ImageTargetAt(0).ID()
 	_, hasResult := result[id]
 	assert.True(t, hasResult)
-	assert.Equal(t, k8s.MagicTestContainerID, result.AsOneResult().ContainerID.String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
 }
 
 func TestContainerBuildSynclet(t *testing.T) {
@@ -182,7 +182,7 @@ func TestContainerBuildSynclet(t *testing.T) {
 		t.Errorf("Expected 1 synclet containerUpdate, actual: %d", f.sCli.UpdateContainerCount)
 	}
 
-	assert.Equal(t, k8s.MagicTestContainerID, result.AsOneResult().ContainerID.String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
 	assert.False(t, f.sCli.UpdateContainerHotReload)
 }
 
@@ -522,7 +522,7 @@ func TestContainerBuildMultiStage(t *testing.T) {
 	assert.False(t, hasResult0)
 	_, hasResult1 := result[manifest.ImageTargetAt(1).ID()]
 	assert.True(t, hasResult1)
-	assert.Equal(t, k8s.MagicTestContainerID, result.AsOneResult().ContainerID.String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
 }
 
 // The API boundaries between BuildAndDeployer and the ImageBuilder aren't obvious and

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -47,7 +47,7 @@ func TestDockerComposeTargetBuilt(t *testing.T) {
 		assert.Equal(t, dcName, call.ServiceName)
 		assert.True(t, call.ShouldBuild)
 	}
-	assert.Equal(t, expectedContainer, res.AsOneResult().ContainerID)
+	assert.Equal(t, expectedContainer, res.OneAndOnlyContainerID())
 }
 
 func TestTiltBuildsImage(t *testing.T) {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -293,7 +293,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	if mt.Manifest.IsDC() {
 		state, _ := ms.ResourceState.(dockercompose.State)
 
-		cid := cb.Result.AsOneResult().ContainerID
+		cid := cb.Result.OneAndOnlyContainerID()
 		if cid != "" {
 			state = state.WithContainerID(cid)
 		}
@@ -312,9 +312,9 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	if engineState.WatchMounts {
 		logger.Get(ctx).Debugf("[timing.py] finished build from file change") // hook for timing.py
 
-		result := cb.Result.AsOneResult()
-		if result.ContainerID != "" {
-			ms.ExpectedContainerID = result.ContainerID
+		cID := cb.Result.OneAndOnlyContainerID()
+		if cID != "" {
+			ms.ExpectedContainerID = cID
 
 			bestPod := ms.MostRecentPod()
 			if bestPod.StartedAt.After(bs.StartTime) ||

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -53,13 +53,22 @@ func (b BuildResult) ShallowCloneForContainerUpdate(filesReplacedSet map[string]
 
 type BuildResultSet map[model.TargetID]BuildResult
 
-func (set BuildResultSet) AsOneResult() BuildResult {
-	if len(set) == 1 {
-		for _, result := range set {
-			return result
+// Returns a container ID iff it's the only container ID in the result set.
+// If there are multiple container IDs, we have to give up.
+func (set BuildResultSet) OneAndOnlyContainerID() container.ID {
+	var id container.ID
+	for _, result := range set {
+		if result.ContainerID == "" {
+			continue
 		}
+
+		if id != "" && result.ContainerID != id {
+			return ""
+		}
+
+		id = result.ContainerID
 	}
-	return BuildResult{}
+	return id
 }
 
 // The state of the system since the last successful build.

--- a/internal/store/build_result_test.go
+++ b/internal/store/build_result_test.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/model"
+)
+
+func imageID(s string) model.TargetID {
+	return model.TargetID{
+		Type: model.TargetTypeImage,
+		Name: model.TargetName(s),
+	}
+}
+
+func TestOneAndOnlyContainerID(t *testing.T) {
+	set := BuildResultSet{
+		imageID("a"): BuildResult{ContainerID: "cA"},
+		imageID("b"): BuildResult{ContainerID: "cB"},
+	}
+	assert.Equal(t, "", string(set.OneAndOnlyContainerID()))
+
+	set = BuildResultSet{
+		imageID("a"): BuildResult{ContainerID: "cA"},
+		imageID("b"): BuildResult{ContainerID: "cA"},
+		imageID("c"): BuildResult{ContainerID: ""},
+	}
+	assert.Equal(t, "cA", string(set.OneAndOnlyContainerID()))
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/asoneresult:

db5a72fc1d2149f9b6785662531194f311708814 (2019-03-08 11:17:50 -0500)
 store: fix a bug in the results api when there are multiple images