### PR TITLE
engine: in-place updates for files from the base image

### DIFF
--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -1,7 +1,11 @@
 package engine
 
 import (
+	"fmt"
+
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/sliceutils"
 	"github.com/windmilleng/tilt/internal/store"
 )
 
@@ -20,22 +24,35 @@ func extractImageAndK8sTargets(specs []model.TargetSpec) (iTargets []model.Image
 	return iTargets, kTargets
 }
 
-// Extract image targets iff they can be updated in-place in a container.
-func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.BuildStateSet) ([]model.ImageTarget, error) {
-	iTargets := make([]model.ImageTarget, 0)
-	for _, spec := range specs {
-		iTarget, ok := spec.(model.ImageTarget)
-		if !ok {
-			continue
-		}
+// If there are images that can be updated in-place in a container, return
+// a state tree of what needs to be updated.
+func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.BuildStateSet) ([]liveUpdateStateTree, error) {
+	g, err := model.NewTargetGraph(specs)
+	if err != nil {
+		return nil, errors.Wrap(err, "extractImageTargetsForLiveUpdates")
+	}
 
+	if !g.IsSingleSourceDAG() {
+		return nil, fmt.Errorf("Cannot extract live updates on this build graph structure")
+	}
+
+	result := make([]liveUpdateStateTree, 0)
+
+	deployedImages := g.DeployedImages()
+	for _, iTarget := range deployedImages {
 		state := stateSet[iTarget.ID()]
 		if state.IsEmpty() {
 			return nil, SilentRedirectToNextBuilderf("In-place build does not support initial deploy")
 		}
 
-		// If this image doesn't need to be built at all, we can skip it.
-		if !state.NeedsImageBuild() {
+		hasFileChangesIDs, err := hasFileChangesTree(g, iTarget, stateSet)
+		if err != nil {
+			return nil, errors.Wrap(err, "extractImageTargetsForLiveUpdates")
+		}
+
+		// If this image and none of its dependencies need a rebuild,
+		// we can skip it.
+		if len(hasFileChangesIDs) == 0 {
 			continue
 		}
 
@@ -50,11 +67,23 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		// that would need to be updated.
 		deployInfo := state.DeployInfo
 		if deployInfo.Empty() {
-			return nil, RedirectToNextBuilderInfof("don't have info for deployed container (often a result of the deployment not yet being ready)")
+			return nil, RedirectToNextBuilderInfof("don't have info for deployed container of image %q (often a result of the deployment not yet being ready)", iTarget.DeploymentRef.String())
 		}
-		iTargets = append(iTargets, iTarget)
+
+		filesChanged, err := filesChangedTree(g, iTarget, stateSet)
+		if err != nil {
+			return nil, errors.Wrap(err, "extractImageTargetsForLiveUpdates")
+		}
+
+		result = append(result, liveUpdateStateTree{
+			iTarget:           iTarget,
+			filesChanged:      filesChanged,
+			iTargetState:      state,
+			hasFileChangesIDs: hasFileChangesIDs,
+		})
 	}
-	return iTargets, nil
+
+	return result, nil
 }
 
 // Returns true if the given image is deployed to one of the given k8s targets.
@@ -81,4 +110,36 @@ func isImageDeployedToDC(iTarget model.ImageTarget, dcTarget model.DockerCompose
 		}
 	}
 	return false
+}
+
+// Given a target, return all the target IDs in its tree of dependencies that
+// have changed files.
+func hasFileChangesTree(g model.TargetGraph, target model.TargetSpec, stateSet store.BuildStateSet) ([]model.TargetID, error) {
+	result := []model.TargetID{}
+	err := g.VisitTree(target, func(current model.TargetSpec) error {
+		state := stateSet[current.ID()]
+		if len(state.FilesChangedSet) > 0 {
+			result = append(result, current.ID())
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Given a target, return all the files in its tree of dependencies that have
+// changed.
+func filesChangedTree(g model.TargetGraph, target model.TargetSpec, stateSet store.BuildStateSet) ([]string, error) {
+	result := []string{}
+	err := g.VisitTree(target, func(current model.TargetSpec) error {
+		state := stateSet[current.ID()]
+		result = append(result, state.FilesChanged()...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sliceutils.DedupedAndSorted(result), nil
 }

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -1,0 +1,37 @@
+package engine
+
+import (
+	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+// A helper data structure that represents a live-update image and
+// the files changed in all of its dependencies.
+type liveUpdateStateTree struct {
+	iTarget           model.ImageTarget
+	filesChanged      []string
+	iTargetState      store.BuildState
+	hasFileChangesIDs []model.TargetID
+}
+
+// Create a successful build result if the live update deploys successfully.
+func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
+	iTargetID := t.iTarget.ID()
+	state := t.iTargetState
+	res := state.LastResult.ShallowCloneForContainerUpdate(state.FilesChangedSet)
+	res.ContainerID = state.DeployInfo.ContainerID
+
+	resultSet := store.BuildResultSet{}
+	resultSet[iTargetID] = res
+
+	// Invalidate all the image builds for images we depend on.
+	// Otherwise, the image builder will think the existing image ID
+	// is valid and won't try to rebuild it.
+	for _, id := range t.hasFileChangesIDs {
+		if id != iTargetID {
+			resultSet[id] = store.BuildResult{}
+		}
+	}
+
+	return resultSet
+}

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -35,16 +35,17 @@ func NewSyncletBuildAndDeployer(sm SyncletManager, kCli k8s.Client, updateMode U
 }
 
 func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
-	iTargets, err := extractImageTargetsForLiveUpdates(specs, stateSet)
+	liveUpdateStateSet, err := extractImageTargetsForLiveUpdates(specs, stateSet)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
 
-	if len(iTargets) != 1 {
+	if len(liveUpdateStateSet) != 1 {
 		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("Synclet container builder needs exactly one image target")
 	}
 
-	iTarget := iTargets[0]
+	liveUpdateState := liveUpdateStateSet[0]
+	iTarget := liveUpdateState.iTarget
 	if !isImageDeployedToK8s(iTarget, model.ExtractK8sTargets(specs)) {
 		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("Synclet container builder can only deploy to k8s")
 	}
@@ -53,19 +54,22 @@ func (sbd *SyncletBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store
 	span.SetTag("target", iTarget.ConfigurationRef.String())
 	defer span.Finish()
 
-	state := stateSet[iTarget.ID()]
-	return sbd.UpdateInCluster(ctx, iTarget, state)
+	return sbd.UpdateInCluster(ctx, liveUpdateState)
 }
 
 func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
-	iTarget model.ImageTarget, state store.BuildState) (store.BuildResultSet, error) {
+	liveUpdateState liveUpdateStateTree) (store.BuildResultSet, error) {
 	var err error
-	var changedFiles []build.PathMapping
+	var changedMappings []build.PathMapping
 	var runs []model.Run
 	var hotReload bool
 
+	iTarget := liveUpdateState.iTarget
+	state := liveUpdateState.iTargetState
+	filesChanged := liveUpdateState.filesChanged
+
 	if fbInfo := iTarget.AnyFastBuildInfo(); !fbInfo.Empty() {
-		changedFiles, err = build.FilesToPathMappings(state.FilesChanged(), fbInfo.Syncs)
+		changedMappings, err = build.FilesToPathMappings(filesChanged, fbInfo.Syncs)
 		if err != nil {
 			return store.BuildResultSet{}, err
 		}
@@ -73,7 +77,7 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 		hotReload = fbInfo.HotReload
 	}
 	if luInfo := iTarget.AnyLiveUpdateInfo(); !luInfo.Empty() {
-		changedFiles, err = build.FilesToPathMappings(state.FilesChanged(), luInfo.SyncSteps())
+		changedMappings, err = build.FilesToPathMappings(filesChanged, luInfo.SyncSteps())
 		if err != nil {
 			if pmErr, ok := err.(*build.PathMappingErr); ok {
 				// expected error for this builder. One of more files don't match sync's;
@@ -85,7 +89,7 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 		}
 
 		// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
-		anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
+		anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedMappings))
 		if err != nil {
 			return nil, err
 		}
@@ -97,16 +101,21 @@ func (sbd *SyncletBuildAndDeployer) UpdateInCluster(ctx context.Context,
 		runs = luInfo.RunSteps()
 		hotReload = !luInfo.ShouldRestart()
 	}
-	return sbd.updateInCluster(ctx, iTarget, state, changedFiles, runs, hotReload)
+
+	err = sbd.updateInCluster(ctx, iTarget, state, changedMappings, runs, hotReload)
+	if err != nil {
+		return store.BuildResultSet{}, err
+	}
+	return liveUpdateState.createResultSet(), nil
 }
 
-func (sbd *SyncletBuildAndDeployer) updateInCluster(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, changedFiles []build.PathMapping, runs []model.Run, hotReload bool) (store.BuildResultSet, error) {
+func (sbd *SyncletBuildAndDeployer) updateInCluster(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, changedMappings []build.PathMapping, runs []model.Run, hotReload bool) error {
 	l := logger.Get(ctx)
 
 	// get files to rm
-	toRemove, toArchive, err := build.MissingLocalPaths(ctx, changedFiles)
+	toRemove, toArchive, err := build.MissingLocalPaths(ctx, changedMappings)
 	if err != nil {
-		return store.BuildResultSet{}, errors.Wrap(err, "missingLocalPaths")
+		return errors.Wrap(err, "missingLocalPaths")
 	}
 
 	if len(toRemove) > 0 {
@@ -122,11 +131,11 @@ func (sbd *SyncletBuildAndDeployer) updateInCluster(ctx context.Context, iTarget
 	ab := build.NewArchiveBuilder(ignore.CreateBuildContextFilter(iTarget))
 	err = ab.ArchivePathsIfExist(ctx, toArchive)
 	if err != nil {
-		return store.BuildResultSet{}, errors.Wrap(err, "archivePathsIfExists")
+		return errors.Wrap(err, "archivePathsIfExists")
 	}
 	archive, err := ab.BytesBuffer()
 	if err != nil {
-		return store.BuildResultSet{}, err
+		return err
 	}
 	archivePaths := ab.Paths()
 
@@ -138,9 +147,9 @@ func (sbd *SyncletBuildAndDeployer) updateInCluster(ctx context.Context, iTarget
 	}
 
 	deployInfo := state.DeployInfo
-	cmds, err := build.BoilRuns(runs, changedFiles)
+	cmds, err := build.BoilRuns(runs, changedMappings)
 	if err != nil {
-		return store.BuildResultSet{}, err
+		return err
 	}
 
 	// TODO(dbentley): it would be even better to check if the pod has the sidecar
@@ -148,22 +157,17 @@ func (sbd *SyncletBuildAndDeployer) updateInCluster(ctx context.Context, iTarget
 		if err := sbd.updateViaExec(ctx,
 			deployInfo.PodID, deployInfo.Namespace, deployInfo.ContainerName,
 			archive, archivePaths, containerPathsToRm, cmds, hotReload); err != nil {
-			return store.BuildResultSet{}, err
+			return err
 		}
 	} else {
 		if err := sbd.updateViaSynclet(ctx,
 			deployInfo.PodID, deployInfo.Namespace, deployInfo.ContainerID,
 			archive, containerPathsToRm, cmds, hotReload); err != nil {
-			return store.BuildResultSet{}, err
+			return err
 		}
 	}
 
-	res := state.LastResult.ShallowCloneForContainerUpdate(state.FilesChangedSet)
-	res.ContainerID = deployInfo.ContainerID // the container we deployed on top of
-
-	resultSet := store.BuildResultSet{}
-	resultSet[iTarget.ID()] = res
-	return resultSet, nil
+	return nil
 }
 
 func (sbd *SyncletBuildAndDeployer) updateViaSynclet(ctx context.Context,


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/liveupdategraph2:

ed079fd30eabb1ac8d4106d6f564eba0a9793577 (2019-04-28 23:33:29 -0400)
engine: in-place updates for files from the base image
Note that this commit doesn't fix the underlying bug yet, because
we still need to update the tiltfile to allow these kinds of live-updates