### PR TITLE
web: fix sidebar flickering

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -95,6 +95,32 @@ it("opens sidebar on click", async () => {
   expect(sidebar.hasClass("is-open")).toBe(true)
 })
 
+it("doesn't re-render the sidebar when the logs change", async () => {
+  const hud = mount(emptyHUD())
+  let resourceView = oneResourceView()
+  hud.setState({ View: resourceView })
+  let oldDOMNode = hud.find(".Sidebar").getDOMNode()
+  resourceView.Resources[0].PodLog += "hello world\n"
+  hud.setState({ View: resourceView })
+  let newDOMNode = hud.find(".Sidebar").getDOMNode()
+
+  expect(oldDOMNode).toBe(newDOMNode)
+})
+
+it("does re-render the sidebar when the resource list changes", async () => {
+  const hud = mount(emptyHUD())
+
+  let resourceView = oneResourceView()
+  hud.setState({ View: resourceView })
+  let sidebarLinks = hud.find(".Sidebar Link")
+  expect(sidebarLinks).toHaveLength(2)
+
+  let newResourceView = twoResourceView()
+  hud.setState({ View: newResourceView })
+  sidebarLinks = hud.find(".Sidebar Link")
+  expect(sidebarLinks).toHaveLength(3)
+})
+
 function oneResourceView() {
   const ts = Date.now().toLocaleString()
   const resource = {
@@ -123,4 +149,60 @@ function oneResourceView() {
     PodLog: "1\n2\n3\n4\nabe vigoda is now dead\n5\n6\n7\n8\n",
   }
   return { Resources: [resource] }
+}
+
+function twoResourceView() {
+  const ts = Date.now().toLocaleString()
+  const vigoda = {
+    Name: "vigoda",
+    DirectoriesWatched: ["foo", "bar"],
+    LastDeployTime: ts,
+    BuildHistory: [
+      {
+        Edits: ["main.go", "cli.go"],
+        Error: "the build failed!",
+        FinishTime: ts,
+        StartTime: ts,
+      },
+    ],
+    PendingBuildEdits: ["main.go", "cli.go", "vigoda.go"],
+    PendingBuildSince: ts,
+    CurrentBuild: {
+      Edits: ["main.go"],
+      StartTime: ts,
+    },
+    PodName: "vigoda-pod",
+    PodCreationTime: ts,
+    PodStatus: "Running",
+    PodRestarts: 1,
+    Endpoints: ["1.2.3.4:8080"],
+    PodLog: "1\n2\n3\n4\nabe vigoda is now dead\n5\n6\n7\n8\n",
+  }
+
+  const snack = {
+    Name: "snack",
+    DirectoriesWatched: ["foo", "bar"],
+    LastDeployTime: ts,
+    BuildHistory: [
+      {
+        Edits: ["main.go", "cli.go"],
+        Error: "the build failed!",
+        FinishTime: ts,
+        StartTime: ts,
+      },
+    ],
+    PendingBuildEdits: ["main.go", "cli.go", "snack.go"],
+    PendingBuildSince: ts,
+    CurrentBuild: {
+      Edits: ["main.go"],
+      StartTime: ts,
+    },
+    PodName: "snack-pod",
+    PodCreationTime: ts,
+    PodStatus: "Running",
+    PodRestarts: 1,
+    Endpoints: ["1.2.3.4:8080"],
+    PodLog: "1\n2\n3\n4\nsnacks are great\n5\n6\n7\n8\n",
+  }
+  return { Resources: [vigoda, snack] }
 }

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -111,14 +111,14 @@ class HUD extends Component<HudProps, HudState> {
     let isSidebarOpen = this.state.isSidebarOpen
     let statusItems = resources.map(res => new StatusItem(res))
     let sidebarItems = resources.map(res => new SidebarItem(res))
-    let SidebarRoute = function(props: RouteComponentProps<any>) {
+    let sidebarRoute = (props: RouteComponentProps<any>) => {
       let name = props.match.params.name
       return (
         <Sidebar selected={name} items={sidebarItems} isOpen={isSidebarOpen} />
       )
     }
 
-    let LogsRoute = (props: RouteComponentProps<any>) => {
+    let logsRoute = (props: RouteComponentProps<any>) => {
       let name = props.match.params ? props.match.params.name : ""
       let logs = ""
       if (view && name !== "") {
@@ -137,8 +137,17 @@ class HUD extends Component<HudProps, HudState> {
       <Router>
         <div className="HUD">
           <Switch>
-            <Route path="/r/:name" component={SidebarRoute} />
-            <Route component={SidebarRoute} />
+            <Route
+              path="/r/:name"
+              render={props => {
+                return sidebarRoute(props)
+              }}
+            />
+            <Route
+              render={props => {
+                return sidebarRoute(props)
+              }}
+            />
           </Switch>
 
           <Statusbar items={statusItems} toggleSidebar={this.toggleSidebar} />
@@ -148,7 +157,7 @@ class HUD extends Component<HudProps, HudState> {
               path="/"
               render={() => <LogPane log={combinedLog} />}
             />
-            <Route exact path="/r/:name" component={LogsRoute} />
+            <Route exact path="/r/:name" render={props => logsRoute(props)} />
             <Route exact path="/r/:name/k8s" render={() => <K8sViewPane />} />
             <Route
               exact

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -137,17 +137,8 @@ class HUD extends Component<HudProps, HudState> {
       <Router>
         <div className="HUD">
           <Switch>
-            <Route
-              path="/r/:name"
-              render={props => {
-                return sidebarRoute(props)
-              }}
-            />
-            <Route
-              render={props => {
-                return sidebarRoute(props)
-              }}
-            />
+            <Route path="/r/:name" render={sidebarRoute} />
+            <Route render={sidebarRoute} />
           </Switch>
 
           <Statusbar items={statusItems} toggleSidebar={this.toggleSidebar} />
@@ -157,7 +148,7 @@ class HUD extends Component<HudProps, HudState> {
               path="/"
               render={() => <LogPane log={combinedLog} />}
             />
-            <Route exact path="/r/:name" render={props => logsRoute(props)} />
+            <Route exact path="/r/:name" render={logsRoute} />
             <Route exact path="/r/:name/k8s" render={() => <K8sViewPane />} />
             <Route
               exact


### PR DESCRIPTION
Okay, let's dive in to some React and JavaScript truisms:

React components re-render under three conditions:
1. The component's state changed
2. The component's prop changed
3. The component's parent changed (See 1 and 2)

What was causing the flicking was a combination of 1, 2 and 3. While the
Sidebar component's props _weren't_ changing, its grandparents state was which
caused an accidental change to the Sidebar's parent's props, which caused
the sidebar to re-render.

Let's examine this flow in detail. First let's establish the component hierarchy:

[HUD] -> [Route] -> [Sidebar]

1. We get new information from the websocket, which changes HUD's state.
2. That change in state causes the HUD's render function to be re-run
3. This creates a new function, `SidebarRoute` which we pass to Route.
4. In JavaScript the following holds with regards to functions and references:
```
let x, y = () => bar, () => bar
assert(x !== y)
```
5. React uses equality to check if props have changed, and due to the
above property Route's properties have changed.
6. This causes Route to re-render which in turn causes Sidebar to re-render,
even though none of _its_ props or state have changed.

To solve this let's wrap references to functions that are passed to
components in anonymous functions so that they don't change every time
the render function is called.