### PR TITLE
ospath: move the function for file display names into the ospath package

### DIFF
--- a/internal/ospath/display.go
+++ b/internal/ospath/display.go
@@ -1,0 +1,23 @@
+package ospath
+
+// Calculate a display name for a file by figuring it out what basedir it's relative
+// to and trimming the basedir prefix off the front
+func FileDisplayName(baseDirs []string, f string) string {
+	ret := f
+	for _, baseDir := range baseDirs {
+		short, isChild := Child(baseDir, f)
+		if isChild && len(short) < len(ret) {
+			ret = short
+		}
+	}
+	return ret
+}
+
+// Calculate display name for list of files.
+func FileListDisplayNames(baseDirs []string, files []string) []string {
+	var ret []string
+	for _, f := range files {
+		ret = append(ret, FileDisplayName(baseDirs, f))
+	}
+	return ret
+}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -563,28 +563,6 @@ func (p Pod) Log() string {
 	return podLog
 }
 
-func shortenFile(baseDirs []string, f string) string {
-	ret := f
-	for _, baseDir := range baseDirs {
-		short, isChild := ospath.Child(baseDir, f)
-		if isChild && len(short) < len(ret) {
-			ret = short
-		}
-	}
-	return ret
-}
-
-// for each filename in `files`, trims the longest appropriate basedir prefix off the front
-func shortenFileList(baseDirs []string, files []string) []string {
-	baseDirs = append([]string{}, baseDirs...)
-
-	var ret []string
-	for _, f := range files {
-		ret = append(ret, shortenFile(baseDirs, f))
-	}
-	return ret
-}
-
 func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []string) {
 	defer func() {
 		sort.Strings(endpoints)
@@ -644,16 +622,16 @@ func StateToView(s EngineState) view.View {
 			}
 		}
 
-		pendingBuildEdits = shortenFileList(absWatchDirs, pendingBuildEdits)
+		pendingBuildEdits = ospath.FileListDisplayNames(absWatchDirs, pendingBuildEdits)
 
 		buildHistory := append([]model.BuildRecord{}, ms.BuildHistory...)
 		for i, build := range buildHistory {
-			build.Edits = shortenFileList(absWatchDirs, build.Edits)
+			build.Edits = ospath.FileListDisplayNames(absWatchDirs, build.Edits)
 			buildHistory[i] = build
 		}
 
 		currentBuild := ms.CurrentBuild
-		currentBuild.Edits = shortenFileList(absWatchDirs, ms.CurrentBuild.Edits)
+		currentBuild.Edits = ospath.FileListDisplayNames(absWatchDirs, ms.CurrentBuild.Edits)
 
 		// Sort the strings to make the outputs deterministic.
 		sort.Strings(pendingBuildEdits)


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/display:

66745d017433b559053edb60c36bfd065e2e8ea1 (2019-03-25 16:19:47 -0400)
ospath: move the function for file display names into the ospath package