### PR TITLE
tiltfile: watch entire directory passed to listdir

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -372,6 +372,11 @@ func (s *tiltfileState) listdir(thread *starlark.Thread, fn *starlark.Builtin, a
 		return nil, err
 	}
 
+	localPath, err := s.localPathFromSkylarkValue(dir)
+	if err != nil {
+		return nil, fmt.Errorf("Argument 0 (path): %v", err)
+	}
+	s.recordConfigFile(localPath.path)
 	var files []string
 	err = filepath.Walk(dir.GoString(), func(path string, info os.FileInfo, err error) error {
 		if path == dir.GoString() {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1715,7 +1715,7 @@ func TestDir(t *testing.T) {
 
 	f.load("foo", "bar")
 	f.assertNumManifests(2)
-	f.assertConfigFiles("Tiltfile", ".tiltignore", "config/foo.yaml", "config/bar.yaml")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "config/foo.yaml", "config/bar.yaml", "config")
 }
 
 func TestDirRecursive(t *testing.T) {
@@ -1743,7 +1743,7 @@ for f in files:
 `)
 
 	f.load()
-	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/bar", "foo/baz/qux")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo", "foo/bar", "foo/baz/qux")
 }
 
 func TestCallCounts(t *testing.T) {


### PR DESCRIPTION
This way if a new file is added to to the directory that you listed it
will trigger Tiltfile execution.