### PR TITLE
hud: remove TiltfileErrorMessage

### DIFF
--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -122,7 +122,7 @@ func (r *Renderer) renderStatusBar(v view.View) rty.Component {
 			errorCount++
 		}
 	}
-	if errorCount == 0 && v.TiltfileErrorMessage == "" {
+	if errorCount == 0 && v.TiltfileErrorMessage() == "" {
 		sb.Fg(cGood).Text("✓").Fg(tcell.ColorDefault).Fg(cText).Text(" OK").Fg(tcell.ColorDefault)
 	} else {
 		var errorCountMessage string
@@ -136,7 +136,7 @@ func (r *Renderer) renderStatusBar(v view.View) rty.Component {
 			errorCountMessage = fmt.Sprintf(" %d %s", errorCount, s)
 		}
 
-		if v.TiltfileErrorMessage != "" {
+		if v.TiltfileErrorMessage() != "" {
 			_, _ = tiltfileError.WriteString(" • Tiltfile error")
 		}
 		sb.Fg(cBad).Text("✖").Fg(tcell.ColorDefault).Fg(cText).Textf("%s%s", errorCountMessage, tiltfileError.String()).Fg(tcell.ColorDefault)

--- a/internal/hud/server/view.go
+++ b/internal/hud/server/view.go
@@ -127,14 +127,6 @@ func StateToWebView(s store.EngineState) webview.View {
 	} else {
 		tr.LastDeployTime = s.LastTiltfileBuild.FinishTime
 	}
-	if !s.LastTiltfileBuild.Empty() {
-		err := s.LastTiltfileBuild.Error
-		if err == nil && s.IsEmpty() {
-			ret.TiltfileErrorMessage = store.EmptyTiltfileMsg
-		} else if err != nil {
-			ret.TiltfileErrorMessage = err.Error()
-		}
-	}
 	ret.Resources = append(ret.Resources, tr)
 
 	ret.Log = s.Log

--- a/internal/hud/server/view_test.go
+++ b/internal/hud/server/view_test.go
@@ -83,42 +83,6 @@ func TestStateViewYAMLManifestWithYAML(t *testing.T) {
 	assert.Equal(t, []string{"global.yaml"}, r.DirectoriesWatched)
 }
 
-func TestEmptyState(t *testing.T) {
-	es := newState([]model.Manifest{}, model.Manifest{})
-
-	v := StateToWebView(*es)
-	assert.Equal(t, "", v.TiltfileErrorMessage)
-
-	es.LastTiltfileBuild = model.BuildRecord{
-		StartTime:  time.Now(),
-		FinishTime: time.Now(),
-	}
-	v = StateToWebView(*es)
-	assert.Equal(t, store.EmptyTiltfileMsg, v.TiltfileErrorMessage)
-
-	yaml := "yamlyaml"
-	m := k8s.NewK8sOnlyManifestForTesting("GlobalYAML", yaml)
-	nes := newState([]model.Manifest{}, m)
-	nes.ConfigFiles = []string{"global.yaml"}
-	v = StateToWebView(*nes)
-	assert.Equal(t, "", v.TiltfileErrorMessage)
-
-	m2 := model.Manifest{
-		Name: "foo",
-	}.WithImageTarget(model.ImageTarget{}.
-		WithBuildDetails(model.FastBuild{
-			Syncs: []model.Sync{
-				{LocalPath: "/a/b"},
-				{LocalPath: "/a/b/c"},
-			},
-		}),
-	)
-
-	nes = newState([]model.Manifest{m2}, model.Manifest{})
-	v = StateToWebView(*nes)
-	assert.Equal(t, "", v.TiltfileErrorMessage)
-}
-
 func TestRelativeTiltfilePath(t *testing.T) {
 	es := newState([]model.Manifest{}, model.Manifest{})
 	wd, err := os.Getwd()

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -171,12 +171,24 @@ func (r Resource) IsCollapsed(rv ResourceViewState) bool {
 // Client should always hold this as a value struct, and copy it
 // whenever they need to mutate something.
 type View struct {
-	Log                  model.Log
-	Resources            []Resource
-	TiltfileErrorMessage string
-	TriggerMode          model.TriggerMode
-	IsProfiling          bool
-	LogTimestamps        bool
+	Log           model.Log
+	Resources     []Resource
+	TriggerMode   model.TriggerMode
+	IsProfiling   bool
+	LogTimestamps bool
+}
+
+func (v View) TiltfileErrorMessage() string {
+	for _, res := range v.Resources {
+		if res.Name == TiltfileResourceName {
+			err := res.LastBuild().Error
+			if err != nil {
+				return err.Error()
+			}
+			return ""
+		}
+	}
+	return ""
 }
 
 type ViewState struct {

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -106,8 +106,7 @@ const (
 )
 
 type View struct {
-	Log                  model.Log
-	Resources            []Resource
-	TiltfileErrorMessage string
-	LogTimestamps        bool
+	Log           model.Log
+	Resources     []Resource
+	LogTimestamps bool
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -20,8 +20,6 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 )
 
-const EmptyTiltfileMsg = "Looks like you don't have any docker builds or services defined in your Tiltfile! Check out https://docs.tilt.dev/tutorial.html to get started."
-
 type EngineState struct {
 	TiltStartTime time.Time
 
@@ -693,12 +691,8 @@ func StateToView(s EngineState) view.View {
 	}
 	if !s.LastTiltfileBuild.Empty() {
 		err := s.LastTiltfileBuild.Error
-		if err == nil && s.IsEmpty() {
-			tr.CrashLog = model.NewLog(EmptyTiltfileMsg)
-			ret.TiltfileErrorMessage = EmptyTiltfileMsg
-		} else if err != nil {
+		if err != nil {
 			tr.CrashLog = model.NewLog(err.Error())
-			ret.TiltfileErrorMessage = err.Error()
 		}
 	}
 	ret.Resources = append(ret.Resources, tr)

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -91,42 +91,6 @@ func TestMostRecentPod(t *testing.T) {
 	assert.Equal(t, "pod-b", podSet.MostRecentPod().PodID.String())
 }
 
-func TestEmptyState(t *testing.T) {
-	es := newState([]model.Manifest{}, model.Manifest{})
-
-	v := StateToView(*es)
-	assert.Equal(t, "", v.TiltfileErrorMessage)
-
-	es.LastTiltfileBuild = model.BuildRecord{
-		StartTime:  time.Now(),
-		FinishTime: time.Now(),
-	}
-	v = StateToView(*es)
-	assert.Equal(t, EmptyTiltfileMsg, v.TiltfileErrorMessage)
-
-	yaml := "yamlyaml"
-	m := k8s.NewK8sOnlyManifestForTesting("GlobalYAML", yaml)
-	nes := newState([]model.Manifest{}, m)
-	nes.ConfigFiles = []string{"global.yaml"}
-	v = StateToView(*nes)
-	assert.Equal(t, "", v.TiltfileErrorMessage)
-
-	m2 := model.Manifest{
-		Name: "foo",
-	}.WithImageTarget(model.ImageTarget{}.
-		WithBuildDetails(model.FastBuild{
-			Syncs: []model.Sync{
-				{LocalPath: "/a/b"},
-				{LocalPath: "/a/b/c"},
-			},
-		}),
-	)
-
-	nes = newState([]model.Manifest{m2}, model.Manifest{})
-	v = StateToView(*nes)
-	assert.Equal(t, "", v.TiltfileErrorMessage)
-}
-
 func TestRelativeTiltfilePath(t *testing.T) {
 	es := newState([]model.Manifest{}, model.Manifest{})
 	wd, err := os.Getwd()

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -54,7 +54,6 @@ type HudState = {
     Resources: Array<Resource>
     Log: string
     LogTimestamps: boolean
-    TiltfileErrorMessage: string
   } | null
   IsSidebarClosed: boolean
 }
@@ -77,7 +76,6 @@ class HUD extends Component<HudProps, HudState> {
         Resources: [],
         Log: "",
         LogTimestamps: false,
-        TiltfileErrorMessage: "",
       },
       IsSidebarClosed: false,
     }


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/tiltfileerrormessage:

4ac7995f9ccdaf7c9c86f71d43f75358d11f34f9 (2019-04-09 15:05:45 -0400)
hud: remove TiltfileErrorMessage
This code is all obsolete. The empty tiltfile case is handled in configs_controller now.