### PR TITLE
tiltfile: add teardowns to tiltfile tests

### DIFF
--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1634,6 +1634,7 @@ k8s_yaml('foo.yaml')
 
 func TestYamlErrorFromLocal(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.file("Tiltfile", `
 yaml = local('echo hi')
 k8s_yaml(yaml)
@@ -1643,6 +1644,7 @@ k8s_yaml(yaml)
 
 func TestYamlErrorFromReadFile(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.file("foo.yaml", "hi")
 	f.file("Tiltfile", `
 k8s_yaml(read_file('foo.yaml'))
@@ -1652,6 +1654,7 @@ k8s_yaml(read_file('foo.yaml'))
 
 func TestYamlErrorFromHelm(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.setupHelm()
 	f.file("helm/templates/foo.yaml", "hi")
 	f.file("Tiltfile", `
@@ -1662,6 +1665,7 @@ k8s_yaml(helm('helm'))
 
 func TestYamlErrorFromBlob(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.file("Tiltfile", `
 k8s_yaml(blob('hi'))
 `)
@@ -1670,7 +1674,7 @@ k8s_yaml(blob('hi'))
 
 func TestCustomBuild(t *testing.T) {
 	f := newFixture(t)
-	fmt.Println(f.TempDirFixture.Path())
+	defer f.TearDown()
 
 	tiltfile := `k8s_yaml('foo.yaml')
 hfb = custom_build(
@@ -1704,6 +1708,7 @@ hfb.hot_reload()`
 
 func TestExtraImageLocationOneImage(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -1723,6 +1728,7 @@ docker_build('test/mycrd-env', 'env')
 
 func TestK8SKind(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -1742,6 +1748,7 @@ docker_build('test/mycrd-env', 'env')
 
 func TestK8SKindImageJSONPathPositional(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -1755,6 +1762,7 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationTwoImages(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -1778,6 +1786,7 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationDeploymentEnvVarByName(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.dockerfile("foo-fetcher/Dockerfile")
@@ -1811,6 +1820,7 @@ k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_I
 
 func TestExtraImageLocationDeploymentEnvVarByNameAndNamespace(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.dockerfile("foo-fetcher/Dockerfile")
@@ -1835,6 +1845,7 @@ k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_I
 
 func TestExtraImageLocationNoMatch(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -1848,6 +1859,7 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationInvalidJsonPath(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -1861,24 +1873,28 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationNoPaths(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(kind='MyType')`)
 	f.loadErrString("missing argument for path")
 }
 
 func TestExtraImageLocationNotListOrString(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(kind='MyType', path=8)`)
 	f.loadErrString("path must be a string or list of strings", "Int")
 }
 
 func TestExtraImageLocationListContainsNonString(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(kind='MyType', path=["foo", 8])`)
 	f.loadErrString("path must be a string or list of strings", "8", "Int")
 }
 
 func TestExtraImageLocationNoSelectorSpecified(t *testing.T) {
 	f := newFixture(t)
+	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(path=["foo"])`)
 	f.loadErrString("at least one of kind, name, or namespace must be specified")
 }


### PR DESCRIPTION
Somehow we started cargo culting not putting these in 😅 