### PR TITLE
web: fine-tune colors

### DIFF
--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -37,7 +37,7 @@
 }
 
 .ansi-black {
-  color: $color-black;
+  color: $color-gray-dark;
 }
 .ansi-red {
   color: $color-red;

--- a/web/src/LogoButton.scss
+++ b/web/src/LogoButton.scss
@@ -11,7 +11,7 @@
   fill: $color-green !important;
 }
 .u-fillGreenLightest {
-  fill: $color-green-lightest !important;
+  fill: $color-green-light !important;
 }
 .LogoButton .notch {
   transition-duration: 0.3s;
@@ -20,29 +20,37 @@
 }
 .LogoButton .notch--1 {
   transition-delay: 0.1s;
-  transform: translate(568.0799865722656px, 30.780078895390034px) rotate(0deg) translate(-568.0799865722656px, -30.780078895390034px);
+  transform: translate(568.0799865722656px, 30.780078895390034px) rotate(0deg)
+    translate(-568.0799865722656px, -30.780078895390034px);
 }
 .LogoButton:hover .notch--1 {
-  transform: translate(568.0799865722656px, 30.780078895390034px) rotate(90deg) translate(-568.0799865722656px, -30.780078895390034px);
+  transform: translate(568.0799865722656px, 30.780078895390034px) rotate(90deg)
+    translate(-568.0799865722656px, -30.780078895390034px);
 }
 .LogoButton .notch--2 {
   transition-delay: 0.06s;
-  transform: translate(31.439985513687134px, 30.77007481828332px) rotate(0deg) translate(-31.439985513687134px, -30.77007481828332px);
+  transform: translate(31.439985513687134px, 30.77007481828332px) rotate(0deg)
+    translate(-31.439985513687134px, -30.77007481828332px);
 }
 .LogoButton:hover .notch--2 {
-  transform: translate(31.439985513687134px, 30.77007481828332px) rotate(-90deg) translate(-31.439985513687134px, -30.77007481828332px);
+  transform: translate(31.439985513687134px, 30.77007481828332px) rotate(-90deg)
+    translate(-31.439985513687134px, -30.77007481828332px);
 }
 .LogoButton .notch--3 {
   transition-delay: 0.13s;
-  transform: translate(238.06499481201172px, 30.77007481828332px) rotate(0deg) translate(-238.06499481201172px, -30.77007481828332px);
+  transform: translate(238.06499481201172px, 30.77007481828332px) rotate(0deg)
+    translate(-238.06499481201172px, -30.77007481828332px);
 }
 .LogoButton:hover .notch--3 {
-  transform: translate(238.06499481201172px, 30.77007481828332px) rotate(90deg) translate(-238.06499481201172px, -30.77007481828332px);;
+  transform: translate(238.06499481201172px, 30.77007481828332px) rotate(90deg)
+    translate(-238.06499481201172px, -30.77007481828332px);
 }
 .LogoButton .notch--4 {
   transition-delay: 0.03s;
-  transform: translate(405.0400085449219px, 169.33999633789062px) rotate(0deg) translate(-405.0400085449219px, -169.33999633789062px);
+  transform: translate(405.0400085449219px, 169.33999633789062px) rotate(0deg)
+    translate(-405.0400085449219px, -169.33999633789062px);
 }
 .LogoButton:hover .notch--4 {
-  transform: translate(405.0400085449219px, 169.33999633789062px) rotate(-90deg) translate(-405.0400085449219px, -169.33999633789062px);
+  transform: translate(405.0400085449219px, 169.33999633789062px) rotate(-90deg)
+    translate(-405.0400085449219px, -169.33999633789062px);
 }

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -16,6 +16,7 @@
   display: flex;
   flex-direction: column;
   z-index: $z-sidebar;
+  box-shadow: -2px 0px 10px 0px rgba(0, 43, 54, 0.5);
 }
 .Sidebar.is-closed {
   transform: translateX(calc(100% - #{$sidebar-collapsed-width}));

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -7,7 +7,7 @@
   bottom: $statusbar-height;
   width: $sidebar-width;
   background-color: $color-gray;
-  border-left: 2px solid $color-off-white;
+  border-left: 2px solid $color-gray-lightest;
   box-sizing: border-box;
   overflow-y: auto;
   transform: translateX(0%);
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: column;
   z-index: $z-sidebar;
-  box-shadow: -2px 0px 10px 0px rgba(0, 43, 54, 0.5);
+  box-shadow: -2px 0px 10px 0px rgba($color-gray-dark, $translucent);
 }
 .Sidebar.is-closed {
   transform: translateX(calc(100% - #{$sidebar-collapsed-width}));
@@ -92,7 +92,7 @@
 }
 .resLink time {
   font-weight: normal;
-  color: $color-off-white;
+  color: $color-gray-lightest;
   margin-right: $spacing-unit / 2;
 }
 

--- a/web/src/Sidebar.scss
+++ b/web/src/Sidebar.scss
@@ -6,8 +6,8 @@
   right: 0;
   bottom: $statusbar-height;
   width: $sidebar-width;
-  background-color: $color-navy;
-  border-left: 2px solid $color-navy-light;
+  background-color: $color-gray;
+  border-left: 2px solid $color-off-white;
   box-sizing: border-box;
   overflow-y: auto;
   transform: translateX(0%);
@@ -32,8 +32,8 @@
 
 .resLink {
   right: 0;
-  background-color: $color-navy;
-  border-bottom: 1px solid $color-navy-light;
+  background-color: $color-gray;
+  border-bottom: 1px solid $color-gray-light;
   color: $color-white;
   text-decoration: none;
   display: flex;
@@ -45,13 +45,13 @@
 }
 .resLink:hover {
   right: 0;
-  background-color: $color-navy-dark;
+  background-color: $color-gray-dark;
   color: $color-blue-light;
 }
 .resLink.is-selected {
   right: 0;
   background-color: $color-white;
-  color: $color-navy;
+  color: $color-gray;
 }
 .resLink::before {
   content: "●";
@@ -70,7 +70,7 @@
 }
 .resLink--all::before {
   content: "┌";
-  color: $color-grey-dark;
+  color: $color-gray-light;
   margin-top: -8px;
 }
 .resLink--ok::before {
@@ -80,7 +80,7 @@
   color: $color-green;
 }
 .resLink--pending::before {
-  color: $color-yellow;
+  color: $color-gray-light;
 }
 .resLink--error::before {
   color: $color-red;
@@ -91,13 +91,12 @@
 }
 .resLink time {
   font-weight: normal;
-  color: $color-white;
-  opacity: 0.5;
+  color: $color-off-white;
   margin-right: $spacing-unit / 2;
 }
 
 .resLink.is-selected time {
-  color: $color-navy;
+  color: $color-gray;
 }
 
 // Collapse/Expand
@@ -106,9 +105,9 @@
   height: 0;
 }
 .Sidebar-toggle {
-  background-color: $color-navy;
+  background-color: $color-gray;
   border: 0 none;
-  border-top: 1px solid $color-navy-light;
+  border-top: 1px solid $color-gray-light;
   color: inherit;
   font-size: inherit;
   font-family: inherit;
@@ -124,7 +123,7 @@
   transition-timing-function: ease;
 }
 .Sidebar-toggle:hover {
-  background-color: $color-navy-dark;
+  background-color: $color-gray-dark;
   color: $color-blue-light;
 }
 .Sidebar-toggle > svg {

--- a/web/src/Statusbar.scss
+++ b/web/src/Statusbar.scss
@@ -7,11 +7,11 @@
   bottom: 0;
   z-index: $z-sidebar;
   height: $statusbar-height;
-  color: $color-navy;
-  background-color: $color-grey-lightest;
+  color: $color-gray;
+  background-color: $color-white;
   display: flex;
   align-items: center;
-  border-top: 1px solid $color-navy-dark;
+  border-top: 1px solid $color-gray-dark;
 }
 .Statusbar-panel {
   padding: $spacing-unit / 4 $spacing-unit / 2;
@@ -43,7 +43,7 @@
   height: $spacing-unit;
 }
 .Statusbar-panel--statusMessage {
-  border-left: 1px dotted $color-navy;
+  border-left: 1px dotted $color-gray;
   padding-left: $spacing-unit/2;
   flex-grow: 1;
 }

--- a/web/src/TabNav.scss
+++ b/web/src/TabNav.scss
@@ -7,6 +7,7 @@
   right: 0;
   padding-right: $sidebar-width;
   background-color: $color-gray-dark;
+  box-shadow: inset 0px -2px 10px 0px rgba($color-gray-darkest, $translucent);
   z-index: $z-tabnav;
 }
 

--- a/web/src/TabNav.scss
+++ b/web/src/TabNav.scss
@@ -20,7 +20,7 @@
 }
 
 .TabNav ul li + li {
-  border-left: 2px solid $color-gray-light;
+  border-left: 1px solid $color-gray-light;
 }
 
 .tabLink {
@@ -33,7 +33,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-bottom: 1px solid $color-gray-light;
   transition-property: color, background-color;
   transition-duration: $animation-timing;
   transition-timing-function: ease;
@@ -41,7 +40,6 @@
 }
 
 .tabLink:hover {
-  background-color: $color-gray-dark;
   color: $color-blue-light;
 }
 

--- a/web/src/TabNav.scss
+++ b/web/src/TabNav.scss
@@ -6,7 +6,7 @@
   left: 0;
   right: 0;
   padding-right: $sidebar-width;
-  background-color: $color-navy-dark;
+  background-color: $color-gray-dark;
   z-index: $z-tabnav;
 }
 
@@ -16,11 +16,11 @@
 }
 
 .TabNav ul li:last-child {
-  border-right: 1px solid $color-navy-light;
+  border-right: 1px solid $color-gray-light;
 }
 
 .TabNav ul li + li {
-  border-left: 2px solid $color-navy-light;
+  border-left: 2px solid $color-gray-light;
 }
 
 .tabLink {
@@ -33,7 +33,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-bottom: 1px solid $color-navy-light;
+  border-bottom: 1px solid $color-gray-light;
   transition-property: color, background-color;
   transition-duration: $animation-timing;
   transition-timing-function: ease;
@@ -41,12 +41,12 @@
 }
 
 .tabLink:hover {
-  background-color: $color-navy-dark;
+  background-color: $color-gray-dark;
   color: $color-blue-light;
 }
 
 .tabLink--is-selected {
   right: 0;
-  background-color: $color-navy;
+  background-color: $color-gray;
   border-bottom: none;
 }

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -9,10 +9,11 @@ $font-size-icon: 24px;
 // COLORS
 // Monochrome
 $color-white: #ffffff;
-$color-off-white: #93a1a1;
+$color-gray-lightest: #93a1a1;
 $color-gray-light: #586e75;
 $color-gray: #073642;
 $color-gray-dark: #002b36;
+$color-gray-darkest: #001b20;
 
 // Tilt Colors
 $color-green: #20ba31;
@@ -23,6 +24,8 @@ $color-purple: #6378ba;
 $color-red: #f6685c;
 $color-pink: #ef5aa0;
 $color-yellow: #fcb41e;
+
+$translucent: 0.3;
 
 // LAYOUT
 $spacing-unit: 32px;

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -1,3 +1,4 @@
+// TYPOGRAPHY
 $font-monospace: "Inconsolata", monospace;
 $font-sans-serif: "Montserrat", sans-serif;
 $font-size: 20px;
@@ -5,29 +6,25 @@ $font-size-large: 26px;
 $font-size-small: 16px;
 $font-size-icon: 24px;
 
+// COLORS
+// Monochrome
 $color-white: #ffffff;
-$color-black: #000000;
+$color-off-white: #93a1a1;
+$color-gray-light: #586e75;
+$color-gray: #073642;
+$color-gray-dark: #002b36;
+
+// Tilt Colors
 $color-green: #20ba31;
-$color-green-lightest: #70d37b;
+$color-green-light: #70d37b;
 $color-blue: #03c7d3;
+$color-blue-light: #5edbe3;
 $color-purple: #6378ba;
 $color-red: #f6685c;
 $color-pink: #ef5aa0;
 $color-yellow: #fcb41e;
-$color-grey: #9a9a9a;
-$color-grey-light: #cacaca;
-$color-grey-lightest: #f1f1f1;
-$color-grey-dark: #606060;
-$color-grey-darkest: #434343;
-$color-red-light: #f99e97;
-$color-blue-light: #5edbe3;
-$color-blue-lightest: #98e8ed;
-$color-green-light: #70d37b;
-$color-yellow-light: #fdcf6e;
-$color-navy: #002f39;
-$color-navy-dark: #002125;
-$color-navy-light: #30545c;
 
+// LAYOUT
 $spacing-unit: 32px;
 $sidebar-width: $spacing-unit * 10;
 $sidebar-collapsed-width: $spacing-unit * 1.5;
@@ -36,7 +33,10 @@ $sidebar-maxWidth: 25vw;
 $tabnav-height: $sidebar-item * 1.5;
 $statusbar-height: $spacing-unit * 1.75;
 
+$z-sidebar: 1000;
+$z-tabnav: 500;
 
+// MISC
 $animation-timing: 200ms;
 
 @mixin button-text() {
@@ -45,6 +45,3 @@ $animation-timing: 200ms;
   font-size: $font-size-small;
   text-transform: uppercase;
 }
-
-$z-sidebar: 1000;
-$z-tabnav: 500;

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -14,7 +14,7 @@ body {
   font-family: $font-monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: $color-navy;
+  background-color: $color-gray;
   color: $color-white;
   font-size: $font-size;
   line-height: 1.5;


### PR DESCRIPTION
- Use Solarized grays (many people use this color scheme, and I think it still goes well with Tilt colors)
- Add some shadows to sidebar and tabnav to create look of depth
- Fewer colors to choose from makes life easier

<img width="1302" alt="Screen Shot 2019-04-23 at 3 41 40 PM" src="https://user-images.githubusercontent.com/20349/56610856-7e712480-65de-11e9-94d6-cc704b4eefc2.png">
