### PR TITLE
web: create preview pane

### DIFF
--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -67,7 +67,7 @@ class AppController {
       this.component.setAppState({
         View: null,
         Message: "Disconnected…",
-        isSidebarClosed: false,
+        IsSidebarClosed: false,
       })
       this.createNewSocket()
       return
@@ -83,7 +83,7 @@ class AppController {
       this.component.setAppState({
         View: null,
         Message: message,
-        isSidebarClosed: false,
+        IsSidebarClosed: false,
       })
       this.createNewSocket()
     }, Math.min(maxTimeout, timeout))

--- a/web/src/HUD.scss
+++ b/web/src/HUD.scss
@@ -1,7 +1,5 @@
-@import 'constants';
+@import "constants";
 
 .HUD {
-  display: flex;
-  background-color: $color-navy;
-  min-height: 100vh;
+  height: 100vh;
 }

--- a/web/src/HUD.scss
+++ b/web/src/HUD.scss
@@ -1,5 +1,8 @@
 @import "constants";
 
 .HUD {
-  height: 100vh;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  min-height: 100vh;
 }

--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -65,11 +65,11 @@ it("does re-render the sidebar when the resource list changes", async () => {
 
   let resourceView = oneResourceView()
   hud.setState({ View: resourceView })
-  let sidebarLinks = hud.find(".Sidebar-main Link")
+  let sidebarLinks = hud.find(".Sidebar-resources Link")
   expect(sidebarLinks).toHaveLength(2)
 
   let newResourceView = twoResourceView()
   hud.setState({ View: newResourceView })
-  sidebarLinks = hud.find(".Sidebar-main Link")
+  sidebarLinks = hud.find(".Sidebar-resources Link")
   expect(sidebarLinks).toHaveLength(3)
 })

--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -65,11 +65,11 @@ it("does re-render the sidebar when the resource list changes", async () => {
 
   let resourceView = oneResourceView()
   hud.setState({ View: resourceView })
-  let sidebarLinks = hud.find(".Sidebar Link")
+  let sidebarLinks = hud.find(".Sidebar-main Link")
   expect(sidebarLinks).toHaveLength(2)
 
   let newResourceView = twoResourceView()
   hud.setState({ View: newResourceView })
-  sidebarLinks = hud.find(".Sidebar Link")
+  sidebarLinks = hud.find(".Sidebar-main Link")
   expect(sidebarLinks).toHaveLength(3)
 })

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -43,6 +43,11 @@ type Resource = {
   ShowBuildStatus: boolean
 }
 
+export enum ResourceView {
+  Log,
+  Preview,
+}
+
 type HudState = {
   Message: string
   View: {
@@ -51,7 +56,7 @@ type HudState = {
     LogTimestamps: boolean
     TiltfileErrorMessage: string
   } | null
-  isSidebarClosed: boolean
+  IsSidebarClosed: boolean
 }
 
 // The Main HUD view, as specified in
@@ -74,7 +79,7 @@ class HUD extends Component<HudProps, HudState> {
         LogTimestamps: false,
         TiltfileErrorMessage: "",
       },
-      isSidebarClosed: false,
+      IsSidebarClosed: false,
     }
 
     this.toggleSidebar = this.toggleSidebar.bind(this)
@@ -95,7 +100,7 @@ class HUD extends Component<HudProps, HudState> {
   toggleSidebar() {
     this.setState(prevState => {
       return Map(prevState)
-        .set("isSidebarClosed", !prevState.isSidebarClosed)
+        .set("IsSidebarClosed", !prevState.IsSidebarClosed)
         .toObject() as HudState // NOTE(dmiller): TypeScript doesn't seem to understand what's going on here so I added a type assertion.
     })
   }
@@ -108,7 +113,7 @@ class HUD extends Component<HudProps, HudState> {
       return <LoadingScreen message={message} />
     }
 
-    let isSidebarClosed = this.state.isSidebarClosed
+    let isSidebarClosed = this.state.IsSidebarClosed
     let toggleSidebar = this.toggleSidebar
     let statusItems = resources.map(res => new StatusItem(res))
     let sidebarItems = resources.map(res => new SidebarItem(res))
@@ -120,6 +125,19 @@ class HUD extends Component<HudProps, HudState> {
           items={sidebarItems}
           isClosed={isSidebarClosed}
           toggleSidebar={toggleSidebar}
+          resourceView={ResourceView.Log}
+        />
+      )
+    }
+    let sidebarPreviewRoute = (props: RouteComponentProps<any>) => {
+      let name = props.match.params.name
+      return (
+        <Sidebar
+          selected={name}
+          items={sidebarItems}
+          isClosed={isSidebarClosed}
+          toggleSidebar={toggleSidebar}
+          resourceView={ResourceView.Preview}
         />
       )
     }
@@ -143,6 +161,7 @@ class HUD extends Component<HudProps, HudState> {
       <Router>
         <div className="HUD">
           <Switch>
+            <Route path="/r/:name/preview" render={sidebarPreviewRoute} />}
             <Route path="/r/:name" render={sidebarRoute} />
             <Route render={sidebarRoute} />
           </Switch>

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -176,8 +176,6 @@ class HUD extends Component<HudProps, HudState> {
             <Route path="/r/:name" render={sidebarRoute} />
             <Route render={sidebarRoute} />
           </Switch>
-
-          <Statusbar items={statusItems} />
           <Switch>
             <Route
               exact
@@ -189,6 +187,7 @@ class HUD extends Component<HudProps, HudState> {
             <Route exact path="/r/:name/preview" render={previewRoute} />
             <Route component={NoMatch} />
           </Switch>
+          <Statusbar items={statusItems} />
         </div>
       </Router>
     )

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -157,6 +157,17 @@ class HUD extends Component<HudProps, HudState> {
       combinedLog = view.Log
     }
 
+    let previewRoute = (props: RouteComponentProps<any>) => {
+      let name = props.match.params ? props.match.params.name : ""
+      let endpoint = ""
+      if (view && name !== "") {
+        let r = view.Resources.find(r => r.Name === name)
+        endpoint = r ? r.Endpoints[0] : ""
+      }
+
+      return <PreviewPane endpoint={endpoint} />
+    }
+
     return (
       <Router>
         <div className="HUD">
@@ -175,11 +186,7 @@ class HUD extends Component<HudProps, HudState> {
             />
             <Route exact path="/r/:name" render={logsRoute} />
             <Route exact path="/r/:name/k8s" render={() => <K8sViewPane />} />
-            <Route
-              exact
-              path="/r/:name/preview"
-              render={() => <PreviewPane />}
-            />
+            <Route exact path="/r/:name/preview" render={previewRoute} />
             <Route component={NoMatch} />
           </Switch>
         </div>

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -149,7 +149,7 @@ class HUD extends Component<HudProps, HudState> {
         let r = view.Resources.find(r => r.Name === name)
         logs = r ? r.CombinedLog : ""
       }
-      return <LogPane log={logs} />
+      return <LogPane log={logs} isExpanded={isSidebarClosed} />
     }
 
     let combinedLog = ""
@@ -176,18 +176,20 @@ class HUD extends Component<HudProps, HudState> {
             <Route path="/r/:name" render={sidebarRoute} />
             <Route render={sidebarRoute} />
           </Switch>
+          <Statusbar items={statusItems} />
           <Switch>
             <Route
               exact
               path="/"
-              render={() => <LogPane log={combinedLog} />}
+              render={() => (
+                <LogPane log={combinedLog} isExpanded={isSidebarClosed} />
+              )}
             />
             <Route exact path="/r/:name" render={logsRoute} />
             <Route exact path="/r/:name/k8s" render={() => <K8sViewPane />} />
             <Route exact path="/r/:name/preview" render={previewRoute} />
             <Route component={NoMatch} />
           </Switch>
-          <Statusbar items={statusItems} />
         </div>
       </Router>
     )

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -165,7 +165,7 @@ class HUD extends Component<HudProps, HudState> {
         endpoint = r ? r.Endpoints[0] : ""
       }
 
-      return <PreviewPane endpoint={endpoint} />
+      return <PreviewPane endpoint={endpoint} isExpanded={isSidebarClosed} />
     }
 
     return (

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -162,7 +162,7 @@ class HUD extends Component<HudProps, HudState> {
       let endpoint = ""
       if (view && name !== "") {
         let r = view.Resources.find(r => r.Name === name)
-        endpoint = r ? r.Endpoints[0] : ""
+        endpoint = r ? r.Endpoints && r.Endpoints[0] : ""
       }
 
       return <PreviewPane endpoint={endpoint} isExpanded={isSidebarClosed} />

--- a/web/src/LoadingScreen.scss
+++ b/web/src/LoadingScreen.scss
@@ -1,13 +1,9 @@
 @import "constants";
 
 .LoadingScreen {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: $sidebar-width;
-  bottom: $statusbar-height;
+  width: 100%;
+  height: 100vh;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: $font-size-large;

--- a/web/src/LoadingScreen.scss
+++ b/web/src/LoadingScreen.scss
@@ -1,8 +1,14 @@
+@import "constants";
+
 .LoadingScreen {
-  min-height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: $sidebar-width;
+  bottom: $statusbar-height;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
+  font-size: $font-size-large;
 }

--- a/web/src/LoadingScreen.tsx
+++ b/web/src/LoadingScreen.tsx
@@ -7,7 +7,7 @@ type props = {
 
 function LoadingScreen(props: props) {
   let message = props.message || "Loading…"
-  return <div className="LoadingScreen">{message}</div>
+  return <section className="LoadingScreen">{message}</section>
 }
 
 export default LoadingScreen

--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -1,14 +1,13 @@
 @import "constants.scss";
 
 .LogPane {
-  position: fixed;
-  left: 0;
-  top: 0;
-  right: $sidebar-width;
-  bottom: $statusbar-height;
-  padding: $spacing-unit / 2;
+  width: 100%;
+  margin-right: $sidebar-width;
+  margin-bottom: $statusbar-height;
   overflow-y: scroll;
+  padding: $spacing-unit / 2;
   font-size: $font-size-small;
+  transition: margin ease $animation-timing;
 }
 @keyframes blink {
   0% {
@@ -24,4 +23,12 @@
 .logEnd {
   animation: blink 1s infinite;
   animation-timing-function: ease;
+}
+
+.LogPane--expanded {
+  margin-right: 0;
+}
+
+.LogPane-empty {
+  margin: 0;
 }

--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -1,14 +1,25 @@
 @import "constants.scss";
 
 .LogPane {
-  margin: $spacing-unit / 2;
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: $sidebar-width;
+  bottom: $statusbar-height;
+  padding: $spacing-unit / 2;
+  overflow-y: scroll;
   font-size: $font-size-small;
-  margin-bottom: $statusbar-height + $spacing-unit / 2;
 }
 @keyframes blink {
-  0% { opacity: 1 }
-  50% { opacity: 0 }
-  100% { opacity: 1 }
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 .logEnd {
   animation: blink 1s infinite;

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -6,13 +6,18 @@ import renderer from "react-test-renderer"
 it("renders without crashing", () => {
   let div = document.createElement("div")
   Element.prototype.scrollIntoView = jest.fn()
-  ReactDOM.render(<LogPane log="hello\nworld\nfoo" message="world" />, div)
+  ReactDOM.render(
+    <LogPane log="hello\nworld\nfoo" message="world" isExpanded={false} />,
+    div
+  )
   ReactDOM.unmountComponentAtNode(div)
 })
 
 it("renders logs", () => {
   const log = "hello\nworld\nfoo\nbar"
-  const tree = renderer.create(<LogPane log={log} />).toJSON()
+  const tree = renderer
+    .create(<LogPane log={log} isExpanded={false} />)
+    .toJSON()
 
   expect(tree).toMatchSnapshot()
 })

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -16,6 +16,7 @@ let AnsiLine = React.memo(function(props: AnsiLineProps) {
 type LogPaneProps = {
   log: string
   message?: string
+  isExpanded: boolean
 }
 type LogPaneState = {
   autoscroll: boolean
@@ -82,9 +83,15 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
   }
 
   render() {
+    let classes = `LogPane ${this.props.isExpanded ? "LogPane--expanded" : ""}`
+
     let log = this.props.log
     if (!log || log.length == 0) {
-      return <p>No logs received</p>
+      return (
+        <section className={classes}>
+          <p className="LogPane-empty">No logs received</p>
+        </section>
+      )
     }
 
     let els: Array<React.ReactElement> = []
@@ -106,7 +113,7 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
       </div>
     )
 
-    return <div className="LogPane">{els}</div>
+    return <section className={classes}>{els}</section>
   }
 }
 

--- a/web/src/PreviewPane.scss
+++ b/web/src/PreviewPane.scss
@@ -4,9 +4,15 @@
   position: fixed;
   top: 0;
   left: 0;
-  right: $sidebar-width;
+  right: 0;
+  padding-right: $sidebar-width;
   bottom: $statusbar-height;
   background-color: $color-white;
+  transition: padding ease-out 200ms;
+}
+
+.PreviewPane--expanded {
+  padding-right: 0;
 }
 
 .PreviewPane iframe {

--- a/web/src/PreviewPane.scss
+++ b/web/src/PreviewPane.scss
@@ -1,0 +1,16 @@
+@import "constants";
+
+.PreviewPane {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: $sidebar-width;
+  bottom: $statusbar-height;
+  background-color: $color-white;
+}
+
+.PreviewPane iframe {
+  border: 0 none;
+  width: 100%;
+  height: 100%;
+}

--- a/web/src/PreviewPane.scss
+++ b/web/src/PreviewPane.scss
@@ -1,22 +1,29 @@
 @import "constants";
 
 .PreviewPane {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  padding-right: $sidebar-width;
-  bottom: $statusbar-height;
+  width: 100%;
+  margin-right: $sidebar-width;
+  margin-bottom: $statusbar-height;
   background-color: $color-white;
-  transition: padding ease-out 200ms;
+  transition: margin ease $animation-timing;
+}
+
+.PreviewPane-empty {
+  color: $color-white;
+  background-color: transparent;
+  padding: $spacing-unit / 2;
+}
+.PreviewPane-empty a {
+  color: $color-white;
 }
 
 .PreviewPane--expanded {
-  padding-right: 0;
+  margin-right: 0;
 }
 
 .PreviewPane iframe {
   border: 0 none;
   width: 100%;
+  margin-right: $sidebar-width;
   height: 100%;
 }

--- a/web/src/PreviewPane.test.tsx
+++ b/web/src/PreviewPane.test.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import PreviewPane from "./PreviewPane"
+import renderer from "react-test-renderer"
+
+it("renders without crashing", () => {
+  let div = document.createElement("div")
+  Element.prototype.scrollIntoView = jest.fn()
+  ReactDOM.render(<PreviewPane endpoint="http://localhost:9000" />, div)
+  ReactDOM.unmountComponentAtNode(div)
+})
+
+it("renders logs", () => {})

--- a/web/src/PreviewPane.test.tsx
+++ b/web/src/PreviewPane.test.tsx
@@ -6,7 +6,17 @@ import renderer from "react-test-renderer"
 it("renders without crashing", () => {
   let div = document.createElement("div")
   Element.prototype.scrollIntoView = jest.fn()
-  ReactDOM.render(<PreviewPane endpoint="http://localhost:9000" />, div)
+  ReactDOM.render(
+    <PreviewPane endpoint="http://localhost:9000" isExpanded={true} />,
+    div
+  )
+  ReactDOM.unmountComponentAtNode(div)
+})
+
+it("renders without crashing when there's no endpoint", () => {
+  let div = document.createElement("div")
+  Element.prototype.scrollIntoView = jest.fn()
+  ReactDOM.render(<PreviewPane endpoint="" isExpanded={true} />, div)
   ReactDOM.unmountComponentAtNode(div)
 })
 

--- a/web/src/PreviewPane.tsx
+++ b/web/src/PreviewPane.tsx
@@ -8,14 +8,29 @@ type PreviewProps = {
 
 class PreviewPane extends PureComponent<PreviewProps> {
   render() {
-    let classes = `PreviewPane ${this.props.isExpanded &&
-      "PreviewPane--expanded"}`
+    let classes = `
+      PreviewPane
+      ${this.props.isExpanded ? "PreviewPane--expanded" : ""}
+      ${this.props.endpoint ? "" : "PreviewPane-empty"}
+    `
 
-    return (
-      <section className={classes}>
-        <iframe src={this.props.endpoint} />
-      </section>
-    )
+    let content
+    if (this.props.endpoint) {
+      content = <iframe src={this.props.endpoint} />
+    } else {
+      content = (
+        <section>
+          <h2>No endpoint found</h2>
+          <p>
+            If this is a resource that can be previewed in the browser, the{" "}
+            <a href="https://docs.tilt.dev/tutorial.html">Tilt Tutorial</a> has
+            more on setting up port forwarding.
+          </p>
+        </section>
+      )
+    }
+
+    return <section className={classes}>{content}</section>
   }
 }
 

--- a/web/src/PreviewPane.tsx
+++ b/web/src/PreviewPane.tsx
@@ -1,8 +1,12 @@
-import React, { Component } from "react"
+import React, { PureComponent } from "react"
 
-class PreviewPane extends Component {
+type PreviewProps = {
+  endpoint: string
+}
+
+class PreviewPane extends PureComponent<PreviewProps> {
   render() {
-    return <div>I'm the preview pane!</div>
+    return <iframe src={this.props.endpoint} />
   }
 }
 

--- a/web/src/PreviewPane.tsx
+++ b/web/src/PreviewPane.tsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from "react"
+import "./PreviewPane.scss"
 
 type PreviewProps = {
   endpoint: string
@@ -6,7 +7,11 @@ type PreviewProps = {
 
 class PreviewPane extends PureComponent<PreviewProps> {
   render() {
-    return <iframe src={this.props.endpoint} />
+    return (
+      <section className="PreviewPane">
+        <iframe src={this.props.endpoint} />
+      </section>
+    )
   }
 }
 

--- a/web/src/PreviewPane.tsx
+++ b/web/src/PreviewPane.tsx
@@ -3,12 +3,16 @@ import "./PreviewPane.scss"
 
 type PreviewProps = {
   endpoint: string
+  isExpanded: boolean
 }
 
 class PreviewPane extends PureComponent<PreviewProps> {
   render() {
+    let classes = `PreviewPane ${this.props.isExpanded &&
+      "PreviewPane--expanded"}`
+
     return (
-      <section className="PreviewPane">
+      <section className={classes}>
         <iframe src={this.props.endpoint} />
       </section>
     )

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -1,31 +1,30 @@
 @import "constants";
 
 .Sidebar {
-  background-color: $color-navy;
-  border-left: 2px solid $color-navy-light;
-  width: $sidebar-width;
-  box-sizing: border-box;
   position: fixed;
-  overflow-y: scroll;
   top: 0;
   right: 0;
-  z-index: 900;
   bottom: $statusbar-height;
+  width: $sidebar-width;
+  background-color: $color-navy;
+  border-left: 2px solid $color-navy-light;
+  box-sizing: border-box;
+  overflow-y: scroll;
   transform: translateX(0%);
-  transition: transform ease-out 200ms;
+  transition: transform ease $animation-timing;
   font-size: $font-size;
   display: flex;
   flex-direction: column;
 }
 .Sidebar.is-closed {
   transform: translateX(calc(100% - #{$spacing-unit} * 1.5));
-  transition: transform ease-in 200ms;
 }
 
 // Resource Views
 .Sidebar-view {
   position: sticky;
   top: 0;
+  right: 0;
   background-color: $color-navy-dark;
   display: flex;
 }
@@ -45,11 +44,14 @@
   border-left: 2px solid $color-navy-light;
 }
 .viewLink:hover {
+  right: 0;
   background-color: $color-navy-dark;
   color: $color-blue-light;
+  right: 0;
   background-color: $color-navy;
 }
 .viewLink--is-selected {
+  right: 0;
   background-color: $color-navy;
   border-bottom: none;
 }
@@ -72,6 +74,7 @@
 .Sidebar-toggle {
   position: sticky;
   bottom: 0;
+  right: 0;
   background-color: $color-navy;
   border: 0 none;
   border-top: 1px solid $color-navy-light;
@@ -87,6 +90,7 @@
 }
 
 .resLink {
+  right: 0;
   background-color: $color-navy;
   border-bottom: 1px solid $color-navy-light;
   color: $color-white;
@@ -97,10 +101,12 @@
   height: $sidebar-item;
 }
 .resLink:hover {
+  right: 0;
   background-color: $color-navy-dark;
   color: $color-blue-light;
 }
 .resLink.is-selected {
+  right: 0;
   background-color: $color-white;
   color: $color-navy;
 }

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -103,3 +103,8 @@
 .resLink--error::before {
   color: $color-red;
 }
+
+.Sidebar-secondary {
+  position: absolute;
+  top: 0;
+}

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -4,7 +4,6 @@
   background-color: $color-navy;
   border-left: 2px solid $color-navy-light;
   width: $sidebar-width;
-  max-width: $sidebar-maxWidth;
   box-sizing: border-box;
   position: fixed;
   overflow-y: scroll;
@@ -25,6 +24,8 @@
 
 // Resource Views
 .Sidebar-view {
+  position: sticky;
+  top: 0;
   background-color: $color-navy-dark;
   display: flex;
 }

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -1,25 +1,55 @@
-@import 'constants';
+@import "constants";
 
 .Sidebar {
+  background-color: $color-navy;
+  border-left: 2px solid $color-navy-light;
   width: $sidebar-width;
   max-width: $sidebar-maxWidth;
-  margin-left: $spacing-unit;
-  border-left: 2px solid $color-navy-light;
   box-sizing: border-box;
   position: fixed;
   overflow-y: scroll;
   top: 0;
-  bottom: $statusbar-height;
   right: 0;
   z-index: 900;
-  background-color: $color-navy;
+  bottom: $statusbar-height;
   transform: translateX(0%);
   transition: transform ease-out 200ms;
   font-size: $font-size;
+  display: flex;
+  flex-direction: column;
 }
 .Sidebar.is-closed {
   transform: translateX(calc(100% - #{$spacing-unit} * 1.5));
   transition: transform ease-in 200ms;
+}
+
+// Resource Views
+.Sidebar-view {
+  background-color: $color-navy-dark;
+  display: flex;
+}
+.viewLink {
+  box-sizing: border-box;
+  height: $sidebar-item * 1.5;
+  flex: 1 0 50%;
+  color: inherit;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-bottom: 1px solid $color-navy-light;
+}
+.viewLink + .viewLink {
+  border-left: 2px solid $color-navy-light;
+}
+.viewLink--is-selected {
+  background-color: $color-navy;
+  border-bottom: none;
+}
+
+// Resource List
+.Sidebar-resources {
+  flex: 1 0 auto;
 }
 .Sidebar-header {
   color: $color-navy-light;
@@ -31,65 +61,49 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  border-bottom: 1px solid $color-navy-light;
 }
-
 .Sidebar-toggle {
   position: sticky;
   bottom: 0;
   background-color: $color-navy;
   border: 0 none;
   border-top: 1px solid $color-navy-light;
-  width: 100%;
   color: inherit;
   font-size: inherit;
   font-family: inherit;
   display: flex;
   align-items: center;
   height: $sidebar-item;
+  line-height: $sidebar-item;
   margin: 0;
   padding: 0;
 }
 
-.Sidebar-toggle svg {
-  fill: $color-white;
-  width: $spacing-unit * 1.5;
-  transform: rotate(180deg);
-  transition-property: transform;
-  transition-duration: 0.2s;
-  transition-timing-function: ease-in;
-}
-
-.Sidebar.is-closed .Sidebar-toggle svg {
-  transform: rotate(0);
-}
-
 .resLink {
   background-color: $color-navy;
-  border-top: 1px solid $color-navy-light;
+  border-bottom: 1px solid $color-navy-light;
   color: $color-white;
-  transition: background-color 200ms ease, color 200ms ease;
+  transition: color $animation-timing ease;
   text-decoration: none;
   display: flex;
   align-items: center;
   height: $sidebar-item;
 }
-
-.resLink.is-selected,
 .resLink:hover {
   background-color: $color-navy-dark;
   color: $color-blue-light;
 }
-
+.resLink.is-selected {
+  background-color: $color-white;
+  color: $color-navy;
+}
 .resLink::before {
   content: "●";
   width: $spacing-unit * 1.5;
   text-align: center;
 }
-
 .resLink--all::before {
   content: "";
-  padding-right: $spacing-unit / 4;
 }
 .resLink--ok::before {
   color: $color-green;
@@ -104,7 +118,15 @@
   color: $color-red;
 }
 
-.Sidebar-secondary {
-  position: absolute;
-  top: 0;
+// Collapse/Expand
+.Sidebar-toggle svg {
+  fill: $color-white;
+  width: $spacing-unit * 1.5;
+  transform: rotate(180deg);
+  transition-property: transform;
+  transition-duration: 0.2s;
+  transition-timing-function: ease-in;
+}
+.Sidebar.is-closed .Sidebar-toggle svg {
+  transform: rotate(0);
 }

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -39,9 +39,15 @@
   align-items: center;
   justify-content: center;
   border-bottom: 1px solid $color-navy-light;
+  transition: color $animation-timing ease;
 }
 .viewLink + .viewLink {
   border-left: 2px solid $color-navy-light;
+}
+.viewLink:hover {
+  background-color: $color-navy-dark;
+  color: $color-blue-light;
+  background-color: $color-navy;
 }
 .viewLink--is-selected {
   background-color: $color-navy;

--- a/web/src/Sidebar.test.tsx
+++ b/web/src/Sidebar.test.tsx
@@ -3,12 +3,19 @@ import ReactDOM from "react-dom"
 import renderer from "react-test-renderer"
 import { MemoryRouter } from "react-router"
 import SideBar from "./Sidebar"
+import { ResourceView } from "./HUD"
 
 it("renders empty resource list without crashing", () => {
   const tree = renderer
     .create(
       <MemoryRouter initialEntries={["/"]}>
-        <SideBar isClosed={true} items={[]} selected="" toggleSidebar={null} />
+        <SideBar
+          isClosed={true}
+          items={[]}
+          selected=""
+          toggleSidebar={null}
+          resourceView={ResourceView.Log}
+        />
       </MemoryRouter>
     )
     .toJSON()

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -40,7 +40,7 @@ class Sidebar extends PureComponent<SidebarProps> {
     let allItem = (
       <li>
         <Link className={allItemClasses} to="/">
-          &nbsp;ALL
+          All
         </Link>
       </li>
     )
@@ -70,23 +70,38 @@ class Sidebar extends PureComponent<SidebarProps> {
       ? `/r/${this.props.selected}/preview`
       : "/preview"
 
+    let logResourceViewClasses = `viewLink ${this.props.resourceView ===
+      ResourceView.Log && "viewLink--is-selected"}`
+    let previewResourceViewClasses = `viewLink ${this.props.resourceView ===
+      ResourceView.Preview && "viewLink--is-selected"}`
+
+    let resourceViewLinks = (
+      <React.Fragment>
+        <Link className={logResourceViewClasses} to={logResourceViewURL}>
+          Logs
+        </Link>
+        <Link
+          className={previewResourceViewClasses}
+          to={previewResourceViewURL}
+        >
+          Preview
+        </Link>
+      </React.Fragment>
+    )
+
     return (
-      <div className={classes.join(" ")}>
-        <nav className="Sidebar-main">
-          <h2 className="Sidebar-header">RESOURCES:</h2>
+      <section className={classes.join(" ")}>
+        <nav className="Sidebar-view">{resourceViewLinks}</nav>
+        <nav className="Sidebar-resources">
           <ul className="Sidebar-list">
             {allItem}
             {listItems}
           </ul>
-          <button className="Sidebar-toggle" onClick={this.props.toggleSidebar}>
-            <ChevronSvg /> Collapse
-          </button>
         </nav>
-        <nav className="Sidebar-secondary">
-          <Link to={logResourceViewURL}>Logs</Link>
-          <Link to={previewResourceViewURL}>Preview</Link>
-        </nav>
-      </div>
+        <button className="Sidebar-toggle" onClick={this.props.toggleSidebar}>
+          <ChevronSvg /> Collapse
+        </button>
+      </section>
     )
   }
 }

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -70,10 +70,16 @@ class Sidebar extends PureComponent<SidebarProps> {
       ? `/r/${this.props.selected}/preview`
       : "/preview"
 
-    let logResourceViewClasses = `viewLink ${this.props.resourceView ===
-      ResourceView.Log && "viewLink--is-selected"}`
-    let previewResourceViewClasses = `viewLink ${this.props.resourceView ===
-      ResourceView.Preview && "viewLink--is-selected"}`
+    let logResourceViewClasses = `viewLink ${
+      this.props.resourceView === ResourceView.Log
+        ? "viewLink--is-selected"
+        : ""
+    }`
+    let previewResourceViewClasses = `viewLink ${
+      this.props.resourceView === ResourceView.Preview
+        ? "viewLink--is-selected"
+        : ""
+    }`
 
     let resourceViewLinks = (
       <React.Fragment>

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -3,6 +3,7 @@ import { ReactComponent as ChevronSvg } from "./assets/svg/chevron.svg"
 import { Link } from "react-router-dom"
 import { combinedStatus } from "./status"
 import "./Sidebar.scss"
+import { ResourceView } from "./HUD"
 
 class SidebarItem {
   name: string
@@ -22,6 +23,7 @@ type SidebarProps = {
   items: SidebarItem[]
   selected: string
   toggleSidebar: any
+  resourceView: ResourceView
 }
 
 class Sidebar extends PureComponent<SidebarProps> {
@@ -45,6 +47,9 @@ class Sidebar extends PureComponent<SidebarProps> {
 
     let listItems = this.props.items.map(item => {
       let link = `/r/${item.name}`
+      if (this.props.resourceView === ResourceView.Preview) {
+        link += "/preview"
+      }
       let classes = `resLink resLink--${item.status}`
       if (this.props.selected === item.name) {
         classes += " is-selected"
@@ -58,17 +63,30 @@ class Sidebar extends PureComponent<SidebarProps> {
       )
     })
 
+    let logResourceViewURL = this.props.selected
+      ? `/r/${this.props.selected}`
+      : "/"
+    let previewResourceViewURL = this.props.selected
+      ? `/r/${this.props.selected}/preview`
+      : "/preview"
+
     return (
-      <nav className={classes.join(" ")}>
-        <h2 className="Sidebar-header">RESOURCES:</h2>
-        <ul className="Sidebar-list">
-          {allItem}
-          {listItems}
-        </ul>
-        <button className="Sidebar-toggle" onClick={this.props.toggleSidebar}>
-          <ChevronSvg /> Collapse
-        </button>
-      </nav>
+      <div className={classes.join(" ")}>
+        <nav className="Sidebar-main">
+          <h2 className="Sidebar-header">RESOURCES:</h2>
+          <ul className="Sidebar-list">
+            {allItem}
+            {listItems}
+          </ul>
+          <button className="Sidebar-toggle" onClick={this.props.toggleSidebar}>
+            <ChevronSvg /> Collapse
+          </button>
+        </nav>
+        <nav className="Sidebar-secondary">
+          <Link to={logResourceViewURL}>Logs</Link>
+          <Link to={previewResourceViewURL}>Preview</Link>
+        </nav>
+      </div>
     )
   }
 }

--- a/web/src/Statusbar.scss
+++ b/web/src/Statusbar.scss
@@ -1,17 +1,18 @@
-@import 'constants';
+@import "constants";
 
 .Statusbar {
   position: fixed;
   font-size: $font-size-small;
   left: 0;
+  right: 0;
   bottom: 0;
-  width: 100%;
   z-index: 1000;
   height: $statusbar-height;
   color: $color-navy;
   background-color: $color-grey-lightest;
   display: flex;
   align-items: center;
+  border-top: 1px solid $color-navy-dark;
 }
 .Statusbar-panel {
   padding: $spacing-unit / 4 $spacing-unit / 2;

--- a/web/src/__snapshots__/LogPane.test.tsx.snap
+++ b/web/src/__snapshots__/LogPane.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders logs 1`] = `
-<div
-  className="LogPane"
+<section
+  className="LogPane "
 >
   <div>
     <code>
@@ -49,5 +49,5 @@ exports[`renders logs 1`] = `
   >
     █
   </div>
-</div>
+</section>
 `;

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -8,14 +8,14 @@ exports[`renders empty resource list without crashing 1`] = `
     className="Sidebar-view"
   >
     <a
-      className="viewLink false"
+      className="viewLink viewLink--is-selected"
       href="/"
       onClick={[Function]}
     >
       Logs
     </a>
     <a
-      className="viewLink false"
+      className="viewLink "
       href="/preview"
       onClick={[Function]}
     >

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -1,17 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders empty resource list without crashing 1`] = `
-<div
+<section
   className="Sidebar is-closed"
 >
   <nav
-    className="Sidebar-main"
+    className="Sidebar-view"
   >
-    <h2
-      className="Sidebar-header"
+    <a
+      className="viewLink false"
+      href="/"
+      onClick={[Function]}
     >
-      RESOURCES:
-    </h2>
+      Logs
+    </a>
+    <a
+      className="viewLink false"
+      href="/preview"
+      onClick={[Function]}
+    >
+      Preview
+    </a>
+  </nav>
+  <nav
+    className="Sidebar-resources"
+  >
     <ul
       className="Sidebar-list"
     >
@@ -21,35 +34,19 @@ exports[`renders empty resource list without crashing 1`] = `
           href="/"
           onClick={[Function]}
         >
-           ALL
+          All
         </a>
       </li>
     </ul>
-    <button
-      className="Sidebar-toggle"
-      onClick={null}
-    >
-      <svg>
-        chevron.svg
-      </svg>
-       Collapse
-    </button>
   </nav>
-  <nav
-    className="Sidebar-secondary"
+  <button
+    className="Sidebar-toggle"
+    onClick={null}
   >
-    <a
-      href="/"
-      onClick={[Function]}
-    >
-      Logs
-    </a>
-    <a
-      href="/preview"
-      onClick={[Function]}
-    >
-      Preview
-    </a>
-  </nav>
-</div>
+    <svg>
+      chevron.svg
+    </svg>
+     Collapse
+  </button>
+</section>
 `;

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -1,35 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders empty resource list without crashing 1`] = `
-<nav
+<div
   className="Sidebar is-closed"
 >
-  <h2
-    className="Sidebar-header"
+  <nav
+    className="Sidebar-main"
   >
-    RESOURCES:
-  </h2>
-  <ul
-    className="Sidebar-list"
+    <h2
+      className="Sidebar-header"
+    >
+      RESOURCES:
+    </h2>
+    <ul
+      className="Sidebar-list"
+    >
+      <li>
+        <a
+          className="resLink resLink--all is-selected"
+          href="/"
+          onClick={[Function]}
+        >
+           ALL
+        </a>
+      </li>
+    </ul>
+    <button
+      className="Sidebar-toggle"
+      onClick={null}
+    >
+      <svg>
+        chevron.svg
+      </svg>
+       Collapse
+    </button>
+  </nav>
+  <nav
+    className="Sidebar-secondary"
   >
-    <li>
-      <a
-        className="resLink resLink--all is-selected"
-        href="/"
-        onClick={[Function]}
-      >
-         ALL
-      </a>
-    </li>
-  </ul>
-  <button
-    className="Sidebar-toggle"
-    onClick={null}
-  >
-    <svg>
-      chevron.svg
-    </svg>
-     Collapse
-  </button>
-</nav>
+    <a
+      href="/"
+      onClick={[Function]}
+    >
+      Logs
+    </a>
+    <a
+      href="/preview"
+      onClick={[Function]}
+    >
+      Preview
+    </a>
+  </nav>
+</div>
 `;

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -1,5 +1,6 @@
 $font-family: "Courier New", Courier, monospace;
 $font-size: 20px;
+$font-size-large: 26px;
 $font-size-small: 16px;
 $font-size-icon: 24px;
 

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -1,31 +1,33 @@
-$font-family: 'Courier New', Courier, monospace;
+$font-family: "Courier New", Courier, monospace;
 $font-size: 20px;
 $font-size-small: 16px;
 $font-size-icon: 24px;
 
 $color-white: #ffffff;
-$color-green: #20BA31;
-$color-green-lightest: #70D37B;
-$color-blue: #03C7D3;
-$color-purple: #6378BA;
-$color-red: #F6685C;
-$color-pink: #EF5AA0;
-$color-yellow: #FCB41E;
+$color-green: #20ba31;
+$color-green-lightest: #70d37b;
+$color-blue: #03c7d3;
+$color-purple: #6378ba;
+$color-red: #f6685c;
+$color-pink: #ef5aa0;
+$color-yellow: #fcb41e;
 $color-grey: #9a9a9a;
 $color-grey-light: #cacaca;
 $color-grey-lightest: #f1f1f1;
 $color-grey-dark: #606060;
 $color-grey-darkest: #434343;
-$color-red-light: #F99E97;
-$color-blue-light: #5EDBE3;
-$color-blue-lightest: #98E8ED;
-$color-green-light: #70D37B;
-$color-navy: #002F39;
+$color-red-light: #f99e97;
+$color-blue-light: #5edbe3;
+$color-blue-lightest: #98e8ed;
+$color-green-light: #70d37b;
+$color-navy: #002f39;
 $color-navy-dark: #002125;
 $color-navy-light: #30545c;
 
-$spacing-unit:     32px;
+$spacing-unit: 32px;
 $sidebar-width: $spacing-unit * 10;
-$sidebar-item: $spacing-unit * 1.75;
+$sidebar-item: $spacing-unit * 1.5;
 $sidebar-maxWidth: 25vw;
 $statusbar-height: $spacing-unit * 1.75;
+
+$animation-timing: 200ms;

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -13,3 +13,8 @@ body {
 code {
   font-family: $font-family;
 }
+
+ul {
+  margin: 0;
+  padding: 0;
+}

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -1,13 +1,19 @@
 @import "constants.scss";
 
+html {
+  width: 100%;
+  height: 100%;
+}
 body {
   margin: 0;
   padding: 0;
   font-family: $font-family;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: $color-grey-darkest;
+  background-color: $color-navy;
   color: $color-white;
+  width: 100%;
+  height: 100%;
 }
 
 code {


### PR DESCRIPTION
I tried tab-like buttons for "Logs" and "Preview" view options.

- In this PR, it's not obvious the view options are buttons. I'll address this in my next design pass.
- When we have more than two views, this design will have to change.

<img width="1680" alt="2019-04-04 - preview" src="https://user-images.githubusercontent.com/20349/55591124-bd5c3a80-5702-11e9-9d89-1c1da29d9e0c.png">

## Nav Design Alternatives considered

I mocked up a design with the view options to the left of the sidebar, but it was a bit too visually obtrusive.

<img width="1442" alt="2019-04-04 - view options mock" src="https://user-images.githubusercontent.com/20349/55591316-33f93800-5703-11e9-9007-a2b23c51ad9e.png">
