### PR TITLE
engine: add newline to a direct call to logger.write

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -69,7 +69,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 		}
 
 		if redirectErr, ok := err.(RedirectToNextBuilder); ok {
-			s := fmt.Sprintf("falling back to next update method because: %v", err)
+			s := fmt.Sprintf("falling back to next update method because: %v\n", err)
 			logger.Get(ctx).Write(redirectErr.level, s)
 		} else {
 			lastUnexpectedErr = err


### PR DESCRIPTION
as mentioned [here](https://github.com/windmilleng/tilt/pull/1454#discussion_r275933560) (#1451), the `write` method doesn't actually append a newline, so we need to do it ourselves.

otherwise, looks like this:
![Screen Shot 2019-04-16 at 2 24 25 PM](https://user-images.githubusercontent.com/6332648/56234921-4f920600-6054-11e9-8525-f94c588b7828.png)
