### PR TITLE
tiltfile: support regex in k8s_kind and k8s_image_json_path

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -205,18 +205,6 @@ func FilterByMetadataLabels(entities []K8sEntity, labels map[string]string) (pas
 	return Filter(entities, func(e K8sEntity) (bool, error) { return e.MatchesMetadataLabels(labels) })
 }
 
-func FilterByName(entities []K8sEntity, name string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasName(name), nil })
-}
-
-func FilterByNamespace(entities []K8sEntity, ns string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasNamespace(ns), nil })
-}
-
-func FilterByKind(entities []K8sEntity, kind string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasKind(kind), nil })
-}
-
 func FilterByHasPodTemplateSpec(entities []K8sEntity) (passing, rest []K8sEntity, err error) {
 	return Filter(entities, func(e K8sEntity) (bool, error) {
 		templateSpecs, err := ExtractPodTemplateSpec(&e)

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -361,11 +361,9 @@ func (s *tiltfileState) k8sImageJsonPath(thread *starlark.Thread, fn *starlark.B
 		return nil, err
 	}
 
-	k := k8sObjectSelector{
-		apiVersion: apiVersion,
-		kind:       kind,
-		name:       name,
-		namespace:  namespace,
+	k, err := newK8SObjectSelector(apiVersion, kind, name, namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	s.k8sImageJSONPaths[k] = paths
@@ -395,10 +393,11 @@ func (s *tiltfileState) k8sKind(thread *starlark.Thread, fn *starlark.Builtin, a
 		return nil, err
 	}
 
-	k := k8sObjectSelector{
-		apiVersion: apiVersion,
-		kind:       kind,
+	k, err := newK8SObjectSelector(apiVersion, kind, "", "")
+	if err != nil {
+		return nil, err
 	}
+
 	s.k8sImageJSONPaths[k] = paths
 
 	return starlark.None, nil

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -97,13 +97,14 @@ func (s *tiltfileState) k8sYaml(thread *starlark.Thread, fn *starlark.Builtin, a
 
 func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var yamlValue, labelsValue starlark.Value
-	var name, namespace, kind string
+	var name, namespace, kind, apiVersion string
 	err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"yaml", &yamlValue,
 		"labels?", &labelsValue,
 		"name?", &name,
 		"namespace?", &namespace,
 		"kind?", &kind,
+		"api_version?", &apiVersion,
 	)
 	if err != nil {
 		return nil, err
@@ -127,48 +128,34 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		return nil, err
 	}
 
-	var allRest []k8s.K8sEntity
-	match := entities
+	k, err := newK8SObjectSelector(apiVersion, kind, name, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var match, rest []k8s.K8sEntity
+	for _, e := range entities {
+		if k.matches(e) {
+			match = append(match, e)
+		} else {
+			rest = append(rest, e)
+		}
+	}
+
 	if len(metaLabels) > 0 {
-		match, allRest, err = k8s.FilterByMetadataLabels(match, metaLabels)
+		var r []k8s.K8sEntity
+		match, r, err = k8s.FilterByMetadataLabels(match, metaLabels)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if name != "" {
-		var rest []k8s.K8sEntity
-		match, rest, err = k8s.FilterByName(match, name)
-		if err != nil {
-			return nil, err
-		}
-		allRest = append(allRest, rest...)
-
-	}
-
-	if namespace != "" {
-		var rest []k8s.K8sEntity
-		match, rest, err = k8s.FilterByNamespace(match, namespace)
-		if err != nil {
-			return nil, err
-		}
-		allRest = append(allRest, rest...)
-	}
-
-	if kind != "" {
-		var rest []k8s.K8sEntity
-		match, rest, err = k8s.FilterByKind(match, kind)
-		if err != nil {
-			return nil, err
-		}
-		allRest = append(allRest, rest...)
+		rest = append(rest, r...)
 	}
 
 	matchingStr, err := k8s.SerializeYAML(match)
 	if err != nil {
 		return nil, err
 	}
-	restStr, err := k8s.SerializeYAML(allRest)
+	restStr, err := k8s.SerializeYAML(rest)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -615,22 +615,22 @@ func newK8SObjectSelector(apiVersion string, kind string, name string, namespace
 
 	ret.apiVersion, err = regexp.Compile(apiVersion)
 	if err != nil {
-		return k8sObjectSelector{}, err
+		return k8sObjectSelector{}, errors.Wrap(err, "error parsing apiVersion regexp")
 	}
 
 	ret.kind, err = regexp.Compile(kind)
 	if err != nil {
-		return k8sObjectSelector{}, err
+		return k8sObjectSelector{}, errors.Wrap(err, "error parsing kind regexp")
 	}
 
 	ret.name, err = regexp.Compile(name)
 	if err != nil {
-		return k8sObjectSelector{}, err
+		return k8sObjectSelector{}, errors.Wrap(err, "error parsing name regexp")
 	}
 
 	ret.namespace, err = regexp.Compile(namespace)
 	if err != nil {
-		return k8sObjectSelector{}, err
+		return k8sObjectSelector{}, errors.Wrap(err, "error parsing namespace regexp")
 	}
 
 	return ret, nil

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1904,9 +1904,11 @@ func TestK8SImageJSONPathArgs(t *testing.T) {
 	}{
 		{"match name", "name='foo'", true},
 		{"don't match name", "name='bar'", false},
+		{"match name w/ regex", "name='.*o'", true},
 		{"match kind", "name='foo', kind='Deployment'", true},
 		{"don't match kind", "name='bar', kind='asdf'", false},
 		{"match apiVersion", "name='foo', api_version='apps/v1'", true},
+		{"match apiVersion+kind w/ regex", "name='foo', kind='Deployment', api_version='apps/.*'", true},
 		{"don't match apiVersion", "name='bar', api_version='apps/v2'", false},
 		{"match namespace", "name='foo', namespace='default'", true},
 		{"don't match namespace", "name='bar', namespace='asdf'", false},

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1052,7 +1052,7 @@ func TestFilterYamlByNameKind(t *testing.T) {
 	f.file("k8s.yaml", yaml.ConcatYAML(
 		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
 		testyaml.SnackYaml, testyaml.SanchoYAML))
-	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', name='doggos', kind='deployment')
+	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', name='doggos', kind='Deployment')
 k8s_resource('doggos', yaml=doggos)
 k8s_resource('rest', yaml=rest)
 `)
@@ -1069,6 +1069,22 @@ func TestFilterYamlByNamespace(t *testing.T) {
 		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
 		testyaml.SnackYaml, testyaml.SanchoYAML))
 	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', namespace='the-dog-zone')
+k8s_resource('doggos', yaml=doggos)
+k8s_resource('rest', yaml=rest)
+`)
+	f.load()
+
+	f.assertNextManifest("doggos", deployment("doggos"))
+	f.assertNextManifest("rest", service("doggos"), deployment("snack"), deployment("sancho"))
+}
+
+func TestFilterYamlByApiVersion(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.file("k8s.yaml", yaml.ConcatYAML(
+		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
+		testyaml.SnackYaml, testyaml.SanchoYAML))
+	f.file("Tiltfile", `doggos, rest = filter_yaml('k8s.yaml', name='doggos', api_version='apps/v1')
 k8s_resource('doggos', yaml=doggos)
 k8s_resource('rest', yaml=rest)
 `)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1786,14 +1786,17 @@ docker_build('test/mycrd-env', 'env')
 
 func TestK8SKind(t *testing.T) {
 	tests := []struct {
-		name        string
-		args        string
-		expectMatch bool
+		name          string
+		args          string
+		expectMatch   bool
+		expectedError string
 	}{
-		{"match kind", "'Environment', image_json_path='{.spec.runtime.image}'", true},
-		{"don't match kind", "'fdas', image_json_path='{.spec.runtime.image}'", false},
-		{"match apiVersion", "'Environment', image_json_path='{.spec.runtime.image}', api_version='fission.io/v1'", true},
-		{"don't match apiVersion", "'Environment', image_json_path='{.spec.runtime.image}', api_version='fission.io/v2'", false},
+		{"match kind", "'Environment', image_json_path='{.spec.runtime.image}'", true, ""},
+		{"don't match kind", "'fdas', image_json_path='{.spec.runtime.image}'", false, ""},
+		{"match apiVersion", "'Environment', image_json_path='{.spec.runtime.image}', api_version='fission.io/v1'", true, ""},
+		{"don't match apiVersion", "'Environment', image_json_path='{.spec.runtime.image}', api_version='fission.io/v2'", false, ""},
+		{"invalid kind regexp", "'*', image_json_path='{.spec.runtime.image}'", false, "error parsing kind regexp"},
+		{"invalid apiVersion regexp", "'Environment', api_version='*', image_json_path='{.spec.runtime.image}'", false, "error parsing apiVersion regexp"},
 	}
 
 	for _, test := range tests {
@@ -1809,6 +1812,9 @@ docker_build('test/mycrd-env', 'env')
 `, test.args))
 
 			if test.expectMatch {
+				if test.expectedError != "" {
+					t.Fatal("invalid test: cannot expect both match and error")
+				}
 				f.load("mycrd-env")
 				f.assertNextManifest("mycrd-env",
 					sb(
@@ -1817,8 +1823,12 @@ docker_build('test/mycrd-env', 'env')
 					k8sObject("mycrd", "Environment"),
 				)
 			} else {
-				w := unusedImageWarning("docker.io/test/mycrd-env", []string{"docker.io/library/golang"})
-				f.loadAssertWarnings(w)
+				if test.expectedError == "" {
+					w := unusedImageWarning("docker.io/test/mycrd-env", []string{"docker.io/library/golang"})
+					f.loadAssertWarnings(w)
+				} else {
+					f.loadErrString(test.expectedError)
+				}
 			}
 		})
 	}
@@ -1898,20 +1908,25 @@ k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_I
 
 func TestK8SImageJSONPathArgs(t *testing.T) {
 	tests := []struct {
-		name        string
-		args        string
-		expectMatch bool
+		name          string
+		args          string
+		expectMatch   bool
+		expectedError string
 	}{
-		{"match name", "name='foo'", true},
-		{"don't match name", "name='bar'", false},
-		{"match name w/ regex", "name='.*o'", true},
-		{"match kind", "name='foo', kind='Deployment'", true},
-		{"don't match kind", "name='bar', kind='asdf'", false},
-		{"match apiVersion", "name='foo', api_version='apps/v1'", true},
-		{"match apiVersion+kind w/ regex", "name='foo', kind='Deployment', api_version='apps/.*'", true},
-		{"don't match apiVersion", "name='bar', api_version='apps/v2'", false},
-		{"match namespace", "name='foo', namespace='default'", true},
-		{"don't match namespace", "name='bar', namespace='asdf'", false},
+		{"match name", "name='foo'", true, ""},
+		{"don't match name", "name='bar'", false, ""},
+		{"match name w/ regex", "name='.*o'", true, ""},
+		{"match kind", "name='foo', kind='Deployment'", true, ""},
+		{"don't match kind", "name='bar', kind='asdf'", false, ""},
+		{"match apiVersion", "name='foo', api_version='apps/v1'", true, ""},
+		{"match apiVersion+kind w/ regex", "name='foo', kind='Deployment', api_version='apps/.*'", true, ""},
+		{"don't match apiVersion", "name='bar', api_version='apps/v2'", false, ""},
+		{"match namespace", "name='foo', namespace='default'", true, ""},
+		{"don't match namespace", "name='bar', namespace='asdf'", false, ""},
+		{"invalid name regex", "name='*'", false, "error parsing name regexp"},
+		{"invalid kind regex", "kind='*'", false, "error parsing kind regexp"},
+		{"invalid apiVersion regex", "name='foo', api_version='*'", false, "error parsing apiVersion regexp"},
+		{"invalid namespace regex", "namespace='*'", false, "error parsing namespace regexp"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1928,6 +1943,9 @@ docker_build('gcr.io/foo-fetcher', 'foo-fetcher')
 k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_IMAGE')].value}", %s)
 	`, test.args))
 			if test.expectMatch {
+				if test.expectedError != "" {
+					t.Fatal("illegal test definition: cannot expect both match and error")
+				}
 				f.load("foo")
 				f.assertNextManifest("foo",
 					sb(
@@ -1938,8 +1956,12 @@ k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_I
 					),
 				)
 			} else {
-				w := unusedImageWarning("gcr.io/foo-fetcher", []string{"gcr.io/foo", "docker.io/library/golang"})
-				f.loadAssertWarnings(w)
+				if test.expectedError == "" {
+					w := unusedImageWarning("gcr.io/foo-fetcher", []string{"gcr.io/foo", "docker.io/library/golang"})
+					f.loadAssertWarnings(w)
+				} else {
+					f.loadErrString(test.expectedError)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
a couple of use cases:
1. When templating entity names, the tiltfile will have to duplicate the templating logic in order to pass the entity name to k8s_image_json path. e.g., in the simple Servantes case, the tiltfile would need `username() + "-vigoda"`. This allows the user to pass `name=".*-vigoda"`.
2. When specifying apiVersion, the user might care about the group but not the version. This allows the user to specify, e.g., `fission.io/.*`.