### PR TITLE
tiltfile: make k8sobjectid starlark type UpperCase

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -512,7 +512,7 @@ func (k k8sObjectID) String() string {
 }
 
 func (k k8sObjectID) Type() string {
-	return "k8sObjectID"
+	return "K8sObjectID"
 }
 
 func (k k8sObjectID) Freeze() {


### PR DESCRIPTION
the type name as we represent it to starlark should follow python naming conventions (i.e., classes start with caps)