### PR TITLE
engine: change how we store/check run.triggers (so can better implement full_rebuild_trigger)"

### DIFF
--- a/internal/build/boil_runs.go
+++ b/internal/build/boil_runs.go
@@ -7,24 +7,20 @@ import (
 
 func BoilRuns(runs []model.Run, pathMappings []PathMapping) ([]model.Cmd, error) {
 	res := []model.Cmd{}
+	localPaths := PathMappingsToLocalPaths(pathMappings)
 	for _, run := range runs {
 		if run.Triggers == nil {
 			res = append(res, run.Cmd)
 			continue
 		}
-		matcher, err := ignore.CreateRunMatcher(run)
+
+		anyMatch, err := ignore.MatchesAnyPaths(run.Triggers, localPaths, run.BaseDirectory)
 		if err != nil {
-			return []model.Cmd{}, err
+			return nil, err
 		}
-		for _, pm := range pathMappings {
-			matches, err := matcher.Matches(pm.LocalPath, false)
-			if err != nil {
-				return []model.Cmd{}, err
-			}
-			if matches {
-				res = append(res, run.Cmd)
-				break
-			}
+
+		if anyMatch {
+			res = append(res, run.Cmd)
 		}
 	}
 	return res, nil

--- a/internal/build/boil_runs.go
+++ b/internal/build/boil_runs.go
@@ -9,12 +9,12 @@ func BoilRuns(runs []model.Run, pathMappings []PathMapping) ([]model.Cmd, error)
 	res := []model.Cmd{}
 	localPaths := PathMappingsToLocalPaths(pathMappings)
 	for _, run := range runs {
-		if run.Triggers == nil {
+		if run.Triggers.Empty() {
 			res = append(res, run.Cmd)
 			continue
 		}
 
-		anyMatch, err := ignore.MatchesAnyPaths(run.Triggers, localPaths, run.BaseDirectory)
+		anyMatch, err := ignore.AnyMatchGlobs(localPaths, run.Triggers)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/build/boil_runs.go
+++ b/internal/build/boil_runs.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"github.com/windmilleng/tilt/internal/ignore"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -14,7 +13,7 @@ func BoilRuns(runs []model.Run, pathMappings []PathMapping) ([]model.Cmd, error)
 			continue
 		}
 
-		anyMatch, err := ignore.AnyMatchGlobs(localPaths, run.Triggers)
+		anyMatch, err := model.AnyMatchGlobs(localPaths, run.Triggers)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/build/boil_runs.go
+++ b/internal/build/boil_runs.go
@@ -13,7 +13,7 @@ func BoilRuns(runs []model.Run, pathMappings []PathMapping) ([]model.Cmd, error)
 			continue
 		}
 
-		anyMatch, err := model.AnyMatchGlobs(localPaths, run.Triggers)
+		anyMatch, err := run.Triggers.AnyMatch(localPaths)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/build/boil_runs_test.go
+++ b/internal/build/boil_runs_test.go
@@ -102,7 +102,7 @@ func TestBoilRunsOneTriggerMatchingFile(t *testing.T) {
 	assert.ElementsMatch(t, expected, actual)
 }
 
-func TestBoilRunsOneTriggerMatchingAbsPath(t *testing.T) {
+func TestBoilRunsTriggerMatchingAbsPath(t *testing.T) {
 	triggers := []string{"/home/tilt/code/test/bar"}
 	runs := []model.Run{
 		model.Run{
@@ -119,6 +119,32 @@ func TestBoilRunsOneTriggerMatchingAbsPath(t *testing.T) {
 	}
 
 	expected := []model.Cmd{model.ToShellCmd("echo world")}
+
+	actual, err := BoilRuns(runs, pathMappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
+
+func TestBoilRunsTriggerNestedPathNoMatch(t *testing.T) {
+	triggers := []string{"bar"}
+	runs := []model.Run{
+		model.Run{
+			Cmd:      model.ToShellCmd("echo world"),
+			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
+		},
+	}
+
+	pathMappings := []PathMapping{
+		PathMapping{
+			LocalPath:     "/home/tilt/code/test/nested/bar",
+			ContainerPath: "/src/bar",
+		},
+	}
+
+	expected := []model.Cmd{}
 
 	actual, err := BoilRuns(runs, pathMappings)
 	if err != nil {

--- a/internal/build/boil_runs_test.go
+++ b/internal/build/boil_runs_test.go
@@ -102,6 +102,32 @@ func TestBoilRunsOneTriggerMatchingFile(t *testing.T) {
 	assert.ElementsMatch(t, expected, actual)
 }
 
+func TestBoilRunsOneTriggerMatchingAbsPath(t *testing.T) {
+	triggers := []string{"/home/tilt/code/test/bar"}
+	runs := []model.Run{
+		model.Run{
+			Cmd:      model.ToShellCmd("echo world"),
+			Triggers: model.NewGlobset(triggers, "/home/tilt/code/test"),
+		},
+	}
+
+	pathMappings := []PathMapping{
+		PathMapping{
+			LocalPath:     "/home/tilt/code/test/bar",
+			ContainerPath: "/src/bar",
+		},
+	}
+
+	expected := []model.Cmd{model.ToShellCmd("echo world")}
+
+	actual, err := BoilRuns(runs, pathMappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
+
 func TestBoilRunsManyTriggersManyFiles(t *testing.T) {
 	wd := "/home/tilt/code/test"
 	triggers1 := []string{"foo"}

--- a/internal/build/boil_runs_test.go
+++ b/internal/build/boil_runs_test.go
@@ -54,9 +54,8 @@ func TestBoilRunsOneTriggerFilesDontMatch(t *testing.T) {
 	triggers := []string{"bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:           model.ToShellCmd("echo hello"),
-			Triggers:      triggers,
-			BaseDirectory: "/home/tilt/code/test",
+			Cmd:      model.ToShellCmd("echo hello"),
+			Triggers: model.NewGlobset(triggers, "/home/tilt/code/test"),
 		},
 	}
 
@@ -81,9 +80,8 @@ func TestBoilRunsOneTriggerMatchingFile(t *testing.T) {
 	triggers := []string{"bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:           model.ToShellCmd("echo world"),
-			Triggers:      triggers,
-			BaseDirectory: "/home/tilt/code/test",
+			Cmd:      model.ToShellCmd("echo world"),
+			Triggers: model.NewGlobset(triggers, "/home/tilt/code/test"),
 		},
 	}
 
@@ -110,14 +108,12 @@ func TestBoilRunsManyTriggersManyFiles(t *testing.T) {
 	triggers2 := []string{"bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:           model.ToShellCmd("echo hello"),
-			Triggers:      triggers1,
-			BaseDirectory: wd,
+			Cmd:      model.ToShellCmd("echo hello"),
+			Triggers: model.NewGlobset(triggers1, wd),
 		},
 		model.Run{
-			Cmd:           model.ToShellCmd("echo world"),
-			Triggers:      triggers2,
-			BaseDirectory: wd,
+			Cmd:      model.ToShellCmd("echo world"),
+			Triggers: model.NewGlobset(triggers2, wd),
 		},
 	}
 

--- a/internal/build/boil_runs_test.go
+++ b/internal/build/boil_runs_test.go
@@ -55,7 +55,7 @@ func TestBoilRunsOneTriggerFilesDontMatch(t *testing.T) {
 	runs := []model.Run{
 		model.Run{
 			Cmd:      model.ToShellCmd("echo hello"),
-			Triggers: model.NewGlobset(triggers, "/home/tilt/code/test"),
+			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
 		},
 	}
 
@@ -81,7 +81,7 @@ func TestBoilRunsOneTriggerMatchingFile(t *testing.T) {
 	runs := []model.Run{
 		model.Run{
 			Cmd:      model.ToShellCmd("echo world"),
-			Triggers: model.NewGlobset(triggers, "/home/tilt/code/test"),
+			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
 		},
 	}
 
@@ -107,7 +107,7 @@ func TestBoilRunsOneTriggerMatchingAbsPath(t *testing.T) {
 	runs := []model.Run{
 		model.Run{
 			Cmd:      model.ToShellCmd("echo world"),
-			Triggers: model.NewGlobset(triggers, "/home/tilt/code/test"),
+			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
 		},
 	}
 
@@ -135,11 +135,11 @@ func TestBoilRunsManyTriggersManyFiles(t *testing.T) {
 	runs := []model.Run{
 		model.Run{
 			Cmd:      model.ToShellCmd("echo hello"),
-			Triggers: model.NewGlobset(triggers1, wd),
+			Triggers: model.NewPathSet(triggers1, wd),
 		},
 		model.Run{
 			Cmd:      model.ToShellCmd("echo world"),
-			Triggers: model.NewGlobset(triggers2, wd),
+			Triggers: model.NewPathSet(triggers2, wd),
 		},
 	}
 

--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -599,7 +599,7 @@ func TestConditionalRunInRealDocker(t *testing.T) {
 	}
 	run1 := model.Run{
 		Cmd:      model.ToShellCmd("cat /src/a.txt >> /src/c.txt"),
-		Triggers: model.NewGlobset([]string{"a.txt"}, f.Path()),
+		Triggers: model.NewPathSet([]string{"a.txt"}, f.Path()),
 	}
 	run2 := model.Run{
 		Cmd: model.ToShellCmd("cat /src/b.txt >> /src/d.txt"),

--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -245,7 +245,7 @@ func TestBuildOneRun(t *testing.T) {
 	f := newDockerBuildFixture(t)
 	defer f.teardown()
 
-	runs := model.ToRuns(f.Path(), []model.Cmd{
+	runs := model.ToRuns([]model.Cmd{
 		model.ToShellCmd("echo -n hello >> hi"),
 	})
 
@@ -264,7 +264,7 @@ func TestBuildMultipleRuns(t *testing.T) {
 	f := newDockerBuildFixture(t)
 	defer f.teardown()
 
-	runs := model.ToRuns(f.Path(), []model.Cmd{
+	runs := model.ToRuns([]model.Cmd{
 		model.ToShellCmd("echo -n hello >> hi"),
 		model.ToShellCmd("echo -n sup >> hi2"),
 	})
@@ -285,7 +285,7 @@ func TestBuildMultipleRunsRemoveFiles(t *testing.T) {
 	f := newDockerBuildFixture(t)
 	defer f.teardown()
 
-	runs := model.ToRuns(f.Path(), []model.Cmd{
+	runs := model.ToRuns([]model.Cmd{
 		model.Cmd{Argv: []string{"sh", "-c", "echo -n hello >> hi"}},
 		model.Cmd{Argv: []string{"sh", "-c", "echo -n sup >> hi2"}},
 		model.Cmd{Argv: []string{"sh", "-c", "rm hi"}},
@@ -307,7 +307,7 @@ func TestBuildFailingRun(t *testing.T) {
 	f := newDockerBuildFixture(t)
 	defer f.teardown()
 
-	runs := model.ToRuns(f.Path(), []model.Cmd{
+	runs := model.ToRuns([]model.Cmd{
 		model.ToShellCmd("echo hello && exit 1"),
 	})
 
@@ -417,7 +417,7 @@ func TestExecRunsOnExisting(t *testing.T) {
 
 	run := model.ToShellCmd("echo -n foo contains: $(cat /src/foo) >> /src/bar")
 
-	runs := model.ToRuns(f.Path(), []model.Cmd{run})
+	runs := model.ToRuns([]model.Cmd{run})
 	ref, err := f.b.BuildImageFromExisting(f.ctx, f.ps, existing, SyncsToPathMappings([]model.Sync{s}), model.EmptyMatcher, runs)
 	if err != nil {
 		t.Fatal(err)
@@ -477,7 +477,7 @@ func TestBuildDockerWithRunsFromExistingPreservesEntrypoint(t *testing.T) {
 	run := model.ToShellCmd("echo -n hello >> /src/baz")
 	entrypoint := model.ToShellCmd("echo -n foo contains: $(cat /src/foo) >> /src/bar")
 
-	runs := model.ToRuns(f.Path(), []model.Cmd{run})
+	runs := model.ToRuns([]model.Cmd{run})
 	existing, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, []model.Sync{s}, model.EmptyMatcher, runs, entrypoint)
 	if err != nil {
 		t.Fatal(err)
@@ -522,7 +522,7 @@ func TestUpdateInContainerE2E(t *testing.T) {
 	entrypoint := model.ToShellCmd(
 		"echo -n $(($(cat /src/startcount)+1)) > /src/startcount && sleep 210")
 
-	runs := model.ToRuns(f.Path(), []model.Cmd{initStartcount})
+	runs := model.ToRuns([]model.Cmd{initStartcount})
 	imgRef, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, []model.Sync{s}, model.EmptyMatcher, runs, entrypoint)
 	if err != nil {
 		t.Fatal(err)
@@ -598,9 +598,8 @@ func TestConditionalRunInRealDocker(t *testing.T) {
 		ContainerPath: "/src",
 	}
 	run1 := model.Run{
-		Cmd:           model.ToShellCmd("cat /src/a.txt >> /src/c.txt"),
-		Triggers:      []string{"a.txt"},
-		BaseDirectory: f.Path(),
+		Cmd:      model.ToShellCmd("cat /src/a.txt >> /src/c.txt"),
+		Triggers: model.NewGlobset([]string{"a.txt"}, f.Path()),
 	}
 	run2 := model.Run{
 		Cmd: model.ToShellCmd("cat /src/b.txt >> /src/d.txt"),

--- a/internal/build/docker_benchmark_test.go
+++ b/internal/build/docker_benchmark_test.go
@@ -19,7 +19,7 @@ func BenchmarkBuildTenRuns(b *testing.B) {
 		for i := 0; i < 10; i++ {
 			cmds = append(cmds, model.ToShellCmd(fmt.Sprintf("echo -n %d > hi", i)))
 		}
-		runs := model.ToRuns(f.Path(), cmds)
+		runs := model.ToRuns(cmds)
 
 		ref, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, []model.Sync{}, model.EmptyMatcher, runs, model.Cmd{})
 		if err != nil {
@@ -48,7 +48,7 @@ func BenchmarkBuildTenRunsInOne(b *testing.B) {
 
 		oneCmd := strings.Join(allCmds, " && ")
 
-		runs := model.ToRuns(f.Path(), []model.Cmd{model.ToShellCmd(oneCmd)})
+		runs := model.ToRuns([]model.Cmd{model.ToShellCmd(oneCmd)})
 		ref, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, nil, model.EmptyMatcher, runs, model.Cmd{})
 		if err != nil {
 			b.Fatal(err)
@@ -67,7 +67,7 @@ func BenchmarkBuildTenRunsInOne(b *testing.B) {
 func BenchmarkIterativeBuildTenTimes(b *testing.B) {
 	f := newDockerBuildFixture(b)
 	defer f.teardown()
-	runs := model.ToRuns(f.Path(), []model.Cmd{model.ToShellCmd("echo 1 >> hi")})
+	runs := model.ToRuns([]model.Cmd{model.ToShellCmd("echo 1 >> hi")})
 	ref, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, nil, model.EmptyMatcher, runs, model.Cmd{})
 	if err != nil {
 		b.Fatal(err)

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -131,7 +131,7 @@ func (d *dockerImageBuilder) addConditionalRuns(df dockerfile.Dockerfile, runs [
 	consumed := 0
 	for _, run := range runs {
 		if run.Triggers.Empty() {
-			continue
+			break
 		}
 
 		matcher, err := ignore.CreateRunMatcher(run)

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -130,8 +130,8 @@ func (d *dockerImageBuilder) applyLabels(df dockerfile.Dockerfile, buildMode doc
 func (d *dockerImageBuilder) addConditionalRuns(df dockerfile.Dockerfile, runs []model.Run, paths []PathMapping) (dockerfile.Dockerfile, []model.Run, error) {
 	consumed := 0
 	for _, run := range runs {
-		if run.Triggers == nil {
-			break
+		if run.Triggers.Empty() {
+			continue
 		}
 
 		matcher, err := ignore.CreateRunMatcher(run)

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -104,9 +104,8 @@ func TestConditionalRunInFakeDocker(t *testing.T) {
 		ContainerPath: "/src",
 	}
 	run1 := model.Run{
-		Cmd:           model.ToShellCmd("cat /src/a.txt > /src/c.txt"),
-		Triggers:      []string{"a.txt"},
-		BaseDirectory: f.Path(),
+		Cmd:      model.ToShellCmd("cat /src/a.txt > /src/c.txt"),
+		Triggers: model.NewGlobset([]string{"a.txt"}, f.Path()),
 	}
 	run2 := model.Run{
 		Cmd: model.ToShellCmd("cat /src/b.txt > /src/d.txt"),
@@ -142,9 +141,8 @@ func TestAllConditionalRunsInFakeDocker(t *testing.T) {
 		ContainerPath: "/src",
 	}
 	run1 := model.Run{
-		Cmd:           model.ToShellCmd("cat /src/a.txt > /src/c.txt"),
-		Triggers:      []string{"a.txt"},
-		BaseDirectory: f.Path(),
+		Cmd:      model.ToShellCmd("cat /src/a.txt > /src/c.txt"),
+		Triggers: model.NewGlobset([]string{"a.txt"}, f.Path()),
 	}
 
 	_, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, []model.Sync{s}, model.EmptyMatcher, []model.Run{run1}, model.Cmd{})

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -105,7 +105,7 @@ func TestConditionalRunInFakeDocker(t *testing.T) {
 	}
 	run1 := model.Run{
 		Cmd:      model.ToShellCmd("cat /src/a.txt > /src/c.txt"),
-		Triggers: model.NewGlobset([]string{"a.txt"}, f.Path()),
+		Triggers: model.NewPathSet([]string{"a.txt"}, f.Path()),
 	}
 	run2 := model.Run{
 		Cmd: model.ToShellCmd("cat /src/b.txt > /src/d.txt"),
@@ -142,7 +142,7 @@ func TestAllConditionalRunsInFakeDocker(t *testing.T) {
 	}
 	run1 := model.Run{
 		Cmd:      model.ToShellCmd("cat /src/a.txt > /src/c.txt"),
-		Triggers: model.NewGlobset([]string{"a.txt"}, f.Path()),
+		Triggers: model.NewPathSet([]string{"a.txt"}, f.Path()),
 	}
 
 	_, err := f.b.BuildImageFromScratch(f.ctx, f.ps, f.getNameFromTest(), simpleDockerfile, []model.Sync{s}, model.EmptyMatcher, []model.Run{run1}, model.Cmd{})

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -187,6 +187,14 @@ func PathMappingsToContainerPaths(mappings []PathMapping) []string {
 	return res
 }
 
+func PathMappingsToLocalPaths(mappings []PathMapping) []string {
+	res := make([]string, len(mappings))
+	for i, m := range mappings {
+		res[i] = m.LocalPath
+	}
+	return res
+}
+
 type PathMappingErr struct {
 	s string
 }

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -148,8 +148,8 @@ func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
 
 	runs := []model.LiveUpdateRunStep{
 		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo hello")},
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo a"), Triggers: f.NewGlobset("a.txt")}, // matches changed file
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo b"), Triggers: f.NewGlobset("b.txt")}, // does NOT match changed file
+		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
+		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
 	}
 	lu := assembleLiveUpdate(t, SanchoSyncSteps(f), runs, true, nil)
 	tCase := testCase{
@@ -172,8 +172,8 @@ func TestLiveUpdateRunTriggerSynclet(t *testing.T) {
 
 	runs := []model.LiveUpdateRunStep{
 		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo hello")},
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo a"), Triggers: f.NewGlobset("a.txt")}, // matches changed file
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo b"), Triggers: f.NewGlobset("b.txt")}, // does NOT match changed file
+		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
+		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
 	}
 	lu := assembleLiveUpdate(t, SanchoSyncSteps(f), runs, true, nil)
 	tCase := testCase{

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -145,7 +145,7 @@ func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
 
 	runs := []model.LiveUpdateRunStep{{
 		Command:  model.ToShellCmd("echo hi"),
-		Triggers: []string{"b.txt"}, // does NOT match changed file
+		Triggers: f.NewGlobset("b.txt"), // does NOT match changed file
 	}}
 	lu := assembleLiveUpdate(t, SanchoSyncSteps(f), runs, true, nil)
 	tCase := testCase{

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -196,8 +196,8 @@ func TestContainerBuildLocalTriggeredRuns(t *testing.T) {
 	fb := iTarg.FastBuildInfo()
 	runs := []model.Run{
 		model.Run{Cmd: model.ToShellCmd("echo hello")},
-		model.Run{Cmd: model.ToShellCmd("echo a"), Triggers: f.NewGlobset("a.txt")}, // matches changed file
-		model.Run{Cmd: model.ToShellCmd("echo b"), Triggers: f.NewGlobset("b.txt")}, // does NOT match changed file
+		model.Run{Cmd: model.ToShellCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
+		model.Run{Cmd: model.ToShellCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
 	}
 	fb.Runs = runs
 	iTarg = iTarg.WithBuildDetails(fb)
@@ -240,8 +240,8 @@ func TestContainerBuildSyncletTriggeredRuns(t *testing.T) {
 	fb := iTarg.FastBuildInfo()
 	runs := []model.Run{
 		model.Run{Cmd: model.ToShellCmd("echo hello")},
-		model.Run{Cmd: model.ToShellCmd("echo a"), Triggers: f.NewGlobset("a.txt")}, // matches changed file
-		model.Run{Cmd: model.ToShellCmd("echo b"), Triggers: f.NewGlobset("b.txt")}, // does NOT match changed file
+		model.Run{Cmd: model.ToShellCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
+		model.Run{Cmd: model.ToShellCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
 	}
 	fb.Runs = runs
 	iTarg = iTarg.WithBuildDetails(fb)

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -186,6 +186,91 @@ func TestContainerBuildSynclet(t *testing.T) {
 	assert.False(t, f.sCli.UpdateContainerHotReload)
 }
 
+func TestContainerBuildLocalTriggeredRuns(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop)
+	defer f.TearDown()
+
+	changed := f.WriteFile("a.txt", "a")
+	manifest := NewSanchoFastBuildManifest(f)
+	iTarg := manifest.ImageTargetAt(0)
+	fb := iTarg.FastBuildInfo()
+	runs := []model.Run{
+		model.Run{Cmd: model.ToShellCmd("echo hello")},
+		model.Run{Cmd: model.ToShellCmd("echo a"), Triggers: f.NewGlobset("a.txt")}, // matches changed file
+		model.Run{Cmd: model.ToShellCmd("echo b"), Triggers: f.NewGlobset("b.txt")}, // does NOT match changed file
+	}
+	fb.Runs = runs
+	iTarg = iTarg.WithBuildDetails(fb)
+	manifest = manifest.WithImageTarget(iTarg)
+
+	targets := buildTargets(manifest)
+	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
+	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.docker.BuildCount != 0 {
+		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
+	}
+	if f.docker.PushCount != 0 {
+		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	}
+	if f.docker.CopyCount != 1 {
+		t.Errorf("Expected 1 copy to docker container call, actual: %d", f.docker.CopyCount)
+	}
+	if len(f.docker.ExecCalls) != 2 {
+		t.Errorf("Expected 2 exec in container calls, actual: %d", len(f.docker.ExecCalls))
+	}
+	f.assertContainerRestarts(1)
+
+	id := manifest.ImageTargetAt(0).ID()
+	_, hasResult := result[id]
+	assert.True(t, hasResult)
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+}
+
+func TestContainerBuildSyncletTriggeredRuns(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvGKE)
+	defer f.TearDown()
+
+	changed := f.WriteFile("a.txt", "a")
+	manifest := NewSanchoFastBuildManifest(f)
+	iTarg := manifest.ImageTargetAt(0)
+	fb := iTarg.FastBuildInfo()
+	runs := []model.Run{
+		model.Run{Cmd: model.ToShellCmd("echo hello")},
+		model.Run{Cmd: model.ToShellCmd("echo a"), Triggers: f.NewGlobset("a.txt")}, // matches changed file
+		model.Run{Cmd: model.ToShellCmd("echo b"), Triggers: f.NewGlobset("b.txt")}, // does NOT match changed file
+	}
+	fb.Runs = runs
+	iTarg = iTarg.WithBuildDetails(fb)
+	manifest = manifest.WithImageTarget(iTarg)
+
+	targets := buildTargets(manifest)
+	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, f.deployInfo())
+	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.docker.BuildCount != 0 {
+		t.Errorf("Expected no docker build, actual: %d", f.docker.BuildCount)
+	}
+	if f.docker.PushCount != 0 {
+		t.Errorf("Expected no push to docker, actual: %d", f.docker.PushCount)
+	}
+	if f.sCli.UpdateContainerCount != 1 {
+		t.Errorf("Expected 1 synclet containerUpdate, actual: %d", f.sCli.UpdateContainerCount)
+	}
+	if f.sCli.CommandsRunCount != 2 {
+		t.Errorf("Expected 2 commands run by the synclet, actual: %d", f.sCli.CommandsRunCount)
+	}
+
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	assert.False(t, f.sCli.UpdateContainerHotReload)
+}
+
 func TestContainerBuildSyncletHotReload(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -68,31 +68,34 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 		return store.BuildResultSet{}, RedirectToNextBuilderf("prev. build state is empty; container build does not support initial deploy")
 	}
 
-	var syncs []model.Sync
+	var changedFiles []build.PathMapping
 	var runs []model.Run
 	var hotReload bool
 
 	if fbInfo := iTarget.MaybeFastBuildInfo(); fbInfo != nil {
-		syncs = fbInfo.Syncs
+		changedFiles, err = build.FilesToPathMappings(state.FilesChanged(), fbInfo.Syncs)
+		if err != nil {
+			return store.BuildResultSet{}, err
+		}
 		runs = fbInfo.Runs
 		hotReload = fbInfo.HotReload
 	}
 	if luInfo := iTarget.MaybeLiveUpdateInfo(); luInfo != nil {
-		syncs = luInfo.SyncSteps()
+		changedFiles, err = build.FilesToPathMappings(state.FilesChanged(), luInfo.SyncSteps())
+		if err != nil {
+			return store.BuildResultSet{}, err
+		}
+
 		runs = luInfo.RunSteps()
 		hotReload = !luInfo.ShouldRestart()
 	}
-	return cbd.buildAndDeploy(ctx, iTarget, state, syncs, runs, hotReload)
+	return cbd.buildAndDeploy(ctx, iTarget, state, changedFiles, runs, hotReload)
 }
 
-func (cbd *LocalContainerBuildAndDeployer) buildAndDeploy(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, syncs []model.Sync, runs []model.Run, hotReload bool) (store.BuildResultSet, error) {
+func (cbd *LocalContainerBuildAndDeployer) buildAndDeploy(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, changedFiles []build.PathMapping, runs []model.Run, hotReload bool) (store.BuildResultSet, error) {
 	deployInfo := state.DeployInfo
-	cf, err := build.FilesToPathMappings(state.FilesChanged(), syncs)
-	if err != nil {
-		return store.BuildResultSet{}, err
-	}
 	logger.Get(ctx).Infof("  → Updating container…")
-	boiledSteps, err := build.BoilRuns(runs, cf)
+	boiledSteps, err := build.BoilRuns(runs, changedFiles)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
@@ -100,7 +103,7 @@ func (cbd *LocalContainerBuildAndDeployer) buildAndDeploy(ctx context.Context, i
 	// TODO - use PipelineState here when we actually do pipeline output for container builds
 	writer := logger.Get(ctx).Writer(logger.InfoLvl)
 
-	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, cf, ignore.CreateBuildContextFilter(iTarget), boiledSteps, hotReload, writer)
+	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, changedFiles, ignore.CreateBuildContextFilter(iTarget), boiledSteps, hotReload, writer)
 	if err != nil {
 		if build.IsUserBuildFailure(err) {
 			return store.BuildResultSet{}, WrapDontFallBackError(err)

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -68,34 +68,31 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 		return store.BuildResultSet{}, RedirectToNextBuilderf("prev. build state is empty; container build does not support initial deploy")
 	}
 
-	var changedFiles []build.PathMapping
+	var syncs []model.Sync
 	var runs []model.Run
 	var hotReload bool
 
 	if fbInfo := iTarget.MaybeFastBuildInfo(); fbInfo != nil {
-		changedFiles, err = build.FilesToPathMappings(state.FilesChanged(), fbInfo.Syncs)
-		if err != nil {
-			return store.BuildResultSet{}, err
-		}
+		syncs = fbInfo.Syncs
 		runs = fbInfo.Runs
 		hotReload = fbInfo.HotReload
 	}
 	if luInfo := iTarget.MaybeLiveUpdateInfo(); luInfo != nil {
-		changedFiles, err = build.FilesToPathMappings(state.FilesChanged(), luInfo.SyncSteps())
-		if err != nil {
-			return store.BuildResultSet{}, err
-		}
-
+		syncs = luInfo.SyncSteps()
 		runs = luInfo.RunSteps()
 		hotReload = !luInfo.ShouldRestart()
 	}
-	return cbd.buildAndDeploy(ctx, iTarget, state, changedFiles, runs, hotReload)
+	return cbd.buildAndDeploy(ctx, iTarget, state, syncs, runs, hotReload)
 }
 
-func (cbd *LocalContainerBuildAndDeployer) buildAndDeploy(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, changedFiles []build.PathMapping, runs []model.Run, hotReload bool) (store.BuildResultSet, error) {
+func (cbd *LocalContainerBuildAndDeployer) buildAndDeploy(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, syncs []model.Sync, runs []model.Run, hotReload bool) (store.BuildResultSet, error) {
 	deployInfo := state.DeployInfo
+	cf, err := build.FilesToPathMappings(state.FilesChanged(), syncs)
+	if err != nil {
+		return store.BuildResultSet{}, err
+	}
 	logger.Get(ctx).Infof("  → Updating container…")
-	boiledSteps, err := build.BoilRuns(runs, changedFiles)
+	boiledSteps, err := build.BoilRuns(runs, cf)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
@@ -103,7 +100,7 @@ func (cbd *LocalContainerBuildAndDeployer) buildAndDeploy(ctx context.Context, i
 	// TODO - use PipelineState here when we actually do pipeline output for container builds
 	writer := logger.Get(ctx).Writer(logger.InfoLvl)
 
-	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, changedFiles, ignore.CreateBuildContextFilter(iTarget), boiledSteps, hotReload, writer)
+	err = cbd.cu.UpdateInContainer(ctx, deployInfo.ContainerID, cf, ignore.CreateBuildContextFilter(iTarget), boiledSteps, hotReload, writer)
 	if err != nil {
 		if build.IsUserBuildFailure(err) {
 			return store.BuildResultSet{}, WrapDontFallBackError(err)

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -40,7 +40,7 @@ func NewSanchoFastBuild(fixture pather) model.FastBuild {
 				ContainerPath: "/go/src/github.com/windmilleng/sancho",
 			},
 		},
-		Runs: model.ToRuns("/", []model.Cmd{
+		Runs: model.ToRuns([]model.Cmd{
 			model.Cmd{Argv: []string{"go", "install", "github.com/windmilleng/sancho"}},
 		}),
 		Entrypoint: model.Cmd{Argv: []string{"/go/bin/sancho"}},

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -851,8 +851,7 @@ k8s_resource('foobar', 'snack.yaml')
 
 	f.withManifestTarget(name, func(mt store.ManifestTarget) {
 		expectedRuns := []model.Run{{
-			Cmd:           model.ToShellCmd("changed"),
-			BaseDirectory: f.Path(),
+			Cmd: model.ToShellCmd("changed"),
 		}}
 		assert.Equal(t, expectedRuns, mt.Manifest.ImageTargetAt(0).FastBuildInfo().Runs)
 	})

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -108,12 +108,35 @@ func CreateFileChangeFilter(m IgnorableTarget) (model.PathMatcher, error) {
 }
 
 func CreateRunMatcher(r model.Run) (model.PathMatcher, error) {
-	dim, err := dockerignore.NewDockerPatternMatcher(r.BaseDirectory, r.Triggers)
+	return CreateTriggerMatcher(r.Triggers, r.BaseDirectory)
+}
+
+func CreateTriggerMatcher(triggers []string, baseDir string) (model.PathMatcher, error) {
+	dim, err := dockerignore.NewDockerPatternMatcher(baseDir, triggers)
 	if err != nil {
 		return nil, err
 	}
 
 	return dim, nil
+}
+
+// MatchesAnyPaths returns true if any of the given patterns match any of the given filepaths.
+func MatchesAnyPaths(patterns, paths []string, baseDir string) (bool, error) {
+	matcher, err := CreateTriggerMatcher(patterns, baseDir)
+	if err != nil {
+		return false, err
+	}
+
+	for _, path := range paths {
+		match, err := matcher.Matches(path, false)
+		if err != nil {
+			return false, err
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // Emacs temp files look like:

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -108,7 +108,7 @@ func CreateFileChangeFilter(m IgnorableTarget) (model.PathMatcher, error) {
 }
 
 func CreateRunMatcher(r model.Run) (model.PathMatcher, error) {
-	return CreateTriggerMatcher(r.Triggers, r.BaseDirectory)
+	return CreateTriggerMatcher(r.Triggers.Globs, r.Triggers.BaseDirectory)
 }
 
 func CreateTriggerMatcher(triggers []string, baseDir string) (model.PathMatcher, error) {
@@ -120,9 +120,9 @@ func CreateTriggerMatcher(triggers []string, baseDir string) (model.PathMatcher,
 	return dim, nil
 }
 
-// MatchesAnyPaths returns true if any of the given patterns match any of the given filepaths.
-func MatchesAnyPaths(patterns, paths []string, baseDir string) (bool, error) {
-	matcher, err := CreateTriggerMatcher(patterns, baseDir)
+// AnyMatchGlobs returns true if any of the given filepaths match any of the given globs.
+func AnyMatchGlobs(paths []string, globs model.Globset) (bool, error) {
+	matcher, err := CreateTriggerMatcher(globs.Globs, globs.BaseDirectory)
 	if err != nil {
 		return false, err
 	}

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -120,25 +120,6 @@ func CreateTriggerMatcher(triggers []string, baseDir string) (model.PathMatcher,
 	return dim, nil
 }
 
-// AnyMatchGlobs returns true if any of the given filepaths match any of the given globs.
-func AnyMatchGlobs(paths []string, globs model.Globset) (bool, error) {
-	matcher, err := CreateTriggerMatcher(globs.Globs, globs.BaseDirectory)
-	if err != nil {
-		return false, err
-	}
-
-	for _, path := range paths {
-		match, err := matcher.Matches(path, false)
-		if err != nil {
-			return false, err
-		}
-		if match {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // Emacs temp files look like:
 // .#a.txt -> [some garbage]
 type tempBrokenSymlinkMatcher struct{}

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -108,7 +108,7 @@ func CreateFileChangeFilter(m IgnorableTarget) (model.PathMatcher, error) {
 }
 
 func CreateRunMatcher(r model.Run) (model.PathMatcher, error) {
-	return CreateTriggerMatcher(r.Triggers.Globs, r.Triggers.BaseDirectory)
+	return CreateTriggerMatcher(r.Triggers.Paths, r.Triggers.BaseDirectory)
 }
 
 func CreateTriggerMatcher(triggers []string, baseDir string) (model.PathMatcher, error) {

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -108,11 +108,7 @@ func CreateFileChangeFilter(m IgnorableTarget) (model.PathMatcher, error) {
 }
 
 func CreateRunMatcher(r model.Run) (model.PathMatcher, error) {
-	return CreateTriggerMatcher(r.Triggers.Paths, r.Triggers.BaseDirectory)
-}
-
-func CreateTriggerMatcher(triggers []string, baseDir string) (model.PathMatcher, error) {
-	dim, err := dockerignore.NewDockerPatternMatcher(baseDir, triggers)
+	dim, err := dockerignore.NewDockerPatternMatcher(r.Triggers.BaseDirectory, r.Triggers.Paths)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -10,7 +10,7 @@ import (
 type LiveUpdate struct {
 	Steps []LiveUpdateStep
 
-	// When files matching any of these globs change, we should fall back to a full rebuild.
+	// When files matching any of these paths change, we should fall back to a full rebuild.
 	FullRebuildTriggers []string
 }
 
@@ -53,10 +53,10 @@ func (l LiveUpdateSyncStep) toSync() Sync {
 
 // Specifies that `Command` should be executed when any files in `Sync` steps have changed
 // If `Trigger` is non-empty, `Command` will only be executed when the local paths of changed files covered by
-// at least one `Sync` match one of `Globset.Globs` (evaluated relative to `Globset.BaseDirectory`.
+// at least one `Sync` match one of `PathSet.Paths` (evaluated relative to `PathSet.BaseDirectory`.
 type LiveUpdateRunStep struct {
 	Command  Cmd
-	Triggers Globset
+	Triggers PathSet
 }
 
 func (l LiveUpdateRunStep) liveUpdateStep() {}

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -44,7 +44,6 @@ type LiveUpdateSyncStep struct {
 
 func (l LiveUpdateSyncStep) liveUpdateStep() {}
 
-// TODO(maia): s/Sync/Sync
 func (l LiveUpdateSyncStep) toSync() Sync {
 	return Sync{
 		LocalPath:     l.Source,
@@ -54,10 +53,10 @@ func (l LiveUpdateSyncStep) toSync() Sync {
 
 // Specifies that `Command` should be executed when any files in `Sync` steps have changed
 // If `Trigger` is non-empty, `Command` will only be executed when the local paths of changed files covered by
-// at least one `Sync` match the glob in `Trigger`.
+// at least one `Sync` match one of `Globset.Globs` (evaluated relative to `Globset.BaseDirectory`.
 type LiveUpdateRunStep struct {
 	Command  Cmd
-	Triggers []string
+	Triggers Globset
 }
 
 func (l LiveUpdateRunStep) liveUpdateStep() {}

--- a/internal/model/live_update_test.go
+++ b/internal/model/live_update_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewLiveUpdate(t *testing.T) {
 	steps := []LiveUpdateStep{
 		LiveUpdateSyncStep{"foo", "bar"},
-		LiveUpdateRunStep{Cmd{[]string{"hello"}}, NewGlobset([]string{"goodbye"}, "/home")},
+		LiveUpdateRunStep{Cmd{[]string{"hello"}}, NewPathSet([]string{"goodbye"}, "/home")},
 		LiveUpdateRestartContainerStep{},
 	}
 	fullRebuildTriggers := []string{"quu", "qux"}

--- a/internal/model/live_update_test.go
+++ b/internal/model/live_update_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewLiveUpdate(t *testing.T) {
 	steps := []LiveUpdateStep{
 		LiveUpdateSyncStep{"foo", "bar"},
-		LiveUpdateRunStep{Cmd{[]string{"hello"}}, []string{"goodbye"}},
+		LiveUpdateRunStep{Cmd{[]string{"hello"}}, NewGlobset([]string{"goodbye"}, "/home")},
 		LiveUpdateRestartContainerStep{},
 	}
 	fullRebuildTriggers := []string{"quu", "qux"}

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -188,9 +188,10 @@ type LocalGitRepo struct {
 
 func (LocalGitRepo) IsRepo() {}
 
+// A Globset stores one or more Globs, along with the director that should be evaluated relative to.
 type Globset struct {
 	Globs         []string
-	BaseDirectory string // Directory the globs are relative to
+	BaseDirectory string
 }
 
 func (gs Globset) Empty() bool { return len(gs.Globs) == 0 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -188,18 +188,35 @@ type LocalGitRepo struct {
 
 func (LocalGitRepo) IsRepo() {}
 
+type Globset struct {
+	Globs         []string
+	BaseDirectory string // Directory the globs are relative to
+}
+
+func (gs Globset) Empty() bool { return len(gs.Globs) == 0 }
+
+func NewGlobset(globs []string, baseDir string) Globset {
+	return Globset{
+		Globs:         globs,
+		BaseDirectory: baseDir,
+	}
+}
+
 type Run struct {
 	// Required. The command to run.
 	Cmd Cmd
 	// Optional. If not specified, this command runs on every change.
-	// If specified, we only run the Cmd if the trigger matches the changed file.
-	Triggers []string
-	// Directory the Triggers are relative to
-	BaseDirectory string
+	// If specified, we only run the Cmd if the changed file matches a trigger.
+	Triggers Globset
 }
 
-func (r Run) WithTriggers(triggers []string) Run {
-	r.Triggers = triggers
+func (r Run) WithTriggers(globs []string, baseDir string) Run {
+	if len(globs) > 0 {
+		r.Triggers = Globset{
+			Globs:         globs,
+			BaseDirectory: baseDir,
+		}
+	}
 	return r
 }
 
@@ -278,14 +295,14 @@ func ToShellCmds(cmds []string) []Cmd {
 	return res
 }
 
-func ToRun(cwd string, cmd Cmd) Run {
-	return Run{BaseDirectory: cwd, Cmd: cmd}
+func ToRun(cmd Cmd) Run {
+	return Run{Cmd: cmd}
 }
 
-func ToRuns(cwd string, cmds []Cmd) []Run {
+func ToRuns(cmds []Cmd) []Run {
 	res := make([]Run, len(cmds))
 	for i, cmd := range cmds {
-		res[i] = ToRun(cwd, cmd)
+		res[i] = ToRun(cmd)
 	}
 	return res
 }

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -188,33 +188,18 @@ type LocalGitRepo struct {
 
 func (LocalGitRepo) IsRepo() {}
 
-// A Globset stores one or more Globs, along with the director that should be evaluated relative to.
-type Globset struct {
-	Globs         []string
-	BaseDirectory string
-}
-
-func (gs Globset) Empty() bool { return len(gs.Globs) == 0 }
-
-func NewGlobset(globs []string, baseDir string) Globset {
-	return Globset{
-		Globs:         globs,
-		BaseDirectory: baseDir,
-	}
-}
-
 type Run struct {
 	// Required. The command to run.
 	Cmd Cmd
 	// Optional. If not specified, this command runs on every change.
 	// If specified, we only run the Cmd if the changed file matches a trigger.
-	Triggers Globset
+	Triggers PathSet
 }
 
-func (r Run) WithTriggers(globs []string, baseDir string) Run {
-	if len(globs) > 0 {
-		r.Triggers = Globset{
-			Globs:         globs,
+func (r Run) WithTriggers(paths []string, baseDir string) Run {
+	if len(paths) > 0 {
+		r.Triggers = PathSet{
+			Paths:         paths,
 			BaseDirectory: baseDir,
 		}
 	}

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -202,6 +202,8 @@ func (r Run) WithTriggers(paths []string, baseDir string) Run {
 			Paths:         paths,
 			BaseDirectory: baseDir,
 		}
+	} else {
+		r.Triggers = PathSet{}
 	}
 	return r
 }

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -40,19 +40,19 @@ var stepSayHi = Run{Cmd: cmdSayHi}
 var stepSayBye = Run{Cmd: cmdSayBye}
 var stepSayHiTriggerFoo = Run{
 	Cmd:      cmdSayHi,
-	Triggers: NewGlobset([]string{"foo"}, "/src"),
+	Triggers: NewPathSet([]string{"foo"}, "/src"),
 }
 var stepSayHiTriggerBar = Run{
 	Cmd:      cmdSayHi,
-	Triggers: NewGlobset([]string{"bar"}, "/src"),
+	Triggers: NewPathSet([]string{"bar"}, "/src"),
 }
 var stepSayHiTriggerDirA = Run{
 	Cmd:      cmdSayHi,
-	Triggers: NewGlobset([]string{"foo"}, "/dirA"),
+	Triggers: NewPathSet([]string{"foo"}, "/dirA"),
 }
 var stepSayHiTriggerDirB = Run{
 	Cmd:      cmdSayHi,
-	Triggers: NewGlobset([]string{"foo"}, "/dirB"),
+	Triggers: NewPathSet([]string{"foo"}, "/dirB"),
 }
 
 var equalitytests = []struct {

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -39,24 +39,20 @@ var cmdSayBye = Cmd{Argv: []string{"bash", "-c", "echo bye"}}
 var stepSayHi = Run{Cmd: cmdSayHi}
 var stepSayBye = Run{Cmd: cmdSayBye}
 var stepSayHiTriggerFoo = Run{
-	Cmd:           cmdSayHi,
-	Triggers:      []string{"foo"},
-	BaseDirectory: "/src",
+	Cmd:      cmdSayHi,
+	Triggers: NewGlobset([]string{"foo"}, "/src"),
 }
 var stepSayHiTriggerBar = Run{
-	Cmd:           cmdSayHi,
-	Triggers:      []string{"bar"},
-	BaseDirectory: "/src",
+	Cmd:      cmdSayHi,
+	Triggers: NewGlobset([]string{"bar"}, "/src"),
 }
 var stepSayHiTriggerDirA = Run{
-	Cmd:           cmdSayHi,
-	Triggers:      []string{"foo"},
-	BaseDirectory: "/dirA",
+	Cmd:      cmdSayHi,
+	Triggers: NewGlobset([]string{"foo"}, "/dirA"),
 }
 var stepSayHiTriggerDirB = Run{
-	Cmd:           cmdSayHi,
-	Triggers:      []string{"foo"},
-	BaseDirectory: "/dirB",
+	Cmd:      cmdSayHi,
+	Triggers: NewGlobset([]string{"foo"}, "/dirB"),
 }
 
 var equalitytests = []struct {

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -29,17 +29,8 @@ func (m fileMatcher) Matches(f string, isDir bool) (bool, error) {
 	return m.paths[f], nil
 }
 
-func NewRelativeSimpleFileMatcher(baseDir string, paths ...string) fileMatcher {
-	pathMap := make(map[string]bool, len(paths))
-	for _, path := range paths {
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(baseDir, path)
-		}
-		pathMap[path] = true
-	}
-	return fileMatcher{paths: pathMap}
-}
-
+// NewSimpleFileMatcher returns a matcher for the given paths; any relative paths
+// are converted to absolute (relative to cwd).
 func NewSimpleFileMatcher(paths ...string) (fileMatcher, error) {
 	pathMap := make(map[string]bool, len(paths))
 	for _, path := range paths {
@@ -52,6 +43,51 @@ func NewSimpleFileMatcher(paths ...string) (fileMatcher, error) {
 		pathMap[path] = true
 	}
 	return fileMatcher{paths: pathMap}, nil
+}
+
+// NewRelativeFileMatcher returns a matcher for the given paths; any relative paths
+// are converted to absolute, relative to the given baseDir.
+func NewRelativeFileMatcher(baseDir string, paths ...string) fileMatcher {
+	pathMap := make(map[string]bool, len(paths))
+	for _, path := range paths {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(baseDir, path)
+		}
+		pathMap[path] = true
+	}
+	return fileMatcher{paths: pathMap}
+}
+
+// A PathSet stores one or more filepaths, along with the directory that any
+// relative paths are relative to
+type PathSet struct {
+	Paths         []string
+	BaseDirectory string
+}
+
+func NewPathSet(paths []string, baseDir string) PathSet {
+	return PathSet{
+		Paths:         paths,
+		BaseDirectory: baseDir,
+	}
+}
+
+func (ps PathSet) Empty() bool { return len(ps.Paths) == 0 }
+
+// AnyMatch returns true if any of the given filepaths match any paths contained in the pathset.
+func (ps PathSet) AnyMatch(paths []string) (bool, error) {
+	matcher := NewRelativeFileMatcher(ps.BaseDirectory, ps.Paths...)
+
+	for _, path := range paths {
+		match, err := matcher.Matches(path, false)
+		if err != nil {
+			return false, err
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 type globMatcher struct {
@@ -75,22 +111,6 @@ func NewGlobMatcher(globs ...string) PathMatcher {
 	}
 
 	return ret
-}
-
-// AnyMatchGlobs returns true if any of the given filepaths match any of the given globs.
-func AnyMatchGlobs(paths []string, globs Globset) (bool, error) {
-	matcher := NewRelativeSimpleFileMatcher(globs.BaseDirectory, globs.Globs...)
-
-	for _, path := range paths {
-		match, err := matcher.Matches(path, false)
-		if err != nil {
-			return false, err
-		}
-		if match {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 type PatternMatcher interface {

--- a/internal/synclet/fake_client.go
+++ b/internal/synclet/fake_client.go
@@ -13,6 +13,7 @@ import (
 // with a fake docker client inside it. But ¯\_(ツ)_/¯
 type FakeSyncletClient struct {
 	UpdateContainerCount         int
+	CommandsRunCount             int
 	UpdateContainerHotReload     bool
 	ClosedCount                  int
 	UpdateContainerErrorToReturn error
@@ -35,6 +36,7 @@ func (c *FakeSyncletClient) UpdateContainer(ctx context.Context, containerID con
 	}
 	c.UpdateContainerCount += 1
 	c.UpdateContainerHotReload = hotReload
+	c.CommandsRunCount += len(commands)
 	return nil
 }
 

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/wmclient/pkg/os/temp"
 )
 
@@ -119,6 +120,10 @@ func (f *TempDirFixture) TempDir(prefix string) string {
 		f.t.Fatal(err)
 	}
 	return name
+}
+
+func (f *TempDirFixture) NewGlobset(globs ...string) model.Globset {
+	return model.NewGlobset(globs, f.Path())
 }
 
 func (f *TempDirFixture) TearDown() {

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -122,8 +122,8 @@ func (f *TempDirFixture) TempDir(prefix string) string {
 	return name
 }
 
-func (f *TempDirFixture) NewGlobset(globs ...string) model.Globset {
-	return model.NewGlobset(globs, f.Path())
+func (f *TempDirFixture) NewPathSet(paths ...string) model.PathSet {
+	return model.NewPathSet(paths, f.Path())
 }
 
 func (f *TempDirFixture) TearDown() {

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -481,8 +481,8 @@ func (b *fastBuild) run(thread *starlark.Thread, fn *starlark.Builtin, args star
 		triggers = []string{string(trigger)}
 	}
 
-	run := model.ToRun(b.s.absWorkingDir(), model.ToShellCmd(cmd))
-	run.Triggers = triggers
+	run := model.ToRun(model.ToShellCmd(cmd))
+	run = run.WithTriggers(triggers, b.s.absWorkingDir())
 
 	b.img.runs = append(b.img.runs, run)
 	return b, nil

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -169,8 +169,8 @@ func (s *tiltfileState) liveUpdateStepToModel(l liveUpdateStep) (model.LiveUpdat
 	case liveUpdateRunStep:
 		return model.LiveUpdateRunStep{
 			Command: model.ToShellCmd(x.command),
-			Triggers: model.Globset{
-				Globs:         x.triggers,
+			Triggers: model.PathSet{
+				Paths:         x.triggers,
 				BaseDirectory: s.absWorkingDir(),
 			},
 		}, nil

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -63,8 +63,13 @@ var _ starlark.Value = liveUpdateRunStep{}
 var _ liveUpdateStep = liveUpdateRunStep{}
 
 func (l liveUpdateRunStep) String() string {
-	return fmt.Sprintf("run step: %s", strconv.Quote(l.command))
+	s := fmt.Sprintf("run step: %s", strconv.Quote(l.command))
+	if len(l.triggers) > 0 {
+		s = fmt.Sprintf("%s (triggers: %s)", s, strings.Join(l.triggers, "; "))
+	}
+	return s
 }
+
 func (l liveUpdateRunStep) Type() string { return "live_update_run_step" }
 func (l liveUpdateRunStep) Freeze()      {}
 func (l liveUpdateRunStep) Truth() starlark.Bool {
@@ -127,7 +132,7 @@ func (s *tiltfileState) liveUpdateRun(thread *starlark.Thread, fn *starlark.Buil
 	for _, t := range triggersSlice {
 		switch t2 := t.(type) {
 		case starlark.String:
-			triggerStrings = append(triggerStrings, s.absPath(string(t2)))
+			triggerStrings = append(triggerStrings, string(t2))
 		default:
 			return nil, fmt.Errorf("run cmd '%s' triggers contained value '%s' of type '%s'. it may only contain strings", command, t.String(), t.Type())
 		}
@@ -154,7 +159,7 @@ func (s *tiltfileState) liveUpdateRestartContainer(thread *starlark.Thread, fn *
 	return ret, nil
 }
 
-func liveUpdateStepToModel(l liveUpdateStep) (model.LiveUpdateStep, error) {
+func (s *tiltfileState) liveUpdateStepToModel(l liveUpdateStep) (model.LiveUpdateStep, error) {
 	switch x := l.(type) {
 	case liveUpdateSyncStep:
 		if !filepath.IsAbs(x.remotePath) {
@@ -163,8 +168,11 @@ func liveUpdateStepToModel(l liveUpdateStep) (model.LiveUpdateStep, error) {
 		return model.LiveUpdateSyncStep{Source: x.localPath, Dest: x.remotePath}, nil
 	case liveUpdateRunStep:
 		return model.LiveUpdateRunStep{
-			Command:  model.ToShellCmd(x.command),
-			Triggers: x.triggers,
+			Command: model.ToShellCmd(x.command),
+			Triggers: model.Globset{
+				Globs:         x.triggers,
+				BaseDirectory: s.absWorkingDir(),
+			},
 		}, nil
 	case liveUpdateRestartContainerStep:
 		return model.LiveUpdateRestartContainerStep{}, nil
@@ -206,7 +214,7 @@ func (s *tiltfileState) liveUpdate(thread *starlark.Thread, fn *starlark.Builtin
 			return starlark.None, fmt.Errorf("'steps' must be a list of live update steps - got value '%v' of type '%s'", v.String(), v.Type())
 		}
 
-		ms, err := liveUpdateStepToModel(step)
+		ms, err := s.liveUpdateStepToModel(step)
 		if err != nil {
 			return starlark.None, err
 		}

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -181,7 +181,7 @@ live_update('gcr.io/foo',
 				model.LiveUpdateSyncStep{Source: f.JoinPath("b"), Dest: "/c"},
 				model.LiveUpdateRunStep{
 					Command:  model.ToShellCmd("f"),
-					Triggers: []string{f.JoinPath("g"), f.JoinPath("h")},
+					Triggers: f.NewGlobset("g", "h"),
 				},
 				model.LiveUpdateRestartContainerStep{},
 			)

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -181,7 +181,7 @@ live_update('gcr.io/foo',
 				model.LiveUpdateSyncStep{Source: f.JoinPath("b"), Dest: "/c"},
 				model.LiveUpdateRunStep{
 					Command:  model.ToShellCmd("f"),
-					Triggers: f.NewGlobset("g", "h"),
+					Triggers: f.NewPathSet("g", "h"),
 				},
 				model.LiveUpdateRestartContainerStep{},
 			)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3207,7 +3207,7 @@ func (fb fbHelper) checkMatchers(f *fixture, m model.Manifest, fbInfo model.Fast
 			run := runs[0]
 			runs = runs[1:]
 			assert.Equal(f.t, model.ToShellCmd(matcher.cmd), run.Cmd)
-			assert.Equal(f.t, matcher.triggers, run.Triggers.Globs)
+			assert.Equal(f.t, matcher.triggers, run.Triggers.Paths)
 			if !run.Triggers.Empty() {
 				assert.Equal(f.t, f.Path(), run.Triggers.BaseDirectory)
 			}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
@@ -2767,6 +2768,8 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 				case model.LiveUpdate:
 					lu := image.MaybeLiveUpdateInfo()
 					if assert.NotNil(f.t, lu) {
+						spew.Dump("expected LU:", matcher)
+						spew.Dump("~~~~~\nactual LU:", *lu)
 						assert.Equal(f.t, matcher, *lu)
 					}
 				default:
@@ -3207,7 +3210,10 @@ func (fb fbHelper) checkMatchers(f *fixture, m model.Manifest, fbInfo model.Fast
 			run := runs[0]
 			runs = runs[1:]
 			assert.Equal(f.t, model.ToShellCmd(matcher.cmd), run.Cmd)
-			assert.Equal(f.t, matcher.triggers, run.Triggers)
+			assert.Equal(f.t, matcher.triggers, run.Triggers.Globs)
+			if !run.Triggers.Empty() {
+				assert.Equal(f.t, f.Path(), run.Triggers.BaseDirectory)
+			}
 		case hotReloadHelper:
 			assert.Equal(f.t, matcher.on, fbInfo.HotReload)
 		default:

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
@@ -2768,8 +2767,6 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 				case model.LiveUpdate:
 					lu := image.MaybeLiveUpdateInfo()
 					if assert.NotNil(f.t, lu) {
-						spew.Dump("expected LU:", matcher)
-						spew.Dump("~~~~~\nactual LU:", *lu)
 						assert.Equal(f.t, matcher, *lu)
 					}
 				default:


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/run-triggers:

2a4675924f9d73972792dde5c89e37553295fa9b (2019-04-01 17:14:08 -0400)
better live update run.trigger tests

9e91704ff32f69807e254b035499b543e6168c3c (2019-04-01 17:06:47 -0400)
change how we store triggers

b94bd9e83978aea80516956313e3446bd874acee (2019-04-01 13:45:29 -0400)
pull up getChangedFiles

964da22a9ebe1acde6d963ec84651d51a22a1391 (2019-04-01 13:45:29 -0400)
red test for local container build

9a1ffb5839fad455878e8419d0cae914ef581e7b (2019-04-01 13:45:29 -0400)
generalize run.trigger matching

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics