### PR TITLE
docker: show build progress

### DIFF
--- a/internal/build/buildkit_printer.go
+++ b/internal/build/buildkit_printer.go
@@ -92,7 +92,8 @@ func (b *buildkitPrinter) parseAndPrint(vertexes []*vertex, logs []*vertexLog) e
 	// If the log level is at least verbose, we want to stream the output as
 	// it comes in. Otherwise, we only want to dump it at the end of there's
 	// an error.
-	streamLogs := b.logger.Level() >= logger.VerboseLvl
+	var streamLevel logger.Level = logger.InfoLvl
+	streamLogs := b.logger.Level() >= streamLevel
 	for _, d := range b.vOrder {
 		vl, ok := b.vData[d]
 		if !ok {
@@ -118,8 +119,8 @@ func (b *buildkitPrinter) parseAndPrint(vertexes []*vertex, logs []*vertexLog) e
 			}
 		}
 
-		if streamLogs && vl.vertex.isRun() {
-			err := b.flushLogs(b.logger.Writer(logger.VerboseLvl), vl)
+		if streamLogs && (vl.vertex.isRun() || vl.vertex.isStep()) {
+			err := b.flushLogs(b.logger.Writer(streamLevel), vl)
 			if err != nil {
 				return err
 			}

--- a/internal/build/buildkit_printer_test.go
+++ b/internal/build/buildkit_printer_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
+
 	"github.com/windmilleng/tilt/internal/logger"
 )
 
@@ -22,61 +24,79 @@ type buildkitTestCase struct {
 	logs     []*vertexLog
 }
 
+var digests = []digest.Digest{
+	"sha8234234546454",
+	"sha1234234234234",
+	"sha82342xxxx454",
+}
+
+var shCmdVertexNames = []string{
+	"/bin/sh -c make",
+	`/bin/sh -c (>&2 echo "hi")`,
+	"docker-image://docker.io/blah",
+}
+
+var stepVertexNames = []string{
+	"[1/2] RUN make",
+	`[2/2] RUN echo "hi"`,
+	"docker-image://docker.io/blah",
+}
+
 func buildkitTestCase1() buildkitTestCase {
 	return buildkitTestCase{
 		name:  "echo-hi-error",
 		level: logger.InfoLvl,
 		vertices: []*vertex{
 			{
-				digest: "sha8234234546454",
-				name:   "/bin/sh -c make",
+				digest: digests[0],
+				name:   shCmdVertexNames[0],
 				error:  "",
 			},
 			{
-				digest:  "sha8234234546454",
-				name:    "/bin/sh -c make",
+				digest:  digests[0],
+				name:    shCmdVertexNames[0],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha8234234546454",
-				name:      "/bin/sh -c make",
+				digest:    digests[0],
+				name:      shCmdVertexNames[0],
 				error:     "",
 				started:   true,
 				completed: true,
 			},
 			{
-				digest: "sha1234234234234",
-				name:   `/bin/sh -c (>&2 echo "hi")`,
+				digest: digests[1],
+				name:   shCmdVertexNames[1],
 				error:  "",
 			},
 			{
-				digest:  "sha1234234234234",
-				name:    `/bin/sh -c (>&2 echo "hi")`,
+				digest:  digests[1],
+				name:    shCmdVertexNames[1],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha1234234234234",
-				name:      `/bin/sh -c (>&2 echo "hi")`,
+				digest:    digests[1],
+				name:      shCmdVertexNames[1],
 				error:     "context canceled",
 				started:   true,
 				completed: true,
 			},
 			{
-				digest: "sha82342xxxx454",
-				name:   "docker-image://docker.io/blah",
+				digest: digests[2],
+				name:   shCmdVertexNames[2],
 				error:  "",
 			},
 			{
-				digest:  "sha82342xxxx454",
-				name:    "docker-image://docker.io/blah",
+				digest:  digests[2],
+				name:    shCmdVertexNames[2],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha1234234234234",
-				name:      `/bin/sh -c (>&2 echo "hi")`,
+				digest:    digests[1],
+				name:      shCmdVertexNames[1],
 				error:     "",
 				started:   true,
 				completed: true,
@@ -84,11 +104,11 @@ func buildkitTestCase1() buildkitTestCase {
 		},
 		logs: []*vertexLog{
 			{
-				vertex: "sha1234234234234",
+				vertex: digests[1],
 				msg:    []byte("hi"),
 			},
 			{
-				vertex: "sha8234234546454",
+				vertex: digests[0],
 				msg:    []byte(""),
 			},
 		},
@@ -101,55 +121,55 @@ func buildkitTestCase2() buildkitTestCase {
 		level: logger.InfoLvl,
 		vertices: []*vertex{
 			{
-				digest: "sha8234234546454",
-				name:   "/bin/sh -c make",
+				digest: digests[0],
+				name:   shCmdVertexNames[0],
 				error:  "",
 			},
 			{
-				digest:  "sha8234234546454",
-				name:    "/bin/sh -c make",
+				digest:  digests[0],
+				name:    shCmdVertexNames[0],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha8234234546454",
-				name:      "/bin/sh -c make",
+				digest:    digests[0],
+				name:      shCmdVertexNames[0],
 				error:     "",
 				started:   true,
 				completed: true,
 			},
 			{
-				digest: "sha1234234234234",
-				name:   `/bin/sh -c (>&2 echo "hi")`,
+				digest: digests[1],
+				name:   shCmdVertexNames[1],
 				error:  "",
 			},
 			{
-				digest:  "sha1234234234234",
-				name:    `/bin/sh -c (>&2 echo "hi")`,
+				digest:  digests[1],
+				name:    shCmdVertexNames[1],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha1234234234234",
-				name:      `/bin/sh -c (>&2 echo "hi")`,
+				digest:    digests[1],
+				name:      shCmdVertexNames[1],
 				error:     "",
 				started:   true,
 				completed: true,
 			},
 			{
-				digest: "sha82342xxxx454",
-				name:   "docker-image://docker.io/blah",
+				digest: digests[2],
+				name:   shCmdVertexNames[2],
 				error:  "",
 			},
 			{
-				digest:  "sha82342xxxx454",
-				name:    "docker-image://docker.io/blah",
+				digest:  digests[2],
+				name:    shCmdVertexNames[2],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha1234234234234",
-				name:      `/bin/sh -c (>&2 echo "hi")`,
+				digest:    digests[1],
+				name:      shCmdVertexNames[1],
 				error:     "",
 				started:   true,
 				completed: true,
@@ -157,11 +177,11 @@ func buildkitTestCase2() buildkitTestCase {
 		},
 		logs: []*vertexLog{
 			{
-				vertex: "sha1234234234234",
+				vertex: digests[1],
 				msg:    []byte("hi"),
 			},
 			{
-				vertex: "sha8234234546454",
+				vertex: digests[0],
 				msg:    []byte(""),
 			},
 		},
@@ -181,55 +201,55 @@ func buildkitTestCase4() buildkitTestCase {
 		level: logger.InfoLvl,
 		vertices: []*vertex{
 			{
-				digest: "sha8234234546454",
-				name:   "[1/2] RUN make",
+				digest: digests[0],
+				name:   stepVertexNames[0],
 				error:  "",
 			},
 			{
-				digest:  "sha8234234546454",
-				name:    "[1/2] RUN make",
+				digest:  digests[0],
+				name:    stepVertexNames[0],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha8234234546454",
-				name:      "[1/2] RUN make",
+				digest:    digests[0],
+				name:      stepVertexNames[0],
 				error:     "",
 				started:   true,
 				completed: true,
 			},
 			{
-				digest: "sha1234234234234",
-				name:   `[2/2] RUN echo "hi"`,
+				digest: digests[1],
+				name:   stepVertexNames[1],
 				error:  "",
 			},
 			{
-				digest:  "sha1234234234234",
-				name:    `[2/2] RUN echo "hi"`,
+				digest:  digests[1],
+				name:    stepVertexNames[1],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha1234234234234",
-				name:      `[2/2] RUN echo "hi"`,
+				digest:    digests[1],
+				name:      stepVertexNames[1],
 				error:     "context canceled",
 				started:   true,
 				completed: true,
 			},
 			{
-				digest: "sha82342xxxx454",
-				name:   "docker-image://docker.io/blah",
+				digest: digests[2],
+				name:   stepVertexNames[2],
 				error:  "",
 			},
 			{
-				digest:  "sha82342xxxx454",
-				name:    "docker-image://docker.io/blah",
+				digest:  digests[2],
+				name:    stepVertexNames[2],
 				error:   "",
 				started: true,
 			},
 			{
-				digest:    "sha1234234234234",
-				name:      `[2/2] RUN echo "hi"`,
+				digest:    digests[1],
+				name:      stepVertexNames[1],
 				error:     "",
 				started:   true,
 				completed: true,
@@ -237,12 +257,12 @@ func buildkitTestCase4() buildkitTestCase {
 		},
 		logs: []*vertexLog{
 			{
-				vertex: "sha1234234234234",
+				vertex: digests[1],
 				msg:    []byte("hi"),
 			},
 			{
-				vertex: "sha8234234546454",
-				msg:    []byte(""),
+				vertex: digests[0],
+				msg:    []byte("hello"),
 			},
 		},
 	}

--- a/internal/build/testdata/TestBuildkitPrinter/docker-18.09-output_master
+++ b/internal/build/testdata/TestBuildkitPrinter/docker-18.09-output_master
@@ -1,4 +1,5 @@
     ╎ [1/2] RUN make
+    ╎   → hello
     ╎ [2/2] RUN echo "hi"
 
     ╎ ERROR IN: [2/2] RUN echo "hi"

--- a/internal/build/testdata/TestBuildkitPrinter/echo-hi-success_master
+++ b/internal/build/testdata/TestBuildkitPrinter/echo-hi-success_master
@@ -1,2 +1,3 @@
     ╎ RUNNING: make
     ╎ RUNNING: (>&2 echo "hi")
+    ╎   → hi


### PR DESCRIPTION
This is two changes:
1. add the `isStep` check to streaming logs (i.e., support streaming logs for the new `[1/4]` buildkit vertex names, not just the old `sh -c` vertex names), so that log streaming works at all with modern buildkit
2. change the log streaming level from verbose to info, so that it shows by default (aside from any opinion changes we might have had after real-world usage, maybe also the verbose decision was made prior to the HUD and separated logs?)

I haven't seen download progress, which is unfortunate, but I've tested this with a shell script that was just a for loop with a sleep and echo, so I think it's worth checking in as-is, and worrying about download progress separately.