### PR TITLE
engine: make target queue more like a real build graph. fixes some bugs in dirtyness checking w/ dependent images

### DIFF
--- a/integration/imagetags_test.go
+++ b/integration/imagetags_test.go
@@ -24,4 +24,18 @@ func TestImageTags(t *testing.T) {
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31000/message.txt", "Hello from regular")
 	f.CurlUntil(ctx, "http://localhost:31001/message.txt", "Hello from stretch")
+
+	f.ReplaceContents("common/message.txt", "regular", "super unleaded")
+
+	ctx, cancel = context.WithTimeout(f.ctx, timePerStage)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:31000/message.txt", "Hello from super unleaded")
+	f.CurlUntil(ctx, "http://localhost:31001/message.txt", "Hello from stretch")
+
+	f.ReplaceContents("common-stretch/message.txt", "stretch", "armstrong")
+
+	ctx, cancel = context.WithTimeout(f.ctx, timePerStage)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:31001/message.txt", "Hello from armstrong")
+	f.CurlUntil(ctx, "http://localhost:31000/message.txt", "Hello from super unleaded")
 }

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -103,7 +103,7 @@ func TestMultiStageDockerCompose(t *testing.T) {
 	f := newDCBDFixture(t)
 	defer f.TearDown()
 
-	manifest := NewSanchoDockerBuildMultiStageManifest().
+	manifest := NewSanchoDockerBuildMultiStageManifest(f).
 		WithDeployTarget(dcTarg)
 	stateSet := store.BuildStateSet{}
 	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
@@ -130,7 +130,7 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 	f := newDCBDFixture(t)
 	defer f.TearDown()
 
-	manifest := NewSanchoDockerBuildMultiStageManifest().
+	manifest := NewSanchoDockerBuildMultiStageManifest(f).
 		WithDeployTarget(dcTarg)
 	iTargetID := manifest.ImageTargets[0].ID()
 	result := store.NewImageBuildResult(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))

--- a/internal/engine/target_queue.go
+++ b/internal/engine/target_queue.go
@@ -7,60 +7,120 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 )
 
-// A little data structure to help iterate through targets in dependency order.
+// Allows the caller to inject its own build strategy for dirty targets.
+type BuildHandler func(
+	target model.TargetSpec,
+	state store.BuildState,
+	depResults []store.BuildResult) (store.BuildResult, error)
+
+// A little data structure to help iterate through dirty targets in dependency order.
 type TargetQueue struct {
-	targets []model.TargetSpec
+	sortedTargets []model.TargetSpec
+
+	// The state from the previous build.
+	// Contains files-changed so we can do incremental builds.
+	state store.BuildStateSet
+
+	// The results of this build.
 	results store.BuildResultSet
+
+	// Whether the target itself needs a rebuilt, either because it has dirty files
+	// or has never been built before.
+	//
+	// A target with dirty files might be able to use the files changed
+	// since the previous result to build the next result.
+	needsOwnBuild map[model.TargetID]bool
+
+	// Whether the target depends transitively on something that needs rebuilding.
+	// A target that depends on a dirty target should never use its previous
+	// result to build the next result.
+	depsNeedBuild map[model.TargetID]bool
 }
 
-func NewImageTargetQueue(iTargets []model.ImageTarget) *TargetQueue {
+func NewImageTargetQueue(iTargets []model.ImageTarget, state store.BuildStateSet) (*TargetQueue, error) {
 	targets := make([]model.TargetSpec, 0, len(iTargets))
 	for _, iTarget := range iTargets {
 		targets = append(targets, iTarget)
 	}
 
-	return &TargetQueue{
-		targets: targets,
-		results: make(store.BuildResultSet, len(targets)),
+	sortedTargets, err := model.TopologicalSort(targets)
+	if err != nil {
+		return nil, err
 	}
-}
 
-// Checks if we have results for all the dependencies of this target.
-func (q *TargetQueue) isReady(target model.TargetSpec) bool {
-	for _, depID := range target.DependencyIDs() {
-		_, ok := q.results[depID]
-		if !ok {
-			return false
+	needsOwnBuild := make(map[model.TargetID]bool)
+	for _, target := range sortedTargets {
+		id := target.ID()
+		if state[id].NeedsImageBuild() {
+			needsOwnBuild[id] = true
 		}
 	}
-	return true
+
+	depsNeedBuild := make(map[model.TargetID]bool)
+	for _, target := range sortedTargets {
+		for _, depID := range target.DependencyIDs() {
+			if needsOwnBuild[depID] || depsNeedBuild[depID] {
+				depsNeedBuild[target.ID()] = true
+				break
+			}
+		}
+	}
+
+	results := make(store.BuildResultSet, len(targets))
+	return &TargetQueue{
+		sortedTargets: sortedTargets,
+		state:         state,
+		results:       results,
+		needsOwnBuild: needsOwnBuild,
+		depsNeedBuild: depsNeedBuild,
+	}, nil
 }
 
-func (q *TargetQueue) SetResult(id model.TargetID, result store.BuildResult) {
-	q.results[id] = result
+func (q *TargetQueue) CountDirty() int {
+	result := 0
+	for _, target := range q.sortedTargets {
+		if q.needsOwnBuild[target.ID()] || q.depsNeedBuild[target.ID()] {
+			result++
+		}
+	}
+	return result
 }
 
-func (q *TargetQueue) DependencyResults(target model.TargetSpec) []store.BuildResult {
+func (q *TargetQueue) RunBuilds(handler BuildHandler) error {
+	for _, target := range q.sortedTargets {
+		id := target.ID()
+		if q.depsNeedBuild[id] {
+			// If the dependencies are dirty, we can't use any state from the previous build.
+			result, err := handler(target, store.BuildState{}, q.dependencyResults(target))
+			if err != nil {
+				return err
+			}
+			q.results[id] = result
+		} else if q.needsOwnBuild[id] {
+			// If only files are dirty, we can try to do an incremental build.
+			result, err := handler(target, q.state[id], q.dependencyResults(target))
+			if err != nil {
+				return err
+			}
+			q.results[id] = result
+		} else {
+			// Otherwise, we can re-use results from the previous build.
+			// If needsOwnBuild is false, then LastResult must exist if it's empty.
+			lastResult := q.state[id].LastResult
+			if lastResult.Image == nil {
+				return fmt.Errorf("Internal error: build marked clean but last result not found: %+v", q.state[id])
+			}
+			q.results[id] = lastResult
+		}
+	}
+	return nil
+}
+
+func (q *TargetQueue) dependencyResults(target model.TargetSpec) []store.BuildResult {
 	depIDs := target.DependencyIDs()
 	results := make([]store.BuildResult, 0, len(depIDs))
 	for _, depID := range depIDs {
 		results = append(results, q.results[depID])
 	}
 	return results
-}
-
-func (q *TargetQueue) Next() (model.TargetSpec, bool, error) {
-	for i, target := range q.targets {
-		if q.isReady(target) {
-			// Remove this target from the queue
-			q.targets = append(q.targets[:i], q.targets[i+1:]...)
-			return target, true, nil
-		}
-	}
-
-	if len(q.targets) == 0 {
-		return nil, false, nil
-	}
-
-	return nil, false, fmt.Errorf("Internal error: TargetQueue has unsatisfiable targets")
 }

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -164,10 +164,10 @@ func NewSanchoDockerBuildManifestWithNestedFastBuild(fixture pather) model.Manif
 	return manifest
 }
 
-func NewSanchoDockerBuildMultiStageManifest() model.Manifest {
+func NewSanchoDockerBuildMultiStageManifest(fixture pather) model.Manifest {
 	baseImage := model.NewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM golang:1.10`,
-		BuildPath:  "/path/to/build",
+		BuildPath:  fixture.JoinPath("sancho-base"),
 	})
 
 	srcImage := model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
@@ -177,7 +177,7 @@ ADD . .
 RUN go install github.com/windmilleng/sancho
 ENTRYPOINT /go/bin/sancho
 `,
-		BuildPath: "/path/to/build",
+		BuildPath: fixture.JoinPath("sancho"),
 	}).WithDependencyIDs([]model.TargetID{baseImage.ID()})
 
 	kTarget := model.K8sTarget{YAML: SanchoYAML}.


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch2033/deps:

ab92cf90cb49e30c567c9c20c9dc016b4eacf457 (2019-03-28 13:20:23 -0400)
engine: make target queue more like a real build graph. fixes some bugs in dirtyness checking w/ dependent images