### PR TITLE
web: dont check libs with tsc

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "allowJs": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
This seems to make webpack a bit faster though it's annoying to precisely measure it since `yarn start` is interactive.