### PR TITLE
docker-compose: use the full build context for now instead of trying to be clever

### DIFF
--- a/internal/dockerfile/dockerfile.go
+++ b/internal/dockerfile/dockerfile.go
@@ -147,7 +147,18 @@ func (d Dockerfile) FindImages() ([]reference.Named, error) {
 // DeriveMounts finds ADD statements in a Dockerfile and turns them into Tilt model.Mounts.
 // Relative paths in an ADD statement are relative to the build context (passed as an arg)
 // and will appear in the Mount as an abs path.
-func (d Dockerfile) DeriveMounts(context string) ([]model.Mount, error) {
+//
+// TODO(nick): This code has several bugs and needs to be revisited.
+// In particular, it doesn't properly handle
+// 1) multi-stage builds
+// 2) ADD/COPY flags
+// 3) workdirs
+// 4) relative dirs vs absolute dirs
+//
+// Should probably be reworked to only return local paths,
+// as part of a rethink of slimming down the docker build
+// context in a way that's not docker-compose specific.
+func (d Dockerfile) BUGGY_DeriveMounts(context string) ([]model.Mount, error) {
 	var nodes []*parser.Node
 	err := d.traverse(func(node *parser.Node) error {
 		switch node.Value {

--- a/internal/dockerfile/dockerfile_test.go
+++ b/internal/dockerfile/dockerfile_test.go
@@ -102,7 +102,7 @@ COPY foo /bar
 ADD /abs/bar /baz
 ADD ./beep/boop /blorp`)
 	context := "/context/dir"
-	mounts, err := df.DeriveMounts(context)
+	mounts, err := df.BUGGY_DeriveMounts(context)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ ADD ./beep/boop /blorp`)
 
 func TestNoAddsToNoMounts(t *testing.T) {
 	df := Dockerfile(`RUN echo 'hi'`)
-	mounts, err := df.DeriveMounts("/context/dir")
+	mounts, err := df.BUGGY_DeriveMounts("/context/dir")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/watchmanager_test.go
+++ b/internal/engine/watchmanager_test.go
@@ -22,8 +22,9 @@ func TestWatchManager_IgnoredLocalDirectories(t *testing.T) {
 	f := newWMFixture(t)
 	defer f.TearDown()
 
-	target := model.DockerComposeTarget{Name: "foo"}.WithIgnoredLocalDirectories([]string{"bar"})
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithIgnoredLocalDirectories([]string{"bar"}).
+		WithBuildPath(".")
 	f.SetManifestTarget(target)
 
 	f.ChangeFile(t, "bar/baz")
@@ -37,8 +38,9 @@ func TestWatchManager_Dockerignore(t *testing.T) {
 	f := newWMFixture(t)
 	defer f.TearDown()
 
-	target := model.DockerComposeTarget{Name: "foo"}.WithDockerignores([]model.Dockerignore{{LocalPath: ".", Contents: "bar"}})
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithDockerignores([]model.Dockerignore{{LocalPath: ".", Contents: "bar"}}).
+		WithBuildPath(".")
 	f.SetManifestTarget(target)
 
 	f.ChangeFile(t, "bar/baz")
@@ -57,8 +59,9 @@ func TestWatchManager_Gitignore(t *testing.T) {
 		return
 	}
 
-	target := model.DockerComposeTarget{Name: "foo"}.WithRepos([]model.LocalGitRepo{{LocalPath: wd, GitignoreContents: "bar"}})
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithRepos([]model.LocalGitRepo{{LocalPath: wd, GitignoreContents: "bar"}}).
+		WithBuildPath(".")
 	f.SetManifestTarget(target)
 
 	f.ChangeFile(t, "bar")
@@ -72,8 +75,8 @@ func TestWatchManager_WatchesReappliedOnDockerComposeMountsChange(t *testing.T) 
 	f := newWMFixture(t)
 	defer f.TearDown()
 
-	target := model.DockerComposeTarget{Name: "foo"}
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithBuildPath(".")
 	f.SetManifestTarget(target.WithIgnoredLocalDirectories([]string{"bar"}))
 	f.SetManifestTarget(target)
 
@@ -90,8 +93,8 @@ func TestWatchManager_WatchesReappliedOnDockerIgnoreChange(t *testing.T) {
 	f := newWMFixture(t)
 	defer f.TearDown()
 
-	target := model.DockerComposeTarget{Name: "foo"}
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithBuildPath(".")
 	f.SetManifestTarget(target.WithDockerignores([]model.Dockerignore{{LocalPath: ".", Contents: "bar"}}))
 	f.SetManifestTarget(target)
 
@@ -113,8 +116,8 @@ func TestWatchManager_WatchesReappliedOnGitIgnoreChange(t *testing.T) {
 		return
 	}
 
-	target := model.DockerComposeTarget{Name: "foo"}
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithBuildPath(".")
 	f.SetManifestTarget(target.WithRepos([]model.LocalGitRepo{{LocalPath: wd, GitignoreContents: "bar"}}))
 	f.SetManifestTarget(target)
 
@@ -131,8 +134,8 @@ func TestWatchManager_IgnoreTiltIgnore(t *testing.T) {
 	f := newWMFixture(t)
 	defer f.TearDown()
 
-	target := model.DockerComposeTarget{Name: "foo"}
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithBuildPath(".")
 	f.SetManifestTarget(target)
 	f.SetTiltIgnoreContents("**/foo")
 
@@ -147,8 +150,8 @@ func TestWatchManager_PickUpTiltIgnoreChanges(t *testing.T) {
 	f := newWMFixture(t)
 	defer f.TearDown()
 
-	target := model.DockerComposeTarget{Name: "foo"}
-	target.Mounts = []model.Mount{{LocalPath: "."}}
+	target := model.DockerComposeTarget{Name: "foo"}.
+		WithBuildPath(".")
 	f.SetManifestTarget(target)
 	f.SetTiltIgnoreContents("**/foo")
 	f.ChangeFile(t, "bar/foo")

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -23,9 +23,12 @@ func (dID DeployID) String() string { return strconv.Itoa(int(dID)) }
 type DockerComposeTarget struct {
 	Name       TargetName
 	ConfigPath string
-	Mounts     []Mount
-	YAMLRaw    []byte // for diff'ing when config files change
-	DfRaw      []byte // for diff'ing when config files change
+
+	// The docker context, like in DockerBuild
+	buildPath string
+
+	YAMLRaw []byte // for diff'ing when config files change
+	DfRaw   []byte // for diff'ing when config files change
 
 	// TODO(nick): It might eventually make sense to represent
 	// Tiltfile as a separate nodes in the build graph, rather
@@ -59,11 +62,15 @@ func (t DockerComposeTarget) DependencyIDs() []TargetID {
 }
 
 func (t DockerComposeTarget) LocalPaths() []string {
-	result := make([]string, len(t.Mounts))
-	for i, mount := range t.Mounts {
-		result[i] = mount.LocalPath
+	if t.buildPath == "" {
+		return []string{}
 	}
-	return result
+	return []string{t.buildPath}
+}
+
+func (t DockerComposeTarget) WithBuildPath(buildPath string) DockerComposeTarget {
+	t.buildPath = buildPath
+	return t
 }
 
 func (t DockerComposeTarget) WithDependencyIDs(ids []TargetID) DockerComposeTarget {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/ch2008/watches:

1205f276e8649dffbe2fb62f92ddf8c916c42a17 (2019-03-26 20:19:48 -0400)
docker-compose: use the full build context for now instead of trying to be clever
fixes a bug where we were not handling multi-stage builds correctly