### PR TITLE
developing: add documentation on sail server, change flag name to --share

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -178,6 +178,39 @@ To run the server on an alternate port (e.g. 8001):
 tilt up --port=8001
 ```
 
+## Tilt Sharing
+
+Tilt has an experimental mode for sharing your Tilt view with other people. All sharing is public.
+
+To enable this feature, run:
+
+```
+tilt up --share
+```
+
+A new button will show up in the Tilt web UI that lets you create a new shareable URL.
+
+When you click the "Share" button, Tilt will send its entire state to this
+public URL. You can then send this URL to your friends (e.g., via a Slack
+message). The URL will be at https://sail.tilt.dev/.
+
+The hub server that coordinates sharing is called Sail.
+If you want to make changes to the sail server, you can run it locally.
+
+```
+make install-sail
+sail
+```
+
+Then tell Tilt to use the local Sail server as the sharing hub.
+
+```
+tilt up --share --share-mode=local
+```
+
+There is also a staging instance of the Sail server, for testing that changes
+work on HTTPS. This is less common.
+
 ## Documentation
 
 The landing page and documentation lives in


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/sail:

f1d72354b2bfac687a26290fb1da9aee3adc067b (2019-05-14 19:32:03 -0400)
developing: add documentation on sail server, change flag name to --share