### PR TITLE
tiltfile: wrap load return values in struct

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -40,16 +40,16 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	manifests, globalYaml, _, _, err := downDeps.tfl.Load(ctx, c.fileName, nil)
+	tlr, err := downDeps.tfl.Load(ctx, c.fileName, nil)
 	if err != nil {
 		return err
 	}
 
-	entities, err := engine.ParseYAMLFromManifests(manifests...)
+	entities, err := engine.ParseYAMLFromManifests(tlr.Manifests...)
 	if err != nil {
 		return errors.Wrap(err, "Parsing manifest YAML")
 	}
-	gyamlEntities, err := k8s.ParseYAMLFromString(globalYaml.K8sTarget().YAML)
+	gyamlEntities, err := k8s.ParseYAMLFromString(tlr.Global.K8sTarget().YAML)
 	if err != nil {
 		return errors.Wrap(err, "Parsing global YAML")
 	}
@@ -61,7 +61,7 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 	}
 
 	var dcConfigPath string
-	for _, m := range manifests {
+	for _, m := range tlr.Manifests {
 		if m.IsDC() {
 			// TODO(maia): when we support up-ing from multiple docker-compose files, we'll
 			// need to support down-ing as well. For now, we `down` the first one we find.

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -186,18 +186,18 @@ func (s Script) Run(ctx context.Context) error {
 
 		tfPath := filepath.Join(dir, tiltfile.FileName)
 		// TODO(dmiller): not this?
-		manifests, _, _, warnings, err := s.tfl.Load(ctx, tfPath, nil)
+		tlr, err := s.tfl.Load(ctx, tfPath, nil)
 		if err != nil {
 			return err
 		}
 
-		defer s.cleanUp(newBackgroundContext(ctx), manifests)
+		defer s.cleanUp(newBackgroundContext(ctx), tlr.Manifests)
 
 		initAction := engine.InitAction{
 			WatchMounts:  true,
-			Manifests:    manifests,
+			Manifests:    tlr.Manifests,
 			TiltfilePath: tfPath,
-			Warnings:     warnings,
+			Warnings:     tlr.Warnings,
 		}
 		return s.upper.Init(ctx, initAction)
 	})

--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -89,21 +89,21 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
 
 		loadCtx := logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), multiWriter))
 
-		manifests, globalYAML, configFiles, warnings, err := cc.tfl.Load(loadCtx, tiltfilePath, matching)
-		if err == nil && len(manifests) == 0 && globalYAML.Empty() {
+		tlr, err := cc.tfl.Load(loadCtx, tiltfilePath, matching)
+		if err == nil && len(tlr.Manifests) == 0 && tlr.Global.Empty() {
 			err = fmt.Errorf("No resources found. Check out https://docs.tilt.dev/tutorial.html to get started!")
 		}
 		if err != nil {
 			logger.Get(ctx).Infof(err.Error())
 		}
 		st.Dispatch(ConfigsReloadedAction{
-			Manifests:   manifests,
-			GlobalYAML:  globalYAML,
-			ConfigFiles: configFiles,
+			Manifests:   tlr.Manifests,
+			GlobalYAML:  tlr.Global,
+			ConfigFiles: tlr.ConfigFiles,
 			StartTime:   startTime,
 			FinishTime:  cc.clock(),
 			Err:         err,
-			Warnings:    warnings,
+			Warnings:    tlr.Warnings,
 		})
 	}()
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2602,11 +2602,11 @@ func (f *testFixture) assertAllBuildsConsumed() {
 }
 
 func (f *testFixture) loadAndStart() {
-	manifests, _, _, _, err := f.tfl.Load(f.ctx, f.JoinPath(tiltfile.FileName), nil)
+	tlr, err := f.tfl.Load(f.ctx, f.JoinPath(tiltfile.FileName), nil)
 	if err != nil {
 		f.T().Fatal(err)
 	}
-	f.Start(manifests, true)
+	f.Start(tlr.Manifests, true)
 }
 
 func (f *testFixture) WriteConfigFiles(args ...string) {
@@ -2651,16 +2651,16 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 
 	f.WriteFile("Tiltfile", `docker_compose('docker-compose.yml')`)
 
-	manifests, _, _, _, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), nil)
+	tlr, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), nil)
 	if err != nil {
 		f.T().Fatal(err)
 	}
 
-	if len(manifests) != 2 {
-		f.T().Fatalf("Expected two manifests. Actual: %v", manifests)
+	if len(tlr.Manifests) != 2 {
+		f.T().Fatalf("Expected two manifests. Actual: %v", tlr.Manifests)
 	}
 
-	return manifests[0], manifests[1]
+	return tlr.Manifests[0], tlr.Manifests[1]
 }
 
 func (f *testFixture) setBuildLogOutput(id model.TargetID, output string) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -777,7 +777,7 @@ docker_build('gcr.io/bar', 'bar')
 k8s_resource('bar', 'bar.yaml')
 `)
 
-	_, _, _, _, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), matchMap("baz"))
+	_, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), matchMap("baz"))
 	if assert.Error(t, err) {
 		assert.Equal(t, "Could not find resources: baz. Existing resources in Tiltfile: foo, bar", err.Error())
 	}
@@ -1264,7 +1264,7 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', '.')
 `)
 	f.load()
 
-	assert.Equal(t, 1, len(f.manifests))
+	assert.Equal(t, 1, len(f.loadResult.Manifests))
 	m := f.assertNextManifest("sancho")
 	assert.Equal(t, 2, len(m.ImageTargets))
 	assert.Equal(t, "gcr.io/some-project-162817/sancho",
@@ -1285,7 +1285,7 @@ docker_build('gcr.io/some-project-162817/sancho', '.')
 `)
 	f.load()
 
-	assert.Equal(t, 1, len(f.manifests))
+	assert.Equal(t, 1, len(f.loadResult.Manifests))
 	m := f.assertNextManifest("sancho")
 	assert.Equal(t, 1, len(m.ImageTargets))
 	assert.Equal(t, "gcr.io/some-project-162817/sancho",
@@ -2127,11 +2127,7 @@ type fixture struct {
 	tfl TiltfileLoader
 	an  *analytics.MemoryAnalytics
 
-	// created by load
-	manifests    []model.Manifest
-	yamlManifest model.Manifest
-	configFiles  []string
-	warnings     []string
+	loadResult TiltfileLoadResult
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -2255,22 +2251,19 @@ func matchMap(names ...string) map[string]bool {
 // Default load. Fails if there are any warnings.
 func (f *fixture) load(names ...string) {
 	f.loadAllowWarnings(names...)
-	if len(f.warnings) != 0 {
-		f.t.Fatalf("Unexpected no warnings. Actual: %s", f.warnings)
+	if len(f.loadResult.Warnings) != 0 {
+		f.t.Fatalf("Unexpected no warnings. Actual: %s", f.loadResult.Warnings)
 	}
 }
 
 // Load the manifests, expecting warnings.
 // Warnigns should be asserted later with assertWarnings
 func (f *fixture) loadAllowWarnings(names ...string) {
-	manifests, yamlManifest, configFiles, warnings, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...))
+	tlr, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...))
 	if err != nil {
 		f.t.Fatal(err)
 	}
-	f.manifests = manifests
-	f.yamlManifest = yamlManifest
-	f.configFiles = configFiles
-	f.warnings = warnings
+	f.loadResult = tlr
 }
 
 func unusedImageWarning(unusedImage string, suggestedImages []string) string {
@@ -2291,13 +2284,11 @@ func (f *fixture) loadAssertWarnings(warnings ...string) {
 }
 
 func (f *fixture) loadErrString(msgs ...string) {
-	manifests, _, configFiles, warnings, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), nil)
+	tlr, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), nil)
 	if err == nil {
 		f.t.Fatalf("expected error but got nil")
 	}
-	f.manifests = manifests
-	f.configFiles = configFiles
-	f.warnings = warnings
+	f.loadResult = tlr
 	errText := err.Error()
 	for _, msg := range msgs {
 		if !strings.Contains(errText, msg) {
@@ -2313,13 +2304,13 @@ func (f *fixture) gitInit(path string) {
 }
 
 func (f *fixture) assertNoYAMLManifest(name string) {
-	assert.Equal(f.t, model.Manifest{}, f.yamlManifest)
+	assert.Equal(f.t, model.Manifest{}, f.loadResult.Global)
 }
 
 func (f *fixture) assertYAMLManifest(resNames ...string) {
-	assert.Equal(f.t, unresourcedName, f.yamlManifest.ManifestName().String())
+	assert.Equal(f.t, unresourcedName, f.loadResult.Global.ManifestName().String())
 
-	entities, err := k8s.ParseYAML(bytes.NewBufferString(f.yamlManifest.K8sTarget().YAML))
+	entities, err := k8s.ParseYAML(bytes.NewBufferString(f.loadResult.Global.K8sTarget().YAML))
 	assert.NoError(f.t, err)
 
 	entityNames := make([]string, len(entities))
@@ -2331,16 +2322,16 @@ func (f *fixture) assertYAMLManifest(resNames ...string) {
 
 // assert functions and helpers
 func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Manifest {
-	if len(f.manifests) == 0 {
+	if len(f.loadResult.Manifests) == 0 {
 		f.t.Fatalf("no more manifests; trying to find %q (did you call `f.load`?)", name)
 	}
 
-	m := f.manifests[0]
+	m := f.loadResult.Manifests[0]
 	if m.Name != model.ManifestName(name) {
 		f.t.Fatalf("expected next manifest to be '%s' but found '%s'", name, m.Name)
 	}
 
-	f.manifests = f.manifests[1:]
+	f.loadResult.Manifests = f.loadResult.Manifests[1:]
 
 	imageIndex := 0
 	nextImageTarget := func() model.ImageTarget {
@@ -2575,7 +2566,7 @@ func (f *fixture) idNames(ids []model.TargetID) []string {
 }
 
 func (f *fixture) assertNumManifests(expected int) {
-	assert.Equal(f.t, expected, len(f.manifests))
+	assert.Equal(f.t, expected, len(f.loadResult.Manifests))
 }
 
 func (f *fixture) assertConfigFiles(filenames ...string) {
@@ -2584,8 +2575,8 @@ func (f *fixture) assertConfigFiles(filenames ...string) {
 		expected = append(expected, f.JoinPath(filename))
 	}
 	sort.Strings(expected)
-	sort.Strings(f.configFiles)
-	assert.Equal(f.t, expected, f.configFiles)
+	sort.Strings(f.loadResult.ConfigFiles)
+	assert.Equal(f.t, expected, f.loadResult.ConfigFiles)
 }
 
 func (f *fixture) assertWarnings(warnings ...string) {
@@ -2594,8 +2585,8 @@ func (f *fixture) assertWarnings(warnings ...string) {
 		expected = append(expected, warning)
 	}
 	sort.Strings(expected)
-	sort.Strings(f.warnings)
-	assert.Equal(f.t, expected, f.warnings)
+	sort.Strings(f.loadResult.Warnings)
+	assert.Equal(f.t, expected, f.loadResult.Warnings)
 }
 
 func (f *fixture) entities(y string) []k8s.K8sEntity {


### PR DESCRIPTION
I was about to add another return value to `Load` and it was getting a bit unwieldy