### PR TITLE
ospath: ensure that IsChild doesn't break on trailing slash

### DIFF
--- a/internal/ospath/ospath.go
+++ b/internal/ospath/ospath.go
@@ -14,7 +14,8 @@ func Child(dir string, file string) (string, bool) {
 		return "", false
 	}
 
-	current := file
+	dir = filepath.Clean(dir)
+	current := filepath.Clean(file)
 	child := "."
 	for {
 		if dir == current {

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -60,6 +60,17 @@ func TestInvalidDir(t *testing.T) {
 	f.assertChild("", "random", "")
 }
 
+func TestDirTrailingSlash(t *testing.T) {
+	f := NewOspathFixture(t)
+	defer f.TearDown()
+
+	f.TouchFiles([]string{"some/dir/file"})
+
+	// Should work regardless of whether directory has trailing slash
+	f.assertChild("some/dir", "some/dir/file", "file")
+	f.assertChild("some/dir/", "some/dir/file", "file")
+}
+
 func TestTryAsCwdChildren(t *testing.T) {
 	f := NewOspathFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/is-child-bug:

477bb8e293f740d84bd9a47a75afcee650bf60e3 (2019-04-18 16:05:11 -0400)
ospath: ensure that IsChild doesn't break on trailing slash

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics