### PR TITLE
tiltfile: allow live_update syncs from dependent images

### DIFF
--- a/integration/live_update_base_image/Tiltfile
+++ b/integration/live_update_base_image/Tiltfile
@@ -1,0 +1,8 @@
+repo = 'gcr.io/windmill-test-containers'
+docker_build(repo + '/live-update-base-image-common', 'common')
+docker_build(repo + '/live-update-base-image-app', 'app', live_update=[
+  sync('common/', '/app/'),
+])
+
+k8s_yaml(['app.yaml'])
+k8s_resource('live-update-base-image', new_name='regular', port_forwards='31000:8000')

--- a/integration/live_update_base_image/app.yaml
+++ b/integration/live_update_base_image/app.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: live-update-base-image
+  namespace: tilt-integration
+  labels:
+    app: live-update-base-image
+spec:
+  selector:
+    matchLabels:
+      app: live-update-base-image
+  template:
+    metadata:
+      labels:
+        app: live-update-base-image
+    spec:
+      containers:
+      - name: live-update-base-image
+        image: gcr.io/windmill-test-containers/live-update-base-image-app
+        ports:
+        - containerPort: 8000
+        resources:
+          requests:
+            cpu: "10m"

--- a/integration/live_update_base_image/app/Dockerfile
+++ b/integration/live_update_base_image/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:alpine
+
+COPY --from=gcr.io/windmill-test-containers/live-update-base-image-common /usr/src/common/regular /app/message.txt
+
+WORKDIR /app
+
+ENTRYPOINT python -m http.server 8000

--- a/integration/live_update_base_image/common/Dockerfile
+++ b/integration/live_update_base_image/common/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN mkdir -p /usr/src/common
+
+ADD message.txt /usr/src/common/regular

--- a/integration/live_update_base_image/common/message.txt
+++ b/integration/live_update_base_image/common/message.txt
@@ -1,0 +1,1 @@
+Hello from regular

--- a/integration/live_update_base_image_test.go
+++ b/integration/live_update_base_image_test.go
@@ -1,0 +1,36 @@
+//+build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLiveUpdateBaseImage(t *testing.T) {
+	f := newK8sFixture(t, "live_update_base_image")
+	defer f.TearDown()
+
+	f.TiltWatch()
+
+	timePerStage := time.Minute
+	ctx, cancel := context.WithTimeout(f.ctx, timePerStage)
+	defer cancel()
+	firstBuild := f.WaitForAllPodsReady(ctx, "app=live-update-base-image")
+
+	ctx, cancel = context.WithTimeout(f.ctx, timePerStage)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:31000/message.txt", "Hello from regular")
+
+	f.ReplaceContents("common/message.txt", "regular", "super unleaded")
+
+	ctx, cancel = context.WithTimeout(f.ctx, timePerStage)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:31000/message.txt", "Hello from super unleaded")
+
+	secondBuild := f.WaitForAllPodsReady(ctx, "app=live-update-base-image")
+	assert.Equal(t, firstBuild, secondBuild)
+}

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -109,6 +109,15 @@ func (m Manifest) WithDeployTarget(t TargetSpec) Manifest {
 	return m
 }
 
+func (m Manifest) TargetSpecs() []TargetSpec {
+	result := []TargetSpec{}
+	for _, t := range m.ImageTargets {
+		result = append(result, t)
+	}
+	result = append(result, m.deployTarget)
+	return result
+}
+
 func (m Manifest) IsImageDeployed(iTarget ImageTarget) bool {
 	id := iTarget.ID()
 	for _, depID := range m.DeployTarget().DependencyIDs() {

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -184,6 +184,41 @@ docker_build('gcr.io/foo', 'foo',
 	f.loadErrString("sync step source", f.JoinPath("bar"), f.JoinPath("foo"), "child", "any watched filepaths")
 }
 
+func TestLiveUpdateSyncFilesImageDep(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.gitInit("")
+	f.file("a/message.txt", "message")
+	f.file("imageA.dockerfile", `FROM golang:1.10
+ADD message.txt /src/message.txt
+`)
+	f.file("imageB.dockerfile", "FROM gcr.io/image-a")
+	f.yaml("foo.yaml", deployment("foo", image("gcr.io/image-b")))
+	f.file("Tiltfile", `
+docker_build('gcr.io/image-b', 'b', dockerfile='imageB.dockerfile',
+             live_update=[
+               sync('a/message.txt', '/src/message.txt'),
+             ])
+docker_build('gcr.io/image-a', 'a', dockerfile='imageA.dockerfile')
+k8s_yaml('foo.yaml')
+`)
+	f.load()
+
+	lu := model.LiveUpdate{
+		Steps: []model.LiveUpdateStep{
+			model.LiveUpdateSyncStep{
+				Source: f.JoinPath("a/message.txt"),
+				Dest:   "/src/message.txt",
+			},
+		},
+		BaseDir: f.Path(),
+	}
+	f.assertNextManifest("foo",
+		db(image("gcr.io/image-a")),
+		db(image("gcr.io/image-b"), lu))
+}
+
 func TestLiveUpdateFallBackTriggersOutsideOfDockerBuildContext(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch2351/liveupdate:

3093f8a14e4e2eb3074702a33a86962a64c6b386 (2019-04-29 15:36:42 -0400)
tiltfile: allow live_update syncs from dependent images
also add integration tests