### PR TITLE
engine: use staticBuild.FastBuild for LiveUpdate where possible [ch1833]

### DIFF
--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -133,6 +133,17 @@ func NewSanchoStaticManifestWithCache(paths []string) model.Manifest {
 	return manifest
 }
 
+func NewSanchoStaticManifestWithNestedFastBuild(fixture pather) model.Manifest {
+	manifest := NewSanchoStaticManifest()
+	iTarg := manifest.ImageTargetAt(0)
+	fb := NewSanchoFastBuild(fixture)
+	sb := iTarg.StaticBuildInfo()
+	sb.FastBuild = &fb
+	iTarg = iTarg.WithBuildDetails(sb)
+	manifest = manifest.WithImageTarget(iTarg)
+	return manifest
+}
+
 func NewSanchoStaticMultiStageManifest() model.Manifest {
 	baseImage := model.ImageTarget{
 		Ref: SanchoBaseRef,

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -109,16 +109,15 @@ func (i ImageTarget) MaybeFastBuildInfo() *FastBuild {
 	return nil
 }
 
+// FastBuildInfo returns the TOP LEVEL BUILD DETAILS, if a FastBuild.
+// Does not return nested FastBuild details.
 func (i ImageTarget) FastBuildInfo() FastBuild {
-	fb := i.MaybeFastBuildInfo()
-	if fb == nil {
-		return FastBuild{}
-	}
-	return *fb
+	ret, _ := i.BuildDetails.(FastBuild)
+	return ret
 }
 
-// Check if the TOP LEVEL BUILD DETAILS are for a FastBuild.
-// (If this target is a StaticBuild || CustomBuild with a nested FastBuild, return FALSE.)
+// IsFastBuild checks if the TOP LEVEL BUILD DETAILS are for a FastBuild.
+// (If this target is a StaticBuild || CustomBuild with a nested FastBuild, returns FALSE.)
 func (i ImageTarget) IsFastBuild() bool {
 	_, ok := i.BuildDetails.(FastBuild)
 	return ok

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -101,6 +101,8 @@ func (i ImageTarget) MaybeFastBuildInfo() *FastBuild {
 	switch details := i.BuildDetails.(type) {
 	case FastBuild:
 		return &details
+	case StaticBuild:
+		return details.FastBuild
 	case CustomBuild:
 		return details.Fast
 	}

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -110,10 +110,15 @@ func (i ImageTarget) MaybeFastBuildInfo() *FastBuild {
 }
 
 func (i ImageTarget) FastBuildInfo() FastBuild {
-	ret, _ := i.BuildDetails.(FastBuild)
-	return ret
+	fb := i.MaybeFastBuildInfo()
+	if fb == nil {
+		return FastBuild{}
+	}
+	return *fb
 }
 
+// Check if the TOP LEVEL BUILD DETAILS are for a FastBuild.
+// (If this target is a StaticBuild || CustomBuild with a nested FastBuild, return FALSE.)
 func (i ImageTarget) IsFastBuild() bool {
 	_, ok := i.BuildDetails.(FastBuild)
 	return ok


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/nested-fb-live-update:

4c668b17fcebd2cb035190df4fcd0fbea5daa0d1 (2019-03-14 12:31:16 -0400)
imageTarget.FastBuildInfo consistent with MaybeFastBuild

67bf8e72b78a198514cabb7c588b9f2421e390de (2019-03-14 12:12:12 -0400)
extract nested fastbuild as a live update target

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics