### PR TITLE
web: analytics nudge in sidebar (placeholder, styling TBD) [ch2531]

### DIFF
--- a/web/src/AnalyticsNudge.scss
+++ b/web/src/AnalyticsNudge.scss
@@ -1,0 +1,12 @@
+@import "constants";
+
+.AnalyticsNudge {
+  border-left: $sidebar-item solid #03c7d3;
+  padding: $spacing-unit/4;
+  border-bottom: 1px solid $color-gray-light;
+}
+
+.AnalyticsNudge-buttons {
+  width: 100%;
+  align-content: center;
+}

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -1,0 +1,24 @@
+import React, { Component } from "react"
+import "./AnalyticsNudge.scss"
+
+class AnalyticsNudge extends Component {
+  render() {
+    return (
+      <div className="AnalyticsNudge" key="AnalyticsNudge">
+        <div>
+          Congrats on your first Tilt resource 🎉 Help us help you: may we
+          collect anonymized data on your usage. (Read more{" "}
+          <a href="https://github.com/windmilleng/tilt#privacy" target="_blank">
+            here
+          </a>
+          .)
+        </div>
+        <div className="AnalyticsNudge-buttons">
+          <button>Yes!</button> <button>Nope!</button>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default AnalyticsNudge

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -7,7 +7,7 @@ class AnalyticsNudge extends Component {
       <div className="AnalyticsNudge" key="AnalyticsNudge">
         <div>
           Congrats on your first Tilt resource 🎉 Help us help you: may we
-          collect anonymized data on your usage. (Read more{" "}
+          collect anonymized data on your usage? (Read more{" "}
           <a href="https://github.com/windmilleng/tilt#privacy" target="_blank">
             here
           </a>

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -57,6 +57,7 @@ type HudState = {
     LogTimestamps: boolean
     SailEnabled: boolean
     SailURL: string
+    NeedsAnalyticsNudge: boolean
   } | null
   IsSidebarClosed: boolean
 }
@@ -92,6 +93,7 @@ class HUD extends Component<HudProps, HudState> {
         LogTimestamps: false,
         SailEnabled: false,
         SailURL: "",
+        NeedsAnalyticsNudge: false,
       },
       IsSidebarClosed: false,
     }
@@ -166,6 +168,7 @@ class HUD extends Component<HudProps, HudState> {
     let view = this.state.View
     let sailEnabled = view && view.SailEnabled ? view.SailEnabled : false
     let sailUrl = view && view.SailURL ? view.SailURL : ""
+    let needsNudge = view ? view.NeedsAnalyticsNudge : false
     let message = this.state.Message
     let resources = (view && view.Resources) || []
     if (!resources.length) {
@@ -182,6 +185,7 @@ class HUD extends Component<HudProps, HudState> {
         <Sidebar
           selected={name}
           items={sidebarItems}
+          needsNudge={needsNudge}
           isClosed={isSidebarClosed}
           toggleSidebar={toggleSidebar}
           resourceView={t}

--- a/web/src/Sidebar.test.tsx
+++ b/web/src/Sidebar.test.tsx
@@ -2,7 +2,12 @@ import React from "react"
 import renderer from "react-test-renderer"
 import { MemoryRouter } from "react-router"
 import Sidebar, { SidebarItem } from "./Sidebar"
-import { oneResource, oneResourceView, twoResourceView } from "./testdata.test"
+import {
+  oneResource,
+  oneResourceView,
+  twoResourceView,
+  allResourcesOK,
+} from "./testdata.test"
 import { mount } from "enzyme"
 import { ResourceView } from "./types"
 import PathBuilder from "./PathBuilder"
@@ -20,6 +25,7 @@ describe("sidebar", () => {
           <Sidebar
             isClosed={true}
             items={[]}
+            needsNudge={false}
             selected=""
             toggleSidebar={null}
             resourceView={ResourceView.Log}
@@ -43,6 +49,7 @@ describe("sidebar", () => {
         <Sidebar
           isClosed={false}
           items={items}
+          needsNudge={false}
           selected=""
           toggleSidebar={null}
           resourceView={ResourceView.Log}
@@ -64,6 +71,7 @@ describe("sidebar", () => {
           <Sidebar
             isClosed={false}
             items={items}
+            needsNudge={false}
             selected=""
             toggleSidebar={null}
             resourceView={ResourceView.Log}
@@ -90,6 +98,7 @@ describe("sidebar", () => {
           <Sidebar
             isClosed={false}
             items={items}
+            needsNudge={false}
             selected=""
             toggleSidebar={null}
             resourceView={ResourceView.Log}
@@ -113,6 +122,53 @@ describe("sidebar", () => {
           <Sidebar
             isClosed={false}
             items={items}
+            needsNudge={false}
+            selected=""
+            toggleSidebar={null}
+            resourceView={ResourceView.Log}
+            pathBuilder={pathBuilder}
+          />
+        </MemoryRouter>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("renders analytics nudge", () => {
+    let items = twoResourceView().Resources.map((res: any) => {
+      return new SidebarItem(res)
+    })
+    const tree = renderer
+      .create(
+        <MemoryRouter initialEntries={["/"]}>
+          <Sidebar
+            isClosed={false}
+            items={items}
+            needsNudge={true}
+            selected=""
+            toggleSidebar={null}
+            resourceView={ResourceView.Log}
+            pathBuilder={pathBuilder}
+          />
+        </MemoryRouter>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("renders analytics nudge as third list item", () => {
+    let items = allResourcesOK().map((res: any) => {
+      return new SidebarItem(res)
+    })
+    const tree = renderer
+      .create(
+        <MemoryRouter initialEntries={["/"]}>
+          <Sidebar
+            isClosed={false}
+            items={items.slice(0, 6)}
+            needsNudge={true}
             selected=""
             toggleSidebar={null}
             resourceView={ResourceView.Log}

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react"
 import { ReactComponent as ChevronSvg } from "./assets/svg/chevron.svg"
 import { ReactComponent as DotSvg } from "./assets/svg/dot.svg"
 import { ReactComponent as DotBuildingSvg } from "./assets/svg/dot-building.svg"
+import AnalyticsNudge from "./AnalyticsNudge"
 import { Link } from "react-router-dom"
 import { combinedStatus, warnings } from "./status"
 import "./Sidebar.scss"
@@ -41,6 +42,7 @@ class SidebarItem {
 type SidebarProps = {
   isClosed: boolean
   items: SidebarItem[]
+  needsNudge: boolean
   selected: string
   toggleSidebar: any
   resourceView: ResourceView
@@ -136,6 +138,19 @@ class Sidebar extends PureComponent<SidebarProps> {
         </li>
       )
     })
+
+    if (this.props.needsNudge) {
+      let nudgeItem = (
+        <li key="AnalyticsNudge">
+          <AnalyticsNudge />
+        </li>
+      )
+      if (listItems.length > 2) {
+        listItems.splice(2, 0, nudgeItem)
+      } else {
+        listItems.push(nudgeItem)
+      }
+    }
 
     return (
       <section className={classes.join(" ")}>

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`sidebar renders analytics nudge 1`] = `
           className="AnalyticsNudge"
         >
           <div>
-            Congrats on your first Tilt resource 🎉 Help us help you: may we collect anonymized data on your usage. (Read more
+            Congrats on your first Tilt resource 🎉 Help us help you: may we collect anonymized data on your usage? (Read more
              
             <a
               href="https://github.com/windmilleng/tilt#privacy"
@@ -436,7 +436,7 @@ exports[`sidebar renders analytics nudge as third list item 1`] = `
           className="AnalyticsNudge"
         >
           <div>
-            Congrats on your first Tilt resource 🎉 Help us help you: may we collect anonymized data on your usage. (Read more
+            Congrats on your first Tilt resource 🎉 Help us help you: may we collect anonymized data on your usage? (Read more
              
             <a
               href="https://github.com/windmilleng/tilt#privacy"

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -234,6 +234,362 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
 </section>
 `;
 
+exports[`sidebar renders analytics nudge 1`] = `
+<section
+  className="Sidebar"
+>
+  <nav
+    className="Sidebar-resources"
+  >
+    <ul
+      className="Sidebar-list"
+    >
+      <li>
+        <a
+          className="resLink resLink--all is-selected"
+          href="/"
+          onClick={[Function]}
+        >
+          All
+        </a>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--building"
+          href="/r/vigoda"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot-building.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            vigoda
+          </span>
+          <span>
+            <time
+              dateTime="2017-12-21T15:36:07.000Z"
+              title="2017-12-21 15:36"
+            >
+              &lt;5s
+            </time>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--building"
+          href="/r/snack"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot-building.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            snack
+          </span>
+          <span>
+            <time
+              dateTime="2017-12-21T15:35:57.000Z"
+              title="2017-12-21 15:35"
+            >
+              &lt;15s
+            </time>
+          </span>
+        </a>
+      </li>
+      <li>
+        <div
+          className="AnalyticsNudge"
+        >
+          <div>
+            Congrats on your first Tilt resource 🎉 Help us help you: may we collect anonymized data on your usage. (Read more
+             
+            <a
+              href="https://github.com/windmilleng/tilt#privacy"
+              target="_blank"
+            >
+              here
+            </a>
+            .)
+          </div>
+          <div
+            className="AnalyticsNudge-buttons"
+          >
+            <button>
+              Yes!
+            </button>
+             
+            <button>
+              Nope!
+            </button>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </nav>
+  <div
+    className="Sidebar-spacer"
+  >
+     
+  </div>
+  <button
+    className="Sidebar-toggle"
+    onClick={null}
+  >
+    <svg>
+      chevron.svg
+    </svg>
+     Collapse
+  </button>
+</section>
+`;
+
+exports[`sidebar renders analytics nudge as third list item 1`] = `
+<section
+  className="Sidebar"
+>
+  <nav
+    className="Sidebar-resources"
+  >
+    <ul
+      className="Sidebar-list"
+    >
+      <li>
+        <a
+          className="resLink resLink--all is-selected"
+          href="/"
+          onClick={[Function]}
+        >
+          All
+        </a>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--ok"
+          href="/r/(Tiltfile)"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            (Tiltfile)
+          </span>
+          <span>
+            <time
+              dateTime="2019-04-22T14:59:53.903Z"
+              title="2019-04-22T10:59:53.903047-04:00"
+            >
+              1yr
+            </time>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--ok"
+          href="/r/fe"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            fe
+          </span>
+          <span>
+            <time
+              dateTime="2019-04-22T15:00:01.337Z"
+              title="2019-04-22T11:00:01.337285-04:00"
+            >
+              1yr
+            </time>
+          </span>
+        </a>
+      </li>
+      <li>
+        <div
+          className="AnalyticsNudge"
+        >
+          <div>
+            Congrats on your first Tilt resource 🎉 Help us help you: may we collect anonymized data on your usage. (Read more
+             
+            <a
+              href="https://github.com/windmilleng/tilt#privacy"
+              target="_blank"
+            >
+              here
+            </a>
+            .)
+          </div>
+          <div
+            className="AnalyticsNudge-buttons"
+          >
+            <button>
+              Yes!
+            </button>
+             
+            <button>
+              Nope!
+            </button>
+          </div>
+        </div>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--ok"
+          href="/r/vigoda"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            vigoda
+          </span>
+          <span>
+            <time
+              dateTime="2019-04-22T15:00:02.810Z"
+              title="2019-04-22T11:00:02.810113-04:00"
+            >
+              1yr
+            </time>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--ok"
+          href="/r/snack"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            snack
+          </span>
+          <span>
+            <time
+              dateTime="2019-04-22T15:00:04.242Z"
+              title="2019-04-22T11:00:04.242586-04:00"
+            >
+              1yr
+            </time>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--ok"
+          href="/r/doggos"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            doggos
+          </span>
+          <span>
+            <time
+              dateTime="2019-04-22T15:00:07.804Z"
+              title="2019-04-22T11:00:07.804953-04:00"
+            >
+              1yr
+            </time>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          className="resLink resLink--ok"
+          href="/r/fortune"
+          onClick={[Function]}
+        >
+          <span
+            className="resLink-icon"
+          >
+            <svg>
+              dot.svg
+            </svg>
+          </span>
+          <span
+            className="resLink-name"
+          >
+            fortune
+          </span>
+          <span>
+            <time
+              dateTime="2019-04-22T15:00:09.205Z"
+              title="2019-04-22T11:00:09.205571-04:00"
+            >
+              1yr
+            </time>
+          </span>
+        </a>
+      </li>
+    </ul>
+  </nav>
+  <div
+    className="Sidebar-spacer"
+  >
+     
+  </div>
+  <button
+    className="Sidebar-toggle"
+    onClick={null}
+  >
+    <svg>
+      chevron.svg
+    </svg>
+     Collapse
+  </button>
+</section>
+`;
+
 exports[`sidebar renders empty resource list without crashing 1`] = `
 <section
   className="Sidebar is-closed"


### PR DESCRIPTION
Hello @yuindustries, @jazzdan,

Styling TBD (look there's even [a ticket for it](https://app.clubhouse.io/windmill/story/2554/style-nudge-in-web)) but this PR displays the analytics nudge in the sidebar. If it's a long list of entries, we show the nudge 3rd in the list to avoid it getting lost in the shuffle. Awkward left-border to make it visible even when the pane is collapsed. Enjoy this hot mess of CSS! (don't worry, this is all gated behind an env variable.)

<img width="773" alt="Screen Shot 2019-05-13 at 5 02 15 PM" src="https://user-images.githubusercontent.com/6332648/57655802-c57e8400-75a4-11e9-9b36-52d4f7adf8aa.png">
