### PR TITLE
tiltfile: rm chdir from tests

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -378,8 +378,8 @@ func (s *tiltfileState) listdir(thread *starlark.Thread, fn *starlark.Builtin, a
 	}
 	s.recordConfigFile(localPath.path)
 	var files []string
-	err = filepath.Walk(dir.GoString(), func(path string, info os.FileInfo, err error) error {
-		if path == dir.GoString() {
+	err = filepath.Walk(localPath.path, func(path string, info os.FileInfo, err error) error {
+		if path == localPath.path {
 			return nil
 		}
 		if !info.IsDir() {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1696,17 +1696,6 @@ k8s_resource('foo', 'foo.yaml')
 func TestDir(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.Chdir(wd)
-	}()
-	err = os.Chdir(f.TempDirFixture.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	f.gitInit("")
 	f.yaml("config/foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -1721,17 +1710,6 @@ func TestDir(t *testing.T) {
 func TestDirRecursive(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.Chdir(wd)
-	}()
-	err = os.Chdir(f.TempDirFixture.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	f.gitInit("")
 	f.file("foo/bar", "bar")
@@ -2252,18 +2230,6 @@ func TestReadJSON(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.Chdir(wd)
-	}()
-	err = os.Chdir(f.TempDirFixture.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	f.setupFooAndBar()
 	f.file("options.json", `["foo", {"baz":["bar", "", 1, 2]}]`)
 	f.file("Tiltfile", `
@@ -2292,18 +2258,6 @@ func TestJSONDoesntExist(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.Chdir(wd)
-	}()
-	err = os.Chdir(f.TempDirFixture.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	f.setupFooAndBar()
 	f.file("Tiltfile", `
 result = read_json("dne.json")
@@ -2322,18 +2276,6 @@ k8s_resource(result[1]["baz"][0], 'bar.yaml')
 func TestMalformedJSON(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
-
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.Chdir(wd)
-	}()
-	err = os.Chdir(f.TempDirFixture.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	f.setupFooAndBar()
 	f.file("options.json", `["foo", {"baz":["bar", "", 1, 2]}`)


### PR DESCRIPTION
just noticed this while doing some other tests

(also fixed a bug where listdir was relative to wd instead of tiltfile)