### PR TITLE
engine: don't kick off a build while tiltfile execution is pending

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -34,6 +34,12 @@ func NewBuildController(b BuildAndDeployer) *BuildController {
 
 // Algorithm to choose a manifest to build next.
 func nextTargetToBuild(state store.EngineState) *store.ManifestTarget {
+	// Don't build anything if there are pending config file changes.
+	// We want the Tiltfile to re-run first.
+	if len(state.PendingConfigFileChanges) > 0 {
+		return nil
+	}
+
 	// put no-build manifests first since they're more likely to be
 	// 1. fast and 2. dependencies of other services (e.g., redis)
 	targets := append([]*store.ManifestTarget{}, state.Targets()...)

--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -24,7 +25,7 @@ func TestConfigsController(t *testing.T) {
 	m := model.Manifest{Name: "foo"}
 	mt := store.NewManifestTarget(m)
 	state.UpsertManifestTarget(mt)
-	state.PendingConfigFileChanges["Tiltfile"] = true
+	state.PendingConfigFileChanges["Tiltfile"] = time.Now()
 	state.TiltfilePath = f.JoinPath("Tiltfile")
 	f.st.UnlockMutableState()
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -62,7 +62,7 @@ type EngineState struct {
 
 	TiltfilePath             string
 	ConfigFiles              []string
-	PendingConfigFileChanges map[string]bool
+	PendingConfigFileChanges map[string]time.Time
 
 	// InitManifests is the list of manifest names that we were told to init from the CLI.
 	InitManifests []model.ManifestName
@@ -255,7 +255,7 @@ func NewState() *EngineState {
 	ret := &EngineState{}
 	ret.Log = model.Log{}
 	ret.ManifestTargets = make(map[model.ManifestName]*ManifestTarget)
-	ret.PendingConfigFileChanges = make(map[string]bool)
+	ret.PendingConfigFileChanges = make(map[string]time.Time)
 	return ret
 }
 


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch1826/manifest:

b12b1646ad721a79ec3b126eea4df5545511995a (2019-03-12 16:10:45 -0400)
engine: don't kick off a build while tiltfile execution is pending