### PR TITLE
k8s: if yaml upsert fails due to immutable field, call delete && apply instead of replace --force to make sure that pods get recreated with new info [ch1734]

### DIFF
--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -41,10 +41,11 @@ func TestUpsertStatefulsetForbidden(t *testing.T) {
 
 	f.setStderr(`The StatefulSet "postgres" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden.`)
 	err = f.client.Upsert(f.ctx, postgres)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(f.runner.calls))
-	assert.Equal(t, []string{"apply", "-f", "-"}, f.runner.calls[0].argv)
-	assert.Equal(t, []string{"replace", "--force", "-f", "-"}, f.runner.calls[1].argv)
+	if assert.Nil(t, err) && assert.Equal(t, 3, len(f.runner.calls)) {
+		assert.Equal(t, []string{"apply", "-f", "-"}, f.runner.calls[0].argv)
+		assert.Equal(t, []string{"delete", "-f", "-"}, f.runner.calls[1].argv)
+		assert.Equal(t, []string{"apply", "-f", "-"}, f.runner.calls[2].argv)
+	}
 }
 
 type call struct {


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/stateful-set-replace:

df33724e9faba62ba59debd888c0d1e9097e8fe8 (2019-03-12 12:58:21 -0400)
k8s: if yaml upsert fails due to immutable field, call delete && apply instead of replace --force to make sure that pods get recreated with new info [ch1734]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics