### PR TITLE
integration/oneup: use default_registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# custom Tiltfile setting
-tilt_personal.json
+# Tiltfile options
+tilt_option.json
 
 # Binaries for programs and plugins
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# custom Tiltfile setting
+tilt_personal.json
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/integration/oneup/Tiltfile
+++ b/integration/oneup/Tiltfile
@@ -1,12 +1,10 @@
 # -*- mode: Python -*-
 
-fs = listdir('.')
-if 'tilt_personal.json' in fs:
-  # TODO(dbentley): use the default flag to read_json
-  settings = read_json('tilt_personal.json')
-else:
-  settings = {'default_registry': 'gcr.io/windmill-test-containers/integration'}
-default_registry(settings.get('default_registry', 'gcr.io/windmill-test-containers/integration'))
+# Read an option from the file tilt_option.json
+# Create this file with json like { "default_registry": "gcr.io/my-personal-project" }
+# tilt_option.json is .gitignore'd, so you'll have a clean status
+default_registry(read_json('tilt_option.json', {})
+                 .get('default_registry', 'gcr.io/windmill-public-containers/servantes'))
 
 docker_build('oneup', '.')
 k8s_resource('oneup', 'oneup.yaml', port_forwards=8100)

--- a/integration/oneup/Tiltfile
+++ b/integration/oneup/Tiltfile
@@ -4,7 +4,7 @@
 # Create tilt_option.json with contents: {"default_registry": "gcr.io/my-personal-project"}
 # (with your registry inserted). tilt_option.json is gitignore'd, unlike Tiltfile
 default_registry(read_json('tilt_option.json', {})
-                 .get('default_registry', 'gcr.io/windmill-public-containers/servantes'))
+                 .get('default_registry', 'gcr.io/windmill-test-containers/servantes'))
 
 docker_build('oneup', '.')
 k8s_resource('oneup', 'oneup.yaml', port_forwards=8100)

--- a/integration/oneup/Tiltfile
+++ b/integration/oneup/Tiltfile
@@ -1,4 +1,12 @@
 # -*- mode: Python -*-
 
-docker_build('gcr.io/windmill-test-containers/integration/oneup', '.')
+fs = listdir('.')
+if 'tilt_personal.json' in fs:
+  # TODO(dbentley): use the default flag to read_json
+  settings = read_json('tilt_personal.json')
+else:
+  settings = {'default_registry': 'gcr.io/windmill-test-containers/integration'}
+default_registry(settings.get('default_registry', 'gcr.io/windmill-test-containers/integration'))
+
+docker_build('oneup', '.')
 k8s_resource('oneup', 'oneup.yaml', port_forwards=8100)

--- a/integration/oneup/Tiltfile
+++ b/integration/oneup/Tiltfile
@@ -1,8 +1,8 @@
 # -*- mode: Python -*-
 
-# Read an option from the file tilt_option.json
-# Create this file with json like { "default_registry": "gcr.io/my-personal-project" }
-# tilt_option.json is .gitignore'd, so you'll have a clean status
+# If you get push errors, you can change the default_registry.
+# Create tilt_option.json with contents: {"default_registry": "gcr.io/my-personal-project"}
+# (with your registry inserted). tilt_option.json is gitignore'd, unlike Tiltfile
 default_registry(read_json('tilt_option.json', {})
                  .get('default_registry', 'gcr.io/windmill-public-containers/servantes'))
 

--- a/integration/oneup/oneup.yaml
+++ b/integration/oneup/oneup.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: oneup
-        image: gcr.io/windmill-test-containers/integration/oneup
+        image: oneup
         command: ["/go/bin/oneup"]
         ports:
         - containerPort: 8000

--- a/internal/container/default_registry.go
+++ b/internal/container/default_registry.go
@@ -21,7 +21,7 @@ func ReplaceRegistry(defaultRegistry string, rs RefSelector) (reference.Named, e
 		return rs.AsNamedOnly(), nil
 	}
 
-	newNs := fmt.Sprintf("%s/%s", defaultRegistry, escapeName(rs.RefName()))
+	newNs := fmt.Sprintf("%s/%s", defaultRegistry, escapeName(rs.RefFamiliarName()))
 	newN, err := reference.ParseNamed(newNs)
 	if err != nil {
 		return nil, err

--- a/internal/container/default_registry_test.go
+++ b/internal/container/default_registry_test.go
@@ -24,7 +24,8 @@ var namedTestCases = []struct {
 	{"myreg.com", "gcr.io/foo/bar", "myreg.com/gcr.io_foo_bar"},
 	{"myreg.com", "gcr.io/foo/bar", "myreg.com/gcr.io_foo_bar"},
 	{"aws_account_id.dkr.ecr.region.amazonaws.com/bar", "gcr.io/baz/foo/bar", "aws_account_id.dkr.ecr.region.amazonaws.com/bar/gcr.io_baz_foo_bar"},
-	{"gcr.io/foo", "docker.io/library/busybox", "gcr.io/foo/docker.io_library_busybox"},
+	{"gcr.io/foo", "docker.io/library/busybox", "gcr.io/foo/busybox"},
+	{"gcr.io/foo", "bar", "gcr.io/foo/bar"},
 }
 
 func TestReplaceTaggedRefDomain(t *testing.T) {

--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -73,6 +73,10 @@ func (s RefSelector) RefName() string {
 	return s.ref.Name()
 }
 
+func (s RefSelector) RefFamiliarName() string {
+	return reference.FamiliarName(s.ref)
+}
+
 func (s RefSelector) AsNamedOnly() reference.Named {
 	return reference.TrimNamed(s.ref)
 }

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -274,15 +274,15 @@ func TestDeployUsesInjectRef(t *testing.T) {
 		{"static build", func(f pather) model.Manifest { return NewSanchoStaticManifest() }, expectedImages},
 		{"fast build", NewSanchoFastBuildManifest, expectedImages},
 		{"custom build", NewSanchoCustomBuildManifest, expectedImages},
-		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/sancho-base")},
+		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/docker.io_library_sancho-base")},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// if test.name == "custom build" {
-			// 	// this test fails because dockerCLI.Images is never populated, and custom build tries to call ImageInspectRaw
-			// 	t.Skip("custom build IBD tests not yet supported")
-			// }
+			if test.name == "custom build" {
+				// this test fails because dockerCLI.Images is never populated, and custom build tries to call ImageInspectRaw
+				t.Skip("custom build IBD tests not yet supported")
+			}
 
 			f := newIBDFixture(t, k8s.EnvGKE)
 			defer f.TearDown()

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -274,7 +274,7 @@ func TestDeployUsesInjectRef(t *testing.T) {
 		{"static build", func(f pather) model.Manifest { return NewSanchoStaticManifest() }, expectedImages},
 		{"fast build", NewSanchoFastBuildManifest, expectedImages},
 		{"custom build", NewSanchoCustomBuildManifest, expectedImages},
-		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/docker.io_library_sancho-base")},
+		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/docker.sancho-base")},
 	}
 
 	for _, test := range tests {

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -274,7 +274,7 @@ func TestDeployUsesInjectRef(t *testing.T) {
 		{"static build", func(f pather) model.Manifest { return NewSanchoStaticManifest() }, expectedImages},
 		{"fast build", NewSanchoFastBuildManifest, expectedImages},
 		{"custom build", NewSanchoCustomBuildManifest, expectedImages},
-		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/docker.sancho-base")},
+		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/sancho-base")},
 	}
 
 	for _, test := range tests {

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -274,15 +274,15 @@ func TestDeployUsesInjectRef(t *testing.T) {
 		{"static build", func(f pather) model.Manifest { return NewSanchoStaticManifest() }, expectedImages},
 		{"fast build", NewSanchoFastBuildManifest, expectedImages},
 		{"custom build", NewSanchoCustomBuildManifest, expectedImages},
-		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/docker.io_library_sancho-base")},
+		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/sancho-base")},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.name == "custom build" {
-				// this test fails because dockerCLI.Images is never populated, and custom build tries to call ImageInspectRaw
-				t.Skip("custom build IBD tests not yet supported")
-			}
+			// if test.name == "custom build" {
+			// 	// this test fails because dockerCLI.Images is never populated, and custom build tries to call ImageInspectRaw
+			// 	t.Skip("custom build IBD tests not yet supported")
+			// }
 
 			f := newIBDFixture(t, k8s.EnvGKE)
 			defer f.TearDown()

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -95,7 +95,7 @@ func injectImageDigestInContainers(entity K8sEntity, selector container.RefSelec
 		}
 
 		if selector.Matches(existingRef) {
-			c.Image = reference.FamiliarString(injectRef)
+			c.Image = injectRef.String()
 			c.ImagePullPolicy = policy
 			replaced = true
 		}
@@ -118,7 +118,7 @@ func injectImageDigestInEnvVars(entity K8sEntity, selector container.RefSelector
 		}
 
 		if selector.Matches(existingRef) {
-			envVar.Value = reference.FamiliarString(injectRef)
+			envVar.Value = injectRef.String()
 			replaced = true
 		}
 	}
@@ -151,7 +151,7 @@ func injectImageInUnstructuredInterface(ui interface{}, injectRef reference.Name
 	case string:
 		ref, err := container.ParseNamed(x)
 		if err == nil && ref.Name() == injectRef.Name() {
-			return reference.FamiliarString(injectRef), true
+			return injectRef.String(), true
 		} else {
 			return x, false
 		}

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -95,7 +95,7 @@ func injectImageDigestInContainers(entity K8sEntity, selector container.RefSelec
 		}
 
 		if selector.Matches(existingRef) {
-			c.Image = injectRef.String()
+			c.Image = reference.FamiliarString(injectRef)
 			c.ImagePullPolicy = policy
 			replaced = true
 		}
@@ -118,7 +118,7 @@ func injectImageDigestInEnvVars(entity K8sEntity, selector container.RefSelector
 		}
 
 		if selector.Matches(existingRef) {
-			envVar.Value = injectRef.String()
+			envVar.Value = reference.FamiliarString(injectRef)
 			replaced = true
 		}
 	}
@@ -151,7 +151,7 @@ func injectImageInUnstructuredInterface(ui interface{}, injectRef reference.Name
 	case string:
 		ref, err := container.ParseNamed(x)
 		if err == nil && ref.Name() == injectRef.Name() {
-			return injectRef.String(), true
+			return reference.FamiliarString(injectRef), true
 		} else {
 			return x, false
 		}


### PR DESCRIPTION
Also changed the behavior to not spew docker.io/library into images.