### PR TITLE
tiltfile: add watch_file function

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -186,6 +186,23 @@ func (s *tiltfileState) readFile(p localPath) ([]byte, error) {
 	return ioutil.ReadFile(p.path)
 }
 
+func (s *tiltfileState) watchFile(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path starlark.Value
+	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "path", &path)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := s.localPathFromSkylarkValue(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid type for path: %v", err)
+	}
+
+	s.recordConfigFile(p.path)
+
+	return starlark.None, nil
+}
+
 func (s *tiltfileState) skylarkReadFile(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var path starlark.Value
 	defaultReturn := ""

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -111,6 +111,7 @@ const (
 	localGitRepoN = "local_git_repo"
 	localN        = "local"
 	readFileN     = "read_file"
+	watchFileN    = "watch_file"
 	kustomizeN    = "kustomize"
 	helmN         = "helm"
 	listdirN      = "listdir"
@@ -143,6 +144,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 
 	addBuiltin(r, localN, s.local)
 	addBuiltin(r, readFileN, s.skylarkReadFile)
+	addBuiltin(r, watchFileN, s.watchFile)
 
 	addBuiltin(r, dockerBuildN, s.dockerBuild)
 	addBuiltin(r, fastBuildN, s.fastBuild)


### PR DESCRIPTION
Makes more sense than `read_file` when you're implementing custom Tiltfile
functionality that wants to add dependencies, while avoiding the perf
hit of actually reading the file.