### PR TITLE
assets: move AssetServer to its own package because it's shared

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/google/wire"
+	"github.com/windmilleng/tilt/internal/assets"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -91,7 +92,7 @@ var BaseWireSet = wire.NewSet(
 	provideWebPort,
 	provideWebDevPort,
 	server.ProvideHeadsUpServer,
-	server.ProvideAssetServer,
+	assets.ProvideAssetServer,
 	server.ProvideHeadsUpServerController,
 
 	provideSailURL,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/docker/docker/api/types"
 	"github.com/google/wire"
+	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/demo"
@@ -131,12 +132,12 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	}
 	webVersion := provideWebVersion(cliBuildInfo)
 	modelWebDevPort := provideWebDevPort()
-	assetServer, err := server.ProvideAssetServer(ctx, webMode, webVersion, modelWebDevPort)
+	assetsServer, err := assets.ProvideAssetServer(ctx, webMode, webVersion, modelWebDevPort)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetServer, analytics)
-	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetServer)
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics)
+	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer)
 	sailURL, err := provideSailURL()
 	if err != nil {
 		return demo.Script{}, err
@@ -256,12 +257,12 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	}
 	webVersion := provideWebVersion(cliBuildInfo)
 	modelWebDevPort := provideWebDevPort()
-	assetServer, err := server.ProvideAssetServer(ctx, webMode, webVersion, modelWebDevPort)
+	assetsServer, err := assets.ProvideAssetServer(ctx, webMode, webVersion, modelWebDevPort)
 	if err != nil {
 		return Threads{}, err
 	}
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetServer, analytics)
-	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetServer)
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics)
+	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer)
 	sailURL, err := provideSailURL()
 	if err != nil {
 		return Threads{}, err
@@ -463,7 +464,7 @@ var BaseWireSet = wire.NewSet(
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,
-	provideWebDevPort, server.ProvideHeadsUpServer, server.ProvideAssetServer, server.ProvideHeadsUpServerController, provideSailURL, client.SailWireSet, provideThreads, engine.NewKINDPusher,
+	provideWebDevPort, server.ProvideHeadsUpServer, assets.ProvideAssetServer, server.ProvideHeadsUpServerController, provideSailURL, client.SailWireSet, provideThreads, engine.NewKINDPusher,
 )
 
 type Threads struct {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/wmclient/pkg/analytics"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
@@ -2316,7 +2317,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	pm := NewProfilerManager()
 	sCli := synclet.NewFakeSyncletClient()
 	sm := NewSyncletManagerForTests(k8s, sCli)
-	hudsc := server.ProvideHeadsUpServerController(0, server.HeadsUpServer{}, server.NewFakeAssetServer())
+	hudsc := server.ProvideHeadsUpServerController(0, server.HeadsUpServer{}, assets.NewFakeServer())
 	subs := []store.Subscriber{
 		fakeHud, pw, sw, plm, pfc, fwm, bc, ic, gybc, cc, dcw, dclm, pm, sm, ar, hudsc,
 	}

--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/network"
 	"github.com/windmilleng/tilt/internal/store"
@@ -13,11 +14,11 @@ import (
 type HeadsUpServerController struct {
 	port        model.WebPort
 	hudServer   HeadsUpServer
-	assetServer AssetServer
+	assetServer assets.Server
 	initDone    bool
 }
 
-func ProvideHeadsUpServerController(port model.WebPort, hudServer HeadsUpServer, assetServer AssetServer) *HeadsUpServerController {
+func ProvideHeadsUpServerController(port model.WebPort, hudServer HeadsUpServer, assetServer assets.Server) *HeadsUpServerController {
 	return &HeadsUpServerController{
 		port:        port,
 		hudServer:   hudServer,

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 	_ "github.com/gorilla/websocket"
+	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/wmclient/pkg/analytics"
 )
@@ -23,7 +24,7 @@ type HeadsUpServer struct {
 	a      analytics.Analytics
 }
 
-func ProvideHeadsUpServer(store *store.Store, assetServer AssetServer, analytics analytics.Analytics) HeadsUpServer {
+func ProvideHeadsUpServer(store *store.Store, assetServer assets.Server, analytics analytics.Analytics) HeadsUpServer {
 	r := mux.NewRouter().UseEncodedPath()
 	s := HeadsUpServer{
 		store:  store,

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/store"
@@ -128,7 +129,7 @@ type serverFixture struct {
 func newTestFixture(t *testing.T) *serverFixture {
 	st := store.NewStore(engine.UpperReducer, store.LogActionsFlag(false))
 	a := analytics.NewMemoryAnalytics()
-	s := server.ProvideHeadsUpServer(st, server.NewFakeAssetServer(), a)
+	s := server.ProvideHeadsUpServer(st, assets.NewFakeServer(), a)
 
 	return &serverFixture{
 		t: t,

--- a/internal/sail/sail.go
+++ b/internal/sail/sail.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	hudServer "github.com/windmilleng/tilt/internal/hud/server"
+	assets2 "github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/network"
@@ -75,7 +75,7 @@ func run(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	assets, err := hudServer.ProvideAssetServer(ctx, mode, model.WebVersion("0.0.0"), provideWebDevPort())
+	assets, err := assets2.ProvideAssetServer(ctx, mode, model.WebVersion("0.0.0"), provideWebDevPort())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/sail/sail.go
+++ b/internal/sail/sail.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	assets2 "github.com/windmilleng/tilt/internal/assets"
+	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/network"
@@ -75,12 +75,12 @@ func run(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	assets, err := assets2.ProvideAssetServer(ctx, mode, model.WebVersion("0.0.0"), provideWebDevPort())
+	assetServ, err := assets.ProvideAssetServer(ctx, mode, model.WebVersion("0.0.0"), provideWebDevPort())
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	ss := server.ProvideSailServer(assets)
+	ss := server.ProvideSailServer(assetServ)
 	httpServer := &http.Server{
 		Addr:    network.AllHostsBindAddr(int(port)),
 		Handler: http.DefaultServeMux,
@@ -102,13 +102,13 @@ func run(cmd *cobra.Command, args []string) {
 
 	g.Go(func() error {
 		defer cancel()
-		return assets.Serve(ctx)
+		return assetServ.Serve(ctx)
 	})
 
 	g.Go(func() error {
 		<-ctx.Done()
 		_ = httpServer.Shutdown(context.Background())
-		assets.Teardown(context.Background())
+		assetServ.Teardown(context.Background())
 		return nil
 	})
 

--- a/internal/sail/server/server.go
+++ b/internal/sail/server/server.go
@@ -9,9 +9,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/model"
-
-	hudServer "github.com/windmilleng/tilt/internal/hud/server"
 )
 
 var upgrader = websocket.Upgrader{
@@ -23,10 +22,10 @@ type SailServer struct {
 	router      *mux.Router
 	rooms       map[model.RoomID]*Room
 	mu          *sync.Mutex
-	assetServer hudServer.AssetServer
+	assetServer assets.Server
 }
 
-func ProvideSailServer(assetServer hudServer.AssetServer) SailServer {
+func ProvideSailServer(assetServer assets.Server) SailServer {
 	r := mux.NewRouter().UseEncodedPath()
 	s := SailServer{
 		router:      r,


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/asset-server-pkg:

82f19200dde4f38e8bf6e6b5d4845b068aadbf8f (2019-04-26 16:12:07 -0400)
assets: move AssetServer to its own package because it's shared

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics