### PR TITLE
web: display tiltfile edit paths relative to tiltfile

### DIFF
--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -2,6 +2,7 @@ package webview
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/windmilleng/tilt/internal/dockercompose"
@@ -124,6 +125,9 @@ func tiltfileResourceView(s store.EngineState) Resource {
 	if !s.CurrentTiltfileBuild.Empty() {
 		ltfb.Log = s.CurrentTiltfileBuild.Log
 	}
+
+	ltfb.Edits = ospath.FileListDisplayNames([]string{filepath.Dir(s.TiltfilePath)}, ltfb.Edits)
+
 	tr := Resource{
 		Name:         view.TiltfileResourceName,
 		IsTiltfile:   true,


### PR DESCRIPTION
to fix this situation:

![image](https://user-images.githubusercontent.com/7453991/57314686-23502f00-70c0-11e9-9eb0-1623c33a1948.png)

Now tiltfile dependency edits are displayed relative to the tiltfile's directory, e.g.:
![image](https://user-images.githubusercontent.com/7453991/57314746-424ec100-70c0-11e9-97d2-572e72fafd9d.png)

(FWIW, this wasn't a problem in the TUI because the renderer just shows `filepath.Base` for all edits, to save space. In the Web UI, we make paths relative to watched paths for normal resources, but didn't do anything for the Tiltfile resource, so we just showed abs paths)