### PR TITLE
engine: don't do container builds in the wrong container

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -311,7 +311,7 @@ func buildStateSet(manifest model.Manifest, specs []model.TargetSpec, ms *store.
 			iTarget, ok := spec.(model.ImageTarget)
 			if ok {
 				if manifest.IsK8s() {
-					buildState = buildState.WithDeployTarget(store.NewDeployInfo(iTarget, ms.PodSet))
+					buildState = buildState.WithDeployTarget(store.NewDeployInfo(iTarget, ms.DeployID, ms.PodSet))
 				}
 
 				if manifest.IsDC() {

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -223,13 +223,17 @@ func (d DeployInfo) Empty() bool {
 
 // Check to see if there's a single, unambiguous Ready container
 // in the given PodSet. If so, create a DeployInfo for that container.
-func NewDeployInfo(iTarget model.ImageTarget, podSet PodSet) DeployInfo {
+func NewDeployInfo(iTarget model.ImageTarget, deployID model.DeployID, podSet PodSet) DeployInfo {
 	if podSet.Len() != 1 {
 		return DeployInfo{}
 	}
 
 	pod := podSet.MostRecentPod()
 	if pod.PodID == "" || pod.ContainerID == "" || pod.ContainerName == "" || !pod.ContainerReady {
+		return DeployInfo{}
+	}
+
+	if podSet.DeployID != deployID {
 		return DeployInfo{}
 	}
 


### PR DESCRIPTION
This addresses one of the issues in [ch2241](https://app.clubhouse.io/windmill/story/2241/infinite-k8s-redeploy-loop) and suffices to stop the looping (at least, in the one repro case I know of). There are a few other things in there that I might like to sort out, but they seem much less pressing.