### PR TITLE
tiltfile: support image json paths by entity name

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -19,8 +19,6 @@ import (
 type K8sEntity struct {
 	Obj  runtime.Object
 	Kind *schema.GroupVersionKind
-	// JSON paths to places that contain images other than Container specs
-	ImageJSONPaths []string
 }
 
 type k8sMeta interface {
@@ -195,8 +193,8 @@ func Filter(entities []K8sEntity, test func(e K8sEntity) (bool, error)) (passing
 	return passing, rest, nil
 }
 
-func FilterByImage(entities []K8sEntity, img container.RefSelector) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img) })
+func FilterByImage(entities []K8sEntity, img container.RefSelector, imageJSONPaths func(K8sEntity) []JSONPath) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img, imageJSONPaths(e)) })
 }
 
 func FilterBySelectorMatchesLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -7,17 +7,20 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/windmilleng/tilt/internal/container"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/windmilleng/tilt/internal/container"
 )
 
 type K8sEntity struct {
 	Obj  runtime.Object
 	Kind *schema.GroupVersionKind
+	// JSON paths to places that contain images other than Container specs
+	ImageJSONPaths []string
 }
 
 type k8sMeta interface {
@@ -192,8 +195,8 @@ func Filter(entities []K8sEntity, test func(e K8sEntity) (bool, error)) (passing
 	return passing, rest, nil
 }
 
-func FilterByImage(entities []K8sEntity, img container.RefSelector, k8sImageJsonPathsByKind map[string][]string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img, k8sImageJsonPathsByKind) })
+func FilterByImage(entities []K8sEntity, img container.RefSelector) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img) })
 }
 
 func FilterBySelectorMatchesLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -1,15 +1,12 @@
 package k8s
 
 import (
-	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/util/jsonpath"
 
 	"github.com/windmilleng/tilt/internal/container"
 )
@@ -178,8 +175,8 @@ func injectImageDigestInUnstructured(entity K8sEntity, injectRef reference.Named
 }
 
 // HasImage indicates whether the given entity is tagged with the given image.
-func (e K8sEntity) HasImage(image container.RefSelector) (bool, error) {
-	images, err := e.FindImages()
+func (e K8sEntity) HasImage(image container.RefSelector, imageJSONPaths []JSONPath) (bool, error) {
+	images, err := e.FindImages(imageJSONPaths)
 	if err != nil {
 		fmt.Printf("error in FindImages: %+v\n", err)
 		return false, err
@@ -194,7 +191,7 @@ func (e K8sEntity) HasImage(image container.RefSelector) (bool, error) {
 	return false, nil
 }
 
-func (e K8sEntity) FindImages() ([]reference.Named, error) {
+func (e K8sEntity) FindImages(imageJSONPaths []JSONPath) ([]reference.Named, error) {
 	var result []reference.Named
 
 	// Look for images in instances of Container
@@ -219,19 +216,11 @@ func (e K8sEntity) FindImages() ([]reference.Named, error) {
 	}
 
 	// also look for images in any json paths that were specified for this entity
-	for _, path := range e.ImageJSONPaths {
-		p := jsonpath.New(fmt.Sprintf("%s_image_json_path", e.Kind.Kind))
-		err := p.Parse(path)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing json path '%s'", path)
-		}
-		out := &bytes.Buffer{}
-		err = p.Execute(out, obj)
+	for _, path := range imageJSONPaths {
+		image, err := path.Execute(obj)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error applying json path '%s'", path)
 		}
-		image := out.String()
-		image = strings.Trim(image, `"`)
 		ref, err := container.ParseNamed(image)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error parsing image '%s' at json path '%s'", image, path)

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -243,19 +243,19 @@ func TestEntityHasImage(t *testing.T) {
 	img := container.MustParseSelector("gcr.io/blorg-dev/blorg-backend:devel-nick")
 	wrongImg := container.MustParseSelector("gcr.io/blorg-dev/wrong-app-whoops:devel-nick")
 
-	match, err := entities[0].HasImage(img)
+	match, err := entities[0].HasImage(img, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.False(t, match, "service yaml should not match (does not contain image)")
 
-	match, err = entities[1].HasImage(img)
+	match, err = entities[1].HasImage(img, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.True(t, match, "deployment yaml should match image %s", img.String())
 
-	match, err = entities[1].HasImage(wrongImg)
+	match, err = entities[1].HasImage(wrongImg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,8 +268,12 @@ func TestEntityHasImage(t *testing.T) {
 
 	img = container.MustParseTaggedSelector("docker.io/bitnami/minideb:latest")
 	e := entities[0]
-	e.ImageJSONPaths = []string{"{.spec.validation.openAPIV3Schema.properties.spec.properties.image}"}
-	match, err = e.HasImage(img)
+	jp, err := NewJSONPath("{.spec.validation.openAPIV3Schema.properties.spec.properties.image}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageJSONPaths := []JSONPath{jp}
+	match, err = e.HasImage(img, imageJSONPaths)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -243,19 +243,19 @@ func TestEntityHasImage(t *testing.T) {
 	img := container.MustParseSelector("gcr.io/blorg-dev/blorg-backend:devel-nick")
 	wrongImg := container.MustParseSelector("gcr.io/blorg-dev/wrong-app-whoops:devel-nick")
 
-	match, err := entities[0].HasImage(img, nil)
+	match, err := entities[0].HasImage(img)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.False(t, match, "service yaml should not match (does not contain image)")
 
-	match, err = entities[1].HasImage(img, nil)
+	match, err = entities[1].HasImage(img)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.True(t, match, "deployment yaml should match image %s", img.String())
 
-	match, err = entities[1].HasImage(wrongImg, nil)
+	match, err = entities[1].HasImage(wrongImg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +267,9 @@ func TestEntityHasImage(t *testing.T) {
 	}
 
 	img = container.MustParseTaggedSelector("docker.io/bitnami/minideb:latest")
-	match, err = entities[0].HasImage(img, map[string][]string{"CustomResourceDefinition": {"{.spec.validation.openAPIV3Schema.properties.spec.properties.image}"}})
+	e := entities[0]
+	e.ImageJSONPaths = []string{"{.spec.validation.openAPIV3Schema.properties.spec.properties.image}"}
+	match, err = e.HasImage(img)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/k8s/json_path.go
+++ b/internal/k8s/json_path.go
@@ -1,0 +1,45 @@
+package k8s
+
+import (
+	"bytes"
+	"strings"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// This is just a wrapper around k8s jsonpath, mostly because k8s jsonpath doesn't produce errors containing
+// the problematic path
+// (and as long as we're here, deal with some of its other annoyances, like taking a "name" that doesn't do anything,
+// and having a separate "Parse" step to make an instance actually useful, and making you use an io.Writer, and
+// wrapping string results in quotes)
+type JSONPath struct {
+	jp   *jsonpath.JSONPath
+	path string
+}
+
+func NewJSONPath(s string) (JSONPath, error) {
+	jp := jsonpath.New("jp")
+	err := jp.Parse(s)
+	if err != nil {
+		return JSONPath{}, err
+	}
+
+	return JSONPath{jp, s}, nil
+}
+
+// Gets the value at the specified path
+// NB: currently strips away surrounding quotes, which the underlying parser includes in its return value
+// If, at some point, we want to distinguish between, e.g., ints and strings by the presence of quotes, this
+// will need to be revisited.
+func (jp JSONPath) Execute(obj interface{}) (string, error) {
+	buf := &bytes.Buffer{}
+	err := jp.jp.Execute(buf, obj)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(buf.String(), "\""), nil
+}
+
+func (jp JSONPath) String() string {
+	return jp.path
+}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -98,6 +98,7 @@ const (
 	filterYamlN       = "filter_yaml"
 	k8sResourceN      = "k8s_resource"
 	portForwardN      = "port_forward"
+	k8sKindN          = "k8s_kind"
 	k8sImageJSONPathN = "k8s_image_json_path"
 
 	// file functions
@@ -144,6 +145,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	addBuiltin(r, filterYamlN, s.filterYaml)
 	addBuiltin(r, k8sResourceN, s.k8sResource)
 	addBuiltin(r, portForwardN, s.portForward)
+	addBuiltin(r, k8sKindN, s.k8sKind)
 	addBuiltin(r, k8sImageJSONPathN, s.k8sImageJsonPath)
 	addBuiltin(r, localGitRepoN, s.localGitRepo)
 	addBuiltin(r, kustomizeN, s.kustomize)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -31,13 +31,15 @@ type tiltfileState struct {
 	dcCli    dockercompose.DockerComposeClient
 
 	// added to during execution
-	configFiles             []string
-	buildIndex              *buildIndex
-	k8s                     []*k8sResource
-	k8sByName               map[string]*k8sResource
-	k8sUnresourced          []k8s.K8sEntity
-	dc                      dcResourceSet // currently only support one d-c.yml
-	k8sImageJsonPathsByKind map[string][]string
+	configFiles    []string
+	buildIndex     *buildIndex
+	k8s            []*k8sResource
+	k8sByName      map[string]*k8sResource
+	k8sUnresourced []k8s.K8sEntity
+	dc             dcResourceSet // currently only support one d-c.yml
+
+	// JSON paths to locations that contain images other than Container specs
+	k8sImageJSONPaths map[imageJSONPathSelector][]string
 
 	// for assembly
 	usedImages map[string]bool
@@ -53,16 +55,16 @@ type tiltfileState struct {
 func newTiltfileState(ctx context.Context, filename string, tfRoot string, l *log.Logger) *tiltfileState {
 	lp := localPath{path: filename}
 	s := &tiltfileState{
-		ctx:                     ctx,
-		filename:                localPath{path: filename},
-		dcCli:                   dockercompose.NewDockerComposeClient(),
-		buildIndex:              newBuildIndex(),
-		k8sByName:               make(map[string]*k8sResource),
-		k8sImageJsonPathsByKind: make(map[string][]string),
-		configFiles:             []string{filename},
-		usedImages:              make(map[string]bool),
-		logger:                  l,
-		builtinCallCounts:       make(map[string]int),
+		ctx:               ctx,
+		filename:          localPath{path: filename},
+		dcCli:             dockercompose.NewDockerComposeClient(),
+		buildIndex:        newBuildIndex(),
+		k8sByName:         make(map[string]*k8sResource),
+		k8sImageJSONPaths: make(map[imageJSONPathSelector][]string),
+		configFiles:       []string{filename},
+		usedImages:        make(map[string]bool),
+		logger:            l,
+		builtinCallCounts: make(map[string]int),
 	}
 	s.filename = s.maybeAttachGitRepo(lp, filepath.Dir(lp.path))
 	return s
@@ -92,11 +94,11 @@ const (
 	dcResourceN    = "dc_resource"
 
 	// k8s functions
-	k8sYamlN     = "k8s_yaml"
-	filterYamlN  = "filter_yaml"
-	k8sResourceN = "k8s_resource"
-	portForwardN = "port_forward"
-	k8sKindN     = "k8s_kind"
+	k8sYamlN          = "k8s_yaml"
+	filterYamlN       = "filter_yaml"
+	k8sResourceN      = "k8s_resource"
+	portForwardN      = "port_forward"
+	k8sImageJSONPathN = "k8s_image_json_path"
 
 	// file functions
 	localGitRepoN = "local_git_repo"
@@ -142,7 +144,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	addBuiltin(r, filterYamlN, s.filterYaml)
 	addBuiltin(r, k8sResourceN, s.k8sResource)
 	addBuiltin(r, portForwardN, s.portForward)
-	addBuiltin(r, k8sKindN, s.k8sKind)
+	addBuiltin(r, k8sImageJSONPathN, s.k8sImageJsonPath)
 	addBuiltin(r, localGitRepoN, s.localGitRepo)
 	addBuiltin(r, kustomizeN, s.kustomize)
 	addBuiltin(r, helmN, s.helm)
@@ -225,6 +227,12 @@ func (s *tiltfileState) assembleDC() error {
 }
 
 func (s *tiltfileState) assembleK8s() error {
+	// populate k8s entities with their image json paths
+	for i, e := range s.k8sUnresourced {
+		e.ImageJSONPaths = s.imageJSONPaths(e)
+		s.k8sUnresourced[i] = e
+	}
+
 	err := s.assembleK8sWithImages()
 	if err != nil {
 		return err
@@ -361,7 +369,7 @@ func (s *tiltfileState) findUnresourcedImages() ([]reference.Named, error) {
 	seen := make(map[string]bool)
 
 	for _, e := range s.k8sUnresourced {
-		images, err := e.FindImages(s.k8sImageJsonPathsByKind)
+		images, err := e.FindImages()
 		if err != nil {
 			return nil, err
 		}
@@ -377,12 +385,12 @@ func (s *tiltfileState) findUnresourcedImages() ([]reference.Named, error) {
 
 // extractEntities extracts k8s entities matching the image ref and stores them on the dest k8sResource
 func (s *tiltfileState) extractEntities(dest *k8sResource, imageRef container.RefSelector) error {
-	extracted, remaining, err := k8s.FilterByImage(s.k8sUnresourced, imageRef, s.k8sImageJsonPathsByKind)
+	extracted, remaining, err := k8s.FilterByImage(s.k8sUnresourced, imageRef)
 	if err != nil {
 		return err
 	}
 
-	err = dest.addEntities(extracted, s.k8sImageJsonPathsByKind)
+	err = dest.addEntities(extracted)
 	if err != nil {
 		return err
 	}
@@ -395,7 +403,7 @@ func (s *tiltfileState) extractEntities(dest *k8sResource, imageRef container.Re
 			return err
 		}
 
-		err = dest.addEntities(match, s.k8sImageJsonPathsByKind)
+		err = dest.addEntities(match)
 		if err != nil {
 			return err
 		}
@@ -583,3 +591,10 @@ const (
 	claimPending
 	claimFinished
 )
+
+// A selector matches an entity if all non-empty selector fields match the corresponding entity fields
+type imageJSONPathSelector struct {
+	kind      string
+	name      string
+	namespace string
+}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1759,7 +1759,7 @@ func TestExtraImageLocationTwoImages(t *testing.T) {
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
 	f.file("Tiltfile", `k8s_yaml('crd.yaml')
-k8s_image_json_path(kind='Environment', path=['{.spec.runtime.image}', '{.spec.builder.image}'])
+k8s_image_json_path(['{.spec.runtime.image}', '{.spec.builder.image}'], kind='Environment')
 docker_build('test/mycrd-builder', 'builder')
 docker_build('test/mycrd-env', 'env')
 `)
@@ -1791,7 +1791,7 @@ func TestExtraImageLocationDeploymentEnvVarByName(t *testing.T) {
 docker_build('gcr.io/foo', 'foo')
 docker_build('gcr.io/foo-fetcher', 'foo-fetcher')
 docker_build('gcr.io/bar', 'bar')
-k8s_image_json_path(name='foo', path="{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_IMAGE')].value}")
+k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_IMAGE')].value}", name='foo')
 	`)
 	f.load("foo", "bar")
 	f.assertNextManifest("foo",
@@ -1820,7 +1820,7 @@ func TestExtraImageLocationDeploymentEnvVarByNameAndNamespace(t *testing.T) {
 	f.file("Tiltfile", `k8s_yaml('foo.yaml')
 docker_build('gcr.io/foo', 'foo')
 docker_build('gcr.io/foo-fetcher', 'foo-fetcher')
-k8s_image_json_path(name='foo', namespace='default', path="{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_IMAGE')].value}")
+k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_IMAGE')].value}", name='foo', namespace='default')
 	`)
 	f.load("foo")
 	f.assertNextManifest("foo",
@@ -1839,7 +1839,7 @@ func TestExtraImageLocationNoMatch(t *testing.T) {
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
 	f.file("Tiltfile", `k8s_yaml('crd.yaml')
-k8s_image_json_path(kind='Environment', path='{.foobar}')
+k8s_image_json_path('{.foobar}', kind='Environment')
 docker_build('test/mycrd-env', 'env')
 `)
 
@@ -1852,7 +1852,7 @@ func TestExtraImageLocationInvalidJsonPath(t *testing.T) {
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
 	f.file("Tiltfile", `k8s_yaml('crd.yaml')
-k8s_image_json_path(kind='Environment', path='{foobar()}')
+k8s_image_json_path('{foobar()}', kind='Environment')
 docker_build('test/mycrd-env', 'env')
 `)
 


### PR DESCRIPTION
Problem:
Using image names in env vars requires monkeying with `k8s_resource`, which doesn't work when there are multiple images for an entity. (I think, anyway? Apparently I didn't write any automated tests for env var support, so I'm not exactly sure what setup I used when manually testing this).

Solution:
Rename `k8s_kind` to `k8s_image_json_paths` and add `name` and `namespace` parameters.

This feature is still incomplete since these paths are not used at injection time. Image ID injection currently looks for image names in all fields (for CRDs) or in all env vars and container specs (for non-CRDs). It's currently sufficiently done to unblock env var usage, and we'll just keep it undocumented for now.