### PR TITLE
engine: container BaD's can handle image targets with LiveUpdate [ch2039]

### DIFF
--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -1,74 +1,166 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/synclet/sidecar"
 )
 
-func TestLiveUpdateLocalContainerUpdate(t *testing.T) {
-	f := newBDFixture(t, k8s.EnvDockerDesktop)
-	defer f.TearDown()
+type testCase struct {
+	env k8s.Env
 
-	changed := f.WriteFile("a.txt", "a")
-	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
-	manifest := NewSanchoDockerBuildManifestWithLiveUpdate(f)
-	targets := buildTargets(manifest)
-	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	baseManifest        model.Manifest
+	liveUpdSyncs        []model.LiveUpdateSyncStep
+	liveUpdRuns         []model.LiveUpdateRunStep
+	restart             bool
+	fullRebuildTriggers []string
 
-	if f.docker.BuildCount != 0 {
-		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
-	}
-	if f.docker.PushCount != 0 {
-		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
-	}
-	if f.docker.CopyCount != 1 {
-		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.CopyCount)
-	}
-	if len(f.docker.ExecCalls) != 1 {
-		t.Errorf("Expected 1 exec in container call, actual: %d", len(f.docker.ExecCalls))
-	}
-	f.assertContainerRestarts(1)
+	changedFile string // leave empty for no changed files
 
-	id := manifest.ImageTargetAt(0).ID()
-	_, hasResult := result[id]
-	assert.True(t, hasResult)
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	expectBuildCount   int
+	expectPushCount    int
+	expectCopyCount    int
+	expectExecCount    int
+	expectRestartCount int
+
+	expectK8sDeploy bool
+	expectSynclet   bool
 }
 
-func TestCustomBuildLiveUpdateLocalContainerUpdate(t *testing.T) {
-	f := newBDFixture(t, k8s.EnvDockerDesktop)
-	defer f.TearDown()
+func runTestCase(t *testing.T, f *bdFixture, tCase testCase) {
+	var bs store.BuildStateSet
+	if tCase.changedFile != "" {
+		changed := f.WriteFile(tCase.changedFile, "blah")
+		bs = resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
+	}
 
-	changed := f.WriteFile("a.txt", "a")
-	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
-	manifest := NewSanchoCustomBuildManifestWithLiveUpdate(f)
+	var steps []model.LiveUpdateStep
+	for _, sync := range tCase.liveUpdSyncs {
+		steps = append(steps, sync)
+	}
+	for _, run := range tCase.liveUpdRuns {
+		steps = append(steps, run)
+	}
+	if tCase.restart {
+		steps = append(steps, model.LiveUpdateRestartContainerStep{})
+	}
+	lu := model.MustNewLiveUpdate(steps, tCase.fullRebuildTriggers)
+
+	manifest := tCase.baseManifest
+	iTarg := manifest.ImageTargetAt(0)
+	db := iTarg.DockerBuildInfo()
+	db.LiveUpdate = &lu
+	manifest = manifest.WithImageTarget(iTarg.WithBuildDetails(db))
 	targets := buildTargets(manifest)
+
 	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if f.docker.BuildCount != 0 {
-		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
-	}
-	if f.docker.PushCount != 0 {
-		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
-	}
-	if f.docker.CopyCount != 1 {
-		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.CopyCount)
-	}
-	if len(f.docker.ExecCalls) != 1 {
-		t.Errorf("Expected 1 exec in container call, actual: %d", len(f.docker.ExecCalls))
-	}
-	f.assertContainerRestarts(1)
+	assert.Equal(t, tCase.expectBuildCount, f.docker.BuildCount, "docker build")
+	assert.Equal(t, tCase.expectPushCount, f.docker.PushCount, "docker push")
+	assert.Equal(t, tCase.expectCopyCount, f.docker.CopyCount, "docker copy")
+	assert.Equal(t, tCase.expectExecCount, len(f.docker.ExecCalls), "docker exec")
+	f.assertContainerRestarts(tCase.expectRestartCount)
 
 	id := manifest.ImageTargetAt(0).ID()
 	_, hasResult := result[id]
 	assert.True(t, hasResult)
 	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+
+	if tCase.expectK8sDeploy {
+		expectedYaml := "image: gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
+		if !strings.Contains(f.k8s.Yaml, expectedYaml) {
+			t.Errorf("Expected yaml to contain %q. Actual:\n%s", expectedYaml, f.k8s.Yaml)
+		}
+		assert.Equal(t, tCase.expectSynclet, strings.Contains(f.k8s.Yaml, sidecar.SyncletImageName), "expected synclet-deploy = %t (deployed yaml was: %s)", tCase.expectSynclet, f.k8s.Yaml)
+	}
+
+}
+
+func TestLiveUpdateDockerBuildLocalContainer(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+	tCase := testCase{
+		env:                k8s.EnvDockerDesktop,
+		baseManifest:       NewSanchoDockerBuildManifest(),
+		liveUpdSyncs:       SanchoSyncSteps(f),
+		liveUpdRuns:        SanchoRunSteps,
+		restart:            true,
+		changedFile:        "a.txt",
+		expectBuildCount:   0,
+		expectPushCount:    0,
+		expectCopyCount:    1,
+		expectExecCount:    1,
+		expectRestartCount: 1,
+	}
+	runTestCase(t, f, tCase)
+}
+
+func TestLiveUpdateCustomBuildLocalContainer(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+	tCase := testCase{
+		env:                k8s.EnvDockerDesktop,
+		baseManifest:       NewSanchoCustomBuildManifest(f),
+		liveUpdSyncs:       SanchoSyncSteps(f),
+		liveUpdRuns:        SanchoRunSteps,
+		restart:            true,
+		changedFile:        "a.txt",
+		expectBuildCount:   0,
+		expectPushCount:    0,
+		expectCopyCount:    1,
+		expectExecCount:    1,
+		expectRestartCount: 1,
+	}
+	runTestCase(t, f, tCase)
+}
+
+func TestLiveUpdateHotReloadLocalContainer(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+	tCase := testCase{
+		env:                k8s.EnvDockerDesktop,
+		baseManifest:       NewSanchoDockerBuildManifest(),
+		liveUpdSyncs:       SanchoSyncSteps(f),
+		liveUpdRuns:        SanchoRunSteps,
+		restart:            false,
+		changedFile:        "a.txt",
+		expectBuildCount:   0,
+		expectPushCount:    0,
+		expectCopyCount:    1,
+		expectExecCount:    1,
+		expectRestartCount: 0,
+	}
+	runTestCase(t, f, tCase)
+}
+
+func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+	tCase := testCase{
+		env:          k8s.EnvDockerDesktop,
+		baseManifest: NewSanchoDockerBuildManifest(),
+		liveUpdSyncs: SanchoSyncSteps(f),
+		liveUpdRuns: []model.LiveUpdateRunStep{
+			{
+				Command: model.ToCmd("echo", "hi"),
+				Trigger: "b.txt", // does NOT match changed file
+			},
+		},
+		restart:            true,
+		changedFile:        "a.txt",
+		expectBuildCount:   0,
+		expectPushCount:    0,
+		expectCopyCount:    1,
+		expectExecCount:    0, // Run doesn't match changed file, so shouldn't exec
+		expectRestartCount: 1,
+	}
+	runTestCase(t, f, tCase)
 }

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -23,10 +23,10 @@ type testCase struct {
 	changedFile string // leave empty for no changed files
 
 	// Docker actions
-	expectBuildCount         int
-	expectPushCount          int
-	expectCopyCount          int
-	expectExecCount          int
+	expectDockerBuildCount   int
+	expectDockerPushCount    int
+	expectDockerCopyCount    int
+	expectDockerExecCount    int
 	expectDockerRestartCount int
 
 	// Synclet actions
@@ -67,13 +67,13 @@ func runTestCase(t *testing.T, f *bdFixture, tCase testCase) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, tCase.expectBuildCount, f.docker.BuildCount, "docker build")
-	assert.Equal(t, tCase.expectPushCount, f.docker.PushCount, "docker push")
-	assert.Equal(t, tCase.expectCopyCount, f.docker.CopyCount, "docker copy")
-	assert.Equal(t, tCase.expectExecCount, len(f.docker.ExecCalls), "docker exec")
+	assert.Equal(t, tCase.expectDockerBuildCount, f.docker.BuildCount, "docker build")
+	assert.Equal(t, tCase.expectDockerPushCount, f.docker.PushCount, "docker push")
+	assert.Equal(t, tCase.expectDockerCopyCount, f.docker.CopyCount, "docker copy")
+	assert.Equal(t, tCase.expectDockerExecCount, len(f.docker.ExecCalls), "docker exec")
 	assert.Equal(t, tCase.expectSyncletUpdateContainerCount, f.sCli.UpdateContainerCount, "synclet update container")
 	f.assertContainerRestarts(tCase.expectDockerRestartCount)
-	assert.Equal(t, tCase.expectSyncletHotReload, f.sCli.UpdateContainerHotReload)
+	assert.Equal(t, tCase.expectSyncletHotReload, f.sCli.UpdateContainerHotReload, "synclet hot reload")
 
 	id := manifest.ImageTargetAt(0).ID()
 	_, hasResult := result[id]
@@ -100,10 +100,10 @@ func TestLiveUpdateDockerBuildLocalContainer(t *testing.T) {
 		liveUpdRuns:              SanchoRunSteps,
 		liveUpdRestart:           true,
 		changedFile:              "a.txt",
-		expectBuildCount:         0,
-		expectPushCount:          0,
-		expectCopyCount:          1,
-		expectExecCount:          1,
+		expectDockerBuildCount:   0,
+		expectDockerPushCount:    0,
+		expectDockerCopyCount:    1,
+		expectDockerExecCount:    1,
 		expectDockerRestartCount: 1,
 	}
 	runTestCase(t, f, tCase)
@@ -119,10 +119,10 @@ func TestLiveUpdateCustomBuildLocalContainer(t *testing.T) {
 		liveUpdRuns:              SanchoRunSteps,
 		liveUpdRestart:           true,
 		changedFile:              "a.txt",
-		expectBuildCount:         0,
-		expectPushCount:          0,
-		expectCopyCount:          1,
-		expectExecCount:          1,
+		expectDockerBuildCount:   0,
+		expectDockerPushCount:    0,
+		expectDockerCopyCount:    1,
+		expectDockerExecCount:    1,
 		expectDockerRestartCount: 1,
 	}
 	runTestCase(t, f, tCase)
@@ -138,10 +138,10 @@ func TestLiveUpdateHotReloadLocalContainer(t *testing.T) {
 		liveUpdRuns:              SanchoRunSteps,
 		liveUpdRestart:           false,
 		changedFile:              "a.txt",
-		expectBuildCount:         0,
-		expectPushCount:          0,
-		expectCopyCount:          1,
-		expectExecCount:          1,
+		expectDockerBuildCount:   0,
+		expectDockerPushCount:    0,
+		expectDockerCopyCount:    1,
+		expectDockerExecCount:    1,
 		expectDockerRestartCount: 0,
 	}
 	runTestCase(t, f, tCase)
@@ -162,10 +162,10 @@ func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
 		},
 		liveUpdRestart:           true,
 		changedFile:              "a.txt",
-		expectBuildCount:         0,
-		expectPushCount:          0,
-		expectCopyCount:          1,
-		expectExecCount:          0, // Run doesn't match changed file, so shouldn't exec
+		expectDockerBuildCount:   0,
+		expectDockerPushCount:    0,
+		expectDockerCopyCount:    1,
+		expectDockerExecCount:    0, // Run doesn't match changed file, so shouldn't exec
 		expectDockerRestartCount: 1,
 	}
 	runTestCase(t, f, tCase)
@@ -179,11 +179,10 @@ func TestLiveUpdateDockerBuildSynclet(t *testing.T) {
 		baseManifest:                      NewSanchoDockerBuildManifest(),
 		liveUpdSyncs:                      SanchoSyncSteps(f),
 		liveUpdRuns:                       SanchoRunSteps,
-		liveUpdRestart:                    false,
+		liveUpdRestart:                    true,
 		changedFile:                       "a.txt",
-		expectBuildCount:                  0,
-		expectPushCount:                   0,
-		expectCopyCount:                   1,
+		expectDockerBuildCount:            0,
+		expectDockerPushCount:             0,
 		expectSyncletUpdateContainerCount: 1,
 		expectSyncletHotReload:            false,
 	}
@@ -198,11 +197,10 @@ func TestLiveUpdateCustomBuildSynclet(t *testing.T) {
 		baseManifest:                      NewSanchoCustomBuildManifest(f),
 		liveUpdSyncs:                      SanchoSyncSteps(f),
 		liveUpdRuns:                       SanchoRunSteps,
-		liveUpdRestart:                    false,
+		liveUpdRestart:                    true,
 		changedFile:                       "a.txt",
-		expectBuildCount:                  0,
-		expectPushCount:                   0,
-		expectCopyCount:                   1,
+		expectDockerBuildCount:            0,
+		expectDockerPushCount:             0,
 		expectSyncletUpdateContainerCount: 1,
 		expectSyncletHotReload:            false,
 	}
@@ -217,11 +215,10 @@ func TestLiveUpdateHotReloadSynclet(t *testing.T) {
 		baseManifest:                      NewSanchoDockerBuildManifest(),
 		liveUpdSyncs:                      SanchoSyncSteps(f),
 		liveUpdRuns:                       SanchoRunSteps,
-		liveUpdRestart:                    true,
+		liveUpdRestart:                    false,
 		changedFile:                       "a.txt",
-		expectBuildCount:                  0,
-		expectPushCount:                   0,
-		expectCopyCount:                   1,
+		expectDockerBuildCount:            0,
+		expectDockerPushCount:             0,
 		expectSyncletUpdateContainerCount: 1,
 		expectSyncletHotReload:            true,
 	}

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/k8s"
+)
+
+func TestLiveUpdateLocalContainerUpdate(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+
+	changed := f.WriteFile("a.txt", "a")
+	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
+	manifest := NewSanchoDockerBuildManifestWithLiveUpdate(f)
+	targets := buildTargets(manifest)
+	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.docker.BuildCount != 0 {
+		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
+	}
+	if f.docker.PushCount != 0 {
+		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	}
+	if f.docker.CopyCount != 1 {
+		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.CopyCount)
+	}
+	if len(f.docker.ExecCalls) != 1 {
+		t.Errorf("Expected 1 exec in container call, actual: %d", len(f.docker.ExecCalls))
+	}
+	f.assertContainerRestarts(1)
+
+	id := manifest.ImageTargetAt(0).ID()
+	_, hasResult := result[id]
+	assert.True(t, hasResult)
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+}
+
+func TestCustomBuildLiveUpdateLocalContainerUpdate(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+
+	changed := f.WriteFile("a.txt", "a")
+	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
+	manifest := NewSanchoCustomBuildManifestWithLiveUpdate(f)
+	targets := buildTargets(manifest)
+	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.docker.BuildCount != 0 {
+		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
+	}
+	if f.docker.PushCount != 0 {
+		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	}
+	if f.docker.CopyCount != 1 {
+		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.CopyCount)
+	}
+	if len(f.docker.ExecCalls) != 1 {
+		t.Errorf("Expected 1 exec in container call, actual: %d", len(f.docker.ExecCalls))
+	}
+	f.assertContainerRestarts(1)
+
+	id := manifest.ImageTargetAt(0).ID()
+	_, hasResult := result[id]
+	assert.True(t, hasResult)
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+}

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -268,6 +268,39 @@ func TestDockerBuildWithNestedFastBuildContainerUpdate(t *testing.T) {
 	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
 }
 
+func TestLiveUpdateContainerUpdate(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+
+	changed := f.WriteFile("a.txt", "a")
+	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
+	manifest := NewSanchoDockerBuildManifestWithLiveUpdate(f)
+	targets := buildTargets(manifest)
+	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.docker.BuildCount != 0 {
+		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
+	}
+	if f.docker.PushCount != 0 {
+		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	}
+	if f.docker.CopyCount != 1 {
+		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.CopyCount)
+	}
+	if len(f.docker.ExecCalls) != 1 {
+		t.Errorf("Expected 1 exec in container call, actual: %d", len(f.docker.ExecCalls))
+	}
+	f.assertContainerRestarts(1)
+
+	id := manifest.ImageTargetAt(0).ID()
+	_, hasResult := result[id]
+	assert.True(t, hasResult)
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+}
+
 func TestIncrementalBuildFailure(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop)
 	defer f.TearDown()

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -268,39 +268,6 @@ func TestDockerBuildWithNestedFastBuildContainerUpdate(t *testing.T) {
 	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
 }
 
-func TestLiveUpdateContainerUpdate(t *testing.T) {
-	f := newBDFixture(t, k8s.EnvDockerDesktop)
-	defer f.TearDown()
-
-	changed := f.WriteFile("a.txt", "a")
-	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
-	manifest := NewSanchoDockerBuildManifestWithLiveUpdate(f)
-	targets := buildTargets(manifest)
-	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if f.docker.BuildCount != 0 {
-		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
-	}
-	if f.docker.PushCount != 0 {
-		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
-	}
-	if f.docker.CopyCount != 1 {
-		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.CopyCount)
-	}
-	if len(f.docker.ExecCalls) != 1 {
-		t.Errorf("Expected 1 exec in container call, actual: %d", len(f.docker.ExecCalls))
-	}
-	f.assertContainerRestarts(1)
-
-	id := manifest.ImageTargetAt(0).ID()
-	_, hasResult := result[id]
-	assert.True(t, hasResult)
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
-}
-
 func TestIncrementalBuildFailure(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop)
 	defer f.TearDown()

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -771,7 +771,8 @@ func (f *bdFixture) assertContainerRestarts(count int) {
 	if count != 0 {
 		expected[string(k8s.MagicTestContainerID)] = count
 	}
-	assert.Equal(f.T(), expected, f.docker.RestartsByContainer)
+	assert.Equal(f.T(), expected, f.docker.RestartsByContainer,
+		"checking for expected # of container restarts")
 }
 
 func resultToStateSet(resultSet store.BuildResultSet, files []string, deploy store.DeployInfo) store.BuildStateSet {

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -141,7 +141,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 		assert.Equal(t, testContainer, ms.ExpectedContainerID.String())
 	})
 
-	// Restart the pod with a new container id, to simulate a container restart.
+	// Restart the pod with a new container id, to simulate a container liveUpdRestart.
 	f.podEvent(f.testPod("pod-id", "fe", "Running", "funnyContainerID", time.Now()))
 	call = f.nextCall()
 	assert.True(t, call.oneState().DeployInfo.Empty())

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -77,8 +77,9 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		}
 
 		fbInfo := iTarget.MaybeFastBuildInfo()
-		if fbInfo == nil {
-			return nil, RedirectToNextBuilderf("In-place build only supports FastBuilds")
+		luInfo := iTarget.MaybeLiveUpdateInfo()
+		if fbInfo == nil && luInfo == nil {
+			return nil, RedirectToNextBuilderf("In-place build requires either FastBuild or LiveUpdate")
 		}
 
 		// Now that we have fast build information, we know this CAN be updated in

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -2,10 +2,8 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
@@ -70,20 +68,31 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 		return store.BuildResultSet{}, RedirectToNextBuilderf("prev. build state is empty; container build does not support initial deploy")
 	}
 
-	fbInfo := iTarget.MaybeFastBuildInfo()
-	// TEMPORARY: just while implementing LiveUpdate support
-	luInfo := iTarget.MaybeLiveUpdateInfo()
-	if fbInfo == nil && luInfo != nil {
-		return store.BuildResultSet{}, fmt.Errorf("currently implementing LiveUpdate support. Got LU: %s", spew.Sdump(luInfo))
-	}
+	var syncs []model.Mount
+	var runs []model.Run
+	var hotReload bool
 
+	if fbInfo := iTarget.MaybeFastBuildInfo(); fbInfo != nil {
+		syncs = fbInfo.Mounts
+		runs = fbInfo.Runs
+		hotReload = fbInfo.HotReload
+	}
+	if luInfo := iTarget.MaybeLiveUpdateInfo(); luInfo != nil {
+		syncs = luInfo.SyncSteps()
+		runs = luInfo.RunSteps()
+		hotReload = !luInfo.ShouldRestart()
+	}
+	return cbd.buildAndDeploy(ctx, iTarget, state, syncs, runs, hotReload)
+}
+
+func (cbd *LocalContainerBuildAndDeployer) buildAndDeploy(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, syncs []model.Mount, runs []model.Run, hotReload bool) (store.BuildResultSet, error) {
 	deployInfo := state.DeployInfo
-	cf, err := build.FilesToPathMappings(state.FilesChanged(), fbInfo.Mounts)
+	cf, err := build.FilesToPathMappings(state.FilesChanged(), syncs)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
 	logger.Get(ctx).Infof("  → Updating container…")
-	boiledSteps, err := build.BoilRuns(fbInfo.Runs, cf)
+	boiledSteps, err := build.BoilRuns(runs, cf)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
@@ -91,7 +100,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 	// TODO - use PipelineState here when we actually do pipeline output for container builds
 	writer := logger.Get(ctx).Writer(logger.InfoLvl)
 
-	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, cf, ignore.CreateBuildContextFilter(iTarget), boiledSteps, fbInfo.HotReload, writer)
+	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, cf, ignore.CreateBuildContextFilter(iTarget), boiledSteps, hotReload, writer)
 	if err != nil {
 		if build.IsUserBuildFailure(err) {
 			return store.BuildResultSet{}, WrapDontFallBackError(err)

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -2,8 +2,10 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
@@ -69,6 +71,12 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 	}
 
 	fbInfo := iTarget.MaybeFastBuildInfo()
+	// TEMPORARY: just while implementing LiveUpdate support
+	luInfo := iTarget.MaybeLiveUpdateInfo()
+	if fbInfo == nil && luInfo != nil {
+		return store.BuildResultSet{}, fmt.Errorf("currently implementing LiveUpdate support. Got LU: %s", spew.Sdump(luInfo))
+	}
+
 	deployInfo := state.DeployInfo
 	cf, err := build.FilesToPathMappings(state.FilesChanged(), fbInfo.Mounts)
 	if err != nil {

--- a/internal/engine/local_container_build_and_deployer_test.go
+++ b/internal/engine/local_container_build_and_deployer_test.go
@@ -1,7 +1,0 @@
-package engine
-
-import (
-	"github.com/windmilleng/tilt/internal/k8s"
-)
-
-const pod1 = k8s.PodID("pod1")

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -77,7 +77,7 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 			shouldPrefix := len(containerInfos) > 1
 
 			for _, cInfo := range containerInfos {
-				// Key the log watcher by the container id, so we auto-restart the
+				// Key the log watcher by the container id, so we auto-liveUpdRestart the
 				// watching if the container crashes.
 				key := podLogKey{
 					podID: pod.PodID,

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -47,6 +47,15 @@ func NewSanchoFastBuild(fixture pather) model.FastBuild {
 	}
 }
 
+func NewSanchoLiveUpdate(fixture pather) model.LiveUpdate {
+	steps := []model.LiveUpdateStep{
+		model.LiveUpdateSyncStep{fixture.Path(), "/go/src/github.com/windmilleng/sancho"},
+		model.LiveUpdateRunStep{Command: model.Cmd{Argv: []string{"go", "install", "github.com/windmilleng/sancho"}}},
+		model.LiveUpdateRestartContainerStep{},
+	}
+	return model.MustNewLiveUpdate(steps, nil)
+}
+
 func NewSanchoFastBuildImage(fixture pather) model.ImageTarget {
 	fbInfo := NewSanchoFastBuild(fixture)
 	return model.NewImageTarget(SanchoRef).WithBuildDetails(fbInfo)
@@ -160,6 +169,17 @@ func NewSanchoDockerBuildManifestWithNestedFastBuild(fixture pather) model.Manif
 	sb := iTarg.DockerBuildInfo()
 	sb.FastBuild = &fb
 	iTarg = iTarg.WithBuildDetails(sb)
+	manifest = manifest.WithImageTarget(iTarg)
+	return manifest
+}
+
+func NewSanchoDockerBuildManifestWithLiveUpdate(fixture pather) model.Manifest {
+	manifest := NewSanchoDockerBuildManifest()
+	iTarg := manifest.ImageTargetAt(0)
+	lu := NewSanchoLiveUpdate(fixture)
+	db := iTarg.DockerBuildInfo()
+	db.LiveUpdate = &lu
+	iTarg = iTarg.WithBuildDetails(db)
 	manifest = manifest.WithImageTarget(iTarg)
 	return manifest
 }

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -115,6 +115,22 @@ func NewSanchoCustomBuildManifestWithFastBuild(fixture pather) model.Manifest {
 		model.NewImageTarget(SanchoRef).WithBuildDetails(cb))
 }
 
+func NewSanchoCustomBuildManifestWithLiveUpdate(fixture pather) model.Manifest {
+	lu := NewSanchoLiveUpdate(fixture)
+	cb := model.CustomBuild{
+		Command:    "true",
+		Deps:       []string{fixture.JoinPath("app")},
+		LiveUpdate: &lu,
+	}
+
+	m := model.Manifest{Name: "sancho"}
+
+	return assembleK8sManifest(
+		m,
+		model.K8sTarget{YAML: SanchoYAML},
+		model.NewImageTarget(SanchoRef).WithBuildDetails(cb))
+}
+
 func NewSanchoCustomBuildManifestWithPushDisabled(fixture pather) model.Manifest {
 	cb := model.CustomBuild{
 		Command:     "true",

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -46,6 +46,11 @@ func NewSanchoFastBuild(fixture pather) model.FastBuild {
 		Entrypoint: model.Cmd{Argv: []string{"/go/bin/sancho"}},
 	}
 }
+func SanchoSyncSteps(fixture pather) []model.LiveUpdateSyncStep {
+	return []model.LiveUpdateSyncStep{model.LiveUpdateSyncStep{fixture.Path(), "/go/src/github.com/windmilleng/sancho"}}
+}
+
+var SanchoRunSteps = []model.LiveUpdateRunStep{model.LiveUpdateRunStep{Command: model.Cmd{Argv: []string{"go", "install", "github.com/windmilleng/sancho"}}}}
 
 func NewSanchoLiveUpdate(fixture pather) model.LiveUpdate {
 	steps := []model.LiveUpdateStep{

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2518,7 +2518,7 @@ func (f *testFixture) restartPod() {
 	f.pod.Status.ContainerStatuses[0].RestartCount = restartCount
 	f.upper.store.Dispatch(PodChangeAction{f.pod})
 
-	f.WaitUntilManifestState("pod restart seen", "foobar", func(ms store.ManifestState) bool {
+	f.WaitUntilManifestState("pod liveUpdRestart seen", "foobar", func(ms store.ManifestState) bool {
 		return ms.MostRecentPod().ContainerRestarts == int(restartCount)
 	})
 }

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -35,6 +35,14 @@ func NewLiveUpdate(steps []LiveUpdateStep, fullRebuildTriggers []string) (LiveUp
 	return LiveUpdate{steps, fullRebuildTriggers}, nil
 }
 
+func MustNewLiveUpdate(steps []LiveUpdateStep, fullRebuildTriggers []string) LiveUpdate {
+	lu, err := NewLiveUpdate(steps, fullRebuildTriggers)
+	if err != nil {
+		panic(err)
+	}
+	return lu
+}
+
 type LiveUpdateStep interface {
 	liveUpdateStep()
 }

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -37,14 +37,6 @@ func NewLiveUpdate(steps []LiveUpdateStep, fullRebuildTriggers []string) (LiveUp
 	return LiveUpdate{steps, fullRebuildTriggers}, nil
 }
 
-func MustNewLiveUpdate(steps []LiveUpdateStep, fullRebuildTriggers []string) LiveUpdate {
-	lu, err := NewLiveUpdate(steps, fullRebuildTriggers)
-	if err != nil {
-		panic(err)
-	}
-	return lu
-}
-
 type LiveUpdateStep interface {
 	liveUpdateStep()
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -198,6 +198,11 @@ type Run struct {
 	BaseDirectory string
 }
 
+func (r Run) WithTriggers(triggers []string) Run {
+	r.Triggers = triggers
+	return r
+}
+
 type Cmd struct {
 	Argv []string
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -207,9 +207,6 @@ type Cmd struct {
 	Argv []string
 }
 
-func ToCmd(argv ...string) Cmd {
-	return Cmd{argv}
-}
 func (c Cmd) IsShellStandardForm() bool {
 	return len(c.Argv) == 3 && c.Argv[0] == "sh" && c.Argv[1] == "-c" && !strings.Contains(c.Argv[2], "\n")
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -207,6 +207,9 @@ type Cmd struct {
 	Argv []string
 }
 
+func ToCmd(argv ...string) Cmd {
+	return Cmd{argv}
+}
 func (c Cmd) IsShellStandardForm() bool {
 	return len(c.Argv) == 3 && c.Argv[0] == "sh" && c.Argv[1] == "-c" && !strings.Contains(c.Argv[2], "\n")
 }


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/targets-for-live-upd:

8442ab8c58bde4092991fc0a55fcdf9849ad5ad3 (2019-03-28 16:45:22 -0400)
synclet BaD can handle LiveUpdate / tests green

ee7e5c0272d16ff931bd51c7f4780ea534603ab0 (2019-03-28 16:35:48 -0400)
red tests for synclet BaD

19182300872febdfa6daf21a9e7302a3b53f1c93 (2019-03-28 15:04:05 -0400)
are these tests better or worse?

8d2d5536ac6d61a724b7c81253f0764591df2d84 (2019-03-28 14:09:59 -0400)
behavior implemented for localContainerBuild / green tests

153e06faf47ee133aeca3440fb973a6398aaed87 (2019-03-28 13:16:24 -0400)
red test for localContainerBaD

e367c3b2ebb7f0f3514bab75a6af04ad57f3dcbd (2019-03-28 13:04:04 -0400)
extract liveupdate targets

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics