### PR TITLE
sail server: send most recent data to new fan on join [ch2310]

### DIFF
--- a/internal/sail/server/room_test.go
+++ b/internal/sail/server/room_test.go
@@ -47,6 +47,19 @@ func TestTwoFans(t *testing.T) {
 	assert.Equal(t, "goodbye", fanB.nextMessage(t))
 }
 
+func TestNewFanGetsMostRecentMessage(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.source.dataCh <- "hello"
+	f.source.dataCh <- "goodbye"
+	time.Sleep(10 * time.Millisecond)
+
+	fan := f.addFan()
+
+	assert.Equal(t, "goodbye", fan.nextMessage(t))
+}
+
 type fixture struct {
 	t      *testing.T
 	ctx    context.Context
@@ -128,7 +141,7 @@ type fakeFan struct {
 func newFakeFan(ctx context.Context) *fakeFan {
 	return &fakeFan{
 		ctx:    ctx,
-		dataCh: make(chan string),
+		dataCh: make(chan string, 0),
 	}
 }
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch maiamcc/current-status-on-join:

97dcf25a6ead5594af3668b511b393fb96884e81 (2019-04-30 17:13:17 -0400)
sail server: send most recent data to new fan on join [ch2310]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics