### PR TITLE
makefile: set parallelism to 4, because the linker is still getting sigkills on circleci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: check-go check-js test-js
 # This makes CI blow up frequently without out-of-memory errors.
 # Manually setting the number of parallel jobs helps fix this.
 # https://github.com/golang/go/issues/26186#issuecomment-435544512
-GO_PARALLEL_JOBS := 8
+GO_PARALLEL_JOBS := 4
 
 SYNCLET_IMAGE := gcr.io/windmill-public-containers/tilt-synclet
 SYNCLET_DEV_IMAGE_TAG_FILE := .synclet-dev-image-tag


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/parallel:

5ddb64b46145241adb9c5119ecbb92e4671a1aa5 (2019-04-29 13:06:16 -0400)
makefile: remove workaround for go linker issues