### PR TITLE
web: don't set the line-height on the collapse button. it's unnecessary and makes an extra scrollbar appear

### DIFF
--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -138,7 +138,6 @@
   margin: 0;
   padding: 0;
   @include button-text;
-  line-height: $sidebar-item;
   cursor: pointer;
   transition-property: color, background-color;
   transition-duration: $animation-timing;


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch nicks/sticky:

b4d67bc10875debf1a497efa14f9361a8c6b7f04 (2019-04-10 11:51:28 -0400)
web: don't set the line-height on the collapse button. it's unnecessary and makes an extra scrollbar appear