### PR TITLE
ci: don't compile gotestsum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,11 @@ jobs:
       - run: curl --silent --show-error --location --fail --retry 3 --output /tmp/helm.tar.gz  https://storage.googleapis.com/kubernetes-helm/helm-v2.12.1-darwin-amd64.tar.gz &&
              tar -xz -C /tmp -f /tmp/helm.tar.gz &&
              mv /tmp/darwin-amd64/helm /usr/local/bin/helm
-      - run: go get -u gotest.tools/gotestsum
+      - run: curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.3.3/gotestsum_0.3.3_darwin_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum 
       # We can't run the container tests on macos because nested
       # VMs don't work on circleci.
       - run: mkdir -p test-results
-      - run: ~/go/bin/gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- -tags 'skipcontainertests' ./...
+      - run: gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- -tags 'skipcontainertests' ./...
       - store_test_results:
           path: test-results
 


### PR DESCRIPTION
Problem:

the macos CI build keeps failing with errors like this:
```
#!/bin/bash -eo pipefail
go get -u gotest.tools/gotestsum
        go get: warning: modules disabled by GO111MODULE=auto in GOPATH/src;
	ignoring go.mod;
	see 'go help modules'
# cd .; git clone https://go.googlesource.com/sys /Users/distiller/go/src/golang.org/x/sys
Cloning into '/Users/distiller/go/src/golang.org/x/sys'...
fatal: remote error: Internal Server Error
package golang.org/x/sys/unix: exit status 128
Exited with code 1
```

Solution:
download gotestsum instead of `go get`ting it

(also this step was taking 30-40 seconds, so we might as well not do that?)