### PR TITLE
web: show number of errors next to errors tab

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -1,12 +1,18 @@
 import React from "react"
 import ReactDOM from "react-dom"
+import { MemoryRouter } from "react-router"
 import HUD from "./HUD"
 import { mount } from "enzyme"
-import { RouteComponentProps } from "react-router-dom"
 import { oneResourceView, twoResourceView } from "./testdata.test"
+import { createMemoryHistory } from "history"
 
+const fakeHistory = createMemoryHistory()
 const emptyHUD = () => {
-  return <HUD />
+  return (
+    <MemoryRouter initialEntries={["/"]}>
+      <HUD history={fakeHistory} />
+    </MemoryRouter>
+  )
 }
 
 beforeEach(() => {
@@ -20,69 +26,75 @@ it("renders without crashing", () => {
 })
 
 it("renders loading screen", async () => {
-  const hud = mount(emptyHUD())
-  expect(hud.html()).toEqual(expect.stringContaining("Loading"))
+  const root = mount(emptyHUD())
+  const hud = root.find(HUD)
+  expect(hud.text()).toEqual(expect.stringContaining("Loading"))
 
   hud.setState({ Message: "Disconnected" })
-  expect(hud.html()).toEqual(expect.stringContaining("Disconnected"))
+  expect(hud.text()).toEqual(expect.stringContaining("Disconnected"))
 })
 
 it("renders resource", async () => {
-  const hud = mount(emptyHUD())
+  const root = mount(emptyHUD())
+  const hud = root.find(HUD)
   hud.setState({ View: oneResourceView() })
-  expect(hud.html())
-  expect(hud.find(".Statusbar")).toHaveLength(1)
-  expect(hud.find(".Sidebar")).toHaveLength(1)
+  expect(root.find(".Statusbar")).toHaveLength(1)
+  expect(root.find(".Sidebar")).toHaveLength(1)
 })
 
 it("opens sidebar on click", async () => {
-  const hud = mount(emptyHUD())
+  const root = mount(emptyHUD())
+  const hud = root.find(HUD)
   hud.setState({ View: oneResourceView() })
 
-  let sidebar = hud.find(".Sidebar")
+  let sidebar = root.find(".Sidebar")
   expect(sidebar).toHaveLength(1)
   expect(sidebar.hasClass("is-closed")).toBe(false)
 
-  let button = hud.find("button.Sidebar-toggle")
+  let button = root.find("button.Sidebar-toggle")
   expect(button).toHaveLength(1)
   button.simulate("click")
 
-  sidebar = hud.find(".Sidebar")
+  sidebar = root.find(".Sidebar")
   expect(sidebar).toHaveLength(1)
   expect(sidebar.hasClass("is-closed")).toBe(true)
 })
 
 it("doesn't re-render the sidebar when the logs change", async () => {
-  const hud = mount(emptyHUD())
+  const root = mount(emptyHUD())
+  const hud = root.find(HUD)
+
   let resourceView = oneResourceView()
   hud.setState({ View: resourceView })
-  let oldDOMNode = hud.find(".Sidebar").getDOMNode()
+  let oldDOMNode = root.find(".Sidebar").getDOMNode()
   resourceView.Resources[0].PodLog += "hello world\n"
   hud.setState({ View: resourceView })
-  let newDOMNode = hud.find(".Sidebar").getDOMNode()
+  let newDOMNode = root.find(".Sidebar").getDOMNode()
 
   expect(oldDOMNode).toBe(newDOMNode)
 })
 
 it("does re-render the sidebar when the resource list changes", async () => {
-  const hud = mount(emptyHUD())
+  const root = mount(emptyHUD())
+  const hud = root.find(HUD)
 
   let resourceView = oneResourceView()
   hud.setState({ View: resourceView })
-  let sidebarLinks = hud.find(".Sidebar-resources Link")
+  let sidebarLinks = root.find(".Sidebar-resources Link")
   expect(sidebarLinks).toHaveLength(2)
 
   let newResourceView = twoResourceView()
   hud.setState({ View: newResourceView })
-  sidebarLinks = hud.find(".Sidebar-resources Link")
+  sidebarLinks = root.find(".Sidebar-resources Link")
   expect(sidebarLinks).toHaveLength(3)
 })
 
 it("renders tab nav", () => {
-  const hud = mount(emptyHUD())
+  const root = mount(emptyHUD())
+  const hud = root.find(HUD)
 
   let resourceView = oneResourceView()
   hud.setState({ View: resourceView })
-  let tabNavLinks = hud.find(".TabNav Link")
+  let tabNavLinks = root.find(".TabNav Link")
   expect(tabNavLinks).toHaveLength(3)
 })

--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -98,3 +98,27 @@ it("renders tab nav", () => {
   let tabNavLinks = root.find(".TabNav Link")
   expect(tabNavLinks).toHaveLength(3)
 })
+
+it("renders number of errors in tabnav when no resource is selected", () => {
+  const root = mount(emptyHUD())
+  const hud = root.find(HUD)
+
+  let resourceView = twoResourceView()
+  hud.setState({ View: resourceView })
+  let errorTab = root.find(".tabLink--errors")
+  expect(errorTab.at(0).text()).toEqual("Errors (2)")
+})
+
+it("renders the number of errors a reosurce has in tabnav when a resource is selected", () => {
+  const root = mount(
+    <MemoryRouter initialEntries={["/r/vigoda"]}>
+      <HUD history={fakeHistory} />
+    </MemoryRouter>
+  )
+  const hud = root.find(HUD)
+
+  let resourceView = twoResourceView()
+  hud.setState({ View: resourceView })
+  let errorTab = root.find(".tabLink--errors")
+  expect(errorTab.at(0).text()).toEqual("Errors (1)")
+})

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -180,6 +180,7 @@ class HUD extends Component<HudProps, HudState> {
           resourceView={t}
           sailEnabled={sailEnabled}
           sailUrl={sailUrl}
+          numberOfErrors={resourcesWithErrors.length}
         />
       )
     }
@@ -244,6 +245,8 @@ class HUD extends Component<HudProps, HudState> {
       }
       return <ErrorPane resources={[]} />
     }
+    let errorResources = resources.map(r => new ErrorResource(r))
+    let resourcesWithErrors = errorResources.filter(r => r.hasError())
 
     return (
       <Router history={this.history}>
@@ -311,11 +314,7 @@ class HUD extends Component<HudProps, HudState> {
             <Route
               exact
               path={this.path("/errors")}
-              render={() => (
-                <ErrorPane
-                  resources={resources.map(r => new ErrorResource(r))}
-                />
-              )}
+              render={() => <ErrorPane resources={errorResources} />}
             />
             <Route exact path={this.path("/preview")} render={previewRoute} />
             <Route exact path={this.path("/r/:name")} render={logsRoute} />

--- a/web/src/TabNav.test.tsx
+++ b/web/src/TabNav.test.tsx
@@ -13,6 +13,7 @@ it("shows logs", () => {
           previewUrl="/r/foo/preview"
           errorsUrl="/r/foo/errors"
           resourceView={ResourceView.Log}
+          numberOfErrors={0}
         />
       </MemoryRouter>
     )
@@ -30,6 +31,7 @@ it("previews resources", () => {
           previewUrl="/r/foo/preview"
           errorsUrl="/r/foo/errors"
           resourceView={ResourceView.Preview}
+          numberOfErrors={0}
         />
       </MemoryRouter>
     )
@@ -47,6 +49,25 @@ it("shows error pane", () => {
           previewUrl="/r/foo/preview"
           errorsUrl="/r/foo/errors"
           resourceView={ResourceView.Errors}
+          numberOfErrors={0}
+        />
+      </MemoryRouter>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
+it("shows the number of errors in the error tab", () => {
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <TabNav
+          logUrl="/r/foo"
+          previewUrl="/r/foo/preview"
+          errorsUrl="/r/foo/errors"
+          resourceView={ResourceView.Errors}
+          numberOfErrors={27}
         />
       </MemoryRouter>
     )

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -17,6 +17,7 @@ class TabNav extends PureComponent<NavProps> {
     let previewIsSelected = this.props.resourceView === ResourceView.Preview
     let errorsIsSelected = this.props.resourceView === ResourceView.Errors
 
+    // The number of errors should be for the selected resource
     return (
       <nav className="TabNav">
         <ul>
@@ -47,7 +48,10 @@ class TabNav extends PureComponent<NavProps> {
               }`}
               to={this.props.errorsUrl}
             >
-              Errors ({this.props.numberOfErrors})
+              Errors{" "}
+              {this.props.numberOfErrors > 0
+                ? `(${this.props.numberOfErrors})`
+                : ""}
             </Link>
           </li>
         </ul>

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -8,6 +8,7 @@ type NavProps = {
   logUrl: string
   errorsUrl: string
   resourceView: ResourceView
+  numberOfErrors: number
 }
 
 class TabNav extends PureComponent<NavProps> {
@@ -46,7 +47,7 @@ class TabNav extends PureComponent<NavProps> {
               }`}
               to={this.props.errorsUrl}
             >
-              Errors
+              Errors ({this.props.numberOfErrors})
             </Link>
           </li>
         </ul>

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -43,7 +43,7 @@ class TabNav extends PureComponent<NavProps> {
           </li>
           <li>
             <Link
-              className={`tabLink ${
+              className={`tabLink tabLink--errors ${
                 errorsIsSelected ? "tabLink--is-selected" : ""
               }`}
               to={this.props.errorsUrl}

--- a/web/src/TopBar.test.tsx
+++ b/web/src/TopBar.test.tsx
@@ -15,6 +15,7 @@ it("shows sail share button", () => {
           resourceView={ResourceView.Errors}
           sailEnabled={true}
           sailUrl=""
+          numberOfErrors={0}
         />
       </MemoryRouter>
     )
@@ -34,6 +35,7 @@ it("shows sail url", () => {
           resourceView={ResourceView.Errors}
           sailEnabled={true}
           sailUrl="www.sail.dev/xyz"
+          numberOfErrors={1}
         />
       </MemoryRouter>
     )

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -11,6 +11,7 @@ type TopBarProps = {
   resourceView: ResourceView
   sailEnabled: boolean
   sailUrl: string
+  numberOfErrors: number
 }
 
 class TopBar extends PureComponent<TopBarProps> {
@@ -22,6 +23,7 @@ class TopBar extends PureComponent<TopBarProps> {
           logUrl={this.props.logUrl}
           errorsUrl={this.props.errorsUrl}
           resourceView={this.props.resourceView}
+          numberOfErrors={this.props.numberOfErrors}
         />
         <span className="TopBar-spacer">&nbsp;</span>
         <SailInfo

--- a/web/src/__snapshots__/TabNav.test.tsx.snap
+++ b/web/src/__snapshots__/TabNav.test.tsx.snap
@@ -29,7 +29,9 @@ exports[`previews resources 1`] = `
         href="/r/foo/errors"
         onClick={[Function]}
       >
-        Errors
+        Errors (
+        0
+        )
       </a>
     </li>
   </ul>
@@ -65,7 +67,9 @@ exports[`shows error pane 1`] = `
         href="/r/foo/errors"
         onClick={[Function]}
       >
-        Errors
+        Errors (
+        0
+        )
       </a>
     </li>
   </ul>
@@ -101,7 +105,47 @@ exports[`shows logs 1`] = `
         href="/r/foo/errors"
         onClick={[Function]}
       >
-        Errors
+        Errors (
+        0
+        )
+      </a>
+    </li>
+  </ul>
+</nav>
+`;
+
+exports[`shows the number of errors in the error tab 1`] = `
+<nav
+  className="TabNav"
+>
+  <ul>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo"
+        onClick={[Function]}
+      >
+        Logs
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink "
+        href="/r/foo/preview"
+        onClick={[Function]}
+      >
+        Preview
+      </a>
+    </li>
+    <li>
+      <a
+        className="tabLink tabLink--is-selected"
+        href="/r/foo/errors"
+        onClick={[Function]}
+      >
+        Errors (
+        27
+        )
       </a>
     </li>
   </ul>

--- a/web/src/__snapshots__/TabNav.test.tsx.snap
+++ b/web/src/__snapshots__/TabNav.test.tsx.snap
@@ -29,9 +29,9 @@ exports[`previews resources 1`] = `
         href="/r/foo/errors"
         onClick={[Function]}
       >
-        Errors (
-        0
-        )
+        Errors
+         
+        
       </a>
     </li>
   </ul>
@@ -67,9 +67,9 @@ exports[`shows error pane 1`] = `
         href="/r/foo/errors"
         onClick={[Function]}
       >
-        Errors (
-        0
-        )
+        Errors
+         
+        
       </a>
     </li>
   </ul>
@@ -105,9 +105,9 @@ exports[`shows logs 1`] = `
         href="/r/foo/errors"
         onClick={[Function]}
       >
-        Errors (
-        0
-        )
+        Errors
+         
+        
       </a>
     </li>
   </ul>
@@ -143,9 +143,9 @@ exports[`shows the number of errors in the error tab 1`] = `
         href="/r/foo/errors"
         onClick={[Function]}
       >
-        Errors (
-        27
-        )
+        Errors
+         
+        (27)
       </a>
     </li>
   </ul>

--- a/web/src/__snapshots__/TabNav.test.tsx.snap
+++ b/web/src/__snapshots__/TabNav.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`previews resources 1`] = `
     </li>
     <li>
       <a
-        className="tabLink "
+        className="tabLink tabLink--errors "
         href="/r/foo/errors"
         onClick={[Function]}
       >
@@ -63,7 +63,7 @@ exports[`shows error pane 1`] = `
     </li>
     <li>
       <a
-        className="tabLink tabLink--is-selected"
+        className="tabLink tabLink--errors tabLink--is-selected"
         href="/r/foo/errors"
         onClick={[Function]}
       >
@@ -101,7 +101,7 @@ exports[`shows logs 1`] = `
     </li>
     <li>
       <a
-        className="tabLink "
+        className="tabLink tabLink--errors "
         href="/r/foo/errors"
         onClick={[Function]}
       >
@@ -139,7 +139,7 @@ exports[`shows the number of errors in the error tab 1`] = `
     </li>
     <li>
       <a
-        className="tabLink tabLink--is-selected"
+        className="tabLink tabLink--errors tabLink--is-selected"
         href="/r/foo/errors"
         onClick={[Function]}
       >

--- a/web/src/__snapshots__/TopBar.test.tsx.snap
+++ b/web/src/__snapshots__/TopBar.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`shows sail share button 1`] = `
       </li>
       <li>
         <a
-          className="tabLink tabLink--is-selected"
+          className="tabLink tabLink--errors tabLink--is-selected"
           href="/r/foo/errors"
           onClick={[Function]}
         >
@@ -85,7 +85,7 @@ exports[`shows sail url 1`] = `
       </li>
       <li>
         <a
-          className="tabLink tabLink--is-selected"
+          className="tabLink tabLink--errors tabLink--is-selected"
           href="/r/foo/errors"
           onClick={[Function]}
         >

--- a/web/src/__snapshots__/TopBar.test.tsx.snap
+++ b/web/src/__snapshots__/TopBar.test.tsx.snap
@@ -32,7 +32,9 @@ exports[`shows sail share button 1`] = `
           href="/r/foo/errors"
           onClick={[Function]}
         >
-          Errors
+          Errors (
+          0
+          )
         </a>
       </li>
     </ul>
@@ -87,7 +89,9 @@ exports[`shows sail url 1`] = `
           href="/r/foo/errors"
           onClick={[Function]}
         >
-          Errors
+          Errors (
+          1
+          )
         </a>
       </li>
     </ul>

--- a/web/src/__snapshots__/TopBar.test.tsx.snap
+++ b/web/src/__snapshots__/TopBar.test.tsx.snap
@@ -32,9 +32,9 @@ exports[`shows sail share button 1`] = `
           href="/r/foo/errors"
           onClick={[Function]}
         >
-          Errors (
-          0
-          )
+          Errors
+           
+          
         </a>
       </li>
     </ul>
@@ -89,9 +89,9 @@ exports[`shows sail url 1`] = `
           href="/r/foo/errors"
           onClick={[Function]}
         >
-          Errors (
-          1
-          )
+          Errors
+           
+          (1)
         </a>
       </li>
     </ul>

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,8 +1,15 @@
-import React from "react"
+import React, { Component } from "react"
 import ReactDOM from "react-dom"
 import "./index.scss"
 import HUD from "./HUD"
+import { Router } from "react-router-dom"
+import { createBrowserHistory, UnregisterCallback } from "history"
 
-let app = <HUD />
+let history = createBrowserHistory()
+let app = (
+  <Router history={history}>
+    <HUD history={history} />
+  </Router>
+)
 let root = document.getElementById("root")
 ReactDOM.render(app, root)


### PR DESCRIPTION
<img width="504" alt="Screen Shot 2019-05-08 at 2 37 09 PM" src="https://user-images.githubusercontent.com/452453/57399202-cf684780-719e-11e9-9cc1-87b145c1c5e6.png">

Future work that will happen in a different PR:
* Styling this number to be a bit better
* When you click on the errors tab the number gets reset to zero.