### PR TITLE
engine: show all files that triggered a Tiltfile build

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"github.com/windmilleng/tilt/internal/tiltfile"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/synclet/sidecar"
+	"github.com/windmilleng/tilt/internal/tiltfile"
 	"github.com/windmilleng/tilt/internal/watch"
 )
 

--- a/internal/engine/watchmanager_test.go
+++ b/internal/engine/watchmanager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/testutils/output"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 	"github.com/windmilleng/tilt/internal/watch"
 )
 
@@ -137,6 +138,7 @@ type wmFixture struct {
 	wm               *WatchManager
 	fakeMultiWatcher *fakeMultiWatcher
 	fakeTimerMaker   fakeTimerMaker
+	*tempdir.TempDirFixture
 }
 
 func newWMFixture(t *testing.T) *wmFixture {
@@ -153,6 +155,12 @@ func newWMFixture(t *testing.T) *wmFixture {
 		}
 	}()
 
+	f := tempdir.NewTempDirFixture(t)
+	err := os.Chdir(f.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return &wmFixture{
 		ctx:              ctx,
 		cancel:           cancel,
@@ -161,10 +169,12 @@ func newWMFixture(t *testing.T) *wmFixture {
 		wm:               wm,
 		fakeMultiWatcher: fakeMultiWatcher,
 		fakeTimerMaker:   timerMaker,
+		TempDirFixture:   f,
 	}
 }
 
 func (f *wmFixture) TearDown() {
+	f.TempDirFixture.TearDown()
 	f.cancel()
 }
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -246,6 +246,9 @@ type ManifestState struct {
 
 	// The log stream for this resource
 	CombinedLog model.Log `testdiff:"ignore"`
+
+	// If this manifest was changed, which config files led to the most recent change in manifest definition
+	ConfigFilesThatCausedChange []string
 }
 
 func NewState() *EngineState {


### PR DESCRIPTION
Now when you change a a config file that causes a manifest's definition to change, and thus be re-deployed, that file will show up as an edited file in both the Tiltfile _and_ the manifest that changed.

Here's an example: I changed `deploy/snack.yaml` in Servantes and both `snack` and `(Tiltfile)` are marked as edited, but `hypothesizer` is not.

![Screen Shot 2019-03-12 at 12 56 33 PM](https://user-images.githubusercontent.com/452453/54219652-4f876f00-44c6-11e9-84b1-3b160613348a.png)
