### PR TITLE
tiltfile: tests should error by default if there are warnings

### DIFF
--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -442,8 +442,7 @@ services:
 docker_build('gcr.typo.io/foo', 'foo')
 docker_compose('docker-compose.yml')
 `)
-	f.load()
-	f.assertWarnings("Image not used in any resource:\n    ✕ gcr.typo.io/foo\nDid you mean…\n    - gcr.io/foo\n    - docker.io/library/golang")
+	f.loadAssertWarnings("Image not used in any resource:\n    ✕ gcr.typo.io/foo\nDid you mean…\n    - gcr.io/foo\n    - docker.io/library/golang")
 }
 
 func TestDockerComposeOnlySomeWithDockerBuild(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch nicks/warnings:

de3158a5c6dedda3100bc03c56db60454bf7b0eb (2019-03-12 14:00:26 -0400)
tiltfile: tests should error by default if there are warnings
we expect most test cases to have no warnings; the test writer
shouldn't have to remember to assert this