### PR TITLE
k8s: add a work-around for bugs in container status image refs

### DIFF
--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -7,11 +7,32 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/windmilleng/tilt/internal/container"
 )
+
+func TestFixContainerStatusImages(t *testing.T) {
+	pod := fakePod(expectedPod, blorgDevImgStr)
+	pod.Status = v1.PodStatus{
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name:  "default",
+				Image: blorgDevImgStr + "v2",
+				Ready: true,
+			},
+		},
+	}
+
+	assert.NotEqual(t,
+		pod.Spec.Containers[0].Image,
+		pod.Status.ContainerStatuses[0].Image)
+	FixContainerStatusImages(&pod)
+	assert.Equal(t,
+		pod.Spec.Containers[0].Image,
+		pod.Status.ContainerStatuses[0].Image)
+}
 
 func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	f := newClientTestFixture(t)

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -38,7 +38,11 @@ func (k K8sClient) ContainerLogs(ctx context.Context, pID PodID, cName container
 }
 
 func (k K8sClient) PodByID(ctx context.Context, pID PodID, n Namespace) (*v1.Pod, error) {
-	return k.core.Pods(n.String()).Get(pID.String(), metav1.GetOptions{})
+	pod, err := k.core.Pods(n.String()).Get(pID.String(), metav1.GetOptions{})
+	if pod != nil {
+		FixContainerStatusImages(pod)
+	}
+	return pod, err
 }
 
 func PodIDFromPod(pod *v1.Pod) PodID {

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +27,7 @@ func fakePod(podID PodID, imageID string) v1.Pod {
 			NodeName: "node1",
 			Containers: []v1.Container{
 				v1.Container{
+					Name:  "default",
 					Image: imageID,
 				},
 			},

--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -74,12 +74,14 @@ func (kCli K8sClient) WatchPods(ctx context.Context, ls labels.Selector) (<-chan
 		AddFunc: func(obj interface{}) {
 			mObj, ok := obj.(*v1.Pod)
 			if ok {
+				FixContainerStatusImages(mObj)
 				ch <- mObj
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			mObj, ok := obj.(*v1.Pod)
 			if ok {
+				FixContainerStatusImages(mObj)
 				ch <- mObj
 			}
 		},
@@ -95,6 +97,7 @@ func (kCli K8sClient) WatchPods(ctx context.Context, ls labels.Selector) (<-chan
 			}
 
 			if oldPod != newPod {
+				FixContainerStatusImages(newPod)
 				ch <- newPod
 			}
 		},


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/badtag:

aea59f869406825b1bb9d444ba64883268c5c678 (2019-04-29 17:09:34 -0400)
k8s: add a work-around for bugs in container status image refs
https://github.com/kubernetes/kubernetes/issues/51017