### PR TITLE
tiltfile: automatically print warnings after loading

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -137,6 +137,10 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		}
 	}
 
+	for _, w := range s.warnings {
+		s.logger.Infof("WARNING: %s\n", w)
+	}
+
 	s.logger.Infof("Successfully loaded Tiltfile")
 
 	tfl.reportTiltfileLoaded(s.builtinCallCounts)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -194,6 +194,11 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	return r
 }
 
+func (s *tiltfileState) warn(w string) {
+	s.logger.Infof("WARNING: %s\n", w)
+	s.warnings = append(s.warnings, w)
+}
+
 func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 	err := s.assembleImages()
 	if err != nil {
@@ -222,8 +227,7 @@ func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 
 	err = s.buildIndex.assertAllMatched()
 	if err != nil {
-		s.logger.Infof("WARNING: %s\n", err)
-		s.warnings = append(s.warnings, err.Error())
+		s.warn(err.Error())
 	}
 
 	return resourceSet{

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -194,11 +194,6 @@ func (s *tiltfileState) builtins() starlark.StringDict {
 	return r
 }
 
-func (s *tiltfileState) warn(w string) {
-	s.logger.Infof("WARNING: %s\n", w)
-	s.warnings = append(s.warnings, w)
-}
-
 func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 	err := s.assembleImages()
 	if err != nil {
@@ -227,7 +222,7 @@ func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 
 	err = s.buildIndex.assertAllMatched()
 	if err != nil {
-		s.warn(err.Error())
+		s.warnings = append(s.warnings, err.Error())
 	}
 
 	return resourceSet{


### PR DESCRIPTION
I was confused when I added a warning and it didn't show up in the log or HUD. It turns out that we don't actually use the strings we put in `s.warnings`, but only check its length.

This was fine since we only had one warning, but now that we're adding more, we might as well put this in a func so we can be consistent about how we log them.