### PR TITLE
optionally nest fastBuild on staticBuild; can specify fastBuild properties in tiltfile on top of  a docker_build [ch1834]"

### DIFF
--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"sort"
 
 	"github.com/windmilleng/tilt/internal/container"
@@ -222,7 +223,8 @@ type FastBuild struct {
 	HotReload bool
 }
 
-func (FastBuild) buildDetails() {}
+func (FastBuild) buildDetails()  {}
+func (fb FastBuild) Empty() bool { return reflect.DeepEqual(fb, FastBuild{}) }
 
 type CustomBuild struct {
 	Command string

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -206,6 +206,7 @@ type StaticBuild struct {
 	Dockerfile string
 	BuildPath  string // the absolute path to the files
 	BuildArgs  DockerBuildArgs
+	FastBuild  *FastBuild // Optionally, can use FastBuild to update this build in place.
 }
 
 func (StaticBuild) buildDetails() {}

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -166,8 +166,21 @@ func (d *dockerImage) Type() dockerImageBuildType {
 	return UnknownBuild
 }
 
-func (d *dockerImage) maybeFastBuild() *model.FastBuild {
-	return nil
+func (s *tiltfileState) fastBuildForImage(image *dockerImage) model.FastBuild {
+	return model.FastBuild{
+		BaseDockerfile: image.baseDockerfile.String(),
+		Mounts:         s.mountsToDomain(image),
+		Steps:          image.steps,
+		Entrypoint:     model.ToShellCmd(image.entrypoint),
+		HotReload:      image.hotReload,
+	}
+}
+func (s *tiltfileState) maybeFastBuild(image *dockerImage) *model.FastBuild {
+	fb := s.fastBuildForImage(image)
+	if fb.Empty() {
+		return nil
+	}
+	return &fb
 }
 
 func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -52,6 +52,22 @@ const (
 	CustomBuild
 )
 
+func (d *dockerImage) Type() dockerImageBuildType {
+	if !d.staticBuildPath.Empty() {
+		return StaticBuild
+	}
+
+	if !d.baseDockerfilePath.Empty() {
+		return FastBuild
+	}
+
+	if d.customCommand != "" {
+		return CustomBuild
+	}
+
+	return UnknownBuild
+}
+
 func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var dockerRef string
 	var contextVal, dockerfilePathVal, buildArgs, cacheVal, dockerfileContentsVal starlark.Value
@@ -148,22 +164,6 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 	// (but use the static build defined by docker_build for image builds)
 	fb := &fastBuild{s: s, img: r}
 	return fb, nil
-}
-
-func (d *dockerImage) Type() dockerImageBuildType {
-	if !d.staticBuildPath.Empty() {
-		return StaticBuild
-	}
-
-	if !d.baseDockerfilePath.Empty() {
-		return FastBuild
-	}
-
-	if d.customCommand != "" {
-		return CustomBuild
-	}
-
-	return UnknownBuild
 }
 
 func (s *tiltfileState) fastBuildForImage(image *dockerImage) model.FastBuild {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -513,16 +513,10 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 				Dockerfile: image.staticDockerfile.String(),
 				BuildPath:  string(image.staticBuildPath.path),
 				BuildArgs:  image.staticBuildArgs,
-				FastBuild:  image.maybeFastBuild(),
+				FastBuild:  s.maybeFastBuild(image),
 			})
 		case FastBuild:
-			iTarget = iTarget.WithBuildDetails(model.FastBuild{
-				BaseDockerfile: image.baseDockerfile.String(),
-				Mounts:         s.mountsToDomain(image),
-				Steps:          image.steps,
-				Entrypoint:     model.ToShellCmd(image.entrypoint),
-				HotReload:      image.hotReload,
-			})
+			iTarget = iTarget.WithBuildDetails(s.fastBuildForImage(image))
 		case CustomBuild:
 			r := model.CustomBuild{
 				Command: image.customCommand,

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -197,10 +197,10 @@ func (s *tiltfileState) assembleImages() error {
 	for _, imageBuilder := range s.buildIndex.images {
 		var depImages []reference.Named
 		var err error
-		if imageBuilder.baseDockerfile != "" {
-			depImages, err = imageBuilder.baseDockerfile.FindImages()
-		} else {
+		if imageBuilder.staticDockerfile != "" {
 			depImages, err = imageBuilder.staticDockerfile.FindImages()
+		} else {
+			depImages, err = imageBuilder.baseDockerfile.FindImages()
 		}
 
 		if err != nil {
@@ -513,6 +513,7 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 				Dockerfile: image.staticDockerfile.String(),
 				BuildPath:  string(image.staticBuildPath.path),
 				BuildArgs:  image.staticBuildArgs,
+				FastBuild:  image.maybeFastBuild(),
 			})
 		case FastBuild:
 			iTarget = iTarget.WithBuildDetails(model.FastBuild{

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -356,7 +356,7 @@ k8s_yaml('foo.yaml')
 docker_build("gcr.io/foo", "foo", cache='/path/to/cache')
 `)
 	f.load()
-	f.assertNextManifest("foo", sb(image("gcr.io/foo"), cache("/path/to/cache")))
+	f.assertNextManifest("foo", sbWithCache(image("gcr.io/foo"), "/path/to/cache"))
 }
 
 func TestFastBuildCache(t *testing.T) {
@@ -369,7 +369,7 @@ k8s_yaml('foo.yaml')
 fast_build("gcr.io/foo", 'foo/Dockerfile', cache='/path/to/cache')
 `)
 	f.load()
-	f.assertNextManifest("foo", fb(image("gcr.io/foo"), cache("/path/to/cache")))
+	f.assertNextManifest("foo", fbWithCache(image("gcr.io/foo"), "/path/to/cache"))
 }
 
 func TestDuplicateResourceNames(t *testing.T) {
@@ -2176,7 +2176,6 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 		switch opt := opt.(type) {
 		case sbHelper:
 			image := nextImageTarget()
-			caches := image.CachePaths()
 
 			ref := image.Ref
 			if ref.Empty() {
@@ -2186,57 +2185,53 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 				f.t.Fatalf("manifest %v image ref: %q; expected %q", m.Name, ref.RefName(), opt.image.ref)
 			}
 
+			if opt.cache != "" {
+				assert.Contains(f.t, image.CachePaths(), opt.cache,
+					"manifest %v cache paths don't include expected value", m.Name)
+			}
+
 			if !image.IsStaticBuild() {
 				f.t.Fatalf("expected static build but manifest %v has no static build info", m.Name)
 			}
 
 			for _, matcher := range opt.matchers {
 				switch matcher := matcher.(type) {
-				case cacheHelper:
-					matcher.check(f.t, m, caches)
+				case nestedFBHelper:
+					sbInfo := image.StaticBuildInfo()
+					if matcher.fb == nil {
+						if sbInfo.FastBuild != nil {
+							f.t.Fatalf("expected static build for manifest %v to have "+
+								"no nested fastbuild, but found one: %v", m.Name, sbInfo.FastBuild)
+						}
+					} else {
+						if sbInfo.FastBuild == nil {
+							f.t.Fatalf("expected static build for manifest %v to have "+
+								"nested fastbuild, but found none", m.Name)
+						}
+						matcher.fb.checkMatchers(f, m, *sbInfo.FastBuild)
+					}
 				default:
 					f.t.Fatalf("unknown sbHelper matcher: %T %v", matcher, matcher)
 				}
 			}
 		case fbHelper:
 			image := nextImageTarget()
-			caches := image.CachePaths()
+
 			ref := image.Ref
 			if ref.RefName() != opt.image.ref {
 				f.t.Fatalf("manifest %v image ref: %q; expected %q", m.Name, ref.RefName(), opt.image.ref)
 			}
 
+			if opt.cache != "" {
+				assert.Contains(f.t, image.CachePaths(), opt.cache,
+					"manifest %v cache paths don't include expected value", m.Name)
+			}
+
 			if !image.IsFastBuild() {
 				f.t.Fatalf("expected fast build but manifest %v has no fast build info", m.Name)
 			}
-			fbInfo := image.FastBuildInfo()
 
-			mounts := fbInfo.Mounts
-			steps := fbInfo.Steps
-			for _, matcher := range opt.matchers {
-				switch matcher := matcher.(type) {
-				case cacheHelper:
-					matcher.check(f.t, m, caches)
-				case addHelper:
-					mount := mounts[0]
-					mounts = mounts[1:]
-					if mount.LocalPath != f.JoinPath(matcher.src) {
-						f.t.Fatalf("manifest %v mount %+v src: %q; expected %q", m.Name, mount, mount.LocalPath, f.JoinPath(matcher.src))
-					}
-					if mount.ContainerPath != matcher.dest {
-						f.t.Fatalf("manifest %v mount %+v dest: %q; expected %q", m.Name, mount, mount.ContainerPath, matcher.dest)
-					}
-				case runHelper:
-					step := steps[0]
-					steps = steps[1:]
-					assert.Equal(f.t, model.ToShellCmd(matcher.cmd), step.Cmd)
-					assert.Equal(f.t, matcher.triggers, step.Triggers)
-				case hotReloadHelper:
-					assert.Equal(f.t, matcher.on, fbInfo.HotReload)
-				default:
-					f.t.Fatalf("unknown fbHelper matcher: %T %v", matcher, matcher)
-				}
-			}
+			opt.checkMatchers(f, m, image.FastBuildInfo())
 		case cbHelper:
 			image := nextImageTarget()
 			ref := image.Ref
@@ -2611,40 +2606,61 @@ func withEnvVars(envVars ...string) envVarHelper {
 	return ret
 }
 
-type cacheHelper struct {
-	path string
-}
-
-func cache(path string) cacheHelper {
-	return cacheHelper{path}
-}
-
-func (c cacheHelper) check(t *testing.T, m model.Manifest, paths []string) {
-	cache := paths[0]
-	paths = paths[1:]
-	if cache != c.path {
-		t.Fatalf("manifest %v cache %q; expected %q", m.Name, cache, c.path)
-	}
-}
-
 // static build helper
 type sbHelper struct {
 	image    imageHelper
+	cache    string
 	matchers []interface{}
 }
 
 func sb(img imageHelper, opts ...interface{}) sbHelper {
-	return sbHelper{img, opts}
+	return sbHelper{image: img, matchers: opts}
+}
+
+func sbWithCache(img imageHelper, cache string, opts ...interface{}) sbHelper {
+	return sbHelper{image: img, cache: cache, matchers: opts}
 }
 
 // fast build helper
 type fbHelper struct {
 	image    imageHelper
+	cache    string
 	matchers []interface{}
 }
 
 func fb(img imageHelper, opts ...interface{}) fbHelper {
-	return fbHelper{img, opts}
+	return fbHelper{image: img, matchers: opts}
+}
+
+func fbWithCache(img imageHelper, cache string, opts ...interface{}) fbHelper {
+	return fbHelper{image: img, cache: cache, matchers: opts}
+}
+
+func (fb fbHelper) checkMatchers(f *fixture, m model.Manifest, fbInfo model.FastBuild) {
+	mounts := fbInfo.Mounts
+	steps := fbInfo.Steps
+	for _, matcher := range fb.matchers {
+		switch matcher := matcher.(type) {
+		case addHelper:
+			mount := mounts[0]
+			mounts = mounts[1:]
+			if mount.LocalPath != f.JoinPath(matcher.src) {
+				f.t.Fatalf("manifest %v mount %+v src: %q; expected %q", m.Name, mount, mount.LocalPath, f.JoinPath(matcher.src))
+			}
+			if mount.ContainerPath != matcher.dest {
+				f.t.Fatalf("manifest %v mount %+v dest: %q; expected %q", m.Name, mount, mount.ContainerPath, matcher.dest)
+			}
+		case runHelper:
+			step := steps[0]
+			steps = steps[1:]
+			assert.Equal(f.t, model.ToShellCmd(matcher.cmd), step.Cmd)
+			assert.Equal(f.t, matcher.triggers, step.Triggers)
+		case hotReloadHelper:
+			assert.Equal(f.t, matcher.on, fbInfo.HotReload)
+		default:
+			f.t.Fatalf("unknown fbHelper matcher: %T %v", matcher, matcher)
+		}
+	}
 }
 
 // custom build helper
@@ -2655,6 +2671,17 @@ type cbHelper struct {
 
 func cb(img imageHelper, opts ...interface{}) cbHelper {
 	return cbHelper{img, opts}
+}
+
+type nestedFBHelper struct {
+	fb *fbHelper
+}
+
+func nestedFB(opts ...interface{}) nestedFBHelper {
+	if len(opts) == 0 {
+		return nestedFBHelper{nil}
+	}
+	return nestedFBHelper{&fbHelper{matchers: opts}}
 }
 
 type addHelper struct {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2279,28 +2279,7 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 						f.t.Fatalf("Expected manifest %v to have fast build, but it didn't", m.Name)
 					}
 
-					mounts := cbInfo.Fast.Mounts
-					steps := cbInfo.Fast.Steps
-
-					for _, m2 := range matcher.matchers {
-						switch matcher := m2.(type) {
-						case addHelper:
-							mount := mounts[0]
-							mounts = mounts[1:]
-							if mount.LocalPath != f.JoinPath(matcher.src) {
-								f.t.Fatalf("manifest %v mount %+v src: %q; expected %q", m.Name, mount, mount.LocalPath, f.JoinPath(matcher.src))
-							}
-						case runHelper:
-							step := steps[0]
-							steps = steps[1:]
-							assert.Equal(f.t, model.ToShellCmd(matcher.cmd), step.Cmd)
-							assert.Equal(f.t, matcher.triggers, step.Triggers)
-						case hotReloadHelper:
-							assert.Equal(f.t, matcher.on, cbInfo.Fast.HotReload)
-						default:
-							f.t.Fatalf("unknown fbHelper matcher: %T %v", matcher, matcher)
-						}
-					}
+					matcher.checkMatchers(f, m, *cbInfo.Fast)
 				}
 			}
 


### PR DESCRIPTION
Hello @dmiller, @nicks,

Please review the following commits I made in branch maiamcc/fastbuild-on-dockerbuild:

e76ec665b73f12f48547bac73806bd8fb303c89f (2019-03-13 17:28:12 -0400)
implement it

a6e757555a7cf0ee1f325398b1855dc9ee784d1e (2019-03-13 17:27:44 -0400)
red test

2128fd242d6770f9ba9f3f284f0e3dbe180e907d (2019-03-13 17:15:39 -0400)
add nested fastbuild, test helpers

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics