### PR TITLE
version check: strip leading 'v' from github versions to be consistent

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ func (cli ghClient) GetLatestRelease(ctx context.Context, org, repo string) (mod
 	}
 
 	return model.TiltBuild{
-		Version: *release.Name,
+		Version: strings.TrimPrefix(*release.Name, "v"),
 		Date:    release.PublishedAt.Time.Format("2006-01-02"),
 	}, nil
 }

--- a/internal/model/tilt_build.go
+++ b/internal/model/tilt_build.go
@@ -6,6 +6,7 @@ import (
 
 // Information on the current built of the Tilt binary
 type TiltBuild struct {
+	// Version w/o leading "v"
 	Version string
 	Date    string
 	Dev     bool

--- a/internal/model/tilt_build.go
+++ b/internal/model/tilt_build.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// Information on the current built of the Tilt binary
+// Information on a build of the Tilt binary
 type TiltBuild struct {
 	// Version w/o leading "v"
 	Version string


### PR DESCRIPTION
prior to this:
the "current" build had no leading "v", e.g. "0.8.3"
the "latest" build fetched from github had a leading "v", e.g., "v0.8.3"

1. strip v from github versions, so that we're all the same
2. document that in the TiltBuild class
3. no unit test since implementing a fake github api doesn't seem like a good use of time right now. unless someone has a cheaper idea?