### PR TITLE
tilt: add .tiltignore support

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -167,9 +167,10 @@ type ConfigsReloadStartedAction struct {
 func (ConfigsReloadStartedAction) Action() {}
 
 type ConfigsReloadedAction struct {
-	Manifests   []model.Manifest
-	GlobalYAML  model.Manifest
-	ConfigFiles []string
+	Manifests          []model.Manifest
+	GlobalYAML         model.Manifest
+	TiltIgnoreContents string
+	ConfigFiles        []string
 
 	StartTime  time.Time
 	FinishTime time.Time

--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -97,13 +97,14 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
 			logger.Get(ctx).Infof(err.Error())
 		}
 		st.Dispatch(ConfigsReloadedAction{
-			Manifests:   tlr.Manifests,
-			GlobalYAML:  tlr.Global,
-			ConfigFiles: tlr.ConfigFiles,
-			StartTime:   startTime,
-			FinishTime:  cc.clock(),
-			Err:         err,
-			Warnings:    tlr.Warnings,
+			Manifests:          tlr.Manifests,
+			GlobalYAML:         tlr.Global,
+			ConfigFiles:        tlr.ConfigFiles,
+			TiltIgnoreContents: tlr.TiltIgnoreContents,
+			StartTime:          startTime,
+			FinishTime:         cc.clock(),
+			Err:                err,
+			Warnings:           tlr.Warnings,
 		})
 	}()
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -479,7 +479,7 @@ func handleConfigsReloaded(
 
 		// EXCEPT for the config file list, because we want to watch new config files even when the tiltfile is broken
 		// append any new config files found in the reload action
-		state.ConfigFiles = sliceutils.AppendWithoutDupes(state.ConfigFiles, event.ConfigFiles)
+		state.ConfigFiles = sliceutils.AppendWithoutDupes(state.ConfigFiles, event.ConfigFiles...)
 
 		return
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -510,6 +510,7 @@ func handleConfigsReloaded(
 	state.ManifestDefinitionOrder = newDefOrder
 	state.GlobalYAML = event.GlobalYAML
 	state.ConfigFiles = event.ConfigFiles
+	state.TiltIgnoreContents = event.TiltIgnoreContents
 
 	// Remove pending file changes that were consumed by this build.
 	for file, modTime := range state.PendingConfigFileChanges {

--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -147,7 +147,6 @@ func (w *WatchManager) diff(ctx context.Context, st store.RStore) (setup []Watch
 		if tiltIgnoreChanged || !watchRulesMatch(m, mnc.target) {
 			teardown = append(teardown, name)
 			setup = append(setup, m)
-			continue
 		}
 	}
 

--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/windmilleng/tilt/internal/dockerignore"
 	"github.com/windmilleng/tilt/internal/ignore"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
@@ -101,6 +102,7 @@ type WatchManager struct {
 	targetWatches      map[model.TargetID]targetNotifyCancel
 	fsWatcherMaker     FsWatcherMaker
 	timerMaker         timerMaker
+	tiltIgnoreContents string
 	disabledForTesting bool
 }
 
@@ -133,6 +135,8 @@ func (w *WatchManager) diff(ctx context.Context, st store.RStore) (setup []Watch
 		targetsToProcess[ConfigsTargetID] = &configsTarget{dependencies: append([]string(nil), state.ConfigFiles...)}
 	}
 
+	tiltIgnoreChanged := w.tiltIgnoreContents != state.TiltIgnoreContents
+
 	for name, mnc := range w.targetWatches {
 		m, ok := targetsToProcess[name]
 		if !ok {
@@ -140,10 +144,10 @@ func (w *WatchManager) diff(ctx context.Context, st store.RStore) (setup []Watch
 			continue
 		}
 
-		if !watchRulesMatch(m, mnc.target) {
+		if tiltIgnoreChanged || !watchRulesMatch(m, mnc.target) {
 			teardown = append(teardown, name)
 			setup = append(setup, m)
-			break
+			continue
 		}
 	}
 
@@ -167,6 +171,11 @@ func watchRulesMatch(w1, w2 WatchableTarget) bool {
 func (w *WatchManager) OnChange(ctx context.Context, st store.RStore) {
 	setup, teardown := w.diff(ctx, st)
 
+	state := st.RLockState()
+	tiltRoot := filepath.Dir(state.TiltfilePath)
+	w.tiltIgnoreContents = state.TiltIgnoreContents
+	st.RUnlockState()
+
 	// setup the watch first, to avoid a gap in coverage between setup and
 	// teardown. it's ok if we get a file event twice.
 	newWatches := make(map[model.TargetID]targetNotifyCancel)
@@ -186,7 +195,7 @@ func (w *WatchManager) OnChange(ctx context.Context, st store.RStore) {
 
 		ctx, cancel := context.WithCancel(ctx)
 
-		go w.dispatchFileChangesLoop(ctx, target, watcher, st)
+		go w.dispatchFileChangesLoop(ctx, target, watcher, st, tiltRoot)
 		newWatches[target.ID()] = targetNotifyCancel{target, watcher, cancel}
 	}
 
@@ -208,12 +217,23 @@ func (w *WatchManager) OnChange(ctx context.Context, st store.RStore) {
 	}
 }
 
-func (w *WatchManager) dispatchFileChangesLoop(ctx context.Context, target WatchableTarget, watcher watch.Notify, st store.RStore) {
+func (w *WatchManager) dispatchFileChangesLoop(
+	ctx context.Context,
+	target WatchableTarget,
+	watcher watch.Notify,
+	st store.RStore,
+	tiltRoot string) {
+
 	filter, err := ignore.CreateFileChangeFilter(target)
 	if err != nil {
 		st.Dispatch(NewErrorAction(err))
 		return
 	}
+	tiltIgnoreFilter, err := dockerignore.DockerIgnoreTesterFromContents(tiltRoot, w.tiltIgnoreContents)
+	if err != nil {
+		st.Dispatch(NewErrorAction(err))
+	}
+	filter = model.NewCompositeMatcher([]model.PathMatcher{filter, tiltIgnoreFilter})
 
 	eventsCh := coalesceEvents(w.timerMaker, watcher.Events())
 

--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -32,7 +32,7 @@ func StringSliceEquals(a, b []string) bool {
 }
 
 // returns a slice that consists of `a`, in order, followed by elements of `b` that are not in `a`
-func AppendWithoutDupes(a, b []string) []string {
+func AppendWithoutDupes(a []string, b ...string) []string {
 	seen := make(map[string]bool)
 	for _, s := range a {
 		seen[s] = true

--- a/internal/sliceutils/sliceutils_test.go
+++ b/internal/sliceutils/sliceutils_test.go
@@ -9,7 +9,7 @@ import (
 func TestAppendWithoutDupesNoDupes(t *testing.T) {
 	a := []string{"a", "b"}
 	b := []string{"c", "d"}
-	observed := AppendWithoutDupes(a, b)
+	observed := AppendWithoutDupes(a, b...)
 	expected := []string{"a", "b", "c", "d"}
 	assert.Equal(t, expected, observed)
 }
@@ -17,7 +17,7 @@ func TestAppendWithoutDupesNoDupes(t *testing.T) {
 func TestAppendWithoutDupesHasADupe(t *testing.T) {
 	a := []string{"a", "b"}
 	b := []string{"c", "b"}
-	observed := AppendWithoutDupes(a, b)
+	observed := AppendWithoutDupes(a, b...)
 	expected := []string{"a", "b", "c"}
 	assert.Equal(t, expected, observed)
 }
@@ -25,7 +25,7 @@ func TestAppendWithoutDupesHasADupe(t *testing.T) {
 func TestAppendWithoutDupesEmptyA(t *testing.T) {
 	a := []string{}
 	b := []string{"c", "b"}
-	observed := AppendWithoutDupes(a, b)
+	observed := AppendWithoutDupes(a, b...)
 	expected := []string{"c", "b"}
 	assert.Equal(t, expected, observed)
 }
@@ -33,7 +33,7 @@ func TestAppendWithoutDupesEmptyA(t *testing.T) {
 func TestAppendWithoutDupesEmptyB(t *testing.T) {
 	a := []string{"a", "b"}
 	b := []string{}
-	observed := AppendWithoutDupes(a, b)
+	observed := AppendWithoutDupes(a, b...)
 	expected := []string{"a", "b"}
 	assert.Equal(t, expected, observed)
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -62,6 +62,7 @@ type EngineState struct {
 
 	TiltfilePath             string
 	ConfigFiles              []string
+	TiltIgnoreContents       string
 	PendingConfigFileChanges map[string]time.Time
 
 	// InitManifests is the list of manifest names that we were told to init from the CLI.

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/windmilleng/tilt/internal/sliceutils"
+
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
 
@@ -175,7 +177,7 @@ func (s *tiltfileState) absWorkingDir() string {
 }
 
 func (s *tiltfileState) recordConfigFile(f string) {
-	s.configFiles = append(s.configFiles, f)
+	s.configFiles = sliceutils.AppendWithoutDupes(s.configFiles, f)
 }
 
 func (s *tiltfileState) readFile(p localPath) ([]byte, error) {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -20,6 +20,7 @@ import (
 )
 
 const FileName = "Tiltfile"
+const TiltIgnoreFileName = ".tiltignore"
 const unresourcedName = "k8s_yaml"
 
 func init() {
@@ -29,10 +30,11 @@ func init() {
 }
 
 type TiltfileLoadResult struct {
-	Manifests   []model.Manifest
-	Global      model.Manifest
-	ConfigFiles []string
-	Warnings    []string
+	Manifests          []model.Manifest
+	Global             model.Manifest
+	ConfigFiles        []string
+	Warnings           []string
+	TiltIgnoreContents string
 }
 
 type TiltfileLoader interface {
@@ -54,7 +56,12 @@ func NewFakeTiltfileLoader() *FakeTiltfileLoader {
 }
 
 func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, matching map[string]bool) (TiltfileLoadResult, error) {
-	return TiltfileLoadResult{tfl.Manifests, tfl.Global, tfl.ConfigFiles, tfl.Warnings}, tfl.Err
+	return TiltfileLoadResult{
+		Manifests:   tfl.Manifests,
+		Global:      tfl.Global,
+		ConfigFiles: tfl.ConfigFiles,
+		Warnings:    tfl.Warnings,
+	}, tfl.Err
 }
 
 func ProvideTiltfileLoader(analytics analytics.Analytics, dcCli dockercompose.DockerComposeClient) TiltfileLoader {
@@ -73,10 +80,10 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	absFilename, err := ospath.RealAbs(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return TiltfileLoadResult{nil, model.Manifest{}, []string{filename}, nil}, fmt.Errorf("No Tiltfile found at path '%s'. Check out https://docs.tilt.dev/tutorial.html", filename)
+			return TiltfileLoadResult{ConfigFiles: []string{filename}}, fmt.Errorf("No Tiltfile found at path '%s'. Check out https://docs.tilt.dev/tutorial.html", filename)
 		}
 		absFilename, _ = filepath.Abs(filename)
-		return TiltfileLoadResult{nil, model.Manifest{}, []string{absFilename}, nil}, err
+		return TiltfileLoadResult{ConfigFiles: []string{absFilename}}, err
 	}
 
 	s := newTiltfileState(ctx, tfl.dcCli, absFilename)
@@ -125,15 +132,26 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		}
 	}
 
-	if err == nil {
-		s.logger.Infof("Successfully loaded Tiltfile")
-	}
+	s.logger.Infof("Successfully loaded Tiltfile")
 
 	tfl.reportTiltfileLoaded(s.builtinCallCounts)
 
+	tiltIgnoreContents, err := s.readFile(s.localPathFromString(tiltIgnorePath(filename)))
+	// missing tiltignore is fine
+	if os.IsNotExist(err) {
+		err = nil
+	} else if err != nil {
+		return TiltfileLoadResult{}, errors.Wrapf(err, "error reading %s", tiltIgnorePath(filename))
+	}
+
 	// TODO(maia): `yamlManifest` should be processed just like any
 	// other manifest (i.e. get rid of "global yaml" concept)
-	return TiltfileLoadResult{manifests, yamlManifest, s.configFiles, s.warnings}, err
+	return TiltfileLoadResult{manifests, yamlManifest, s.configFiles, s.warnings, string(tiltIgnoreContents)}, err
+}
+
+// .tiltignore sits next to Tiltfile
+func tiltIgnorePath(tiltfilePath string) string {
+	return filepath.Join(filepath.Dir(tiltfilePath), TiltIgnoreFileName)
 }
 
 func skylarkStringDictToGoMap(d *starlark.Dict) (map[string]string, error) {

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -77,7 +78,7 @@ func TestDockerComposeManifest(t *testing.T) {
 		// TODO(maia): assert m.tiltFilename
 	)
 
-	expectedConfFiles := []string{"Tiltfile", "docker-compose.yml", "foo/Dockerfile"}
+	expectedConfFiles := []string{"Tiltfile", ".tiltignore", "docker-compose.yml", "foo/Dockerfile"}
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
@@ -100,7 +101,7 @@ services:
 		// TODO(maia): assert m.tiltFilename
 	)
 
-	expectedConfFiles := []string{"Tiltfile", "docker-compose.yml"}
+	expectedConfFiles := []string{"Tiltfile", ".tiltignore", "docker-compose.yml"}
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
@@ -131,7 +132,7 @@ services:
 		// TODO(maia): assert m.tiltFilename
 	)
 
-	expectedConfFiles := []string{"Tiltfile", "docker-compose.yml", "baz/alternate-Dockerfile"}
+	expectedConfFiles := []string{"Tiltfile", ".tiltignore", "docker-compose.yml", "baz/alternate-Dockerfile"}
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
@@ -220,7 +221,7 @@ RUN echo hi`
 		// TODO(maia): assert m.tiltFilename
 	)
 
-	expectedConfFiles := []string{"Tiltfile", "docker-compose.yml", "foo/Dockerfile"}
+	expectedConfFiles := []string{"Tiltfile", ".tiltignore", "docker-compose.yml", "foo/Dockerfile"}
 	f.assertConfigFiles(expectedConfFiles...)
 }
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -63,7 +63,7 @@ func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClie
 		buildIndex:        newBuildIndex(),
 		k8sByName:         make(map[string]*k8sResource),
 		k8sImageJSONPaths: make(map[k8sObjectSelector][]k8s.JSONPath),
-		configFiles:       []string{filename},
+		configFiles:       []string{filename, TiltIgnoreFileName},
 		usedImages:        make(map[string]bool),
 		logger:            logger.Get(ctx),
 		builtinCallCounts: make(map[string]int),

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -63,7 +63,7 @@ func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClie
 		buildIndex:        newBuildIndex(),
 		k8sByName:         make(map[string]*k8sResource),
 		k8sImageJSONPaths: make(map[k8sObjectSelector][]k8s.JSONPath),
-		configFiles:       []string{filename, TiltIgnoreFileName},
+		configFiles:       []string{filename, tiltIgnorePath(filename)},
 		usedImages:        make(map[string]bool),
 		logger:            logger.Get(ctx),
 		builtinCallCounts: make(map[string]int),

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -77,7 +77,7 @@ k8s_resource('foo', 'foo.yaml')
 	f.assertNextManifest("foo",
 		sb(image("gcr.io/foo")),
 		deployment("foo"))
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 // I.e. make sure that we handle de/normalization between `fooimage` <--> `docker.io/library/fooimage`
@@ -98,7 +98,7 @@ k8s_resource('foo', 'foo.yaml')
 	f.assertNextManifest("foo",
 		sb(imageNormalized("fooimage")),
 		deployment("foo"))
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 func TestExplicitDockerfileIsConfigFile(t *testing.T) {
@@ -111,7 +111,7 @@ docker_build('gcr.io/foo', 'foo', dockerfile='other/Dockerfile')
 k8s_resource('foo', 'foo.yaml')
 `)
 	f.load()
-	f.assertConfigFiles("Tiltfile", "foo.yaml", "other/Dockerfile")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml", "other/Dockerfile")
 }
 
 func TestExplicitDockerfileAsLocalPath(t *testing.T) {
@@ -125,7 +125,7 @@ docker_build('gcr.io/foo', 'foo', dockerfile=r.path('other/Dockerfile'))
 k8s_resource('foo', 'foo.yaml')
 `)
 	f.load()
-	f.assertConfigFiles("Tiltfile", "foo.yaml", "other/Dockerfile")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml", "other/Dockerfile")
 }
 
 func TestExplicitDockerfileContents(t *testing.T) {
@@ -137,7 +137,7 @@ docker_build('gcr.io/foo', 'foo', dockerfile_contents='FROM alpine')
 k8s_resource('foo', 'foo.yaml')
 `)
 	f.load()
-	f.assertConfigFiles("Tiltfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml")
 	f.assertNextManifest("foo", sb(image("gcr.io/foo")))
 }
 
@@ -152,7 +152,7 @@ docker_build('gcr.io/foo', 'foo', dockerfile_contents=df)
 k8s_resource('foo', 'foo.yaml')
 `)
 	f.load()
-	f.assertConfigFiles("Tiltfile", "foo.yaml", "other/Dockerfile")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml", "other/Dockerfile")
 	f.assertNextManifest("foo", sb(image("gcr.io/foo")))
 }
 
@@ -185,7 +185,7 @@ k8s_resource('foo', 'foo.yaml')
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi"), hotReload(false)),
 		deployment("foo"),
 	)
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 func TestFastBuildHotReload(t *testing.T) {
@@ -205,7 +205,7 @@ k8s_resource('foo', 'foo.yaml')
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi"), hotReload(true)),
 		deployment("foo"),
 	)
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 func TestFastBuildPassedToResource(t *testing.T) {
@@ -224,7 +224,7 @@ k8s_resource('foo', 'foo.yaml', image=fb)
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi")),
 		deployment("foo"),
 	)
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 func TestFastBuildValidates(t *testing.T) {
@@ -303,7 +303,7 @@ k8s_resource('foo', 'foo.yaml')
 		),
 		deployment("foo"),
 	)
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 func TestVerifiesGitRepo(t *testing.T) {
@@ -349,7 +349,7 @@ k8s_resource('foo', yaml)
 	f.assertNextManifest("foo",
 		sb(image("gcr.io/foo")),
 		deployment("foo"))
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 func TestKustomize(t *testing.T) {
@@ -367,7 +367,7 @@ k8s_resource('foo', kustomize("."))
 `)
 	f.load()
 	f.assertNextManifest("foo", deployment("the-deployment"), numEntities(3))
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "configMap.yaml", "deployment.yaml", "kustomization.yaml", "service.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "configMap.yaml", "deployment.yaml", "kustomization.yaml", "service.yaml")
 }
 
 func TestDockerBuildCache(t *testing.T) {
@@ -554,7 +554,7 @@ docker_build('gcr.io/d', 'd')
 	f.assertNextManifest("c", sb(image("gcr.io/c")), deployment("c"))
 	f.assertNextManifest("d", sb(image("gcr.io/d")), deployment("d"))
 	f.assertNoYAMLManifest("")
-	f.assertConfigFiles("Tiltfile", "all.yaml", "a/Dockerfile", "b/Dockerfile", "c/Dockerfile", "d/Dockerfile")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "all.yaml", "a/Dockerfile", "b/Dockerfile", "c/Dockerfile", "d/Dockerfile")
 }
 
 func TestExpandUnresourced(t *testing.T) {
@@ -761,7 +761,7 @@ k8s_resource('bar', 'bar.yaml')
 		sb(image("gcr.io/foo")),
 		deployment("foo"))
 
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml", "bar/Dockerfile", "bar.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml", "bar/Dockerfile", "bar.yaml")
 }
 
 func TestLoadTypoManifest(t *testing.T) {
@@ -1148,7 +1148,7 @@ if True:
 	f.assertNextManifest("foo",
 		sb(image("gcr.io/foo")),
 		deployment("foo"))
-	f.assertConfigFiles("Tiltfile", "foo/Dockerfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo.yaml")
 }
 
 func TestTopLevelForLoop(t *testing.T) {
@@ -1195,6 +1195,7 @@ k8s_yaml(yml)
 	f.assertYAMLManifest("release-name-helloworld-chart")
 	f.assertConfigFiles(
 		"Tiltfile",
+		".tiltignore",
 		"helm",
 	)
 }
@@ -1217,6 +1218,7 @@ k8s_yaml(yml)
 	f.assertYAMLManifest("release-name-helloworld-chart")
 	f.assertConfigFiles(
 		"Tiltfile",
+		".tiltignore",
 		"helm",
 	)
 }
@@ -1672,7 +1674,7 @@ func TestDir(t *testing.T) {
 
 	f.load("foo", "bar")
 	f.assertNumManifests(2)
-	f.assertConfigFiles("Tiltfile", "config/foo.yaml", "config/bar.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "config/foo.yaml", "config/bar.yaml")
 }
 
 func TestDirRecursive(t *testing.T) {
@@ -1700,7 +1702,7 @@ for f in files:
 `)
 
 	f.load()
-	f.assertConfigFiles("Tiltfile", "foo/bar", "foo/baz/qux")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/bar", "foo/baz/qux")
 }
 
 func TestCallCounts(t *testing.T) {
@@ -1789,7 +1791,7 @@ hfb.hot_reload()`
 
 	f.load("foo")
 	f.assertNumManifests(1)
-	f.assertConfigFiles("Tiltfile", "foo.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml")
 	f.assertNextManifest("foo",
 		cb(
 			image("gcr.io/foo"),


### PR DESCRIPTION
docs: https://github.com/windmilleng/tilt.build/pull/77

1. I'm not super thrilled about doing the loading itself in the Tiltfile loader, but that's where we're already loading configs, and that's what the Configs Controller deals with? Maybe the answer is just to wrap the tiltfile loader with a configs loader that does tiltfile + tiltignore?
2. One unfortunate behavior right now is that changing .tiltignore causes reexecution of the Tiltfile, but that doesn't seem like a blocker.