### PR TITLE
assets: prod asset server can accept version to serve as query param [ch2284]

### DIFF
--- a/internal/assets/prod_server_test.go
+++ b/internal/assets/prod_server_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	testUrl     = "https://fake.tilt.dev"
-	testVersion = model.WebVersion("v1.2.3")
-	version666  = model.WebVersion("v6.6.6")
+	testUrl        = "https://fake.tilt.dev"
+	versionDefault = model.WebVersion("v1.2.3")
+	version666     = model.WebVersion("v6.6.6")
 )
 
 func TestBuildUrlForReq(t *testing.T) {
@@ -56,7 +56,7 @@ func TestBuildUrlForReqWithVersionParamAndStaticPath(t *testing.T) {
 }
 
 func prodServerForTest(t *testing.T) prodServer {
-	s, err := newProdServer(testUrl, testVersion)
+	s, err := newProdServer(testUrl, versionDefault)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/assets/prod_server_test.go
+++ b/internal/assets/prod_server_test.go
@@ -1,0 +1,66 @@
+package assets
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/model"
+)
+
+const (
+	testUrl     = "https://fake.tilt.dev"
+	testVersion = model.WebVersion("v1.2.3")
+)
+
+func TestBuildUrlForReq(t *testing.T) {
+	s := prodServerForTest(t)
+	expected := "https://fake.tilt.dev/v1.2.3/index.html"
+	req := reqForTest(t, "/", "")
+	actual := s.buildUrlForReq(req)
+	assert.Equal(t, expected, actual.String())
+}
+
+func TestBuildUrlForReqRedirectsToIndex(t *testing.T) {
+	s := prodServerForTest(t)
+	expected := "https://fake.tilt.dev/v1.2.3/index.html"
+	req := reqForTest(t, "/some/random/path", "")
+	actual := s.buildUrlForReq(req)
+	assert.Equal(t, expected, actual.String())
+}
+
+func TestBuildUrlForReqRespectsStatic(t *testing.T) {
+	s := prodServerForTest(t)
+	expected := "https://fake.tilt.dev/v1.2.3/static/stuff.html"
+	req := reqForTest(t, "/static/stuff.html", "")
+	actual := s.buildUrlForReq(req)
+	assert.Equal(t, expected, actual.String())
+}
+
+func TestBuildUrlForReqWithVersionParam(t *testing.T) {}
+
+func TestBuildUrlForReqWithVersionParamAndStaticPath(t *testing.T) {}
+
+func prodServerForTest(t *testing.T) prodServer {
+	s, err := newProdServer(testUrl, testVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func reqForTest(t *testing.T, path string, version model.WebVersion) *http.Request {
+	u, err := url.Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if version != "" {
+		q := u.Query()
+		q.Set(webVersionKey, string(version))
+		u.RawQuery = q.Encode()
+	}
+
+	return &http.Request{URL: u}
+}

--- a/internal/assets/prod_server_test.go
+++ b/internal/assets/prod_server_test.go
@@ -12,6 +12,7 @@ import (
 const (
 	testUrl     = "https://fake.tilt.dev"
 	testVersion = model.WebVersion("v1.2.3")
+	version666  = model.WebVersion("v6.6.6")
 )
 
 func TestBuildUrlForReq(t *testing.T) {
@@ -38,9 +39,21 @@ func TestBuildUrlForReqRespectsStatic(t *testing.T) {
 	assert.Equal(t, expected, actual.String())
 }
 
-func TestBuildUrlForReqWithVersionParam(t *testing.T) {}
+func TestBuildUrlForReqWithVersionParam(t *testing.T) {
+	s := prodServerForTest(t)
+	expected := "https://fake.tilt.dev/v6.6.6/index.html"
+	req := reqForTest(t, "/", version666)
+	actual := s.buildUrlForReq(req)
+	assert.Equal(t, expected, actual.String())
+}
 
-func TestBuildUrlForReqWithVersionParamAndStaticPath(t *testing.T) {}
+func TestBuildUrlForReqWithVersionParamAndStaticPath(t *testing.T) {
+	s := prodServerForTest(t)
+	expected := "https://fake.tilt.dev/v6.6.6/static/stuff.html"
+	req := reqForTest(t, "/static/stuff.html", version666)
+	actual := s.buildUrlForReq(req)
+	assert.Equal(t, expected, actual.String())
+}
 
 func prodServerForTest(t *testing.T) prodServer {
 	s, err := newProdServer(testUrl, testVersion)

--- a/internal/assets/server.go
+++ b/internal/assets/server.go
@@ -25,6 +25,9 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 )
 
+const prodAssetBucket = "https://storage.googleapis.com/tilt-static-assets/"
+const webVersionKey = "web_version"
+
 type Server interface {
 	http.Handler
 	Serve(ctx context.Context) error
@@ -135,15 +138,27 @@ func (s *devServer) Serve(ctx context.Context) error {
 }
 
 type prodServer struct {
-	url *url.URL
+	baseUrl        *url.URL
+	defaultVersion model.WebVersion
 }
 
+func newProdServer(baseUrl string, version model.WebVersion) (prodServer, error) {
+	loc, err := url.Parse(baseUrl)
+	if err != nil {
+		return prodServer{}, errors.Wrap(err, "ProvideAssetServer")
+	}
+	return prodServer{
+		baseUrl:        loc,
+		defaultVersion: version,
+	}, nil
+}
 func (s prodServer) TearDown(ctx context.Context) {
 }
 
 // This doesn't actually do any setup right now.
 func (s prodServer) Serve(ctx context.Context) error {
-	logger.Get(ctx).Verbosef("Serving Tilt production web assets from %s", s.url)
+	logger.Get(ctx).Verbosef("Serving Tilt production web assets from %s with default version %s",
+		s.baseUrl, s.defaultVersion)
 	<-ctx.Done()
 	return nil
 }
@@ -152,14 +167,7 @@ func (s prodServer) Serve(ctx context.Context) error {
 // why. But this only needs a very limited GET interface without query params,
 // so just make the request by hand.
 func (s prodServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	outurl := *s.url
-	origPath := req.URL.Path
-	if !strings.HasPrefix(origPath, "/static/") {
-		// redirect everything to the main entry point.
-		origPath = "index.html"
-	}
-
-	outurl.Path = path.Join(outurl.Path, origPath)
+	outurl := s.buildUrlForReq(req)
 	outreq, err := http.NewRequest("GET", outurl.String(), bytes.NewBuffer(nil))
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -182,6 +190,18 @@ func (s prodServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	copyHeader(w.Header(), outres.Header)
 	w.WriteHeader(outres.StatusCode)
 	_, _ = io.Copy(w, outres.Body)
+}
+
+func (s prodServer) buildUrlForReq(req *http.Request) url.URL {
+	u := *s.baseUrl
+	origPath := req.URL.Path
+	if !strings.HasPrefix(origPath, "/static/") {
+		// redirect everything to the main entry point.
+		origPath = "index.html"
+
+	}
+	u.Path = path.Join(u.Path, string(s.defaultVersion), origPath)
+	return u
 }
 
 type precompiledServer struct {
@@ -232,7 +252,7 @@ func NewFakeServer() Server {
 	if err != nil {
 		panic(err)
 	}
-	return prodServer{url: loc}
+	return prodServer{baseUrl: loc}
 }
 
 func ProvideAssetServer(ctx context.Context, webMode model.WebMode, webVersion model.WebVersion, devPort model.WebDevPort) (Server, error) {
@@ -261,13 +281,7 @@ func ProvideAssetServer(ctx context.Context, webMode model.WebMode, webVersion m
 	}
 
 	if webMode == model.ProdWebMode {
-		loc, err := url.Parse(fmt.Sprintf("https://storage.googleapis.com/tilt-static-assets/%s", webVersion))
-		if err != nil {
-			return nil, errors.Wrap(err, "ProvideAssetServer")
-		}
-		return prodServer{
-			url: loc,
-		}, nil
+		return newProdServer(prodAssetBucket, webVersion)
 	}
 
 	return nil, model.UnrecognizedWebModeError(string(webMode))

--- a/internal/assets/server.go
+++ b/internal/assets/server.go
@@ -198,9 +198,14 @@ func (s prodServer) buildUrlForReq(req *http.Request) url.URL {
 	if !strings.HasPrefix(origPath, "/static/") {
 		// redirect everything to the main entry point.
 		origPath = "index.html"
-
 	}
-	u.Path = path.Join(u.Path, string(s.defaultVersion), origPath)
+
+	version := req.URL.Query().Get(webVersionKey)
+	if version == "" {
+		version = string(s.defaultVersion)
+	}
+
+	u.Path = path.Join(u.Path, version, origPath)
 	return u
 }
 


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/specify-asset-version:

de425dd03db3c61cc3cac7df5a57ec0e0a3b203e (2019-05-02 13:59:54 -0400)
respect version query param

558a14aafb93c2cbe7ec3bef40a64c08206bff7e (2019-05-02 12:21:31 -0400)
preserve existing behavior constructing with default url

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics