### PR TITLE
k8s: correctly detect k8s env for docker edge

### DIFF
--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -72,7 +72,7 @@ func EnvFromConfig(config *api.Config) Env {
 	cn := c.Cluster
 	if Env(cn) == EnvMinikube {
 		return EnvMinikube
-	} else if cn == "docker-for-desktop-cluster" {
+	} else if cn == "docker-for-desktop-cluster" || cn == "docker-desktop" {
 		return EnvDockerDesktop
 	} else if strings.HasPrefix(cn, string(EnvGKE)) {
 		// GKE cluster strings look like:

--- a/internal/k8s/env_test.go
+++ b/internal/k8s/env_test.go
@@ -49,6 +49,11 @@ func TestEnvFromConfig(t *testing.T) {
 			Cluster: "docker-for-desktop-cluster",
 		},
 	}
+	dockerDesktopEdgeContexts := map[string]*api.Context{
+		"docker-for-desktop": &api.Context{
+			Cluster: "docker-desktop",
+		},
+	}
 	gkeContexts := map[string]*api.Context{
 		"gke_blorg-dev_us-central1-b_blorg": &api.Context{
 			Cluster: "gke_blorg-dev_us-central1-b_blorg",
@@ -68,6 +73,7 @@ func TestEnvFromConfig(t *testing.T) {
 		{EnvUnknown, &api.Config{CurrentContext: "aws"}},
 		{EnvMinikube, &api.Config{CurrentContext: "minikube", Contexts: minikubeContexts}},
 		{EnvDockerDesktop, &api.Config{CurrentContext: "docker-for-desktop", Contexts: dockerDesktopContexts}},
+		{EnvDockerDesktop, &api.Config{CurrentContext: "docker-for-desktop", Contexts: dockerDesktopEdgeContexts}},
 		{EnvGKE, &api.Config{CurrentContext: "gke_blorg-dev_us-central1-b_blorg", Contexts: gkeContexts}},
 		{EnvKIND, &api.Config{CurrentContext: "kubernetes-admin@kind-1", Contexts: kindContexts}},
 		{EnvMicroK8s, &api.Config{CurrentContext: "microk8s", Contexts: microK8sContexts}},


### PR DESCRIPTION
@landism on docker v18.09.2:
```
$ kc config get-clusters
NAME
gke_blorg-dev_us-central1-b_blorg
gke_some-project-162817_us-central1-b_windmill
gke_windmill-prod_us-central1-b_windmill
docker-for-desktop-cluster <-- !
```

me on docker v18.09.3:
```
$ kc config get-clusters
NAME
gke_blorg-dev_us-central1-b_blorg
gke_some-project-162817_us-central1-b_windmill
minikube
docker-desktop <-- different from string in code
```