### PR TITLE
engine: A BuildState's FileChanged field should only contain files that the image depends on. Fix up the tests to accurately reflect this

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
+	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
 
 	"github.com/docker/docker/api/types"
@@ -866,6 +867,44 @@ func (f *bdFixture) assertContainerRestarts(count int) {
 	}
 	assert.Equal(f.T(), expected, f.docker.RestartsByContainer,
 		"checking for expected # of container restarts")
+}
+
+func (f *bdFixture) createBuildStateSet(manifest model.Manifest, changedFiles []string) store.BuildStateSet {
+	bs := store.BuildStateSet{}
+	consumedFiles := make(map[string]bool)
+	for _, iTarget := range manifest.ImageTargets {
+		filesChangingImage := []string{}
+		for _, file := range changedFiles {
+			fullPath := f.JoinPath(file)
+			inDeps := false
+			for _, dep := range iTarget.Dependencies() {
+				if ospath.IsChild(dep, fullPath) {
+					inDeps = true
+					break
+				}
+			}
+
+			if inDeps {
+				filesChangingImage = append(filesChangingImage, f.WriteFile(file, "blah"))
+				consumedFiles[file] = true
+			}
+		}
+
+		if len(filesChangingImage) > 0 {
+			state := store.NewBuildState(alreadyBuilt, filesChangingImage)
+			if manifest.IsImageDeployed(iTarget) {
+				state = state.WithDeployTarget(f.deployInfo())
+			}
+			bs[iTarget.ID()] = state
+		}
+	}
+
+	if len(consumedFiles) != len(changedFiles) {
+		f.T().Fatalf("testCase has files that weren't consumed by an image. "+
+			"Was that intentional?\nChangedFiles: %v\nConsumedFiles: %v\n",
+			changedFiles, consumedFiles)
+	}
+	return bs
 }
 
 func resultToStateSet(resultSet store.BuildResultSet, files []string, deploy store.DeployInfo) store.BuildStateSet {

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -31,7 +31,7 @@ func TestDockerBuildWithCache(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	manifest := NewSanchoDockerBuildManifestWithCache([]string{"/root/.cache"})
+	manifest := NewSanchoDockerBuildManifestWithCache(f, []string{"/root/.cache"})
 	cache := "gcr.io/some-project-162817/sancho:tilt-cache-3de427a264f80719a58a9abd456487b3"
 	f.docker.Images[cache] = types.ImageInspect{}
 
@@ -99,8 +99,8 @@ func TestDeployPodWithMultipleImages(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	iTarget1 := NewSanchoDockerBuildImageTarget()
-	iTarget2 := NewSanchoSidecarDockerBuildImageTarget()
+	iTarget1 := NewSanchoDockerBuildImageTarget(f)
+	iTarget2 := NewSanchoSidecarDockerBuildImageTarget(f)
 	kTarget := model.K8sTarget{Name: "sancho", YAML: testyaml.SanchoSidecarYAML}.
 		WithDependencyIDs([]model.TargetID{iTarget1.ID(), iTarget2.ID()})
 	targets := []model.TargetSpec{iTarget1, iTarget2, kTarget}
@@ -165,7 +165,7 @@ func TestDeployIDInjectedAndSent(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	manifest := NewSanchoDockerBuildManifest()
+	manifest := NewSanchoDockerBuildManifest(f)
 
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
@@ -337,7 +337,7 @@ func TestKINDPush(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvKIND)
 	defer f.TearDown()
 
-	manifest := NewSanchoDockerBuildManifest()
+	manifest := NewSanchoDockerBuildManifest(f)
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
@@ -371,7 +371,7 @@ func TestDeployUsesInjectRef(t *testing.T) {
 		manifest       func(f pather) model.Manifest
 		expectedImages []string
 	}{
-		{"docker build", func(f pather) model.Manifest { return NewSanchoDockerBuildManifest() }, expectedImages},
+		{"docker build", func(f pather) model.Manifest { return NewSanchoDockerBuildManifest(f) }, expectedImages},
 		{"fast build", NewSanchoFastBuildManifest, expectedImages},
 		{"custom build", NewSanchoCustomBuildManifest, expectedImages},
 		{"fast multi stage", NewSanchoFastMultiStageManifest, append(expectedImages, "foo.com/sancho-base")},


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/stateset:

ff1b4fc29647b002e1ce05daad79e7a48359658e (2019-04-26 17:06:57 -0400)
engine: A BuildState's FileChanged field should only contain files that the image depends on. Fix up the tests to accurately reflect this