### PR TITLE
web: use runtime instead of the build loader to load assets

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -20,7 +20,7 @@ func StaticPath() (string, error) {
 		if os.IsNotExist(err) {
 			return "", fmt.Errorf("Could not find Tilt web static files at path: %s", dir)
 		}
-		return "", fmt.Errorf("Coult not find Tilt web static files: %v", err)
+		return "", fmt.Errorf("Could not find Tilt web static files: %v", err)
 	}
 
 	return dir, nil

--- a/web/web.go
+++ b/web/web.go
@@ -1,0 +1,27 @@
+package web
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func StaticPath() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("Could not locate path to Tilt web static files")
+	}
+
+	// Double-check that the directory exists on disk and at least contains package.json
+	dir := filepath.Dir(file)
+	_, err := os.Stat(filepath.Join(dir, "package.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("Could not find Tilt web static files at path: %s", dir)
+		}
+		return "", fmt.Errorf("Coult not find Tilt web static files: %v", err)
+	}
+
+	return dir, nil
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/runtime:

a82182c5a6411c604de6d419a66cfdc20e941ff3 (2019-05-13 17:51:05 -0400)
web: use runtime instead of the build loader to load assets