### PR TITLE
tiltfile: rejigger live update declaration syntax"

### DIFF
--- a/integration/live_update/Tiltfile
+++ b/integration/live_update/Tiltfile
@@ -6,14 +6,12 @@
 default_registry(read_json('tilt_option.json', {})
                  .get('default_registry', 'gcr.io/windmill-test-containers/servantes'))
 
-docker_build('gcr.io/windmill-test-containers/integration/live-update', '.')
-live_update(
-    'gcr.io/windmill-test-containers/integration/live-update',
-    [
-        sync('.', '/go/src/github.com/windmilleng/integration/live_update'),
-        run('go install github.com/windmilleng/integration/live_update'),
-        restart_container(),
-    ]
+docker_build('gcr.io/windmill-test-containers/integration/live-update', '.',
+             live_update=[
+                 sync('.', '/go/src/github.com/windmilleng/integration/live_update'),
+                 run('go install github.com/windmilleng/integration/live_update'),
+                 restart_container(),
+             ]
 )
 
 k8s_resource('live-update', 'deploy.yaml')

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -37,6 +37,13 @@ type LiveUpdateStep interface {
 	liveUpdateStep()
 }
 
+// Specifies that changes to any of the given files should cause the builder to fall back (i.e. do a full image build)
+type LiveUpdateFallBackOnStep struct {
+	Files []string
+}
+
+func (l LiveUpdateFallBackOnStep) liveUpdateStep() {}
+
 // Specifies that changes to local path `Source` should be synced to container path `Dest`
 type LiveUpdateSyncStep struct {
 	Source, Dest string

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -33,6 +33,8 @@ func NewLiveUpdate(steps []LiveUpdateStep, fullRebuildTriggers PathSet) (LiveUpd
 	return LiveUpdate{steps, fullRebuildTriggers}, nil
 }
 
+func (lu LiveUpdate) Empty() bool { return len(lu.Steps) == 0 }
+
 type LiveUpdateStep interface {
 	liveUpdateStep()
 }

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -20,13 +20,13 @@ func NewLiveUpdate(steps []LiveUpdateStep, fullRebuildTriggers PathSet) (LiveUpd
 		switch step.(type) {
 		case LiveUpdateSyncStep:
 			if seenRunStep {
-				return LiveUpdate{}, errors.New("live_update: all sync steps must precede all run steps")
+				return LiveUpdate{}, errors.New("all sync steps must precede all run steps")
 			}
 		case LiveUpdateRunStep:
 			seenRunStep = true
 		case LiveUpdateRestartContainerStep:
 			if i != len(steps)-1 {
-				return LiveUpdate{}, errors.New("live_update: restart container is only valid as the last step")
+				return LiveUpdate{}, errors.New("restart container is only valid as the last step")
 			}
 		}
 	}

--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -20,13 +20,13 @@ func NewLiveUpdate(steps []LiveUpdateStep, fullRebuildTriggers PathSet) (LiveUpd
 		switch step.(type) {
 		case LiveUpdateSyncStep:
 			if seenRunStep {
-				return LiveUpdate{}, errors.New("all sync steps must precede all run steps")
+				return LiveUpdate{}, errors.New("live_update: all sync steps must precede all run steps")
 			}
 		case LiveUpdateRunStep:
 			seenRunStep = true
 		case LiveUpdateRestartContainerStep:
 			if i != len(steps)-1 {
-				return LiveUpdate{}, errors.New("restart container is only valid as the last step")
+				return LiveUpdate{}, errors.New("live_update: restart container is only valid as the last step")
 			}
 		}
 	}

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -154,7 +154,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 
 	liveUpdate, err := s.liveUpdateFromSteps(liveUpdateVal)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "live_update")
 	}
 	r := &dockerImage{
 		dbDockerfilePath: dockerfilePath,
@@ -272,7 +272,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 
 	liveUpdate, err := s.liveUpdateFromSteps(liveUpdateVal)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "live_update")
 	}
 
 	img := &dockerImage{

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -40,6 +40,8 @@ type dockerImage struct {
 
 	dependencyIDs []model.TargetID
 	disablePush   bool
+
+	liveUpdate model.LiveUpdate
 }
 
 func (d *dockerImage) ID() model.TargetID {
@@ -73,7 +75,7 @@ func (d *dockerImage) Type() dockerImageBuildType {
 
 func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var dockerRef string
-	var contextVal, dockerfilePathVal, buildArgs, cacheVal, dockerfileContentsVal starlark.Value
+	var contextVal, dockerfilePathVal, buildArgs, dockerfileContentsVal, cacheVal, liveUpdateVal starlark.Value
 	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
 		"context", &contextVal,
@@ -81,6 +83,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		"dockerfile?", &dockerfilePathVal,
 		"dockerfile_contents?", &dockerfileContentsVal,
 		"cache?", &cacheVal,
+		"live_update?", &liveUpdateVal,
 	); err != nil {
 		return nil, err
 	}
@@ -149,6 +152,10 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
+	liveUpdate, err := s.liveUpdateFromSteps(liveUpdateVal)
+	if err != nil {
+		return nil, err
+	}
 	r := &dockerImage{
 		dbDockerfilePath: dockerfilePath,
 		dbDockerfile:     dockerfile.Dockerfile(dockerfileContents),
@@ -156,6 +163,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		configurationRef: container.NewRefSelector(ref),
 		dbBuildArgs:      sba,
 		cachePaths:       cachePaths,
+		liveUpdate:       liveUpdate,
 	}
 	err = s.buildIndex.addImage(r)
 	if err != nil {
@@ -186,37 +194,32 @@ func (s *tiltfileState) maybeFastBuild(image *dockerImage) *model.FastBuild {
 	return &fb
 }
 
-func (s *tiltfileState) maybeLiveUpdate(image *dockerImage) (*model.LiveUpdate, error) {
-	if lu, ok := s.liveUpdates[image.configurationRef.RefFamiliarString()]; ok {
-		lu.matched = true
-		ret, err := s.liveUpdateToModel(*lu)
+func (s *tiltfileState) validatedLiveUpdate(image *dockerImage) (*model.LiveUpdate, error) {
+	lu := image.liveUpdate
 
-		// if it's a docker build + live update, verify that all
-		// a) sync steps and
-		// b) full_rebuild_triggers
-		// are from within the docker build context
-		if image.Type() == DockerBuild {
-			for _, step := range lu.steps {
-				if syncStep, ok := step.(model.LiveUpdateSyncStep); ok {
-					if !ospath.IsChild(image.dbBuildPath.path, syncStep.Source) {
-						return nil, fmt.Errorf("sync step source '%s' is not a child of docker build context '%s'",
-							syncStep.Source, image.dbBuildPath.path)
-					}
-				}
-			}
-			for _, trigger := range lu.fullRebuildTriggers {
-				absTrigger := s.absPath(trigger)
-				if !ospath.IsChild(image.dbBuildPath.path, absTrigger) {
-					return nil, fmt.Errorf("full_rebuild_trigger '%s' is not a child of docker build context '%s'",
-						absTrigger, image.dbBuildPath.path)
+	// if it's a docker build + live update, verify that all
+	// a) sync steps and
+	// b) full_rebuild_triggers
+	// are from within the docker build context
+	if image.Type() == DockerBuild {
+		for _, step := range lu.Steps {
+			if syncStep, ok := step.(model.LiveUpdateSyncStep); ok {
+				if !ospath.IsChild(image.dbBuildPath.path, syncStep.Source) {
+					return nil, fmt.Errorf("sync step source '%s' is not a child of docker build context '%s'",
+						syncStep.Source, image.dbBuildPath.path)
 				}
 			}
 		}
-
-		return &ret, err
-	} else {
-		return nil, nil
+		// for _, trigger := range lu.fullRebuildTriggers {
+		// 	absTrigger := s.absPath(trigger)
+		// 	if !ospath.IsChild(image.dbBuildPath.path, absTrigger) {
+		// 		return nil, fmt.Errorf("full_rebuild_trigger '%s' is not a child of docker build context '%s'",
+		// 			absTrigger, image.dbBuildPath.path)
+		// 	}
+		// }
 	}
+
+	return &lu, nil
 }
 
 func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -210,13 +210,13 @@ func (s *tiltfileState) validatedLiveUpdate(image *dockerImage) (*model.LiveUpda
 				}
 			}
 		}
-		// for _, trigger := range lu.fullRebuildTriggers {
-		// 	absTrigger := s.absPath(trigger)
-		// 	if !ospath.IsChild(image.dbBuildPath.path, absTrigger) {
-		// 		return nil, fmt.Errorf("full_rebuild_trigger '%s' is not a child of docker build context '%s'",
-		// 			absTrigger, image.dbBuildPath.path)
-		// 	}
-		// }
+		for _, trigger := range lu.FullRebuildTriggers.Paths {
+			absTrigger := s.absPath(trigger)
+			if !ospath.IsChild(image.dbBuildPath.path, absTrigger) {
+				return nil, fmt.Errorf("fall_back_on path '%s' is not a child of docker build context '%s'",
+					absTrigger, image.dbBuildPath.path)
+			}
+		}
 	}
 
 	return &lu, nil

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -244,7 +244,7 @@ func (s *tiltfileState) liveUpdateFromSteps(maybeSteps starlark.Value) (model.Li
 		if fallBackStep, ok := ms.(model.LiveUpdateFallBackOnStep); ok {
 			if len(fallBackOn) != 0 {
 				return model.LiveUpdate{}, fmt.Errorf("live_update: cannot specify more than one "+
-					"fall_back_on step. (already had step: %v; got second step: %v)", fallBackOn, fallBackStep.Files)
+					"'fall_back_on' step. (already had step: %v; got second step: %v)", fallBackOn, fallBackStep.Files)
 			}
 			fallBackOn = fallBackStep.Files
 		} else {

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -242,11 +242,7 @@ func (s *tiltfileState) liveUpdateFromSteps(maybeSteps starlark.Value) (model.Li
 		// use the existing LiveUpdate constructor. (Soon, we'll treat fall_back_on as
 		// just another step INTERNALLY too (instead of as a non-step property of a LiveUpdate).
 		if fallBackStep, ok := ms.(model.LiveUpdateFallBackOnStep); ok {
-			if len(fallBackOn) != 0 {
-				return model.LiveUpdate{}, fmt.Errorf("live_update: cannot specify more than one "+
-					"'fall_back_on' step. (already had step: %v; got second step: %v)", fallBackOn, fallBackStep.Files)
-			}
-			fallBackOn = fallBackStep.Files
+			fallBackOn = append(fallBackOn, fallBackStep.Files...)
 		} else {
 			modelSteps = append(modelSteps, ms)
 		}

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -12,7 +12,7 @@ func TestLiveUpdateStepNotUsed(t *testing.T) {
 	defer f.TearDown()
 
 	f.WriteFile("Tiltfile", "restart_container()")
-	f.loadErrString("not used by any live_update", "restart_container", "<builtin>:1")
+	f.loadErrString("steps that were created but not used in a live_update", "restart_container", "<builtin>:1")
 }
 
 func TestLiveUpdateRestartContainerNotLast(t *testing.T) {

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -65,6 +65,23 @@ docker_build('gcr.io/foo', 'foo',
 	f.loadErrString("live_update", "all sync steps must precede all run steps")
 }
 
+func TestLiveUpdateMultipleFallBackSteps(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+
+	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
+docker_build('gcr.io/foo', 'foo',
+  live_update=[
+	fall_back_on('a'),
+    fall_back_on('b'),
+  ]
+)`)
+	f.loadErrString("live_update", "cannot specify more than one 'fall_back_on' step")
+}
+
 func TestLiveUpdateNonStepInSteps(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -65,23 +65,6 @@ docker_build('gcr.io/foo', 'foo',
 	f.loadErrString("live_update", "all sync steps must precede all run steps")
 }
 
-func TestLiveUpdateMultipleFallBackSteps(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupFoo()
-
-	f.file("Tiltfile", `
-k8s_yaml('foo.yaml')
-docker_build('gcr.io/foo', 'foo',
-  live_update=[
-	fall_back_on('a'),
-    fall_back_on('b'),
-  ]
-)`)
-	f.loadErrString("live_update", "cannot specify more than one 'fall_back_on' step")
-}
-
 func TestLiveUpdateNonStepInSteps(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -242,8 +225,6 @@ k8s_yaml('foo.yaml')
 %s
 `, codeToInsert)
 	f.file("Tiltfile", tiltfile)
-
-	fmt.Println(tiltfile)
 }
 
 func newLiveUpdateFixture(t *testing.T) *liveUpdateFixture {

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -22,13 +22,14 @@ func TestLiveUpdateRestartContainerNotLast(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `
-docker_build('gcr.io/foo', 'foo'
+k8s_yaml('foo.yaml')
+docker_build('gcr.io/foo', 'foo',
   live_update=[
     restart_container(),
     sync('foo', '/baz'),
   ]
 )`)
-	f.loadErrString("image build info for foo", "live_update", "restart container is only valid as the last step")
+	f.loadErrString("live_update", "restart container is only valid as the last step")
 }
 
 func TestLiveUpdateSyncRelDest(t *testing.T) {
@@ -38,6 +39,7 @@ func TestLiveUpdateSyncRelDest(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
 docker_build('gcr.io/foo', 'foo',
   live_update=[
     sync('foo', 'baz'),
@@ -53,13 +55,14 @@ func TestLiveUpdateRunBeforeSync(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
 docker_build('gcr.io/foo', 'foo',
   live_update=[
 	run('quu'),
     sync('foo', '/baz'),
   ]
 )`)
-	f.loadErrString("image build info for foo", "live_update", "all sync steps must precede all run steps")
+	f.loadErrString("live_update", "all sync steps must precede all run steps")
 }
 
 func TestLiveUpdateNonStepInSteps(t *testing.T) {
@@ -69,6 +72,7 @@ func TestLiveUpdateNonStepInSteps(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
 docker_build('gcr.io/foo', 'foo',
   live_update=[
     'quu',
@@ -85,6 +89,7 @@ func TestLiveUpdateNonStringInFullBuildTriggers(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
 docker_build('gcr.io/foo', 'foo',
   live_update=[
 	fall_back_on(4),
@@ -101,6 +106,7 @@ func TestLiveUpdateNonStringInRunTriggers(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
 docker_build('gcr.io/foo', 'foo',
   live_update=[
     run('bar', [4]),
@@ -116,6 +122,7 @@ func TestLiveUpdateSyncFilesOutsideOfDockerContext(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
 docker_build('gcr.io/foo', 'foo',
   live_update=[
     sync('bar', '/baz'),

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -119,7 +119,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		}
 	}
 
-	err = s.validateLiveUpdates()
+	err = s.checkForUnconsumedLiveUpdateSteps()
 	if err != nil {
 		return TiltfileLoadResult{}, err
 	}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -125,6 +125,7 @@ const (
 	readJSONN     = "read_json"
 
 	// live update functions
+	fallBackOnN       = "fall_back_on"
 	syncN             = "sync"
 	runN              = "run"
 	restartContainerN = "restart_container"
@@ -178,6 +179,7 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	addBuiltin(r, decodeJSONN, s.decodeJSON)
 	addBuiltin(r, readJSONN, s.readJson)
 
+	addBuiltin(r, fallBackOnN, s.liveUpdateFallBackOn)
 	addBuiltin(r, syncN, s.liveUpdateSync)
 	addBuiltin(r, runN, s.liveUpdateRun)
 	addBuiltin(r, restartContainerN, s.liveUpdateRestartContainer)


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/live-update-syntax:

13940be1bc1bb1632fe9f5900e70919ce191cc6e (2019-04-04 14:09:50 -0400)
integration test

f8092c6197e4c734a8c3f9b95cf544ed09fe050e (2019-04-04 14:02:04 -0400)
custom build support

de1c7559431243ba8d4d971e436fb75c23b9a3fc (2019-04-04 13:58:09 -0400)
fall_back_on works

0a28d00d15fa997ec6801be35c3b46108d3f6138 (2019-04-04 12:54:30 -0400)
more red tests - ready for fall_back_on

24608d86b280b877f5745cb5bfe3bbba249e124e (2019-04-04 12:47:01 -0400)
tests so far mostly green

d5fcf8f51e2790be4f6f0b35d1b0de613b07efa5 (2019-04-04 12:22:30 -0400)
red tests

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics