### PR TITLE
tests: clean up some uses of chdir

### DIFF
--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -51,7 +51,10 @@ func (f *ccFixture) run() ConfigsReloadedAction {
 	}
 	defer func() {
 		if origDir != "" {
-			_ = os.Chdir(origDir)
+			err = os.Chdir(origDir)
+			if err != nil {
+				f.T().Fatalf("unable to restore original wd: '%v'", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
chdir keeps breaking tests in annoying ways (one test fails to clean up its chdir, and then some other test, which passes when run by itself, fails when run as part of the suite, because it starts off with an invalid chdir)

1. remove the chdirs from upper_test, which were pretty much just unnecessary
2. removing it from ConfigsController is non-trivial since it calls `state.RelativeTiltfilePath`, which depends on WD, but at least catching errors on restoring the WD will make these issues easier to diagnose when we run into them