### PR TITLE
docker-compose: strip newline off docker-compose output

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -188,7 +188,7 @@ func (c *cmdDCClient) dcOutput(ctx context.Context, configPath string, args ...s
 		}
 		err = fmt.Errorf(errorMessage)
 	}
-	return string(output), err
+	return strings.TrimSpace(string(output)), err
 }
 
 func FormatError(cmd *exec.Cmd, stdout []byte, err error) error {


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/newline:

de46c77129d27a472e73a4e5aa3918b91e76d04c (2019-03-12 22:33:13 -0400)
docker-compose: strip newline off docker-compose output
this was causing all sorts of weird behavior, depending on whether the api trimmed spaces implicitly