### PR TITLE
store: add optional SetUp method for subscribers

### DIFF
--- a/internal/assets/server.go
+++ b/internal/assets/server.go
@@ -28,7 +28,7 @@ import (
 type Server interface {
 	http.Handler
 	Serve(ctx context.Context) error
-	Teardown(ctx context.Context)
+	TearDown(ctx context.Context)
 }
 
 type devServer struct {
@@ -39,7 +39,7 @@ type devServer struct {
 	disposed bool
 }
 
-func (s *devServer) Teardown(ctx context.Context) {
+func (s *devServer) TearDown(ctx context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -138,7 +138,7 @@ type prodServer struct {
 	url *url.URL
 }
 
-func (s prodServer) Teardown(ctx context.Context) {
+func (s prodServer) TearDown(ctx context.Context) {
 }
 
 // This doesn't actually do any setup right now.
@@ -188,7 +188,7 @@ type precompiledServer struct {
 	path string
 }
 
-func (s precompiledServer) Teardown(ctx context.Context) {
+func (s precompiledServer) TearDown(ctx context.Context) {
 }
 
 // This doesn't actually do any setup right now.

--- a/internal/demo/script.go
+++ b/internal/demo/script.go
@@ -57,7 +57,7 @@ func NewScript(upper engine.Upper, hud hud.HeadsUpDisplay, kClient k8s.Client,
 		runtime:        runtime,
 		tfl:            tfl,
 	}
-	st.AddSubscriber(s.podMonitor)
+	st.AddSubscriber(context.Background(), s.podMonitor)
 	return s
 }
 

--- a/internal/engine/analytics_reporter.go
+++ b/internal/engine/analytics_reporter.go
@@ -10,7 +10,7 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 )
 
-// How often to perodically report data for analytics while Tilt is running
+// How often to periodically report data for analytics while Tilt is running
 const analyticsReportingInterval = time.Hour * 1
 
 type AnalyticsReporter struct {

--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -89,7 +89,7 @@ func newCCFixture(t *testing.T) *ccFixture {
 	fc := testutils.NewRandomFakeClock()
 	cc.clock = fc.Clock()
 	ctx := output.CtxForTest()
-	st.AddSubscriber(cc)
+	st.AddSubscriber(ctx, cc)
 	go st.Loop(ctx)
 	return &ccFixture{
 		TempDirFixture: f,

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -73,7 +73,7 @@ func NewUpper(ctx context.Context, st *store.Store, subs []store.Subscriber) Upp
 	// There's not really a good reason to add all the subscribers
 	// in NewUpper(), but it's as good a place as any.
 	for _, sub := range subs {
-		st.AddSubscriber(sub)
+		st.AddSubscriber(ctx, sub)
 	}
 
 	return Upper{

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2289,7 +2289,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	fSub := fixtureSub{ch: make(chan bool, 1000)}
 	st := store.NewStore(UpperReducer, store.LogActionsFlag(false))
-	st.AddSubscriber(fSub)
+	st.AddSubscriber(ctx, fSub)
 
 	plm := NewPodLogManager(k8s)
 	bc := NewBuildController(b)

--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -26,8 +26,8 @@ func ProvideHeadsUpServerController(port model.WebPort, hudServer HeadsUpServer,
 	}
 }
 
-func (s *HeadsUpServerController) Teardown(ctx context.Context) {
-	s.assetServer.Teardown(ctx)
+func (s *HeadsUpServerController) TearDown(ctx context.Context) {
+	s.assetServer.TearDown(ctx)
 }
 
 func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore) {
@@ -73,4 +73,4 @@ func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore)
 	}()
 }
 
-var _ store.SubscriberLifecycle = &HeadsUpServerController{}
+var _ store.TearDowner = &HeadsUpServerController{}

--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -42,7 +42,7 @@ func (ws WebsocketSubscriber) Stream(ctx context.Context, store *store.Store) {
 		}
 	}()
 
-	store.AddSubscriber(ws)
+	store.AddSubscriber(ctx, ws)
 
 	// Fire a fake OnChange event to initialize the stream.
 	ws.OnChange(ctx, store)

--- a/internal/sail/client/client.go
+++ b/internal/sail/client/client.go
@@ -52,7 +52,7 @@ func ProvideSailClient(addr model.SailURL, roomer SailRoomer, dialer SailDialer)
 	}
 }
 
-func (s *sailClient) Teardown(ctx context.Context) {
+func (s *sailClient) TearDown(ctx context.Context) {
 	s.disconnect()
 }
 
@@ -188,4 +188,4 @@ func (s *sailClient) shareToRoom(ctx context.Context, roomID model.RoomID, secre
 	return nil
 }
 
-var _ store.SubscriberLifecycle = &sailClient{}
+var _ store.TearDowner = &sailClient{}

--- a/internal/sail/client/fake_client.go
+++ b/internal/sail/client/fake_client.go
@@ -17,7 +17,7 @@ func NewFakeSailClient() *FakeSailClient {
 }
 
 func (c *FakeSailClient) OnChange(ctx context.Context, st store.RStore) {}
-func (c *FakeSailClient) Teardown(ctx context.Context)                  {}
+func (c *FakeSailClient) TearDown(ctx context.Context)                  {}
 
 func (c *FakeSailClient) NewRoom(ctx context.Context, st store.RStore) error {
 	c.ConnectCalls += 1

--- a/internal/sail/sail.go
+++ b/internal/sail/sail.go
@@ -108,7 +108,7 @@ func run(cmd *cobra.Command, args []string) {
 	g.Go(func() error {
 		<-ctx.Done()
 		_ = httpServer.Shutdown(context.Background())
-		assetServ.Teardown(context.Background())
+		assetServ.TearDown(context.Background())
 		return nil
 	})
 

--- a/internal/sail/server/server_test.go
+++ b/internal/sail/server/server_test.go
@@ -45,4 +45,4 @@ type fakeAssetServer struct{}
 
 func (as fakeAssetServer) ServeHTTP(http.ResponseWriter, *http.Request) {}
 func (as fakeAssetServer) Serve(ctx context.Context) error              { return nil }
-func (as fakeAssetServer) Teardown(ctx context.Context)                 {}
+func (as fakeAssetServer) TearDown(ctx context.Context)                 {}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -119,7 +119,7 @@ func (s *Store) Close() {
 }
 
 func (s *Store) Loop(ctx context.Context) error {
-	s.subscribers.Setup(ctx)
+	s.subscribers.SetUp(ctx)
 	defer s.subscribers.TeardownAll(context.Background())
 
 	for {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,8 +75,8 @@ func NewStoreForTesting() (st *Store, getActions func() []Action) {
 	return NewStore(reducer, false), getActions
 }
 
-func (s *Store) AddSubscriber(sub Subscriber) {
-	s.subscribers.Add(sub)
+func (s *Store) AddSubscriber(ctx context.Context, sub Subscriber) {
+	s.subscribers.Add(ctx, sub)
 }
 
 func (s *Store) RemoveSubscriber(ctx context.Context, sub Subscriber) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -24,7 +24,7 @@ func TestBroadcastActions(t *testing.T) {
 	f := newFixture(t)
 
 	s := newFakeSubscriber()
-	f.store.AddSubscriber(s)
+	f.store.AddSubscriber(f.ctx, s)
 
 	f.Start()
 
@@ -40,7 +40,7 @@ func TestBroadcastActionsBatching(t *testing.T) {
 	f := newFixture(t)
 
 	s := newFakeSubscriber()
-	f.store.AddSubscriber(s)
+	f.store.AddSubscriber(f.ctx, s)
 
 	f.Start()
 

--- a/internal/store/subscriber.go
+++ b/internal/store/subscriber.go
@@ -17,13 +17,19 @@ type Subscriber interface {
 	OnChange(ctx context.Context, st RStore)
 }
 
-// Some subscribers need to do teardown.
-// Teardown holds the subscriber lock, so we expect it
-// to return quickly.
-// TODO(nick): A Setup method would also be useful for subscribers
-// that do one-time setup.
+// Some subscribers need to do SetUp or TearDown.
+// Both hold the subscriber lock, so should return quickly.
+type SetUpper interface {
+	SetUp(ctx context.Context)
+}
+type TearDowner interface {
+	TearDown(ctx context.Context)
+}
+
+// Convenience interface for subscriber fulfilling both SetUpper and TearDowner
 type SubscriberLifecycle interface {
-	Teardown(ctx context.Context)
+	SetUpper
+	TearDowner
 }
 
 type subscriberList struct {
@@ -59,10 +65,15 @@ func (l *subscriberList) Remove(ctx context.Context, s Subscriber) error {
 	return fmt.Errorf("Subscriber not found: %T: %+v", s, s)
 }
 
-func (l *subscriberList) Setup(ctx context.Context) {
+func (l *subscriberList) SetUp(ctx context.Context) {
 	l.mu.Lock()
+	subscribers := append([]*subscriberEntry{}, l.subscribers...)
 	l.setup = true
 	l.mu.Unlock()
+
+	for _, s := range subscribers {
+		s.maybeSetUp(ctx)
+	}
 }
 
 func (l *subscriberList) TeardownAll(ctx context.Context) {
@@ -107,11 +118,20 @@ func (e *subscriberEntry) notify(ctx context.Context, store *Store) {
 	e.dirtyBit.FinishBuild(startToken)
 }
 
-func (e *subscriberEntry) maybeTeardown(ctx context.Context) {
-	sl, ok := e.subscriber.(SubscriberLifecycle)
+func (e *subscriberEntry) maybeSetUp(ctx context.Context) {
+	s, ok := e.subscriber.(SetUpper)
 	if ok {
 		e.mu.Lock()
 		defer e.mu.Unlock()
-		sl.Teardown(ctx)
+		s.SetUp(ctx)
+	}
+}
+
+func (e *subscriberEntry) maybeTeardown(ctx context.Context) {
+	s, ok := e.subscriber.(TearDowner)
+	if ok {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		s.TearDown(ctx)
 	}
 }

--- a/internal/store/subscriber.go
+++ b/internal/store/subscriber.go
@@ -38,14 +38,19 @@ type subscriberList struct {
 	mu          sync.Mutex
 }
 
-func (l *subscriberList) Add(s Subscriber) {
+func (l *subscriberList) Add(ctx context.Context, s Subscriber) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.subscribers = append(l.subscribers, &subscriberEntry{
+	e := &subscriberEntry{
 		subscriber: s,
 		dirtyBit:   NewDirtyBit(),
-	})
+	}
+	l.subscribers = append(l.subscribers, e)
+	if l.setup {
+		// the rest of the subscriberList has already been set up, so set up this subscriber directly
+		e.maybeSetUp(ctx)
+	}
 }
 
 func (l *subscriberList) Remove(ctx context.Context, s Subscriber) error {

--- a/internal/store/subscriber_test.go
+++ b/internal/store/subscriber_test.go
@@ -68,6 +68,17 @@ func TestRemoveSubscriberNotFound(t *testing.T) {
 	}
 }
 
+func TestSubscriberSetup(t *testing.T) {
+	st, _ := NewStoreForTesting()
+	ctx := context.Background()
+	s := newFakeSubscriber()
+	st.AddSubscriber(s)
+
+	st.subscribers.SetUp(ctx)
+
+	assert.Equal(t, 1, s.setupCount)
+}
+
 func TestSubscriberTeardown(t *testing.T) {
 	st, _ := NewStoreForTesting()
 	ctx := context.Background()
@@ -117,6 +128,7 @@ func TestSubscriberTeardownOnRemove(t *testing.T) {
 
 type fakeSubscriber struct {
 	onChange      chan onChangeCall
+	setupCount    int
 	teardownCount int
 }
 
@@ -164,6 +176,10 @@ func (f *fakeSubscriber) OnChange(ctx context.Context, st RStore) {
 	<-call.done
 }
 
-func (f *fakeSubscriber) Teardown(ctx context.Context) {
+func (f *fakeSubscriber) SetUp(ctx context.Context) {
+	f.setupCount++
+}
+
+func (f *fakeSubscriber) TearDown(ctx context.Context) {
 	f.teardownCount++
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch maiamcc/subscriber-setup:

2f2613ba1668f3acacf8a0c332dbf6c1fb54d52e (2019-04-30 14:33:55 -0400)
store: add optional SetUp method for subscribers

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics