### PR TITLE
sail: re-unify new room and room connect so that we can surface the sail url right away, w/o waiting for OnChange

### DIFF
--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -106,7 +106,7 @@ func (s HeadsUpServer) HandleSail(w http.ResponseWriter, req *http.Request) {
 		return nil
 	})
 
-	err := s.sailCli.NewRoom(logger.WithLogger(req.Context(), l), s.store)
+	err := s.sailCli.Connect(logger.WithLogger(req.Context(), l), s.store)
 	if err != nil {
 		log.Printf("sailClient.NewRoom: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/sail/client/client.go
+++ b/internal/sail/client/client.go
@@ -23,27 +23,18 @@ type SailClient interface {
 	store.Subscriber
 	store.SubscriberLifecycle
 
-	NewRoom(ctx context.Context, st store.RStore) error
+	Connect(ctx context.Context, st store.RStore) error
 }
 
 var _ SailClient = &sailClient{}
 
 type sailClient struct {
-	ctx    context.Context
-	addr   model.SailURL
-	roomer SailRoomer
-	dialer SailDialer
-	conn   SailConn
-	mu     sync.Mutex
-
-	roomInfo model.SailRoomInfo // Info for room this client is talking to
-}
-
-func (s *sailClient) RoomInfo() model.SailRoomInfo {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.roomInfo
+	persistentCtx context.Context
+	addr          model.SailURL
+	roomer        SailRoomer
+	dialer        SailDialer
+	conn          SailConn
+	mu            sync.Mutex
 }
 
 func ProvideSailClient(addr model.SailURL, roomer SailRoomer, dialer SailDialer) *sailClient {
@@ -55,8 +46,8 @@ func ProvideSailClient(addr model.SailURL, roomer SailRoomer, dialer SailDialer)
 }
 
 func (s *sailClient) SetUp(ctx context.Context) {
-	if s.ctx == nil {
-		s.ctx = ctx
+	if s.persistentCtx == nil {
+		s.persistentCtx = ctx
 	}
 }
 
@@ -68,15 +59,12 @@ func (s *sailClient) disconnect() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.roomInfo = model.SailRoomInfo{}
-
 	if s.conn == nil {
 		return
 	}
 
 	_ = s.conn.Close()
 	s.conn = nil
-
 }
 
 func (s *sailClient) isConnected() bool {
@@ -85,24 +73,9 @@ func (s *sailClient) isConnected() bool {
 	return s.conn != nil
 }
 
-func (s *sailClient) hasRoomInfo() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.roomInfo != model.SailRoomInfo{}
-}
-
 func (s *sailClient) OnChange(ctx context.Context, st store.RStore) {
-	if !s.hasRoomInfo() {
-		return
-	}
-
 	if !s.isConnected() {
-		err := s.ShareToRoom(ctx, st)
-		if err != nil {
-			logger.Get(ctx).Infof("sailClient.ShareToRoom(%s): %v", s.addr, err)
-			s.disconnect()
-			return
-		}
+		return
 	}
 
 	state := st.RLockState()
@@ -145,27 +118,19 @@ func (s *sailClient) setConnection(ctx context.Context, conn SailConn) {
 	}()
 }
 
-func (s *sailClient) NewRoom(ctx context.Context, st store.RStore) error {
+func (s *sailClient) Connect(ctx context.Context, st store.RStore) error {
 	if s.addr.Empty() {
 		return fmt.Errorf("tried to connect a sailClient with an empty address")
 	}
-	roomInfo, err := s.roomer.NewRoom(ctx)
+	roomID, secret, err := s.roomer.NewRoom(ctx)
 	if err != nil {
 		st.Dispatch(SailRoomConnectedAction{Err: err})
 		return err
 	}
 
-	// Attach room info to sailClient so we can connect to it later
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.roomInfo = roomInfo
-
-	return nil
-}
-
-func (s *sailClient) ShareToRoom(ctx context.Context, st store.RStore) error {
-	roomInfo := s.RoomInfo()
-	err := s.shareToRoom(ctx, roomInfo.RoomID, roomInfo.Secret)
+	// NOTE(maia): this call sets up the web socket, so it needs a long-lived ctx
+	// (can't just use the context from an HTTP request, as above).
+	err = s.shareToRoom(s.persistentCtx, roomID, secret)
 	if err != nil {
 		st.Dispatch(SailRoomConnectedAction{Err: err})
 		return err
@@ -173,7 +138,7 @@ func (s *sailClient) ShareToRoom(ctx context.Context, st store.RStore) error {
 
 	// Send back URL to surface to user for sharing
 	viewUrl := s.addr.Http()
-	viewUrl.Path = fmt.Sprintf("/view/%s", roomInfo.RoomID)
+	viewUrl.Path = fmt.Sprintf("/view/%s", roomID)
 	st.Dispatch(SailRoomConnectedAction{ViewURL: viewUrl.String()})
 
 	return nil

--- a/internal/sail/client/client.go
+++ b/internal/sail/client/client.go
@@ -21,6 +21,7 @@ func (SailRoomConnectedAction) Action() {}
 
 type SailClient interface {
 	store.Subscriber
+	store.SubscriberLifecycle
 
 	NewRoom(ctx context.Context, st store.RStore) error
 }
@@ -28,6 +29,7 @@ type SailClient interface {
 var _ SailClient = &sailClient{}
 
 type sailClient struct {
+	ctx    context.Context
 	addr   model.SailURL
 	roomer SailRoomer
 	dialer SailDialer
@@ -49,6 +51,12 @@ func ProvideSailClient(addr model.SailURL, roomer SailRoomer, dialer SailDialer)
 		addr:   addr,
 		roomer: roomer,
 		dialer: dialer,
+	}
+}
+
+func (s *sailClient) SetUp(ctx context.Context) {
+	if s.ctx == nil {
+		s.ctx = ctx
 	}
 }
 
@@ -187,5 +195,3 @@ func (s *sailClient) shareToRoom(ctx context.Context, roomID model.RoomID, secre
 	s.setConnection(ctx, conn)
 	return nil
 }
-
-var _ store.TearDowner = &sailClient{}

--- a/internal/sail/client/client_test.go
+++ b/internal/sail/client/client_test.go
@@ -35,6 +35,7 @@ func TestConnectAndBroadcast(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.assertNewRoomCalls(1)
+	assert.NotNil(t, f.conn()) // connection is established (nothing sent down it yet)
 
 	f.client.OnChange(f.ctx, f.store)
 	assert.Equal(t, 1, len(f.conn().json.(webview.View).Resources))
@@ -86,6 +87,7 @@ func newFixture(t *testing.T) *fixture {
 	st, getActions := store.NewStoreForTesting()
 
 	client := ProvideSailClient(model.SailURL(*u), &fakeSailRoomer{}, fakeSailDialer{})
+	client.persistentCtx = ctx
 	return &fixture{
 		t:          t,
 		ctx:        ctx,

--- a/internal/sail/client/client_test.go
+++ b/internal/sail/client/client_test.go
@@ -16,36 +16,27 @@ import (
 	"github.com/windmilleng/tilt/internal/testutils/output"
 )
 
-var testRoomInfo = model.SailRoomInfo{
-	RoomID: model.RoomID("some-room"),
-	Secret: "shh-very-secret",
-}
-
-func TestNewRoomStoresRoomInfo(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	err := f.client.NewRoom(f.ctx, f.store)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f.assertNewRoomCalls(1)
-	assert.Equal(t, testRoomInfo, f.client.roomInfo)
-}
+const (
+	testRoomID = model.RoomID("some-room")
+	testSecret = "shh-very-secret"
+)
 
 func TestConnectAndBroadcast(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	// Trying to broadcast without a room does nothing
+	// Trying to broadcast before connecting does nothing
 	f.client.OnChange(f.ctx, f.store)
 	assert.Nil(t, f.client.conn)
 
-	// Spoof new room creation -- OnChange should connect and broadcast
-	f.client.roomInfo = testRoomInfo
-	f.client.OnChange(f.ctx, f.store)
+	// Initial connect
+	err := f.client.Connect(f.ctx, f.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.assertNewRoomCalls(1)
 
+	f.client.OnChange(f.ctx, f.store)
 	assert.Equal(t, 1, len(f.conn().json.(webview.View).Resources))
 	assert.Equal(t, view.TiltfileResourceName, f.conn().json.(webview.View).Resources[0].Name.String())
 
@@ -56,6 +47,7 @@ func TestConnectAndBroadcast(t *testing.T) {
 
 	f.client.OnChange(f.ctx, f.store)
 	assert.Equal(t, 2, len(f.conn().json.(webview.View).Resources))
+	f.assertNewRoomCalls(1) // room already connected, shouldn't have any more NewRoom calls
 }
 
 func TestSailRoomConnectedAction(t *testing.T) {
@@ -63,8 +55,7 @@ func TestSailRoomConnectedAction(t *testing.T) {
 	defer f.TearDown()
 	go f.store.Loop(f.ctx)
 
-	f.client.roomInfo = testRoomInfo
-	err := f.client.ShareToRoom(f.ctx, f.store)
+	err := f.client.Connect(f.ctx, f.store)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,9 +119,9 @@ type fakeSailRoomer struct {
 	newRoomCalls int
 }
 
-func (r *fakeSailRoomer) NewRoom(ctx context.Context) (info model.SailRoomInfo, err error) {
+func (r *fakeSailRoomer) NewRoom(ctx context.Context) (roomID model.RoomID, secret string, err error) {
 	r.newRoomCalls += 1
-	return testRoomInfo, nil
+	return testRoomID, testSecret, nil
 }
 
 type fakeSailDialer struct{}

--- a/internal/sail/client/fake_client.go
+++ b/internal/sail/client/fake_client.go
@@ -10,13 +10,14 @@ type FakeSailClient struct {
 	ConnectCalls int
 }
 
-var _ SailClient = &sailClient{}
+var _ SailClient = &FakeSailClient{}
 
 func NewFakeSailClient() *FakeSailClient {
 	return &FakeSailClient{}
 }
 
 func (c *FakeSailClient) OnChange(ctx context.Context, st store.RStore) {}
+func (c *FakeSailClient) SetUp(ctx context.Context)                     {}
 func (c *FakeSailClient) TearDown(ctx context.Context)                  {}
 
 func (c *FakeSailClient) NewRoom(ctx context.Context, st store.RStore) error {

--- a/internal/sail/client/fake_client.go
+++ b/internal/sail/client/fake_client.go
@@ -20,7 +20,7 @@ func (c *FakeSailClient) OnChange(ctx context.Context, st store.RStore) {}
 func (c *FakeSailClient) SetUp(ctx context.Context)                     {}
 func (c *FakeSailClient) TearDown(ctx context.Context)                  {}
 
-func (c *FakeSailClient) NewRoom(ctx context.Context, st store.RStore) error {
+func (c *FakeSailClient) Connect(ctx context.Context, st store.RStore) error {
 	c.ConnectCalls += 1
 	return nil
 }

--- a/internal/sail/client/roomer.go
+++ b/internal/sail/client/roomer.go
@@ -12,33 +12,33 @@ import (
 
 // For injecting room creation logic (because the real way involves an HTTP request)
 type SailRoomer interface {
-	NewRoom(ctx context.Context) (info model.SailRoomInfo, err error)
+	NewRoom(ctx context.Context) (roomID model.RoomID, secret string, err error)
 }
 
 type httpRoomer struct {
 	addr model.SailURL
 }
 
-func (r httpRoomer) NewRoom(ctx context.Context) (info model.SailRoomInfo, err error) {
+func (r httpRoomer) NewRoom(ctx context.Context) (roomID model.RoomID, secret string, err error) {
 	u := r.addr.Http()
 	u.Path = "/room"
 	resp, err := http.Post(u.String(), "text/plain", nil)
 	if err != nil {
-		return model.SailRoomInfo{}, errors.Wrapf(err, "GET %s", u.String())
+		return "", "", errors.Wrapf(err, "GET %s", u.String())
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return model.SailRoomInfo{}, errors.Wrap(err, "reading /new_room response")
+		return "", "", errors.Wrap(err, "reading /new_room response")
 	}
 
 	var roomInfo model.SailRoomInfo
 	err = json.Unmarshal(body, &roomInfo)
 	if err != nil {
-		return model.SailRoomInfo{}, errors.Wrapf(err, "unmarshaling json: %s", string(body))
+		return "", "", errors.Wrapf(err, "unmarshaling json: %s", string(body))
 	}
 
-	return roomInfo, nil
+	return roomInfo.RoomID, roomInfo.Secret, nil
 }
 
 func ProvideSailRoomer(addr model.SailURL) SailRoomer {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch maiamcc/surface-url-right-away:

269580dedd50dc11882c3e01a864ee833ba42614 (2019-04-30 15:53:19 -0400)
fix tests

b7fae20f1de4ae27d1fb9b94a388b03891f6967a (2019-04-30 15:47:12 -0400)
http new room and room connect are one step (but use persistent ctx for websocket)

c3638e5cb58ec801a67783fe6d678aaebfca41e7 (2019-04-30 15:40:46 -0400)
use SetUp to get ctx on the sail client

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics