### PR TITLE
engine: Separate the image selector from the image being injected

### DIFF
--- a/internal/dockerfile/ast.go
+++ b/internal/dockerfile/ast.go
@@ -81,10 +81,10 @@ func (a AST) traverseImageRefs(visitor func(node *parser.Node, ref reference.Nam
 	})
 }
 
-func (a AST) InjectImageDigest(ref reference.NamedTagged) (bool, error) {
+func (a AST) InjectImageDigest(selector container.RefSelector, ref reference.NamedTagged) (bool, error) {
 	modified := false
 	err := a.traverseImageRefs(func(node *parser.Node, toReplace reference.Named) reference.Named {
-		if toReplace.Name() == ref.Name() {
+		if selector.Matches(toReplace) {
 			modified = true
 			return ref
 		}

--- a/internal/dockerfile/inject.go
+++ b/internal/dockerfile/inject.go
@@ -2,15 +2,16 @@ package dockerfile
 
 import (
 	"github.com/docker/distribution/reference"
+	"github.com/windmilleng/tilt/internal/container"
 )
 
-func InjectImageDigest(df Dockerfile, ref reference.NamedTagged) (Dockerfile, bool, error) {
+func InjectImageDigest(df Dockerfile, selector container.RefSelector, ref reference.NamedTagged) (Dockerfile, bool, error) {
 	ast, err := ParseAST(df)
 	if err != nil {
 		return "", false, err
 	}
 
-	modified, err := ast.InjectImageDigest(ref)
+	modified, err := ast.InjectImageDigest(selector, ref)
 	if err != nil {
 		return "", false, err
 	}

--- a/internal/dockerfile/inject_test.go
+++ b/internal/dockerfile/inject_test.go
@@ -13,7 +13,7 @@ FROM gcr.io/windmill/foo
 ADD . .
 `)
 	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
-	newDf, modified, err := InjectImageDigest(df, ref)
+	newDf, modified, err := InjectImageDigest(df, container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.True(t, modified)
 		assert.Equal(t, `
@@ -29,7 +29,7 @@ FROM gcr.io/windmill/foo:v1
 ADD . .
 `)
 	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
-	newDf, modified, err := InjectImageDigest(df, ref)
+	newDf, modified, err := InjectImageDigest(df, container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.True(t, modified)
 		assert.Equal(t, `
@@ -45,7 +45,7 @@ FROM gcr.io/windmill/bar:v1
 ADD . .
 `)
 	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
-	newDf, modified, err := InjectImageDigest(df, ref)
+	newDf, modified, err := InjectImageDigest(df, container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.False(t, modified)
 		assert.Equal(t, df, newDf)
@@ -59,7 +59,7 @@ COPY --from=gcr.io/windmill/foo /src/package.json /src/package.json
 ADD . .
 `)
 	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
-	newDf, modified, err := InjectImageDigest(df, ref)
+	newDf, modified, err := InjectImageDigest(df, container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.True(t, modified)
 		assert.Equal(t, `
@@ -77,7 +77,7 @@ COPY --from=gcr.io/windmill/foo:bar /src/package.json /src/package.json
 ADD . .
 `)
 	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
-	newDf, modified, err := InjectImageDigest(df, ref)
+	newDf, modified, err := InjectImageDigest(df, container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.True(t, modified)
 		assert.Equal(t, `
@@ -95,7 +95,7 @@ COPY --from=vandelay/common /usr/src/common/package.json /usr/src/common/yarn.lo
 ADD . .
 `)
 	ref := container.MustParseNamedTagged("vandelay/common:deadbeef")
-	newDf, modified, err := InjectImageDigest(df, ref)
+	newDf, modified, err := InjectImageDigest(df, container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.True(t, modified)
 		assert.Equal(t, `
@@ -118,7 +118,7 @@ ADD . .
 		t.Fatal(err)
 	}
 
-	modified, err := ast.InjectImageDigest(ref)
+	modified, err := ast.InjectImageDigest(container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.True(t, modified)
 
@@ -133,7 +133,7 @@ ADD . .
 `, string(newDf))
 	}
 
-	modified, err = ast.InjectImageDigest(ref)
+	modified, err = ast.InjectImageDigest(container.NewRefSelector(ref), ref)
 	if assert.NoError(t, err) {
 		assert.True(t, modified)
 

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -36,7 +36,7 @@ var imageTargetID = model.TargetID{
 	Name: "gcr.io/some-project-162817/sancho",
 }
 
-var alreadyBuilt = store.BuildResult{Image: testImageRef}
+var alreadyBuilt = store.NewImageBuildResult(imageTargetID, testImageRef)
 var alreadyBuiltSet = store.BuildResultSet{imageTargetID: alreadyBuilt}
 
 type expectedFile = testutils.ExpectedFile
@@ -503,8 +503,9 @@ func TestContainerBuildMultiStage(t *testing.T) {
 	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
 
 	// There are two image targets, and only the second one is dirty
-	firstResult := store.BuildResult{Image: container.MustParseNamedTagged("sancho-base:tilt-prebuilt")}
-	bs[targets[0].ID()] = store.NewBuildState(firstResult, nil)
+	iTargetID := targets[0].ID()
+	firstResult := store.NewImageBuildResult(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
+	bs[iTargetID] = store.NewBuildState(firstResult, nil)
 
 	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
 	if err != nil {

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -136,9 +136,9 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 
 	manifest := NewSanchoStaticMultiStageManifest().
 		WithDeployTarget(dcTarg)
-	result := store.BuildResult{Image: container.MustParseNamedTagged("sancho-base:tilt-prebuilt")}
-	state := store.NewBuildState(result, nil)
 	iTargetID := manifest.ImageTargets[0].ID()
+	result := store.NewImageBuildResult(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
+	state := store.NewBuildState(result, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
 	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -33,6 +33,18 @@ func extractK8sTargets(specs []model.TargetSpec) []model.K8sTarget {
 	return kTargets
 }
 
+func extractImageTargets(specs []model.TargetSpec) []model.ImageTarget {
+	iTargets := make([]model.ImageTarget, 0)
+	for _, spec := range specs {
+		t, ok := spec.(model.ImageTarget)
+		if !ok {
+			continue
+		}
+		iTargets = append(iTargets, t)
+	}
+	return iTargets
+}
+
 // Extract image targets iff they can be updated in-place in a container.
 func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.BuildStateSet) ([]model.ImageTarget, error) {
 	iTargets := make([]model.ImageTarget, 0)
@@ -78,6 +90,18 @@ func isImageDeployedToK8s(iTarget model.ImageTarget, kTargets []model.K8sTarget)
 			if depID == id {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// Returns true if the given image is deployed to one of the given docker-compose targets.
+// Note that some images are injected into other images, so may never be deployed.
+func isImageDeployedToDC(iTarget model.ImageTarget, dcTarget model.DockerComposeTarget) bool {
+	id := iTarget.ID()
+	for _, depID := range dcTarget.DependencyIDs() {
+		if depID == id {
+			return true
 		}
 	}
 	return false

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -200,9 +200,9 @@ func TestMultiStageStaticBuildWithOnlyOneDirtyImage(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := NewSanchoStaticMultiStageManifest()
-	result := store.BuildResult{Image: container.MustParseNamedTagged("sancho-base:tilt-prebuilt")}
-	state := store.NewBuildState(result, nil)
 	iTargetID := manifest.ImageTargets[0].ID()
+	result := store.NewImageBuildResult(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
+	state := store.NewBuildState(result, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -164,7 +164,7 @@ func TestInjectDigestBlorgBackendYAML(t *testing.T) {
 	entity := entities[1]
 	name := "gcr.io/blorg-dev/blorg-backend"
 	namedTagged, _ := reference.ParseNamed(fmt.Sprintf("%s:wm-tilt", name))
-	newEntity, replaced, err := InjectImageDigest(entity, namedTagged, v1.PullNever)
+	newEntity, replaced, err := InjectImageDigest(entity, container.NewRefSelector(namedTagged), namedTagged, v1.PullNever)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func InjectImageDigestWithStrings(entity K8sEntity, original string, newDigest s
 		return K8sEntity{}, false, err
 	}
 
-	return InjectImageDigest(entity, canonicalRef, policy)
+	return InjectImageDigest(entity, container.NewRefSelector(originalRef), canonicalRef, policy)
 }
 
 func TestInjectSyncletImage(t *testing.T) {
@@ -217,7 +217,7 @@ func TestInjectSyncletImage(t *testing.T) {
 	entity := entities[0]
 	name := "gcr.io/windmill-public-containers/synclet"
 	namedTagged, _ := container.ParseNamedTagged(fmt.Sprintf("%s:tilt-deadbeef", name))
-	newEntity, replaced, err := InjectImageDigest(entity, namedTagged, v1.PullNever)
+	newEntity, replaced, err := InjectImageDigest(entity, container.NewRefSelector(namedTagged), namedTagged, v1.PullNever)
 	if err != nil {
 		t.Fatal(err)
 	} else if !replaced {

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -45,6 +45,8 @@ func (t DockerComposeTarget) ManifestName() ManifestName {
 	return ManifestName(t.Name)
 }
 
+func (t DockerComposeTarget) Empty() bool { return t.ID().Empty() }
+
 func (t DockerComposeTarget) ID() TargetID {
 	return TargetID{
 		Type: TargetTypeDockerCompose,

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -194,6 +194,14 @@ func (i ImageTarget) Dependencies() []string {
 	return sliceutils.DedupedAndSorted(i.LocalPaths())
 }
 
+func ImageTargetsByID(iTargets []ImageTarget) map[TargetID]ImageTarget {
+	result := make(map[TargetID]ImageTarget, len(iTargets))
+	for _, target := range iTargets {
+		result[target.ID()] = target
+	}
+	return result
+}
+
 type StaticBuild struct {
 	Dockerfile string
 	BuildPath  string // the absolute path to the files


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/selectors:

90ddcd1778e4cde132d9f3c2182134da039f6275 (2019-03-08 12:42:15 -0500)
engine: Separate the image selector from the image being injected
This will help with a variety of things we want to do, including https://github.com/windmilleng/tilt/issues/1259 (multiple dockerfiles per image name) and subsituting a private repo at runtime.