### PR TITLE
model: add a helper struct for traversing image graphs

### DIFF
--- a/internal/model/target_graph.go
+++ b/internal/model/target_graph.go
@@ -1,0 +1,123 @@
+package model
+
+import "fmt"
+
+type TargetGraph struct {
+	// Targets in topological order.
+	sortedTargets []TargetSpec
+	byID          map[TargetID]TargetSpec
+}
+
+func NewTargetGraph(targets []TargetSpec) (TargetGraph, error) {
+	sortedTargets, err := TopologicalSort(targets)
+	if err != nil {
+		return TargetGraph{}, err
+	}
+
+	return TargetGraph{
+		sortedTargets: sortedTargets,
+		byID:          MakeTargetMap(sortedTargets),
+	}, nil
+}
+
+// In Tilt, Manifests should always be DAGs with a single root node
+// (the deploy target). This is just a quick sanity check to make sure
+// that's true, because many of our graph-traversal algorithms won't work if
+// it's not true.
+func (g TargetGraph) IsSingleSourceDAG() bool {
+	seenIDs := make(map[TargetID]bool, len(g.sortedTargets))
+	lastIdx := len(g.sortedTargets) - 1
+	for i := lastIdx; i >= 0; i-- {
+		t := g.sortedTargets[i]
+		id := t.ID()
+		isLastTarget := i == lastIdx
+		if !isLastTarget && !seenIDs[id] {
+			return false
+		}
+
+		for _, depID := range t.DependencyIDs() {
+			seenIDs[depID] = true
+		}
+	}
+	return true
+}
+
+// Visit t and its transitive dependencies in post-order (aka depth-first)
+func (g TargetGraph) VisitTree(root TargetSpec, visit func(dep TargetSpec) error) error {
+	visitedIDs := make(map[TargetID]bool)
+
+	// pre-declare the variable, so that this function can recurse
+	var helper func(current TargetSpec) error
+	helper = func(current TargetSpec) error {
+		deps, err := g.DepsOf(current)
+		if err != nil {
+			return err
+		}
+
+		for _, dep := range deps {
+			if visitedIDs[dep.ID()] {
+				continue
+			}
+
+			err := helper(dep)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = visit(current)
+		if err != nil {
+			return err
+		}
+		visitedIDs[current.ID()] = true
+		return nil
+	}
+
+	return helper(root)
+}
+
+// Return the direct dependency targets.
+func (g TargetGraph) DepsOf(t TargetSpec) ([]TargetSpec, error) {
+	depIDs := t.DependencyIDs()
+	result := make([]TargetSpec, len(depIDs))
+	for i, depID := range depIDs {
+		dep, ok := g.byID[depID]
+		if !ok {
+			return nil, fmt.Errorf("Dep %q not found in graph", depID)
+		}
+		result[i] = dep
+	}
+	return result, nil
+}
+
+// Is this image directly deployed a container?
+func (g TargetGraph) IsDeployedImage(iTarget ImageTarget) bool {
+	id := iTarget.ID()
+	for _, t := range g.sortedTargets {
+		switch t := t.(type) {
+		case K8sTarget, DockerComposeTarget:
+			// Returns true if a K8s or DC target directly depends on this image.
+			for _, depID := range t.DependencyIDs() {
+				if depID == id {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (g TargetGraph) Images() []ImageTarget {
+	return ExtractImageTargets(g.sortedTargets)
+}
+
+// Returns all the images in the graph that are directly deployed to a container.
+func (g TargetGraph) DeployedImages() []ImageTarget {
+	result := []ImageTarget{}
+	for _, iTarget := range g.Images() {
+		if g.IsDeployedImage(iTarget) {
+			result = append(result, iTarget)
+		}
+	}
+	return result
+}

--- a/internal/model/target_graph_test.go
+++ b/internal/model/target_graph_test.go
@@ -1,0 +1,105 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOneImageGraph(t *testing.T) {
+	iTarget := newDepTarget("image-a")
+	kTarget := newK8sTarget("fe", "image-a")
+	g, err := NewTargetGraph([]TargetSpec{
+		iTarget,
+		kTarget,
+	})
+	assert.NoError(t, err)
+	assert.True(t, g.IsSingleSourceDAG())
+	assert.Equal(t, 1, len(g.DeployedImages()))
+
+	ids := []TargetID{}
+	g.VisitTree(kTarget, func(t TargetSpec) error {
+		ids = append(ids, t.ID())
+		return nil
+	})
+	assert.Equal(t, []TargetID{iTarget.ID(), kTarget.ID()}, ids)
+}
+
+func TestTwoImageGraph(t *testing.T) {
+	targetA := newDepTarget("image-a")
+	targetB := newDepTarget("image-b")
+	kTarget := newK8sTarget("fe", "image-a", "image-b")
+	g, err := NewTargetGraph([]TargetSpec{
+		targetA,
+		targetB,
+		kTarget,
+	})
+	assert.NoError(t, err)
+	assert.True(t, g.IsSingleSourceDAG())
+	assert.Equal(t, 2, len(g.DeployedImages()))
+
+	ids := []TargetID{}
+	g.VisitTree(kTarget, func(t TargetSpec) error {
+		ids = append(ids, t.ID())
+		return nil
+	})
+	assert.Equal(t, []TargetID{targetA.ID(), targetB.ID(), kTarget.ID()}, ids)
+}
+
+func TestDependentImageGraph(t *testing.T) {
+	targetA := newDepTarget("image-a")
+	targetB := newDepTarget("image-b", "image-a")
+	kTarget := newK8sTarget("fe", "image-b")
+	g, err := NewTargetGraph([]TargetSpec{
+		targetA,
+		targetB,
+		kTarget,
+	})
+	assert.NoError(t, err)
+	assert.True(t, g.IsSingleSourceDAG())
+	assert.Equal(t, 1, len(g.DeployedImages()))
+
+	ids := []TargetID{}
+	g.VisitTree(kTarget, func(t TargetSpec) error {
+		ids = append(ids, t.ID())
+		return nil
+	})
+	assert.Equal(t, []TargetID{targetA.ID(), targetB.ID(), kTarget.ID()}, ids)
+}
+
+func TestDiamondImageGraph(t *testing.T) {
+	targetA := newDepTarget("image-a")
+	targetB := newDepTarget("image-b", "image-a")
+	targetC := newDepTarget("image-c", "image-a")
+	targetD := newDepTarget("image-d", "image-b", "image-c")
+	kTarget := newK8sTarget("fe", "image-d")
+	g, err := NewTargetGraph([]TargetSpec{
+		targetA,
+		targetB,
+		targetC,
+		targetD,
+		kTarget,
+	})
+	assert.NoError(t, err)
+	assert.True(t, g.IsSingleSourceDAG())
+	assert.Equal(t, 1, len(g.DeployedImages()))
+
+	ids := []TargetID{}
+	g.VisitTree(kTarget, func(t TargetSpec) error {
+		ids = append(ids, t.ID())
+		return nil
+	})
+	assert.Equal(t, []TargetID{targetA.ID(), targetB.ID(), targetC.ID(), targetD.ID(), kTarget.ID()}, ids)
+}
+
+func TestTwoDeployGraph(t *testing.T) {
+	kTargetA := newK8sTarget("fe-a")
+	kTargetB := newK8sTarget("fe-b")
+	g, err := NewTargetGraph([]TargetSpec{
+		kTargetA,
+		kTargetB,
+	})
+	assert.NoError(t, err)
+	assert.False(t, g.IsSingleSourceDAG())
+	assert.Equal(t, 0, len(g.DeployedImages()))
+}

--- a/internal/model/target_test.go
+++ b/internal/model/target_test.go
@@ -107,3 +107,11 @@ func newDepTarget(name string, deps ...string) ImageTarget {
 	}
 	return NewImageTarget(ref).WithDependencyIDs(depIDs)
 }
+
+func newK8sTarget(name string, deps ...string) K8sTarget {
+	depIDs := make([]TargetID, len(deps))
+	for i, dep := range deps {
+		depIDs[i] = ImageID(container.MustParseSelector(dep))
+	}
+	return K8sTarget{Name: TargetName(name)}.WithDependencyIDs(depIDs)
+}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/liveupdategraph:

83c6780b60f53b11fc5d8957bef11985c6b857b8 (2019-04-26 15:20:40 -0400)
model: add a helper struct for traversing image graphs