### PR TITLE
k8s: get KubeContext from config instead of context name

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -59,6 +59,13 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 
 	kContext, err := wireKubeContext(ctx)
 	printField("Context", kContext, err)
+	kConfig, err := wireKubeConfig(ctx)
+	kc, ok := kConfig.Contexts[kConfig.CurrentContext]
+	clusterName := "Unknown"
+	if ok {
+		clusterName = kc.Cluster
+	}
+	printField("Cluster Name", clusterName, err)
 
 	ns, err := wireNamespace(ctx)
 	printField("Namespace", ns, err)

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/google/wire"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/container"
@@ -121,6 +122,11 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 	wire.Build(K8sWireSet)
 	return "", nil
+}
+
+func wireKubeConfig(ctx context.Context) (*api.Config, error) {
+	wire.Build(K8sWireSet)
+	return nil, nil
 }
 
 func wireEnv(ctx context.Context) (k8s.Env, error) {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -29,6 +29,7 @@ var K8sWireSet = wire.NewSet(
 	k8s.ProvideEnv,
 	k8s.DetectNodeIP,
 	k8s.ProvideKubeContext,
+	k8s.ProvideKubeConfig,
 	k8s.ProvideClientConfig,
 	k8s.ProvideClientSet,
 	k8s.ProvideRESTConfig,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -41,13 +41,17 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 		return demo.Script{}, err
 	}
 	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return demo.Script{}, err
+	}
+	env := k8s.ProvideEnv(config)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	env := k8s.ProvideEnv(kubeContext)
-	portForwarder := k8s.ProvidePortForwarder()
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	podWatcher := engine.NewPodWatcher(client)
@@ -149,13 +153,17 @@ func wireThreads(ctx context.Context) (Threads, error) {
 		return Threads{}, err
 	}
 	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return Threads{}, err
+	}
+	env := k8s.ProvideEnv(config)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return Threads{}, err
 	}
-	env := k8s.ProvideEnv(kubeContext)
-	portForwarder := k8s.ProvidePortForwarder()
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	podWatcher := engine.NewPodWatcher(client)
@@ -241,13 +249,17 @@ func wireThreads(ctx context.Context) (Threads, error) {
 
 func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	env := k8s.ProvideEnv(config)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return nil, err
 	}
-	env := k8s.ProvideEnv(kubeContext)
-	portForwarder := k8s.ProvidePortForwarder()
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	return client, nil
@@ -264,11 +276,11 @@ func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 
 func wireEnv(ctx context.Context) (k8s.Env, error) {
 	clientConfig := k8s.ProvideClientConfig()
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	config, err := k8s.ProvideKubeConfig(clientConfig)
 	if err != nil {
 		return "", err
 	}
-	env := k8s.ProvideEnv(kubeContext)
+	env := k8s.ProvideEnv(config)
 	return env, nil
 }
 
@@ -280,13 +292,17 @@ func wireNamespace(ctx context.Context) (k8s.Namespace, error) {
 
 func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return "", err
+	}
+	env := k8s.ProvideEnv(config)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return "", err
 	}
-	env := k8s.ProvideEnv(kubeContext)
-	portForwarder := k8s.ProvidePortForwarder()
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
@@ -312,13 +328,17 @@ func wireK8sVersion(ctx context.Context) (*version.Info, error) {
 
 func wireDockerVersion(ctx context.Context) (types.Version, error) {
 	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return types.Version{}, err
+	}
+	env := k8s.ProvideEnv(config)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return types.Version{}, err
 	}
-	env := k8s.ProvideEnv(kubeContext)
-	portForwarder := k8s.ProvidePortForwarder()
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
@@ -340,13 +360,17 @@ func wireDockerVersion(ctx context.Context) (types.Version, error) {
 
 func wireDockerEnv(ctx context.Context) (docker.Env, error) {
 	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return docker.Env{}, err
+	}
+	env := k8s.ProvideEnv(config)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return docker.Env{}, err
 	}
-	env := k8s.ProvideEnv(kubeContext)
-	portForwarder := k8s.ProvidePortForwarder()
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
@@ -364,13 +388,17 @@ func wireDownDeps(ctx context.Context) (DownDeps, error) {
 		return DownDeps{}, err
 	}
 	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return DownDeps{}, err
+	}
+	env := k8s.ProvideEnv(config)
+	portForwarder := k8s.ProvidePortForwarder()
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
 	if err != nil {
 		return DownDeps{}, err
 	}
-	env := k8s.ProvideEnv(kubeContext)
-	portForwarder := k8s.ProvidePortForwarder()
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
@@ -387,7 +415,7 @@ func wireDownDeps(ctx context.Context) (DownDeps, error) {
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideKubeContext, k8s.ProvideClientConfig, k8s.ProvideClientSet, k8s.ProvideRESTConfig, k8s.ProvidePortForwarder, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient)
+var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientSet, k8s.ProvideRESTConfig, k8s.ProvidePortForwarder, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet, docker.ProvideDockerClient, docker.ProvideDockerVersion, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, tiltfile.ProvideTiltfileLoader, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), engine.NewUpper, provideAnalytics, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -48,7 +48,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	env := k8s.ProvideEnv(config)
 	portForwarder := k8s.ProvidePortForwarder()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return demo.Script{}, err
 	}
@@ -160,7 +160,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	env := k8s.ProvideEnv(config)
 	portForwarder := k8s.ProvidePortForwarder()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return Threads{}, err
 	}
@@ -256,7 +256,7 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 	env := k8s.ProvideEnv(config)
 	portForwarder := k8s.ProvidePortForwarder()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,11 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 
 func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 	clientConfig := k8s.ProvideClientConfig()
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return "", err
+	}
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return "", err
 	}
@@ -299,7 +303,7 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	env := k8s.ProvideEnv(config)
 	portForwarder := k8s.ProvidePortForwarder()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return "", err
 	}
@@ -335,7 +339,7 @@ func wireDockerVersion(ctx context.Context) (types.Version, error) {
 	env := k8s.ProvideEnv(config)
 	portForwarder := k8s.ProvidePortForwarder()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return types.Version{}, err
 	}
@@ -367,7 +371,7 @@ func wireDockerEnv(ctx context.Context) (docker.Env, error) {
 	env := k8s.ProvideEnv(config)
 	portForwarder := k8s.ProvidePortForwarder()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return docker.Env{}, err
 	}
@@ -395,7 +399,7 @@ func wireDownDeps(ctx context.Context) (DownDeps, error) {
 	env := k8s.ProvideEnv(config)
 	portForwarder := k8s.ProvidePortForwarder()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return DownDeps{}, err
 	}

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -23,6 +23,7 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"time"
 )
 
@@ -276,6 +277,15 @@ func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 		return "", err
 	}
 	return kubeContext, nil
+}
+
+func wireKubeConfig(ctx context.Context) (*api.Config, error) {
+	clientConfig := k8s.ProvideClientConfig()
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
 }
 
 func wireEnv(ctx context.Context) (k8s.Env, error) {

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -115,6 +115,7 @@ func provideDockerComposeBuildAndDeployer(
 		k8s.ProvideK8sClient,
 		k8s.ProvidePortForwarder,
 		k8s.ProvideContainerRuntime,
+		k8s.ProvideKubeConfig,
 	)
 
 	return nil, nil

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -90,7 +90,11 @@ func provideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 	portForwarder := k8s.ProvidePortForwarder()
 	clientConfig := k8s.ProvideClientConfig()
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
-	kubeContext, err := k8s.ProvideKubeContext(clientConfig)
+	config, err := k8s.ProvideKubeConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -28,12 +28,7 @@ func ProvideEnv(kubeConfig *api.Config) Env {
 	return EnvFromConfig(kubeConfig)
 }
 
-func ProvideKubeContext(clientLoader clientcmd.ClientConfig) (KubeContext, error) {
-	access := clientLoader.ConfigAccess()
-	config, err := access.GetStartingConfig()
-	if err != nil {
-		return "", errors.Wrap(err, "Loading Kubernetes current-context")
-	}
+func ProvideKubeContext(config *api.Config) (KubeContext, error) {
 	return KubeContext(config.CurrentContext), nil
 }
 

--- a/internal/k8s/env_test.go
+++ b/internal/k8s/env_test.go
@@ -1,6 +1,10 @@
 package k8s
 
-import "testing"
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+)
 
 type expectedEnv struct {
 	expected Env
@@ -22,6 +26,56 @@ func TestEnvFromString(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.string, func(t *testing.T) {
 			actual := EnvFromString(tt.string)
+			if actual != tt.expected {
+				t.Errorf("Expected %s, actual %s", tt.expected, actual)
+			}
+		})
+	}
+}
+
+type expectedConfig struct {
+	expected Env
+	input    *api.Config
+}
+
+func TestEnvFromConfig(t *testing.T) {
+	minikubeContexts := map[string]*api.Context{
+		"minikube": &api.Context{
+			Cluster: "minikube",
+		},
+	}
+	dockerDesktopContexts := map[string]*api.Context{
+		"docker-for-desktop": &api.Context{
+			Cluster: "docker-for-desktop-cluster",
+		},
+	}
+	gkeContexts := map[string]*api.Context{
+		"gke_blorg-dev_us-central1-b_blorg": &api.Context{
+			Cluster: "gke_blorg-dev_us-central1-b_blorg",
+		},
+	}
+	kindContexts := map[string]*api.Context{
+		"kubernetes-admin@kind-1": &api.Context{
+			Cluster: "kind",
+		},
+	}
+	microK8sContexts := map[string]*api.Context{
+		"microk8s": &api.Context{
+			Cluster: "microk8s-cluster",
+		},
+	}
+	table := []expectedConfig{
+		{EnvUnknown, &api.Config{CurrentContext: "aws"}},
+		{EnvMinikube, &api.Config{CurrentContext: "minikube", Contexts: minikubeContexts}},
+		{EnvDockerDesktop, &api.Config{CurrentContext: "docker-for-desktop", Contexts: dockerDesktopContexts}},
+		{EnvGKE, &api.Config{CurrentContext: "gke_blorg-dev_us-central1-b_blorg", Contexts: gkeContexts}},
+		{EnvKIND, &api.Config{CurrentContext: "kubernetes-admin@kind-1", Contexts: kindContexts}},
+		{EnvMicroK8s, &api.Config{CurrentContext: "microk8s", Contexts: microK8sContexts}},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.input.CurrentContext, func(t *testing.T) {
+			actual := EnvFromConfig(tt.input)
 			if actual != tt.expected {
 				t.Errorf("Expected %s, actual %s", tt.expected, actual)
 			}


### PR DESCRIPTION
This is a more reliable way to detect cluster types that are likely to have different names, like KIND.