### PR TITLE
k8s: fix a bogus fmt.Print

### DIFF
--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/windmilleng/tilt/internal/container"
@@ -178,8 +178,7 @@ func injectImageDigestInUnstructured(entity K8sEntity, injectRef reference.Named
 func (e K8sEntity) HasImage(image container.RefSelector, imageJSONPaths []JSONPath) (bool, error) {
 	images, err := e.FindImages(imageJSONPaths)
 	if err != nil {
-		fmt.Printf("error in FindImages: %+v\n", err)
-		return false, err
+		return false, errors.Wrap(err, "HasImage")
 	}
 
 	for _, existingRef := range images {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/fmt:

b55efeb0dea4938cc4a000d2a497a5795996b695 (2019-04-02 12:06:40 -0400)
k8s: fix a bogus fmt.Print