### PR TITLE
integration: fix exec test

### DIFF
--- a/integration/oneup_watch_exec_test.go
+++ b/integration/oneup_watch_exec_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWatchExec(t *testing.T) {
@@ -22,6 +24,7 @@ func TestWatchExec(t *testing.T) {
 	// new pod.
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
+	oneUpPods := f.WaitForAllPodsReady(ctx, "app=onewatchexec")
 
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
@@ -32,4 +35,10 @@ func TestWatchExec(t *testing.T) {
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "🍄 Two-Up! 🍄")
+
+	twoUpPods := f.WaitForAllPodsReady(ctx, "app=onewatchexec")
+	// Assert that the pods were changed in-place, and not that we
+	// created new pods.
+	assert.Equal(t, oneUpPods, twoUpPods)
+
 }

--- a/integration/onewatch_exec/Dockerfile
+++ b/integration/onewatch_exec/Dockerfile
@@ -1,1 +1,3 @@
 FROM python:alpine
+# TODO(dmiller): remove this when we have fixed GNU/busybox tar incompatibilites
+RUN apk add tar

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -193,7 +193,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaExec(ctx context.Context,
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncletBuildAndDeployer-updateViaExec")
 	defer span.Finish()
 	if !hotReload {
-		return fmt.Errorf("kubectl exec syncing is only supported with hotReload set to true")
+		return fmt.Errorf("kubectl exec syncing is only supported on resources that don't use container_restart")
 	}
 	l := logger.Get(ctx)
 	w := l.Writer(logger.InfoLvl)
@@ -220,7 +220,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaExec(ctx context.Context,
 		}
 		l.Infof("updating %v files %v", len(archivePaths), filesToShow)
 		if err := sbd.kCli.Exec(ctx, podID, container, namespace,
-			[]string{"tar", "-x", "-f", "/dev/stdin"}, archive, w, w); err != nil {
+			[]string{"tar", "-C", "/", "-x", "-f", "/dev/stdin"}, archive, w, w); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Prior to this change the exec test wasn't really testing exec. When
we tried to do an exec update it would fail due to incompatibilites
between GNU tar and busybox tar. This would cause the update to fall
back to an image build, which caused the test to pass.

Let's make sure that the pods dont change AND install GNU tar in the
container so that the test passes.

While this feels a little gross, it's at least testing more than it was.

Discovered while looking in to #1611 