### PR TITLE
web: tweak LogPane styles a bit to make room for blinking cursor

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -124,7 +124,7 @@ class HUD extends Component<HudProps, HudState> {
         <Statusbar items={statusItems} toggleSidebar={this.toggleSidebar}  />
         <Switch>
           <Route exact path="/hud" render={() => <LogPane log={view.Log} />}/>
-          <Route exact path="/hud/r/:name/log" component={LogsRoute} />
+          <Route exact path="/hud/r/:name" component={LogsRoute} />
           <Route exact path="/hud/r/:name/k8s"  render={() => <K8sViewPane />}  />
           <Route exact path="/hud/r/:name/preview" render={() => <PreviewPane />} />
           <Route component={NoMatch} />

--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -1,0 +1,16 @@
+@import "constants.scss";
+
+.LogPane {
+  margin: $spacing-unit / 2;
+  font-size: $font-size-small;
+  margin-bottom: $statusbar-height + $spacing-unit / 2;
+}
+@keyframes blink {
+  0% { opacity: 1 }
+  50% { opacity: 0 }
+  100% { opacity: 1 }
+}
+.logEnd {
+  animation: blink 1s infinite;
+  animation-timing-function: ease;
+}

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -1,5 +1,6 @@
 import React, { Component, createRef } from 'react';
 import Ansi from "ansi-to-react";
+import "./LogPane.scss";
 
 type AnsiLineProps = {
   line: string
@@ -86,7 +87,7 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
       <div key="logEnd" className="logEnd" ref={(el) => { this.lastElement = el }}>&#9608;</div>
     )
 
-    return (<div>{els}</div>)
+    return (<div className="LogPane">{els}</div>)
   }
 }
 

--- a/web/src/Statusbar.scss
+++ b/web/src/Statusbar.scss
@@ -7,7 +7,7 @@
   bottom: 0;
   width: 100%;
   z-index: 1000;
-  height: $spacing-unit * 1.75;
+  height: $statusbar-height;
   color: $color-navy;
   background-color: $color-grey-lightest;
   display: flex;

--- a/web/src/__snapshots__/LogPane.test.tsx.snap
+++ b/web/src/__snapshots__/LogPane.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders logs 1`] = `
-<div>
+<div
+  className="LogPane"
+>
   <div>
     <code>
       <span

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -27,3 +27,4 @@ $opacity-light: 0.64;
 $spacing-unit:     32px;
 $sidebar-width: $spacing-unit * 10;
 $sidebar-maxWidth: 25vw;
+$statusbar-height: $spacing-unit * 1.75;


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/logpane:

aa563c19cbb88081ccadc6d2d7724abaf7260013 (2019-03-28 22:29:11 -0400)
web: tweak LogPane styles a bit to make room for blinking cursor