### PR TITLE
build: skip iterating through directories that are ignored

### DIFF
--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -158,7 +158,11 @@ func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string
 		matches, err := a.filter.Matches(path, info.IsDir())
 		if err != nil {
 			return err
-		} else if matches {
+		}
+		if matches {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 


### PR DESCRIPTION
This results in a significant performance improvements for initial builds that ignore directories with lots of files in them, in the area of 2x-4x improvement on macOS.