### PR TITLE
kustomize: support alternative file names

### DIFF
--- a/internal/kustomize/dependencies.go
+++ b/internal/kustomize/dependencies.go
@@ -32,6 +32,7 @@ type configMapGenerator struct {
 	Files []string `yaml:"files"`
 }
 
+// Mostly taken from the [kustomize source code](https://github.com/kubernetes-sigs/kustomize/blob/ee68a9c450bc884b0d657fb7e3d62eb1ac59d14f/pkg/target/kusttarget.go#L97) itself.
 func loadKustFile(dir string) ([]byte, string, error) {
 	var content []byte
 	var path string

--- a/internal/kustomize/dependencies.go
+++ b/internal/kustomize/dependencies.go
@@ -1,11 +1,18 @@
 package kustomize
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
 	yaml "gopkg.in/yaml.v2"
 )
+
+var kustomizationFileNames = []string{
+	"kustomization.yaml",
+	"kustomization.yml",
+	"Kustomization",
+}
 
 // kustomization is the content of a kustomization.yaml file.
 type kustomization struct {
@@ -25,11 +32,37 @@ type configMapGenerator struct {
 	Files []string `yaml:"files"`
 }
 
+func loadKustFile(dir string) ([]byte, string, error) {
+	var content []byte
+	var path string
+	match := 0
+	for _, kf := range kustomizationFileNames {
+		p := filepath.Join(dir, kf)
+		c, err := ioutil.ReadFile(p)
+		if err == nil {
+			path = p
+			match += 1
+			content = c
+		}
+	}
+
+	switch match {
+	case 0:
+		return nil, "", fmt.Errorf(
+			"unable to find one of %v in directory '%s'",
+			kustomizationFileNames, dir)
+	case 1:
+		return content, path, nil
+	default:
+		return nil, "", fmt.Errorf(
+			"Found multiple kustomization files under: %s\n", dir)
+	}
+}
+
 func dependenciesForKustomization(dir string) ([]string, error) {
 	var deps []string
 
-	path := filepath.Join(dir, "kustomization.yaml")
-	buf, err := ioutil.ReadFile(path)
+	buf, path, err := loadKustFile(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kustomize/dependencies_test.go
+++ b/internal/kustomize/dependencies_test.go
@@ -12,7 +12,7 @@ import (
 func TestNoFile(t *testing.T) {
 	f := newKustomizeFixture(t)
 
-	f.assertErrorContains("kustomization.yaml: no such file or directory")
+	f.assertErrorContains("unable to find one of [kustomization.yaml kustomization.yml Kustomization] in directory ")
 }
 
 func TestEmpty(t *testing.T) {

--- a/internal/kustomize/dependencies_test.go
+++ b/internal/kustomize/dependencies_test.go
@@ -15,6 +15,14 @@ func TestNoFile(t *testing.T) {
 	f.assertErrorContains("unable to find one of [kustomization.yaml kustomization.yml Kustomization] in directory ")
 }
 
+func TestTooManyFiles(t *testing.T) {
+	f := newKustomizeFixture(t)
+	f.tempdir.WriteFile("kustomization.yml", "")
+	f.tempdir.WriteFile("kustomization.yaml", "")
+
+	f.assertErrorContains("Found multiple kustomization files under")
+}
+
 func TestEmpty(t *testing.T) {
 	f := newKustomizeFixture(t)
 	kustomizeFile := ""


### PR DESCRIPTION
Mostly taken from the [kustomize source code](https://github.com/kubernetes-sigs/kustomize/blob/ee68a9c450bc884b0d657fb7e3d62eb1ac59d14f/pkg/target/kusttarget.go#L97) itself.

Fixes #1503