### PR TITLE
model: new matcher that matches on either exact match of child of given paths (for better tiltfile for Sail)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -7,8 +7,8 @@ repo = local_git_repo('.')
 live_update = [
   sync('internal', '/go/src/github.com/windmilleng/tilt/internal'),
   sync('web', '/go/src/github.com/windmilleng/tilt/web'),
-  run('make build-js'),  # trigger=['web'] (when support directory/glob triggers)
-  run('make install-sail'),  # trigger=['internal'] (when support directory/glob triggers)
+  run('make build-js', trigger=['web/']),
+  run('make install-sail', trigger=['internal/']),
   restart_container(),
 ]
 docker_build('gcr.io/windmill-public-containers/sail',

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -845,6 +845,10 @@ func newBDFixture(t *testing.T, env k8s.Env) *bdFixture {
 	}
 }
 
+func (f *bdFixture) NewPathSet(paths ...string) model.PathSet {
+	return model.NewPathSet(paths, f.Path())
+}
+
 func (f *bdFixture) deployInfo() store.DeployInfo {
 	return store.DeployInfo{
 		PodID:         "pod-id",

--- a/internal/model/matcher_test.go
+++ b/internal/model/matcher_test.go
@@ -1,0 +1,56 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+)
+
+func TestNewRelativeFileOrChildMatcher(t *testing.T) {
+	f := tempdir.NewTempDirFixture(t)
+	defer f.TearDown()
+
+	paths := []string{
+		"a",
+		"b/c/d",
+		"/already/abs",
+	}
+	matcher := NewRelativeFileOrChildMatcher(f.Path(), paths...)
+
+	expected := map[string]bool{
+		f.JoinPath("a"):     true,
+		f.JoinPath("b/c/d"): true,
+		"/already/abs":      true,
+	}
+
+	assert.Equal(t, expected, matcher.paths)
+}
+
+func TestFileOrChildMatcher(t *testing.T) {
+	f := tempdir.NewTempDirFixture(t)
+	defer f.TearDown()
+
+	matcher := fileOrChildMatcher{map[string]bool{
+		"file.txt":        true,
+		"nested/file.txt": true,
+		"directory":       true,
+	}}
+
+	// map test case --> expected match
+	expectedMatch := map[string]bool{
+		"file.txt":                true,
+		"nested/file.txt":         true,
+		"nested":                  false,
+		"nested/otherfile.txt":    false,
+		"directory/some/file.txt": true,
+		"other/dir/entirely":      false,
+	}
+
+	for f, expected := range expectedMatch {
+		match, err := matcher.Matches(f, false)
+		if assert.NoError(t, err) {
+			assert.Equal(t, expected, match, "expected file '%s' match --> %t", f, expected)
+		}
+	}
+}

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/wmclient/pkg/os/temp"
 )
 
@@ -120,10 +119,6 @@ func (f *TempDirFixture) TempDir(prefix string) string {
 		f.t.Fatal(err)
 	}
 	return name
-}
-
-func (f *TempDirFixture) NewPathSet(paths ...string) model.PathSet {
-	return model.NewPathSet(paths, f.Path())
 }
 
 func (f *TempDirFixture) TearDown() {

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -273,7 +273,7 @@ func newLiveUpdateFixture(t *testing.T) *liveUpdateFixture {
 		model.LiveUpdateSyncStep{Source: f.JoinPath("foo", "b"), Dest: "/c"},
 		model.LiveUpdateRunStep{
 			Command:  model.ToShellCmd("f"),
-			Triggers: f.NewPathSet("g", "h"),
+			Triggers: model.NewPathSet([]string{"g", "h"}, f.Path()),
 		},
 		model.LiveUpdateRestartContainerStep{},
 	)


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/file-or-child-matcher:

51f641ee2de47ed80bb016f8d149e36eccd6b9c0 (2019-04-22 17:01:19 -0400)
add directory-based run triggers back to Tiltfile for sail

e0a1f09cfeaa7a00023b163f6bb9d0aa1efe621d (2019-04-22 16:54:31 -0400)
test

a1f1ec8c9836f9ca4b6f19b115677223dea3619a (2019-04-22 16:40:41 -0400)
model: new matcher that matches on either exact match of child of given paths

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics