### PR TITLE
titltfile: fix the impossible live update check when there are undeployed images

### DIFF
--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -109,6 +109,16 @@ func (m Manifest) WithDeployTarget(t TargetSpec) Manifest {
 	return m
 }
 
+func (m Manifest) IsImageDeployed(iTarget ImageTarget) bool {
+	id := iTarget.ID()
+	for _, depID := range m.DeployTarget().DependencyIDs() {
+		if depID == id {
+			return true
+		}
+	}
+	return false
+}
+
 func (m Manifest) LocalPaths() []string {
 	// TODO(matt?) DC syncs should probably stored somewhere more consistent with Docker/Fast Build
 	switch di := m.deployTarget.(type) {


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/busted:

c448e728bc2badd0d24054ad2ce36814e9f27d07 (2019-04-25 18:38:27 -0400)
titltfile: fix the impossible live update check when there are undeployed images