### PR TITLE
remove position:sticky from the sidebar collapse button. this isn't really what sticky is for

### DIFF
--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -87,10 +87,11 @@
 }
 
 // Collapse/Expand
+.Sidebar-spacer {
+  flex-grow: 1;
+  height: 0;
+}
 .Sidebar-toggle {
-  position: sticky;
-  bottom: 0;
-  right: 0;
   background-color: $color-navy;
   border: 0 none;
   border-top: 1px solid $color-navy-light;
@@ -99,7 +100,7 @@
   font-family: inherit;
   display: flex;
   align-items: center;
-  height: $sidebar-item;
+  min-height: $sidebar-item;
   margin: 0;
   padding: 0;
   @include button-text;

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -99,6 +99,7 @@ class Sidebar extends PureComponent<SidebarProps> {
             {listItems}
           </ul>
         </nav>
+        <div className="Sidebar-spacer">&nbsp;</div>
         <button className="Sidebar-toggle" onClick={this.props.toggleSidebar}>
           <ChevronSvg /> Collapse
         </button>

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -21,6 +21,11 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
       </li>
     </ul>
   </nav>
+  <div
+    className="Sidebar-spacer"
+  >
+     
+  </div>
   <button
     className="Sidebar-toggle"
     onClick={null}
@@ -72,6 +77,11 @@ exports[`sidebar renders list of resources 1`] = `
       </li>
     </ul>
   </nav>
+  <div
+    className="Sidebar-spacer"
+  >
+     
+  </div>
   <button
     className="Sidebar-toggle"
     onClick={null}


### PR DESCRIPTION
Hello @yuindustries, @jazzdan,

Please review the following commits I made in branch nicks/sticky:

1c1730f10215fddeeaf829713a85dc59f419096c (2019-04-18 18:40:37 -0400)
remove position:sticky from the sidebar collapse button. this isn't really what sticky is for