### PR TITLE
engine: make sure tiltfile errors show up in the tiltfile pane

### DIFF
--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -94,7 +94,7 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
 			err = fmt.Errorf("No resources found. Check out https://docs.tilt.dev/tutorial.html to get started!")
 		}
 		if err != nil {
-			logger.Get(ctx).Infof(err.Error())
+			logger.Get(loadCtx).Infof(err.Error())
 		}
 		st.Dispatch(ConfigsReloadedAction{
 			Manifests:          tlr.Manifests,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2075,6 +2075,7 @@ func TestEmptyTiltfile(t *testing.T) {
 	})
 	f.withState(func(st store.EngineState) {
 		assert.Contains(t, st.LastTiltfileBuild.Error.Error(), "No resources found. Check out ")
+		assert.Contains(t, st.TiltfileCombinedLog.String(), "No resources found. Check out ")
 	})
 }
 


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/errors:

424aefa00529ce8199d0af9bdef822997bc0e474 (2019-04-04 13:28:02 -0400)
engine: make sure tiltfile errors show up in the tiltfile pane