### PR TITLE
engine: fix up dupe tiltfile logs by making the tiltfile logs more consistent with other logs

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -474,7 +474,7 @@ func handleConfigsReloaded(
 	status.Error = event.Err
 	status.Warnings = event.Warnings
 
-	setLastTiltfileBuild(state, status)
+	state.LastTiltfileBuild = status
 	state.CurrentTiltfileBuild = model.BuildRecord{}
 	if event.Err != nil {
 		// There was an error, so don't update status with the new, nonexistent state
@@ -847,7 +847,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 			Warnings:   action.Warnings,
 			Reason:     model.BuildReasonFlagInit,
 		}
-		setLastTiltfileBuild(engineState, status)
+		engineState.LastTiltfileBuild = status
 
 		manifests := action.Manifests
 		for _, m := range manifests {
@@ -864,14 +864,6 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 	engineState.GlobalYAMLState = store.NewYAMLManifestState()
 	engineState.WatchFiles = watchFiles
 	return nil
-}
-
-func setLastTiltfileBuild(state *store.EngineState, status model.BuildRecord) {
-	if status.Error != nil {
-		le := logEvent{time.Now(), []byte(fmt.Sprintf("%v\n", status.Error))}
-		status.Log = model.AppendLog(status.Log, le, state.LogTimestamps)
-	}
-	state.LastTiltfileBuild = status
 }
 
 func handleExitAction(state *store.EngineState, action hud.ExitAction) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2077,7 +2077,8 @@ func TestEmptyTiltfile(t *testing.T) {
 	})
 	f.withState(func(st store.EngineState) {
 		assert.Contains(t, st.LastTiltfileBuild.Error.Error(), "No resources found. Check out ")
-		assert.Contains(t, st.TiltfileCombinedLog.String(), "No resources found. Check out ")
+		assertContainsOnce(t, st.TiltfileCombinedLog.String(), "No resources found. Check out ")
+		assertContainsOnce(t, st.LastTiltfileBuild.Log.String(), "No resources found. Check out ")
 	})
 }
 
@@ -2699,4 +2700,9 @@ func assertLineMatches(t *testing.T, lines []string, re *regexp.Regexp) {
 		}
 	}
 	t.Fatalf("Expected line to match: %s. Lines: %v", re.String(), lines)
+}
+
+func assertContainsOnce(t *testing.T, s string, val string) {
+	assert.Contains(t, s, val)
+	assert.Equal(t, 1, strings.Count(s, val), "Expected string to appear only once")
 }


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/nicks/ch2152/tiltfile:

fbf44d031c2fa73f785963144c922789e27a7063 (2019-04-05 17:26:06 -0400)
engine: fix up dupe tiltfile logs by making the tiltfile logs more consistent with other logs