### PR TITLE
sail: sail serves the correct assets for the requested room [ch2283]

### DIFF
--- a/deployments/sail.dockerfile
+++ b/deployments/sail.dockerfile
@@ -19,4 +19,4 @@ RUN make build-js
 ADD . .
 RUN make install-sail
 
-ENTRYPOINT sail --web-mode=precompiled
+ENTRYPOINT sail --web-mode=prod

--- a/deployments/sail.dockerfile
+++ b/deployments/sail.dockerfile
@@ -19,4 +19,4 @@ RUN make build-js
 ADD . .
 RUN make install-sail
 
-ENTRYPOINT sail --web-mode=prod
+ENTRYPOINT sail --web-mode=precompiled

--- a/internal/assets/prod_server_test.go
+++ b/internal/assets/prod_server_test.go
@@ -71,7 +71,7 @@ func reqForTest(t *testing.T, path string, version model.WebVersion) *http.Reque
 
 	if version != "" {
 		q := u.Query()
-		q.Set(webVersionKey, string(version))
+		q.Set(WebVersionKey, string(version))
 		u.RawQuery = q.Encode()
 	}
 

--- a/internal/assets/prod_server_test.go
+++ b/internal/assets/prod_server_test.go
@@ -19,40 +19,63 @@ func TestBuildUrlForReq(t *testing.T) {
 	s := prodServerForTest(t)
 	expected := "https://fake.tilt.dev/v1.2.3/index.html"
 	req := reqForTest(t, "/", "")
-	actual := s.buildUrlForReq(req)
-	assert.Equal(t, expected, actual.String())
+	u, v := s.urlAndVersionForReq(req)
+	assert.Equal(t, expected, u.String())
+	assert.Equal(t, string(versionDefault), v)
 }
 
 func TestBuildUrlForReqRedirectsToIndex(t *testing.T) {
 	s := prodServerForTest(t)
 	expected := "https://fake.tilt.dev/v1.2.3/index.html"
 	req := reqForTest(t, "/some/random/path", "")
-	actual := s.buildUrlForReq(req)
-	assert.Equal(t, expected, actual.String())
+	u, v := s.urlAndVersionForReq(req)
+	assert.Equal(t, expected, u.String())
+	assert.Equal(t, string(versionDefault), v)
 }
 
 func TestBuildUrlForReqRespectsStatic(t *testing.T) {
 	s := prodServerForTest(t)
 	expected := "https://fake.tilt.dev/v1.2.3/static/stuff.html"
 	req := reqForTest(t, "/static/stuff.html", "")
-	actual := s.buildUrlForReq(req)
-	assert.Equal(t, expected, actual.String())
+	u, v := s.urlAndVersionForReq(req)
+	assert.Equal(t, expected, u.String())
+	assert.Equal(t, string(versionDefault), v)
+}
+
+func TestBuildUrlForReqRespectsVersion(t *testing.T) {
+	s := prodServerForTest(t)
+	expected := "https://fake.tilt.dev/v111.222.333/stuff.html"
+	req := reqForTest(t, "/v111.222.333/stuff.html", "")
+	u, v := s.urlAndVersionForReq(req)
+	assert.Equal(t, expected, u.String())
+	assert.Equal(t, "v111.222.333", v)
 }
 
 func TestBuildUrlForReqWithVersionParam(t *testing.T) {
 	s := prodServerForTest(t)
 	expected := "https://fake.tilt.dev/v6.6.6/index.html"
 	req := reqForTest(t, "/", version666)
-	actual := s.buildUrlForReq(req)
-	assert.Equal(t, expected, actual.String())
+	u, v := s.urlAndVersionForReq(req)
+	assert.Equal(t, expected, u.String())
+	assert.Equal(t, string(version666), v)
 }
 
 func TestBuildUrlForReqWithVersionParamAndStaticPath(t *testing.T) {
 	s := prodServerForTest(t)
 	expected := "https://fake.tilt.dev/v6.6.6/static/stuff.html"
 	req := reqForTest(t, "/static/stuff.html", version666)
-	actual := s.buildUrlForReq(req)
-	assert.Equal(t, expected, actual.String())
+	u, v := s.urlAndVersionForReq(req)
+	assert.Equal(t, expected, u.String())
+	assert.Equal(t, string(version666), v)
+}
+
+func TestBuildUrlForReqWithVersionParamAndVersionPrefix(t *testing.T) {
+	s := prodServerForTest(t)
+	expected := "https://fake.tilt.dev/v111.222.333/stuff.html"
+	req := reqForTest(t, "/v111.222.333/stuff.html", version666)
+	u, v := s.urlAndVersionForReq(req)
+	assert.Equal(t, expected, u.String())
+	assert.Equal(t, "v111.222.333", v)
 }
 
 func prodServerForTest(t *testing.T) prodServer {

--- a/internal/assets/server.go
+++ b/internal/assets/server.go
@@ -30,7 +30,7 @@ import (
 const prodAssetBucket = "https://storage.googleapis.com/tilt-static-assets/"
 const WebVersionKey = "web_version"
 
-var versionRe = regexp.MustCompile(`/(v\d*\.\d*\.\d*)/.*`) // matches `/vA.B.C/...`
+var versionRe = regexp.MustCompile(`/(v\d+\.\d+\.\d+)/.*`) // matches `/vA.B.C/...`
 
 type Server interface {
 	http.Handler

--- a/internal/assets/server.go
+++ b/internal/assets/server.go
@@ -26,7 +26,7 @@ import (
 )
 
 const prodAssetBucket = "https://storage.googleapis.com/tilt-static-assets/"
-const webVersionKey = "web_version"
+const WebVersionKey = "web_version"
 
 type Server interface {
 	http.Handler
@@ -200,7 +200,7 @@ func (s prodServer) buildUrlForReq(req *http.Request) url.URL {
 		origPath = "index.html"
 	}
 
-	version := req.URL.Query().Get(webVersionKey)
+	version := req.URL.Query().Get(WebVersionKey)
 	if version == "" {
 		version = string(s.defaultVersion)
 	}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -83,5 +83,5 @@ func provideTiltInfo() model.TiltBuild {
 }
 
 func provideWebVersion(b model.TiltBuild) model.WebVersion {
-	return model.WebVersion(fmt.Sprintf("v%s", b.Version))
+	return b.WebVersion()
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -109,8 +109,7 @@ func (s HeadsUpServer) HandleSail(w http.ResponseWriter, req *http.Request) {
 	err := s.sailCli.Connect(logger.WithLogger(req.Context(), l), s.store)
 	if err != nil {
 		log.Printf("sailClient.NewRoom: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(fmt.Sprintf("error creating new Sail room: %v", err)))
+		http.Error(w, fmt.Sprintf("error creating new Sail room: %v", err), http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/model/sail.go
+++ b/internal/model/sail.go
@@ -18,6 +18,10 @@ type SailRoomInfo struct {
 	Secret string `json:"secret"`
 }
 
+type SailNewRoomRequest struct {
+	WebVersion WebVersion `json:"web_version"`
+}
+
 type SailPort int
 type SailURL url.URL
 

--- a/internal/model/tilt_build.go
+++ b/internal/model/tilt_build.go
@@ -1,5 +1,9 @@
 package model
 
+import (
+	"fmt"
+)
+
 // Information on the current built of the Tilt binary
 type TiltBuild struct {
 	Version string
@@ -17,4 +21,8 @@ func (b TiltBuild) AnalyticsVersion() string {
 	}
 
 	return b.Version
+}
+
+func (b TiltBuild) WebVersion() WebVersion {
+	return WebVersion(fmt.Sprintf("v%s", b.Version))
 }

--- a/internal/sail/client/client.go
+++ b/internal/sail/client/client.go
@@ -122,7 +122,12 @@ func (s *sailClient) Connect(ctx context.Context, st store.RStore) error {
 	if s.addr.Empty() {
 		return fmt.Errorf("tried to connect a sailClient with an empty address")
 	}
-	roomID, secret, err := s.roomer.NewRoom(ctx)
+
+	state := st.RLockState()
+	version := state.TiltBuildInfo.WebVersion()
+	st.RUnlockState()
+
+	roomID, secret, err := s.roomer.NewRoom(ctx, version)
 	if err != nil {
 		st.Dispatch(SailRoomConnectedAction{Err: err})
 		return err

--- a/internal/sail/client/roomer.go
+++ b/internal/sail/client/roomer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -35,15 +34,10 @@ func (r httpRoomer) NewRoom(ctx context.Context, version model.WebVersion) (room
 		return "", "", errors.Wrapf(err, "GET %s", u.String())
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", "", errors.Wrap(err, "reading /new_room response")
-	}
-
 	var roomInfo model.SailRoomInfo
-	err = json.Unmarshal(body, &roomInfo)
+	err = json.NewDecoder(resp.Body).Decode(&roomInfo)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "unmarshaling json: %s", string(body))
+		return "", "", errors.Wrap(err, "json-decoding POST /room response body")
 	}
 
 	return roomInfo.RoomID, roomInfo.Secret, nil

--- a/internal/sail/server/room.go
+++ b/internal/sail/server/room.go
@@ -14,11 +14,12 @@ import (
 // A room where messages from a source are broadcast to all the followers.
 type Room struct {
 	// Immutable data
-	id     model.RoomID
-	secret string // used to authorize attempts to share to this room
-	source SourceConn
-	addFan chan AddFanAction
-	fanOut chan FanOutAction
+	id      model.RoomID
+	secret  string // used to authorize attempts to share to this room
+	source  SourceConn
+	addFan  chan AddFanAction
+	fanOut  chan FanOutAction
+	version model.WebVersion // version of data feeding this room (+ version of assets to serve)
 
 	// Mutable data, only read/written in the action loop.
 	fans       []FanConn
@@ -53,11 +54,12 @@ type FanOutAction struct {
 
 func (a FanOutAction) Empty() bool { return a.messageType == 0 && len(a.data) == 0 }
 
-func NewRoom() *Room {
+func NewRoom(version model.WebVersion) *Room {
 	return &Room{
-		id:     model.RoomID(uuid.New().String()),
-		secret: uuid.New().String(),
-		addFan: make(chan AddFanAction, 0),
+		id:      model.RoomID(uuid.New().String()),
+		secret:  uuid.New().String(),
+		version: version,
+		addFan:  make(chan AddFanAction, 0),
 	}
 }
 

--- a/internal/sail/server/room_test.go
+++ b/internal/sail/server/room_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/model"
 )
 
 func TestNoFans(t *testing.T) {
@@ -72,7 +73,7 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 	ctx, cancel := context.WithCancel(context.Background())
 	source := newFakeSource(ctx)
-	room := NewRoom()
+	room := NewRoom(model.WebVersion("v1.2.3"))
 	room.source = source
 	errCh := make(chan error)
 	go func() {

--- a/internal/sail/server/server.go
+++ b/internal/sail/server/server.go
@@ -178,11 +178,17 @@ func (s SailServer) joinRoom(w http.ResponseWriter, req *http.Request) {
 func (s SailServer) viewRoom(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	roomID := model.RoomID(vars["roomID"])
-	if !s.hasRoom(roomID) {
+	room, ok := s.rooms[roomID]
+	if !ok {
 		http.Error(w, fmt.Sprintf("Room not found: %q", roomID), http.StatusNotFound)
 		return
 	}
 
-	req.URL.Path = "/index.html"
+	u := req.URL
+	u.Path = "/index.html"
+	q := u.Query()
+	q.Set(assets.WebVersionKey, string(room.version))
+	u.RawQuery = q.Encode()
+
 	s.assetServer.ServeHTTP(w, req)
 }

--- a/internal/sail/server/server.go
+++ b/internal/sail/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"sync"
@@ -58,16 +57,10 @@ func (s SailServer) newRoom(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("error reading request: %v", err), http.StatusBadRequest)
-		return
-	}
-
 	var newRoomReq model.SailNewRoomRequest
-	err = json.Unmarshal(body, &newRoomReq)
+	err := json.NewDecoder(req.Body).Decode(&newRoomReq)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("error unmarshaling request: %v", err), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("json-decoding request body: %v", err), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/sail/server/server.go
+++ b/internal/sail/server/server.go
@@ -71,7 +71,6 @@ func (s SailServer) newRoom(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	fmt.Println("made new room with version:", newRoomReq.WebVersion)
 	room := NewRoom(newRoomReq.WebVersion)
 	s.rooms[room.id] = room
 
@@ -186,6 +185,8 @@ func (s SailServer) viewRoom(w http.ResponseWriter, req *http.Request) {
 
 	u := req.URL
 	u.Path = "/index.html"
+
+	// Request the correct version of assets
 	q := u.Query()
 	q.Set(assets.WebVersionKey, string(room.version))
 	u.RawQuery = q.Encode()


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/sail-serve-right-version:

5354bb72b31ff3be23609d1db1c50c2f007b71a3 (2019-05-02 18:36:42 -0400)
clean-up

b721f358e26d563261e8374a5a05a7c288198b47 (2019-05-02 18:28:40 -0400)
inject version into returned html

744c3f5f0a6ecb5c452040eea3415f895f12f3db (2019-05-02 18:28:35 -0400)
respect versions in prod server urls

0a1daa52a902c1198415e662b5800174253ec593 (2019-05-02 18:28:32 -0400)
wip

0bf54aa51c65cb443511f995bfcb475485e266a6 (2019-05-02 18:28:30 -0400)
send version with new_room request

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics