### PR TITLE
docker: normalize DOCKER_HOST addresses

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
@@ -161,6 +162,11 @@ func ProvideEnv(ctx context.Context, env k8s.Env, runtime container.Runtime, min
 
 	host := os.Getenv("DOCKER_HOST")
 	if host != "" {
+		host, err := opts.ParseHost(true, host)
+		if err != nil {
+			return Env{}, errors.Wrap(err, "ProvideDockerEnv")
+		}
+
 		// If the docker host is set from the env, ignore all the variables
 		// from minikube/microk8s
 		result = Env{Host: host}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -122,10 +122,10 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_API_VERSION": "1.35",
 			},
 			osEnv: map[string]string{
-				"DOCKER_HOST": "registry.local:80",
+				"DOCKER_HOST": "tcp://registry.local:80",
 			},
 			expected: Env{
-				Host: "registry.local:80",
+				Host: "tcp://registry.local:80",
 			},
 		},
 		{
@@ -138,6 +138,21 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_API_VERSION": "1.35",
 			},
 			expected: Env{},
+		},
+		{
+			env: k8s.EnvUnknown,
+			osEnv: map[string]string{
+				"DOCKER_TLS_VERIFY":  "1",
+				"DOCKER_HOST":        "localhost:2376",
+				"DOCKER_CERT_PATH":   "/home/nick/.minikube/certs",
+				"DOCKER_API_VERSION": "1.35",
+			},
+			expected: Env{
+				TLSVerify:  "1",
+				Host:       "tcp://localhost:2376",
+				CertPath:   "/home/nick/.minikube/certs",
+				APIVersion: "1.35",
+			},
 		},
 	}
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/tcp:

2aa5674cba80b8325a85e236a9683b49025cb607 (2019-05-13 11:16:54 -0400)
docker: normalize DOCKER_HOST addresses