### PR TITLE
engine: (for now) don't require image TAGS to match when checking container image for match with image target

### DIFF
--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -44,6 +44,11 @@ func (s RefSelector) RefsEqual(other RefSelector) bool {
 	return s.ref.String() == other.ref.String()
 }
 
+func (s RefSelector) WithNameMatch() RefSelector {
+	s.matchType = matchName
+	return s
+}
+
 func (s RefSelector) WithExactMatch() RefSelector {
 	s.matchType = matchExact
 	return s

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -682,7 +682,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, pod *v
 	if len(manifest.ImageTargets) > 0 {
 		// Get status of (first) container matching (an) image we built for this manifest.
 		for _, iTarget := range manifest.ImageTargets {
-			cStatus, err = k8s.ContainerMatching(pod, iTarget.Ref)
+			cStatus, err = k8s.ContainerMatching(pod, iTarget.Ref.WithNameMatch())
 			if err != nil {
 				logger.Get(ctx).Debugf("Error matching container: %v", err)
 				return

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1002,6 +1002,11 @@ func (f *testFixture) testPodWithDeployID(podID string, manifestName string, pha
 	}
 }
 
+func setImage(pod *v1.Pod, image string) {
+	pod.Spec.Containers[0].Image = image
+	pod.Status.ContainerStatuses[0].Image = image
+}
+
 func setRestartCount(pod *v1.Pod, restartCount int) {
 	pod.Status.ContainerStatuses[0].RestartCount = int32(restartCount)
 }
@@ -2573,11 +2578,16 @@ func (f *testFixture) imageNameForManifest(manifestName string) reference.Named 
 }
 
 func (f *testFixture) newManifest(name string, mounts []model.Mount) model.Manifest {
-	ref := container.NewRefSelector(f.imageNameForManifest(name))
+	ref := f.imageNameForManifest(name)
+	return f.newManifestWithRef(name, ref, mounts)
+}
+
+func (f *testFixture) newManifestWithRef(name string, ref reference.Named, mounts []model.Mount) model.Manifest {
+	refSel := container.NewRefSelector(ref)
 	return assembleK8sManifest(
 		model.Manifest{Name: model.ManifestName(name)},
 		model.K8sTarget{YAML: "fake-yaml"},
-		model.ImageTarget{Ref: ref}.
+		model.ImageTarget{Ref: refSel}.
 			WithBuildDetails(model.FastBuild{
 				BaseDockerfile: `from golang:1.10`,
 				Mounts:         mounts,

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -233,7 +233,7 @@ func NewDeployInfo(iTarget model.ImageTarget, podSet PodSet) DeployInfo {
 	}
 
 	// Only return the pod if it matches our image.
-	if pod.ContainerImageRef == nil || !iTarget.Ref.Matches(pod.ContainerImageRef) {
+	if pod.ContainerImageRef == nil || !iTarget.Ref.WithNameMatch().Matches(pod.ContainerImageRef) {
 		return DeployInfo{}
 	}
 


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/match-tagged-images:

c1bdbb632fa44ad53d2cbcea549d50ab34afff10 (2019-03-19 17:21:16 -0400)
test

e367b7e29b3b6c6ec8133a031c4aa1d18bbb33cd (2019-03-19 17:20:29 -0400)
engine: (for now) don't require image TAGS to match when checking container image for match with image target

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics