### PR TITLE
build: don't skip ignored directories

### DIFF
--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/model"
-
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
 type ArchiveBuilder struct {
@@ -160,9 +160,6 @@ func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string
 			return err
 		}
 		if matches {
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
 			return nil
 		}
 


### PR DESCRIPTION
This might be mildly controversial. This is effectively just reverting #1445, which gave us a big build speedup in some cases. Unfortunately, it introduced a problem:
If, e.g., vigoda's .dockerignore has `*` and `!main.go`, we'll `filepath.Walk` to `vigoda`, it will be ignored because it matches `*`, and we'll never descend into `vigoda` to discover `vigoda/main.go`.

This change makes the associated test go red -> green and also fixes the vigoda repro mentioned above.

We could be clever by parsing out the exclusions and descending more intelligently (or even only descending if there exists any `!` at all), but that's a more complex fix, and it seems best for today to apply this cheap fix to make things work, even if it comes with a perf hit.