### PR TITLE
engine: add flag to disable push on custom build

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -170,9 +170,14 @@ func (ibd *ImageBuildAndDeployer) push(ctx context.Context, ref reference.NamedT
 	ps.StartPipelineStep(ctx, "Pushing %s", ref.String())
 	defer ps.EndPipelineStep(ctx)
 
+	cbSkip := false
+	if iTarget.IsCustomBuild() {
+		cbSkip = iTarget.CustomBuildInfo().DisablePush
+	}
+
 	// We can also skip the push of the image if it isn't used
 	// in any k8s resources! (e.g., it's consumed by another image).
-	if ibd.canAlwaysSkipPush() || !isImageDeployedToK8s(iTarget, kTargets) {
+	if ibd.canAlwaysSkipPush() || !isImageDeployedToK8s(iTarget, kTargets) || cbSkip {
 		ps.Printf(ctx, "Skipping push")
 		return ref, nil
 	}

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/wmclient/pkg/dirs"
@@ -268,12 +269,12 @@ func TestKINDPush(t *testing.T) {
 func TestCustomBuildDisablePush(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvKIND)
 	defer f.TearDown()
+	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
+	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build"] = types.ImageInspect{ID: string(sha)}
 
 	manifest := NewSanchoCustomBuildManifestWithPushDisabled(f)
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
-	// the image doesn't exist, so the custom build fails
-	// TODO(dmiller): change this test to use the static tag parameter when that's added
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
 	// but we also didn't try to build or push an image
 	assert.Equal(t, 0, f.docker.BuildCount)

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -262,6 +262,23 @@ func TestKINDPush(t *testing.T) {
 
 	assert.Equal(t, 1, f.docker.BuildCount)
 	assert.Equal(t, 1, f.kp.pushCount)
+	assert.Equal(t, 0, f.docker.PushCount)
+}
+
+func TestCustomBuildDisablePush(t *testing.T) {
+	f := newIBDFixture(t, k8s.EnvKIND)
+	defer f.TearDown()
+
+	manifest := NewSanchoCustomBuildManifestWithPushDisabled(f)
+	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
+	// the image doesn't exist, so the custom build fails
+	// TODO(dmiller): change this test to use the static tag parameter when that's added
+	assert.Error(t, err)
+
+	// but we also didn't try to build or push an image
+	assert.Equal(t, 0, f.docker.BuildCount)
+	assert.Equal(t, 0, f.kp.pushCount)
+	assert.Equal(t, 0, f.docker.PushCount)
 }
 
 func TestDeployUsesInjectRef(t *testing.T) {

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -118,7 +118,7 @@ func NewSanchoCustomBuildManifestWithPushDisabled(fixture pather) model.Manifest
 	return assembleK8sManifest(
 		m,
 		model.K8sTarget{YAML: SanchoYAML},
-		model.ImageTarget{Ref: SanchoRef}.WithBuildDetails(cb))
+		model.NewImageTarget(SanchoRef).WithBuildDetails(cb))
 }
 
 func NewSanchoStaticImageTarget() model.ImageTarget {

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -111,6 +111,7 @@ func NewSanchoCustomBuildManifestWithPushDisabled(fixture pather) model.Manifest
 		Command:     "true",
 		Deps:        []string{fixture.JoinPath("app")},
 		DisablePush: true,
+		Tag:         "tilt-build",
 	}
 
 	m := model.Manifest{Name: "sancho"}

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -106,6 +106,21 @@ func NewSanchoCustomBuildManifestWithFastBuild(fixture pather) model.Manifest {
 		model.NewImageTarget(SanchoRef).WithBuildDetails(cb))
 }
 
+func NewSanchoCustomBuildManifestWithPushDisabled(fixture pather) model.Manifest {
+	cb := model.CustomBuild{
+		Command:     "true",
+		Deps:        []string{fixture.JoinPath("app")},
+		DisablePush: true,
+	}
+
+	m := model.Manifest{Name: "sancho"}
+
+	return assembleK8sManifest(
+		m,
+		model.K8sTarget{YAML: SanchoYAML},
+		model.ImageTarget{Ref: SanchoRef}.WithBuildDetails(cb))
+}
+
 func NewSanchoStaticImageTarget() model.ImageTarget {
 	return model.NewImageTarget(SanchoRef).WithBuildDetails(model.StaticBuild{
 		Dockerfile: SanchoStaticDockerfile,

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -249,7 +249,8 @@ type CustomBuild struct {
 	// If empty, we create an expected tag at the beginning of CustomBuild (as $TAG)
 	Tag string
 
-	Fast *FastBuild
+	Fast        *FastBuild
+	DisablePush bool
 }
 
 func (CustomBuild) buildDetails() {}

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -39,6 +39,7 @@ type dockerImage struct {
 	matched bool
 
 	dependencyIDs []model.TargetID
+	disablePush   bool
 }
 
 func (d *dockerImage) ID() model.TargetID {
@@ -190,12 +191,14 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 	var command string
 	var deps *starlark.List
 	var tag string
+	var disablePush bool
 
 	err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
 		"command", &command,
 		"deps", &deps,
 		"tag?", &tag,
+		"disable_push?", &disablePush,
 	)
 	if err != nil {
 		return nil, err
@@ -231,6 +234,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		customCommand:    command,
 		customDeps:       localDeps,
 		customTag:        tag,
+		disablePush:      disablePush,
 	}
 
 	err = s.buildIndex.addImage(img)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -539,9 +539,10 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 			iTarget = iTarget.WithBuildDetails(s.fastBuildForImage(image))
 		case CustomBuild:
 			r := model.CustomBuild{
-				Command: image.customCommand,
-				Deps:    image.customDeps,
-				Tag:     image.customTag,
+				Command:     image.customCommand,
+				Deps:        image.customDeps,
+				Tag:         image.customTag,
+				DisablePush: image.disablePush,
 			}
 			if len(image.mounts) > 0 || len(image.steps) > 0 {
 				r.Fast = &model.FastBuild{

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1797,6 +1797,7 @@ hfb.hot_reload()`
 			image("gcr.io/foo"),
 			deps(f.JoinPath("foo")),
 			cmd("docker build -t $TAG foo"),
+			disablePush(false),
 			fb(
 				image("gcr.io/foo"),
 				add("foo", "/app"),
@@ -1830,6 +1831,34 @@ custom_build(
 			deps(f.JoinPath("foo")),
 			cmd("docker build -t gcr.io/foo:my-great-tag foo"),
 			tag("my-great-tag"),
+		),
+		deployment("foo"))
+}
+
+func TestCustomBuildDisablePush(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	tiltfile := `k8s_yaml('foo.yaml')
+hfb = custom_build(
+  'gcr.io/foo',
+  'docker build -t $TAG foo',
+	['foo'],
+	disable_push=True,
+).add_fast_build()`
+
+	f.setupFoo()
+	f.file("Tiltfile", tiltfile)
+
+	f.load("foo")
+	f.assertNumManifests(1)
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml")
+	f.assertNextManifest("foo",
+		cb(
+			image("gcr.io/foo"),
+			deps(f.JoinPath("foo")),
+			cmd("docker build -t $TAG foo"),
+			disablePush(true),
 		),
 		deployment("foo"))
 }
@@ -2689,6 +2718,8 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 					assert.Equal(f.t, matcher.cmd, cbInfo.Command)
 				case tagHelper:
 					assert.Equal(f.t, matcher.tag, cbInfo.Tag)
+				case disablePushHelper:
+					assert.Equal(f.t, matcher.disabled, cbInfo.DisablePush)
 				case fbHelper:
 					if cbInfo.Fast == nil {
 						f.t.Fatalf("Expected manifest %v to have fast build, but it didn't", m.Name)
@@ -3156,6 +3187,14 @@ type depsHelper struct {
 
 func deps(deps ...string) depsHelper {
 	return depsHelper{deps}
+}
+
+type disablePushHelper struct {
+	disabled bool
+}
+
+func disablePush(disable bool) disablePushHelper {
+	return disablePushHelper{disable}
 }
 
 // useful scenarios to setup


### PR DESCRIPTION
@rohansingh needs this for his bazel + KIND setup. For the moment bazel is much better at doing the layer negotiation and pushing only what is necessary. `kind load` is less efficient. @rohansingh has a workaround where he tees the image to both docker and KIND, allowing custom_build to verify that the image was created correctly and allowing KIND to get the image in a fast way. What he needs is a way to disable the image push in this case. 

I decided to add this as a flag to `custom_build` because its a pretty special case, only is used from `custom_builds` right now and fits in with `custom_build`'s evolving, experimental API.