### PR TITLE
web: make sail-info its own component, show "connect to sail" button if sail enabled and no url

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -147,7 +147,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 
 	g.Go(func() error {
 		defer cancel()
-		return upper.Start(ctx, args, c.watch, triggerMode, c.fileName, c.hud)
+		return upper.Start(ctx, args, c.watch, triggerMode, c.fileName, c.hud, enableSail)
 	})
 
 	err = g.Wait()

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -106,6 +106,8 @@ type InitAction struct {
 	Warnings   []string
 
 	ExecuteTiltfile bool
+
+	EnableSail bool
 }
 
 func (InitAction) Action() {}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -85,7 +85,7 @@ func (u Upper) Dispatch(action store.Action) {
 	u.store.Dispatch(action)
 }
 
-func (u Upper) Start(ctx context.Context, args []string, watch bool, triggerMode model.TriggerMode, fileName string, useActionWriter bool) error {
+func (u Upper) Start(ctx context.Context, args []string, watch bool, triggerMode model.TriggerMode, fileName string, useActionWriter bool, enableSail bool) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Start")
 	defer span.Finish()
 
@@ -114,6 +114,7 @@ func (u Upper) Start(ctx context.Context, args []string, watch bool, triggerMode
 		StartTime:       startTime,
 		FinishTime:      time.Now(),
 		ExecuteTiltfile: false,
+		EnableSail:      enableSail,
 	})
 }
 
@@ -851,6 +852,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 	engineState.TriggerMode = action.TriggerMode
 	engineState.ConfigFiles = action.ConfigFiles
 	engineState.InitManifests = action.InitManifests
+	engineState.SailEnabled = action.EnableSail
 
 	if action.ExecuteTiltfile {
 		engineState.GlobalYAML = action.GlobalYAMLManifest

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2135,7 +2135,7 @@ func TestDockerComposeBuildCompletedDoesntSetStatusIfNotSuccessful(t *testing.T)
 func TestEmptyTiltfile(t *testing.T) {
 	f := newTestFixture(t)
 	f.WriteFile("Tiltfile", "")
-	go f.upper.Start(f.ctx, []string{}, false, model.TriggerAuto, f.JoinPath("Tiltfile"), true)
+	go f.upper.Start(f.ctx, []string{}, false, model.TriggerAuto, f.JoinPath("Tiltfile"), true, false)
 	f.WaitUntil("build is set", func(st store.EngineState) bool {
 		return !st.LastTiltfileBuild.Empty()
 	})

--- a/internal/hud/server/view.go
+++ b/internal/hud/server/view.go
@@ -111,6 +111,7 @@ func StateToWebView(s store.EngineState) webview.View {
 	}
 
 	ret.Log = s.Log
+	ret.SailEnabled = s.SailEnabled
 	ret.SailURL = s.SailURL
 
 	return ret

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -109,7 +109,9 @@ type View struct {
 	Log           model.Log
 	Resources     []Resource
 	LogTimestamps bool
-	SailURL       string
+
+	SailEnabled bool
+	SailURL     string
 }
 
 func (v View) Resource(n model.ManifestName) (Resource, bool) {

--- a/internal/sail/client/client.go
+++ b/internal/sail/client/client.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/logger"
@@ -141,17 +140,20 @@ func (s *SailClient) init(ctx context.Context, st store.RStore) error {
 }
 
 func (s *SailClient) OnChange(ctx context.Context, st store.RStore) {
-	if !s.initDone {
-		s.initDone = true
+	// ~~ TODO:
+	// if state.NeedsSailConnect: s.init(ctx, st)
 
-		// TODO(nick): To get an end-to-end connection working, we're just
-		// going to connect to the Sail server on startup. Eventually this
-		// should be changed to connect on user action.
-		err := s.init(ctx, st)
-		if err != nil {
-			st.Dispatch(store.NewErrorAction(errors.Wrap(err, "SailClient")))
-		}
-	}
+	// if !s.initDone {
+	// 	s.initDone = true
+	//
+	// 	// TODO(nick): To get an end-to-end connection working, we're just
+	// 	// going to connect to the Sail server on startup. Eventually this
+	// 	// should be changed to connect on user action.
+	// 	err := s.init(ctx, st)
+	// 	if err != nil {
+	// 		st.Dispatch(store.NewErrorAction(errors.Wrap(err, "SailClient")))
+	// 	}
+	// }
 
 	if !s.isConnected() {
 		return

--- a/internal/sail/client/client.go
+++ b/internal/sail/client/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/logger"
@@ -140,20 +141,17 @@ func (s *SailClient) init(ctx context.Context, st store.RStore) error {
 }
 
 func (s *SailClient) OnChange(ctx context.Context, st store.RStore) {
-	// ~~ TODO:
-	// if state.NeedsSailConnect: s.init(ctx, st)
+	if !s.initDone {
+		s.initDone = true
 
-	// if !s.initDone {
-	// 	s.initDone = true
-	//
-	// 	// TODO(nick): To get an end-to-end connection working, we're just
-	// 	// going to connect to the Sail server on startup. Eventually this
-	// 	// should be changed to connect on user action.
-	// 	err := s.init(ctx, st)
-	// 	if err != nil {
-	// 		st.Dispatch(store.NewErrorAction(errors.Wrap(err, "SailClient")))
-	// 	}
-	// }
+		// TODO(nick): To get an end-to-end connection working, we're just
+		// going to connect to the Sail server on startup. Eventually this
+		// should be changed to connect on user action.
+		err := s.init(ctx, st)
+		if err != nil {
+			st.Dispatch(store.NewErrorAction(errors.Wrap(err, "SailClient")))
+		}
+	}
 
 	if !s.isConnected() {
 		return

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -76,7 +76,8 @@ type EngineState struct {
 	CurrentTiltfileBuild model.BuildRecord
 	TiltfileCombinedLog  model.Log
 
-	SailURL string
+	SailEnabled bool
+	SailURL     string
 }
 
 func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.ManifestName {

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -18,7 +18,7 @@ import {
 } from "react-router-dom"
 import { createBrowserHistory, History, UnregisterCallback } from "history"
 import { incr, pathToTag } from "./analytics"
-import TabNav from "./TabNav"
+import TopBar from "./TopBar"
 import "./HUD.scss"
 import { ResourceView } from "./types"
 import ErrorPane, { ErrorResource } from "./ErrorPane"
@@ -179,13 +179,13 @@ class HUD extends Component<HudProps, HudState> {
       )
     }
 
-    let tabNavRoute = (t: ResourceView, props: RouteComponentProps<any>) => {
+    let topBarRoute = (t: ResourceView, props: RouteComponentProps<any>) => {
       let name =
         props.match.params && props.match.params.name
           ? props.match.params.name
           : ""
       return (
-        <TabNav
+        <TopBar
           logUrl={name === "" ? "/" : `/r/${name}`}
           errorsUrl={name === "" ? "/errors" : `/r/${name}/errors`}
           previewUrl={this.getEndpointForName(name, sidebarItems)}
@@ -240,21 +240,21 @@ class HUD extends Component<HudProps, HudState> {
           <Switch>
             <Route
               path={this.path("/r/:name/errors")}
-              render={tabNavRoute.bind(null, ResourceView.Errors)}
+              render={topBarRoute.bind(null, ResourceView.Errors)}
             />
             <Route
               path={this.path("/r/:name/preview")}
-              render={tabNavRoute.bind(null, ResourceView.Preview)}
+              render={topBarRoute.bind(null, ResourceView.Preview)}
             />
             <Route
               path={this.path("/r/:name")}
-              render={tabNavRoute.bind(null, ResourceView.Log)}
+              render={topBarRoute.bind(null, ResourceView.Log)}
             />
             <Route
               path={this.path("/errors")}
-              render={tabNavRoute.bind(null, ResourceView.Errors)}
+              render={topBarRoute.bind(null, ResourceView.Errors)}
             />
-            <Route render={tabNavRoute.bind(null, ResourceView.Log)} />
+            <Route render={topBarRoute.bind(null, ResourceView.Log)} />
           </Switch>
           <Switch>
             <Route

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -91,7 +91,7 @@ class HUD extends Component<HudProps, HudState> {
         Resources: [],
         Log: "",
         LogTimestamps: false,
-        SailEnabled: false, // this isn't realllly the place for this info?
+        SailEnabled: false,
         SailURL: "",
       },
       IsSidebarClosed: false,

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -56,6 +56,7 @@ type HudState = {
     Resources: Array<Resource>
     Log: string
     LogTimestamps: boolean
+    SailEnabled: boolean
     SailURL: string
   } | null
   IsSidebarClosed: boolean
@@ -90,6 +91,7 @@ class HUD extends Component<HudProps, HudState> {
         Resources: [],
         Log: "",
         LogTimestamps: false,
+        SailEnabled: false, // this isn't realllly the place for this info?
         SailURL: "",
       },
       IsSidebarClosed: false,
@@ -151,6 +153,7 @@ class HUD extends Component<HudProps, HudState> {
 
   render() {
     let view = this.state.View
+    let sailEnabled = view && view.SailEnabled ? view.SailEnabled : false
     let sailUrl = view && view.SailURL ? view.SailURL : ""
     let message = this.state.Message
     let resources = (view && view.Resources) || []
@@ -187,6 +190,7 @@ class HUD extends Component<HudProps, HudState> {
           errorsUrl={name === "" ? "/errors" : `/r/${name}/errors`}
           previewUrl={this.getEndpointForName(name, sidebarItems)}
           resourceView={t}
+          sailEnabled={sailEnabled}
           sailUrl={sailUrl}
         />
       )

--- a/web/src/SailInfo.scss
+++ b/web/src/SailInfo.scss
@@ -1,0 +1,3 @@
+.SailInfo {
+  padding: 1em;
+}

--- a/web/src/SailInfo.scss
+++ b/web/src/SailInfo.scss
@@ -1,3 +1,11 @@
+@import "constants";
+
 .SailInfo {
-  padding: 1em;
+  padding-right: $spacing-unit;
+  a {
+    color: $color-gray-lightest;
+  }
+  a:hover {
+    color: $color-white;
+  }
 }

--- a/web/src/SailInfo.tsx
+++ b/web/src/SailInfo.tsx
@@ -1,0 +1,31 @@
+import React, { PureComponent } from "react"
+import "./SailInfo.scss"
+
+type SailProps = {
+  sailEnabled: boolean
+  sailUrl: string
+}
+
+class SailInfo extends PureComponent<SailProps> {
+  render() {
+    if (this.props.sailEnabled) {
+      if (this.props.sailUrl) {
+        return (
+          <span className="SailInfo">
+            <a href={this.props.sailUrl}>Share this view!</a>
+          </span>
+        )
+      }
+
+      return (
+        <span className="SailInfo">
+          <button type="button">Share me!</button>
+        </span>
+      )
+    }
+
+    return <span className="sail-url">&nbsp;</span>
+  }
+}
+
+export default SailInfo

--- a/web/src/TabNav.scss
+++ b/web/src/TabNav.scss
@@ -1,19 +1,5 @@
 @import "constants";
 
-.TabNav {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  padding-right: $sidebar-width;
-  background-color: $color-gray-darkest;
-  box-shadow: inset 0px -2px 10px 0px rgba($color-black, $translucent);
-  z-index: $z-tabnav;
-  color: $color-gray-light;
-  display: flex;
-  flex-direction: row;
-}
-
 .TabNav ul {
   list-style: none;
   display: flex;
@@ -25,16 +11,6 @@
 
 .TabNav ul li + li {
   border-left: 1px solid $color-gray;
-}
-
-.TabNav span.sail-url {
-  padding: 1em;
-}
-
-// Collapse/Expand
-.TabNav-spacer {
-  flex-grow: 1;
-  height: 0;
 }
 
 .tabLink {

--- a/web/src/TabNav.test.tsx
+++ b/web/src/TabNav.test.tsx
@@ -31,6 +31,7 @@ it("previews resources", () => {
           previewUrl="/r/foo/preview"
           errorsUrl="/r/foo/errors"
           resourceView={ResourceView.Preview}
+          sailEnabled={false}
           sailUrl=""
         />
       </MemoryRouter>
@@ -49,6 +50,26 @@ it("shows error pane", () => {
           previewUrl="/r/foo/preview"
           errorsUrl="/r/foo/errors"
           resourceView={ResourceView.Errors}
+          sailEnabled={false}
+          sailUrl=""
+        />
+      </MemoryRouter>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
+it("shows sail share button", () => {
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <TabNav
+          logUrl="/r/foo"
+          previewUrl="/r/foo/preview"
+          errorsUrl="/r/foo/errors"
+          resourceView={ResourceView.Errors}
+          sailEnabled={true}
           sailUrl=""
         />
       </MemoryRouter>
@@ -67,6 +88,7 @@ it("shows sail url", () => {
           previewUrl="/r/foo/preview"
           errorsUrl="/r/foo/errors"
           resourceView={ResourceView.Errors}
+          sailEnabled={true}
           sailUrl="www.sail.dev/xyz"
         />
       </MemoryRouter>

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -2,14 +2,13 @@ import React, { PureComponent } from "react"
 import { Link } from "react-router-dom"
 import { ResourceView } from "./types"
 import "./TabNav.scss"
+import SailInfo from "./SailInfo"
 
 type NavProps = {
   previewUrl: string
   logUrl: string
   errorsUrl: string
   resourceView: ResourceView
-  sailEnabled: boolean
-  sailUrl: string
 }
 
 class TabNav extends PureComponent<NavProps> {
@@ -18,8 +17,8 @@ class TabNav extends PureComponent<NavProps> {
     let previewIsSelected = this.props.resourceView == ResourceView.Preview
     let errorsIsSelected = this.props.resourceView == ResourceView.Errors
 
-    let spans: Array<JSX.Element> = [
-      <span key="TabNav">
+    return (
+      <nav className="TabNav">
         <ul>
           <li>
             <Link
@@ -52,30 +51,8 @@ class TabNav extends PureComponent<NavProps> {
             </Link>
           </li>
         </ul>
-      </span>,
-    ]
-
-    if (this.props.sailEnabled) {
-      spans.push(
-        <span className="TabNav-spacer" key="spacer">
-          &nbsp;
-        </span>
-      )
-      if (this.props.sailUrl) {
-        spans.push(
-          <span className="sail-url" key="sail-url">
-            <a href={this.props.sailUrl}>Share this view!</a>
-          </span>
-        )
-      } else {
-        spans.push(
-          <span className="sail-url" key="sail-url">
-            <button type="button">Share me!</button>
-          </span>
-        )
-      }
-    }
-    return <nav className="TabNav">{spans}</nav>
+      </nav>
+    )
   }
 }
 

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -8,6 +8,7 @@ type NavProps = {
   logUrl: string
   errorsUrl: string
   resourceView: ResourceView
+  sailEnabled: boolean
   sailUrl: string
 }
 
@@ -54,17 +55,25 @@ class TabNav extends PureComponent<NavProps> {
       </span>,
     ]
 
-    if (this.props.sailUrl) {
+    if (this.props.sailEnabled) {
       spans.push(
         <span className="TabNav-spacer" key="spacer">
           &nbsp;
         </span>
       )
-      spans.push(
-        <span className="sail-url" key="sail-url">
-          Share this view! <a href={this.props.sailUrl}>{this.props.sailUrl}</a>
-        </span>
-      )
+      if (this.props.sailUrl) {
+        spans.push(
+          <span className="sail-url" key="sail-url">
+            <a href={this.props.sailUrl}>Share this view!</a>
+          </span>
+        )
+      } else {
+        spans.push(
+          <span className="sail-url" key="sail-url">
+            <button type="button">Share me!</button>
+          </span>
+        )
+      }
     }
     return <nav className="TabNav">{spans}</nav>
   }

--- a/web/src/TopBar.scss
+++ b/web/src/TopBar.scss
@@ -1,0 +1,21 @@
+@import "constants";
+
+.TopBar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding-right: $sidebar-width;
+  background-color: $color-gray-darkest;
+  box-shadow: inset 0px -2px 10px 0px rgba($color-black, $translucent);
+  z-index: $z-topbar;
+  color: $color-gray-light;
+  display: flex;
+  flex-direction: row;
+}
+
+// Collapse/Expand
+.TopBar-spacer {
+  flex-grow: 1;
+  height: 0;
+}

--- a/web/src/TopBar.scss
+++ b/web/src/TopBar.scss
@@ -10,8 +10,10 @@
   box-shadow: inset 0px -2px 10px 0px rgba($color-black, $translucent);
   z-index: $z-topbar;
   color: $color-gray-light;
+
   display: flex;
   flex-direction: row;
+  align-items: center;
 }
 
 // Collapse/Expand

--- a/web/src/TopBar.test.tsx
+++ b/web/src/TopBar.test.tsx
@@ -1,52 +1,39 @@
 import React from "react"
 import renderer from "react-test-renderer"
-import TabNav from "./TabNav"
 import { MemoryRouter } from "react-router"
 import { ResourceView } from "./types"
+import TopBar from "./TopBar"
 
-it("shows logs", () => {
+it("shows sail share button", () => {
   const tree = renderer
     .create(
       <MemoryRouter>
-        <TabNav
-          logUrl="/r/foo"
-          previewUrl="/r/foo/preview"
-          errorsUrl="/r/foo/errors"
-          resourceView={ResourceView.Log}
-        />
-      </MemoryRouter>
-    )
-    .toJSON()
-
-  expect(tree).toMatchSnapshot()
-})
-
-it("previews resources", () => {
-  const tree = renderer
-    .create(
-      <MemoryRouter>
-        <TabNav
-          logUrl="/r/foo"
-          previewUrl="/r/foo/preview"
-          errorsUrl="/r/foo/errors"
-          resourceView={ResourceView.Preview}
-        />
-      </MemoryRouter>
-    )
-    .toJSON()
-
-  expect(tree).toMatchSnapshot()
-})
-
-it("shows error pane", () => {
-  const tree = renderer
-    .create(
-      <MemoryRouter>
-        <TabNav
+        <TopBar
           logUrl="/r/foo"
           previewUrl="/r/foo/preview"
           errorsUrl="/r/foo/errors"
           resourceView={ResourceView.Errors}
+          sailEnabled={true}
+          sailUrl=""
+        />
+      </MemoryRouter>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
+it("shows sail url", () => {
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <TopBar
+          logUrl="/r/foo"
+          previewUrl="/r/foo/preview"
+          errorsUrl="/r/foo/errors"
+          resourceView={ResourceView.Errors}
+          sailEnabled={true}
+          sailUrl="www.sail.dev/xyz"
         />
       </MemoryRouter>
     )

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -1,0 +1,37 @@
+import React, { PureComponent } from "react"
+import { Link } from "react-router-dom"
+import { ResourceView } from "./types"
+import "./TopBar.scss"
+import SailInfo from "./SailInfo"
+import TabNav from "./TabNav"
+
+type TopBarProps = {
+  previewUrl: string
+  logUrl: string
+  errorsUrl: string
+  resourceView: ResourceView
+  sailEnabled: boolean
+  sailUrl: string
+}
+
+class TopBar extends PureComponent<TopBarProps> {
+  render() {
+    return (
+      <div className="TopBar">
+        <TabNav
+          previewUrl={this.props.previewUrl}
+          logUrl={this.props.logUrl}
+          errorsUrl={this.props.errorsUrl}
+          resourceView={this.props.resourceView}
+        />
+        <span className="TopBar-spacer">&nbsp;</span>
+        <SailInfo
+          sailEnabled={this.props.sailEnabled}
+          sailUrl={this.props.sailUrl}
+        />
+      </div>
+    )
+  }
+}
+
+export default TopBar

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -1,5 +1,4 @@
 import React, { PureComponent } from "react"
-import { Link } from "react-router-dom"
 import { ResourceView } from "./types"
 import "./TopBar.scss"
 import SailInfo from "./SailInfo"

--- a/web/src/__snapshots__/TabNav.test.tsx.snap
+++ b/web/src/__snapshots__/TabNav.test.tsx.snap
@@ -114,6 +114,58 @@ exports[`shows logs 1`] = `
 </nav>
 `;
 
+exports[`shows sail share button 1`] = `
+<nav
+  className="TabNav"
+>
+  <span>
+    <ul>
+      <li>
+        <a
+          className="tabLink "
+          href="/r/foo"
+          onClick={[Function]}
+        >
+          Logs
+        </a>
+      </li>
+      <li>
+        <a
+          className="tabLink "
+          href="/r/foo/preview"
+          onClick={[Function]}
+        >
+          Preview
+        </a>
+      </li>
+      <li>
+        <a
+          className="tabLink tabLink--is-selected"
+          href="/r/foo/errors"
+          onClick={[Function]}
+        >
+          Errors
+        </a>
+      </li>
+    </ul>
+  </span>
+  <span
+    className="TabNav-spacer"
+  >
+     
+  </span>
+  <span
+    className="sail-url"
+  >
+    <button
+      type="button"
+    >
+      Share me!
+    </button>
+  </span>
+</nav>
+`;
+
 exports[`shows sail url 1`] = `
 <nav
   className="TabNav"
@@ -157,11 +209,10 @@ exports[`shows sail url 1`] = `
   <span
     className="sail-url"
   >
-    Share this view! 
     <a
       href="www.sail.dev/xyz"
     >
-      www.sail.dev/xyz
+      Share this view!
     </a>
   </span>
 </nav>

--- a/web/src/__snapshots__/TabNav.test.tsx.snap
+++ b/web/src/__snapshots__/TabNav.test.tsx.snap
@@ -4,37 +4,35 @@ exports[`previews resources 1`] = `
 <nav
   className="TabNav"
 >
-  <span>
-    <ul>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo"
-          onClick={[Function]}
-        >
-          Logs
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink tabLink--is-selected"
-          href="/r/foo/preview"
-          onClick={[Function]}
-        >
-          Preview
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo/errors"
-          onClick={[Function]}
-        >
-          Errors
-        </a>
-      </li>
-    </ul>
-  </span>
+  <ul>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo"
+        onClick={[Function]}
+      >
+        Logs
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink tabLink--is-selected"
+        href="/r/foo/preview"
+        onClick={[Function]}
+      >
+        Preview
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo/errors"
+        onClick={[Function]}
+      >
+        Errors
+      </a>
+    </li>
+  </ul>
 </nav>
 `;
 
@@ -42,37 +40,35 @@ exports[`shows error pane 1`] = `
 <nav
   className="TabNav"
 >
-  <span>
-    <ul>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo"
-          onClick={[Function]}
-        >
-          Logs
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo/preview"
-          onClick={[Function]}
-        >
-          Preview
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink tabLink--is-selected"
-          href="/r/foo/errors"
-          onClick={[Function]}
-        >
-          Errors
-        </a>
-      </li>
-    </ul>
-  </span>
+  <ul>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo"
+        onClick={[Function]}
+      >
+        Logs
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo/preview"
+        onClick={[Function]}
+      >
+        Preview
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink tabLink--is-selected"
+        href="/r/foo/errors"
+        onClick={[Function]}
+      >
+        Errors
+      </a>
+    </li>
+  </ul>
 </nav>
 `;
 
@@ -80,140 +76,34 @@ exports[`shows logs 1`] = `
 <nav
   className="TabNav"
 >
-  <span>
-    <ul>
-      <li>
-        <a
-          className="tabLink tabLink--is-selected"
-          href="/r/foo"
-          onClick={[Function]}
-        >
-          Logs
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo/preview"
-          onClick={[Function]}
-        >
-          Preview
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo/errors"
-          onClick={[Function]}
-        >
-          Errors
-        </a>
-      </li>
-    </ul>
-  </span>
-</nav>
-`;
-
-exports[`shows sail share button 1`] = `
-<nav
-  className="TabNav"
->
-  <span>
-    <ul>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo"
-          onClick={[Function]}
-        >
-          Logs
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo/preview"
-          onClick={[Function]}
-        >
-          Preview
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink tabLink--is-selected"
-          href="/r/foo/errors"
-          onClick={[Function]}
-        >
-          Errors
-        </a>
-      </li>
-    </ul>
-  </span>
-  <span
-    className="TabNav-spacer"
-  >
-     
-  </span>
-  <span
-    className="sail-url"
-  >
-    <button
-      type="button"
-    >
-      Share me!
-    </button>
-  </span>
-</nav>
-`;
-
-exports[`shows sail url 1`] = `
-<nav
-  className="TabNav"
->
-  <span>
-    <ul>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo"
-          onClick={[Function]}
-        >
-          Logs
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink "
-          href="/r/foo/preview"
-          onClick={[Function]}
-        >
-          Preview
-        </a>
-      </li>
-      <li>
-        <a
-          className="tabLink tabLink--is-selected"
-          href="/r/foo/errors"
-          onClick={[Function]}
-        >
-          Errors
-        </a>
-      </li>
-    </ul>
-  </span>
-  <span
-    className="TabNav-spacer"
-  >
-     
-  </span>
-  <span
-    className="sail-url"
-  >
-    <a
-      href="www.sail.dev/xyz"
-    >
-      Share this view!
-    </a>
-  </span>
+  <ul>
+    <li>
+      <a
+        className="tabLink tabLink--is-selected"
+        href="/r/foo"
+        onClick={[Function]}
+      >
+        Logs
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo/preview"
+        onClick={[Function]}
+      >
+        Preview
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo/errors"
+        onClick={[Function]}
+      >
+        Errors
+      </a>
+    </li>
+  </ul>
 </nav>
 `;

--- a/web/src/__snapshots__/TopBar.test.tsx.snap
+++ b/web/src/__snapshots__/TopBar.test.tsx.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`shows sail share button 1`] = `
+<div
+  className="TopBar"
+>
+  <nav
+    className="TabNav"
+  >
+    <ul>
+      <li>
+        <a
+          className="tabLink "
+          href="/r/foo"
+          onClick={[Function]}
+        >
+          Logs
+        </a>
+      </li>
+      <li>
+        <a
+          className="tabLink "
+          href="/r/foo/preview"
+          onClick={[Function]}
+        >
+          Preview
+        </a>
+      </li>
+      <li>
+        <a
+          className="tabLink tabLink--is-selected"
+          href="/r/foo/errors"
+          onClick={[Function]}
+        >
+          Errors
+        </a>
+      </li>
+    </ul>
+  </nav>
+  <span
+    className="TopBar-spacer"
+  >
+     
+  </span>
+  <span
+    className="SailInfo"
+  >
+    <button
+      type="button"
+    >
+      Share me!
+    </button>
+  </span>
+</div>
+`;
+
+exports[`shows sail url 1`] = `
+<div
+  className="TopBar"
+>
+  <nav
+    className="TabNav"
+  >
+    <ul>
+      <li>
+        <a
+          className="tabLink "
+          href="/r/foo"
+          onClick={[Function]}
+        >
+          Logs
+        </a>
+      </li>
+      <li>
+        <a
+          className="tabLink "
+          href="/r/foo/preview"
+          onClick={[Function]}
+        >
+          Preview
+        </a>
+      </li>
+      <li>
+        <a
+          className="tabLink tabLink--is-selected"
+          href="/r/foo/errors"
+          onClick={[Function]}
+        >
+          Errors
+        </a>
+      </li>
+    </ul>
+  </nav>
+  <span
+    className="TopBar-spacer"
+  >
+     
+  </span>
+  <span
+    className="SailInfo"
+  >
+    <a
+      href="www.sail.dev/xyz"
+    >
+      Share this view!
+    </a>
+  </span>
+</div>
+`;

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -39,7 +39,7 @@ $tabnav-height: $sidebar-item * 1.5;
 $statusbar-height: $spacing-unit * 1.75;
 
 $z-sidebar: 1000;
-$z-tabnav: 500;
+$z-topbar: 500;
 
 // MISC
 $animation-timing: 200ms;


### PR DESCRIPTION
Hello @yuindustries, @nicks,

Please review the following commits I made in branch maiamcc/sail-info-component:

05454210c972ade589254606635e38c555f97545 (2019-04-26 13:36:28 -0400)
clean up go

b8e711c168237345b5d485d1b670e6dc20571ec6 (2019-04-26 13:35:36 -0400)
update tests

04bb99e5981e52bbd7b1edb89109a268db702d91 (2019-04-26 13:09:55 -0400)
sailinfo is its own component

b463de5c385e48f33be49d515c8c78dbd7e86b7f (2019-04-26 11:24:32 -0400)
share button in ui if sail enabled but no url

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics