### PR TITLE
build: customBuild now relies on $EXPECTED_REF env var (rather than $TAG)

### DIFF
--- a/integration/oneup_custom/Tiltfile
+++ b/integration/oneup_custom/Tiltfile
@@ -2,7 +2,7 @@
 
 custom_build(
   'gcr.io/windmill-test-containers/integration/oneup-custom',
-  'docker build -t $TAG .',
+  'docker build -t $EXPECTED_REF .',
   ["Dockerfile", "main.go"],
  )
 k8s_resource('oneup-custom', 'oneup_custom.yaml', port_forwards=8100)

--- a/internal/build/custom_builder.go
+++ b/internal/build/custom_builder.go
@@ -45,8 +45,9 @@ func (b *ExecCustomBuilder) Build(ctx context.Context, ref reference.Named, comm
 
 	l := logger.Get(ctx)
 	l.Infof("Custom Build: Injecting Environment Variables")
-	l.Infof("TAG=%s", expectedRef.String())
-	env := append(os.Environ(), fmt.Sprintf("TAG=%s", expectedRef.String()))
+	l.Infof("EXPECTED_REF=%s", expectedRef.String())
+	env := append(os.Environ(), fmt.Sprintf("EXPECTED_REF=%s", expectedRef.String()))
+
 	for _, e := range b.env.AsEnviron() {
 		env = append(env, e)
 		l.Infof("%s", e)

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -246,7 +246,8 @@ type CustomBuild struct {
 
 	// Optional: tag we expect the image to be built with (we use this to check that
 	// the expected image+tag has been created).
-	// If empty, we create an expected tag at the beginning of CustomBuild (as $TAG)
+	// If empty, we create an expected tag at the beginning of CustomBuild (and
+	// export $EXPECTED_REF=name:expected_tag )
 	Tag string
 
 	Fast *FastBuild

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1779,7 +1779,7 @@ func TestCustomBuild(t *testing.T) {
 	tiltfile := `k8s_yaml('foo.yaml')
 hfb = custom_build(
   'gcr.io/foo',
-  'docker build -t $TAG foo',
+  'docker build -t $EXPECTED_REF foo',
   ['foo']
 ).add_fast_build()
 hfb.add('foo', '/app')
@@ -1796,7 +1796,7 @@ hfb.hot_reload()`
 		cb(
 			image("gcr.io/foo"),
 			deps(f.JoinPath("foo")),
-			cmd("docker build -t $TAG foo"),
+			cmd("docker build -t $EXPECTED_REF foo"),
 			fb(
 				image("gcr.io/foo"),
 				add("foo", "/app"),


### PR DESCRIPTION
Hello @jazzdan, @dbentley,

Please review the following commits I made in branch maiamcc/tag-env-var-to-ref:

d7dcfcaed7d19a12f9919b00338402b376683c09 (2019-03-22 13:25:19 -0400)
build: customBuild now relies on $EXPECTED_REF env var (rather than $TAG)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics