### PR TITLE
engine: specify which files matched FallBackOn, surface message to user [ch2129]

### DIFF
--- a/internal/build/boil_runs.go
+++ b/internal/build/boil_runs.go
@@ -13,7 +13,7 @@ func BoilRuns(runs []model.Run, pathMappings []PathMapping) ([]model.Cmd, error)
 			continue
 		}
 
-		anyMatch, err := run.Triggers.AnyMatch(localPaths)
+		anyMatch, _, err := run.Triggers.AnyMatch(localPaths)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -68,9 +68,10 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 			return store.BuildResultSet{}, err
 		}
 
-		if _, ok := err.(RedirectToNextBuilder); ok {
-			logger.Get(ctx).Debugf("(expected error) falling back to next build and deploy method "+
-				"after error: %v", err)
+		if redirectErr, ok := err.(RedirectToNextBuilder); ok {
+			s := fmt.Sprintf("(expected error) falling back to next build and deploy method "+
+				"after error: %v\n", err)
+			logger.Get(ctx).Write(redirectErr.level, s)
 		} else {
 			lastUnexpectedErr = err
 			if i+1 < len(composite.builders) {

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -69,8 +69,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 		}
 
 		if redirectErr, ok := err.(RedirectToNextBuilder); ok {
-			s := fmt.Sprintf("(expected error) falling back to next build and deploy method "+
-				"after error: %v\n", err)
+			s := fmt.Sprintf("falling back to next update method because: %v\n", err)
 			logger.Get(ctx).Write(redirectErr.level, s)
 		} else {
 			lastUnexpectedErr = err

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -69,7 +69,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 		}
 
 		if redirectErr, ok := err.(RedirectToNextBuilder); ok {
-			s := fmt.Sprintf("falling back to next update method because: %v\n", err)
+			s := fmt.Sprintf("falling back to next update method because: %v", err)
 			logger.Get(ctx).Write(redirectErr.level, s)
 		} else {
 			lastUnexpectedErr = err

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -279,7 +279,7 @@ func TestLiveUpdateDockerBuildDeploysSynclet(t *testing.T) {
 	runTestCase(t, f, tCase)
 }
 
-func TestLiveUpdateLocalContainerFullBuildTrigger(t *testing.T) {
+func TestLiveUpdateLocalContainerFallBackOn(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop)
 	defer f.TearDown()
 
@@ -295,11 +295,12 @@ func TestLiveUpdateLocalContainerFullBuildTrigger(t *testing.T) {
 		expectDockerExecCount:    0,
 		expectDockerRestartCount: 0,
 		expectK8sDeploy:          true, // Because we fell back to image builder, we also did a k8s deploy
+		logsContain:              []string{"detected change to FallBackOn file", f.JoinPath("a.txt")},
 	}
 	runTestCase(t, f, tCase)
 }
 
-func TestLiveUpdateSyncletFullBuildTrigger(t *testing.T) {
+func TestLiveUpdateSyncletFallBackOn(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
@@ -316,6 +317,7 @@ func TestLiveUpdateSyncletFullBuildTrigger(t *testing.T) {
 		expectDockerRestartCount: 0,
 		expectK8sDeploy:          true, // because we fell back to image builder, we also did a k8s deploy
 		expectSyncletDeploy:      true, // (and expect that yaml to have contained the synclet)
+		logsContain:              []string{"detected change to FallBackOn file", f.JoinPath("a.txt")},
 	}
 	runTestCase(t, f, tCase)
 }

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -295,7 +295,7 @@ func TestLiveUpdateLocalContainerFallBackOn(t *testing.T) {
 		expectDockerExecCount:    0,
 		expectDockerRestartCount: 0,
 		expectK8sDeploy:          true, // Because we fell back to image builder, we also did a k8s deploy
-		logsContain:              []string{"detected change to FallBackOn file", f.JoinPath("a.txt")},
+		logsContain:              []string{"detected change to fall_back_on file", f.JoinPath("a.txt")},
 	}
 	runTestCase(t, f, tCase)
 }
@@ -317,7 +317,7 @@ func TestLiveUpdateSyncletFallBackOn(t *testing.T) {
 		expectDockerRestartCount: 0,
 		expectK8sDeploy:          true, // because we fell back to image builder, we also did a k8s deploy
 		expectSyncletDeploy:      true, // (and expect that yaml to have contained the synclet)
-		logsContain:              []string{"detected change to FallBackOn file", f.JoinPath("a.txt")},
+		logsContain:              []string{"detected change to fall_back_on file", f.JoinPath("a.txt")},
 	}
 	runTestCase(t, f, tCase)
 }

--- a/internal/engine/build_errors.go
+++ b/internal/engine/build_errors.go
@@ -5,20 +5,28 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/logger"
 )
 
 // Nothing is on fire, this is an expected case like a container builder being
-// passed a build with no attached container. Don't need to show this to a user.
+// passed a build with no attached container.
+// `level` indicates at what log level this error should be shown to the user
 type RedirectToNextBuilder struct {
 	error
+	level logger.Level
 }
 
-func WrapRedirectToNextBuilder(err error) RedirectToNextBuilder {
-	return RedirectToNextBuilder{err}
+func WrapRedirectToNextBuilder(err error, level logger.Level) RedirectToNextBuilder {
+	return RedirectToNextBuilder{err, level}
 }
 
-func RedirectToNextBuilderf(msg string, a ...interface{}) RedirectToNextBuilder {
-	return RedirectToNextBuilder{fmt.Errorf(msg, a...)}
+func SilentRedirectToNextBuilderf(msg string, a ...interface{}) RedirectToNextBuilder {
+	// Only show to user in Debug mode
+	return RedirectToNextBuilder{fmt.Errorf(msg, a...), logger.DebugLvl}
+}
+
+func RedirectToNextBuilderInfof(msg string, a ...interface{}) RedirectToNextBuilder {
+	return RedirectToNextBuilder{fmt.Errorf(msg, a...), logger.InfoLvl}
 }
 
 var _ error = RedirectToNextBuilder{}

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -57,7 +57,7 @@ func (bd *DockerComposeBuildAndDeployer) extract(specs []model.TargetSpec) ([]mo
 func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error) {
 	iTargets, dcTargets := bd.extract(specs)
 	if len(dcTargets) != 1 {
-		return store.BuildResultSet{}, RedirectToNextBuilderf(
+		return store.BuildResultSet{}, SilentRedirectToNextBuilderf(
 			"DockerComposeBuildAndDeployer requires exactly one dcTarget (got %d)", len(dcTargets))
 	}
 	dcTarget := dcTargets[0]

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -68,7 +68,7 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 
 		state := stateSet[iTarget.ID()]
 		if state.IsEmpty() {
-			return nil, RedirectToNextBuilderf("In-place build does not support initial deploy")
+			return nil, SilentRedirectToNextBuilderf("In-place build does not support initial deploy")
 		}
 
 		// If this image doesn't need to be built at all, we can skip it.
@@ -79,7 +79,7 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		fbInfo := iTarget.MaybeFastBuildInfo()
 		luInfo := iTarget.MaybeLiveUpdateInfo()
 		if fbInfo == nil && luInfo == nil {
-			return nil, RedirectToNextBuilderf("In-place build requires either FastBuild or LiveUpdate")
+			return nil, SilentRedirectToNextBuilderf("In-place build requires either FastBuild or LiveUpdate")
 		}
 
 		// Now that we have fast build information, we know this CAN be updated in
@@ -87,7 +87,7 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		// that would need to be updated.
 		deployInfo := state.DeployInfo
 		if deployInfo.Empty() {
-			return nil, RedirectToNextBuilderf("In-place build needs container info")
+			return nil, SilentRedirectToNextBuilderf("In-place build needs container info")
 		}
 		iTargets = append(iTargets, iTarget)
 	}

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -87,7 +87,7 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		// that would need to be updated.
 		deployInfo := state.DeployInfo
 		if deployInfo.Empty() {
-			return nil, SilentRedirectToNextBuilderf("In-place build needs container info")
+			return nil, RedirectToNextBuilderInfof("don't have info for deployed container (often a result of the deployment not yet being ready)")
 		}
 		iTargets = append(iTargets, iTarget)
 	}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -89,7 +89,7 @@ func (ibd *ImageBuildAndDeployer) SetInjectSynclet(inject bool) {
 func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (resultSet store.BuildResultSet, err error) {
 	iTargets, kTargets := extractImageAndK8sTargets(specs)
 	if len(kTargets) == 0 && len(iTargets) == 0 {
-		return store.BuildResultSet{}, RedirectToNextBuilderf("ImageBuildAndDeployer does not support these specs")
+		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("ImageBuildAndDeployer does not support these specs")
 	}
 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuildAndDeployer-BuildAndDeploy")

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -99,7 +99,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 		}
 		if anyMatch {
 			return store.BuildResultSet{}, RedirectToNextBuilderInfof(
-				"detected change to FallBackOn file '%s', so falling back to an image build", file)
+				"detected change to fall_back_on file '%s'", file)
 		}
 
 		runs = luInfo.RunSteps()

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -93,13 +93,13 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 		}
 
 		// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
-		anyMatch, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
+		anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
 		if err != nil {
 			return nil, err
 		}
 		if anyMatch {
 			return store.BuildResultSet{}, RedirectToNextBuilderf(
-				"one or more changed files match a FallBackOn file, so falling back to an image build")
+				"detected change to FallBackOn file '%s', so falling back to an image build", file)
 		}
 
 		runs = luInfo.RunSteps()

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -86,7 +86,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 			if pmErr, ok := err.(*build.PathMappingErr); ok {
 				// expected error for this builder. One of more files don't match sync's;
 				// i.e. they're within the docker context but not within a sync; do a full image build.
-				return nil, SilentRedirectToNextBuilderf(
+				return nil, RedirectToNextBuilderInfof(
 					"at least one file (%s) doesn't match a LiveUpdate sync, so performing a full build", pmErr.File)
 			}
 			return store.BuildResultSet{}, err

--- a/internal/engine/local_container_build_and_deployer.go
+++ b/internal/engine/local_container_build_and_deployer.go
@@ -40,14 +40,14 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 	}
 
 	if len(iTargets) != 1 {
-		return store.BuildResultSet{}, RedirectToNextBuilderf("Local container builder needs exactly one image target")
+		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("Local container builder needs exactly one image target")
 	}
 
 	isDC := len(extractDockerComposeTargets(specs)) > 0
 	isK8s := len(extractK8sTargets(specs)) > 0
 	canLocalUpdate := isDC || (isK8s && cbd.env.IsLocalCluster())
 	if !canLocalUpdate {
-		return store.BuildResultSet{}, RedirectToNextBuilderf("Local container builder needs docker-compose or k8s cluster w/ local updates")
+		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("Local container builder needs docker-compose or k8s cluster w/ local updates")
 	}
 
 	iTarget := iTargets[0]
@@ -65,7 +65,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 
 	// LocalContainerBuildAndDeployer doesn't support initial build
 	if state.IsEmpty() {
-		return store.BuildResultSet{}, RedirectToNextBuilderf("prev. build state is empty; container build does not support initial deploy")
+		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("prev. build state is empty; container build does not support initial deploy")
 	}
 
 	var changedFiles []build.PathMapping
@@ -86,7 +86,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 			if pmErr, ok := err.(*build.PathMappingErr); ok {
 				// expected error for this builder. One of more files don't match sync's;
 				// i.e. they're within the docker context but not within a sync; do a full image build.
-				return nil, RedirectToNextBuilderf(
+				return nil, SilentRedirectToNextBuilderf(
 					"at least one file (%s) doesn't match a LiveUpdate sync, so performing a full build", pmErr.File)
 			}
 			return store.BuildResultSet{}, err
@@ -98,7 +98,7 @@ func (cbd *LocalContainerBuildAndDeployer) BuildAndDeploy(ctx context.Context, s
 			return nil, err
 		}
 		if anyMatch {
-			return store.BuildResultSet{}, RedirectToNextBuilderf(
+			return store.BuildResultSet{}, RedirectToNextBuilderInfof(
 				"detected change to FallBackOn file '%s', so falling back to an image build", file)
 		}
 

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -41,12 +41,12 @@ func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store
 	}
 
 	if len(iTargets) != 1 {
-		return store.BuildResultSet{}, RedirectToNextBuilderf("Synclet container builder needs exactly one image target")
+		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("Synclet container builder needs exactly one image target")
 	}
 
 	iTarget := iTargets[0]
 	if !isImageDeployedToK8s(iTarget, extractK8sTargets(specs)) {
-		return store.BuildResultSet{}, RedirectToNextBuilderf("Synclet container builder can only deploy to k8s")
+		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("Synclet container builder can only deploy to k8s")
 	}
 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncletBuildAndDeployer-BuildAndDeploy")
@@ -78,7 +78,7 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 			if pmErr, ok := err.(*build.PathMappingErr); ok {
 				// expected error for this builder. One of more files don't match sync's;
 				// i.e. they're within the docker context but not within a sync; do a full image build.
-				return nil, RedirectToNextBuilderf(
+				return nil, SilentRedirectToNextBuilderf(
 					"at least one file (%s) doesn't match a LiveUpdate sync, so performing a full build", pmErr.File)
 			}
 			return store.BuildResultSet{}, err
@@ -90,7 +90,7 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 			return nil, err
 		}
 		if anyMatch {
-			return store.BuildResultSet{}, RedirectToNextBuilderf(
+			return store.BuildResultSet{}, RedirectToNextBuilderInfof(
 				"detected change to FallBackOn file '%s', so falling back to an image build", file)
 		}
 

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -78,7 +78,7 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 			if pmErr, ok := err.(*build.PathMappingErr); ok {
 				// expected error for this builder. One of more files don't match sync's;
 				// i.e. they're within the docker context but not within a sync; do a full image build.
-				return nil, SilentRedirectToNextBuilderf(
+				return nil, RedirectToNextBuilderInfof(
 					"at least one file (%s) doesn't match a LiveUpdate sync, so performing a full build", pmErr.File)
 			}
 			return store.BuildResultSet{}, err

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -91,7 +91,7 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 		}
 		if anyMatch {
 			return store.BuildResultSet{}, RedirectToNextBuilderInfof(
-				"detected change to FallBackOn file '%s', so falling back to an image build", file)
+				"detected change to fall_back_on file '%s'", file)
 		}
 
 		runs = luInfo.RunSteps()

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -85,13 +85,13 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 		}
 
 		// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
-		anyMatch, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
+		anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
 		if err != nil {
 			return nil, err
 		}
 		if anyMatch {
 			return store.BuildResultSet{}, RedirectToNextBuilderf(
-				"one or more changed files match a FallBackOn file, so falling back to an image build")
+				"detected change to FallBackOn file '%s', so falling back to an image build", file)
 		}
 
 		runs = luInfo.RunSteps()

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -78,20 +78,21 @@ func NewPathSet(paths []string, baseDir string) PathSet {
 
 func (ps PathSet) Empty() bool { return len(ps.Paths) == 0 }
 
-// AnyMatch returns true if any of the given filepaths match any paths contained in the pathset.
-func (ps PathSet) AnyMatch(paths []string) (bool, error) {
+// AnyMatch returns true if any of the given filepaths match any paths contained in the pathset
+// (along with the first path that matched).
+func (ps PathSet) AnyMatch(paths []string) (bool, string, error) {
 	matcher := NewRelativeFileMatcher(ps.BaseDirectory, ps.Paths...)
 
 	for _, path := range paths {
 		match, err := matcher.Matches(path, false)
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 		if match {
-			return true, nil
+			return true, path, nil
 		}
 	}
-	return false, nil
+	return false, "", nil
 }
 
 type globMatcher struct {


### PR DESCRIPTION
Hello @dbentley, @landism,

Please review the following commits I made in branch maiamcc/which-matched-fall-back:

c0c3d2d270dd3233d34487298068cabd49c982b5 (2019-04-08 12:47:48 -0400)
can specify log level for RedirectToNextBuilder error

070fc4a4289a0f3161a9d66e6872020b1dd9c55b (2019-04-08 12:36:33 -0400)
engine: better logging around which FallBackOn file matched

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics