### PR TITLE
hud/server: record user choice from opt in/out button [ch2533]

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1744,6 +1744,7 @@
     "github.com/docker/cli/cli/command",
     "github.com/docker/cli/cli/config",
     "github.com/docker/cli/cli/flags",
+    "github.com/docker/cli/opts",
     "github.com/docker/distribution/reference",
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/api/types/container",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1134,8 +1134,7 @@
   version = "v1.4.7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ed39a6c301e5d16c82cafc73fe605cc1ea2555ecdf908f070c52b58e3cb7b63c"
+  digest = "1:97d7703c85cdbccfc7113b8450ef5a18d6af5e0a971e8bd0118c5d4ed10adf4e"
   name = "github.com/windmilleng/wmclient"
   packages = [
     "pkg/analytics",
@@ -1144,7 +1143,7 @@
     "pkg/os/temp",
   ]
   pruneopts = "UT"
-  revision = "7ee652d5293faba12e5416c032c223610a851848"
+  revision = "8c79525371f0309c91459153ab7c6afd152b9531"
 
 [[projects]]
   digest = "1:2ae8314c44cd413cfdb5b1df082b350116dd8d2fff973e62c01b285b7affd89e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,6 +57,10 @@
   name = "k8s.io/api"
   version = "kubernetes-1.14.0"
 
+[[constraint]]
+  name = "github.com/windmilleng/wmclient"
+  revision = "8c79525371f0309c91459153ab7c6afd152b9531"
+
 # these need to be here. https://github.com/golang/dep/issues/1415
 [[override]]
   name = "github.com/docker/docker"

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -97,6 +97,7 @@ var BaseWireSet = wire.NewSet(
 	server.ProvideHeadsUpServer,
 	assets.ProvideAssetServer,
 	server.ProvideHeadsUpServerController,
+	server.ProvideAnalyticsOpter,
 
 	provideSailMode,
 	provideSailURL,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -147,7 +147,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	sailRoomer := client.ProvideSailRoomer(sailURL)
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics, sailClient)
+	analyticsOpter := server.ProvideAnalyticsOpter(storeStore)
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics, sailClient, analyticsOpter)
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL)
 	githubClientFactory := engine.NewGithubClientFactory()
 	tiltVersionChecker := engine.NewTiltVersionChecker(githubClientFactory, timerMaker)
@@ -277,7 +278,8 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	sailRoomer := client.ProvideSailRoomer(sailURL)
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics, sailClient)
+	analyticsOpter := server.ProvideAnalyticsOpter(storeStore)
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics, sailClient, analyticsOpter)
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL)
 	githubClientFactory := engine.NewGithubClientFactory()
 	tiltVersionChecker := engine.NewTiltVersionChecker(githubClientFactory, timerMaker)
@@ -475,7 +477,7 @@ var BaseWireSet = wire.NewSet(
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,
-	provideWebDevPort, server.ProvideHeadsUpServer, assets.ProvideAssetServer, server.ProvideHeadsUpServerController, provideSailMode,
+	provideWebDevPort, server.ProvideHeadsUpServer, assets.ProvideAssetServer, server.ProvideHeadsUpServerController, server.ProvideAnalyticsOpter, provideSailMode,
 	provideSailURL, client.SailWireSet, provideThreads, engine.NewKINDPusher,
 )
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/windmilleng/tilt/internal/hud/server"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -179,7 +178,7 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		handleDumpEngineStateAction(ctx, state)
 	case LatestVersionAction:
 		handleLatestVersionAction(state, action)
-	case server.AnalyticsOptAction:
+	case store.AnalyticsOptAction:
 		handleAnalyticsOptAction(state, action)
 	default:
 		err = fmt.Errorf("unrecognized action: %T", action)
@@ -952,6 +951,6 @@ func handleTiltfileLogAction(ctx context.Context, state *store.EngineState, acti
 	state.TiltfileCombinedLog = model.AppendLog(state.TiltfileCombinedLog, action, state.LogTimestamps)
 }
 
-func handleAnalyticsOptAction(state *store.EngineState, action server.AnalyticsOptAction) {
+func handleAnalyticsOptAction(state *store.EngineState, action store.AnalyticsOptAction) {
 	state.AnalyticsOpt = action.Opt
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/view"
+	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
@@ -178,6 +179,8 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		handleDumpEngineStateAction(ctx, state)
 	case LatestVersionAction:
 		handleLatestVersionAction(state, action)
+	case webview.AnalyticsOptAction:
+		handleAnalyticsOptAction(state, action)
 	default:
 		err = fmt.Errorf("unrecognized action: %T", action)
 	}
@@ -947,4 +950,8 @@ func handleDockerComposeLogAction(state *store.EngineState, action DockerCompose
 func handleTiltfileLogAction(ctx context.Context, state *store.EngineState, action TiltfileLogAction) {
 	state.CurrentTiltfileBuild.Log = model.AppendLog(state.CurrentTiltfileBuild.Log, action, state.LogTimestamps)
 	state.TiltfileCombinedLog = model.AppendLog(state.TiltfileCombinedLog, action, state.LogTimestamps)
+}
+
+func handleAnalyticsOptAction(state *store.EngineState, action webview.AnalyticsOptAction) {
+	state.AnalyticsOpt = action.Opt
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/windmilleng/tilt/internal/hud/server"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -19,7 +20,6 @@ import (
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/view"
-	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
@@ -179,7 +179,7 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		handleDumpEngineStateAction(ctx, state)
 	case LatestVersionAction:
 		handleLatestVersionAction(state, action)
-	case webview.AnalyticsOptAction:
+	case server.AnalyticsOptAction:
 		handleAnalyticsOptAction(state, action)
 	default:
 		err = fmt.Errorf("unrecognized action: %T", action)
@@ -952,6 +952,6 @@ func handleTiltfileLogAction(ctx context.Context, state *store.EngineState, acti
 	state.TiltfileCombinedLog = model.AppendLog(state.TiltfileCombinedLog, action, state.LogTimestamps)
 }
 
-func handleAnalyticsOptAction(state *store.EngineState, action webview.AnalyticsOptAction) {
+func handleAnalyticsOptAction(state *store.EngineState, action server.AnalyticsOptAction) {
 	state.AnalyticsOpt = action.Opt
 }

--- a/internal/hud/server/analytics_opt.go
+++ b/internal/hud/server/analytics_opt.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"github.com/windmilleng/tilt/internal/hud/webview"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/wmclient/pkg/analytics"
+)
+
+type AnalyticsOpter interface {
+	// OptStatus() (analytics.Opt, error)
+	SetOptStr(s string) error
+}
+
+type AnalyticsOptAction struct {
+	Opt analytics.Opt
+}
+
+func (AnalyticsOptAction) Action() {}
+
+type WriteToFileOpter struct {
+	st store.RStore
+}
+
+var _ AnalyticsOpter = &WriteToFileOpter{}
+
+func ProvideAnalyticsOpter(st store.RStore) AnalyticsOpter {
+	return &WriteToFileOpter{st: st}
+}
+
+func (*WriteToFileOpter) OptStatus() (analytics.Opt, error) {
+	return analytics.OptStatus()
+}
+
+func (o *WriteToFileOpter) SetOptStr(s string) error {
+	if !webview.NewAnalyticsOn() {
+		return nil
+	}
+
+	choice, err := analytics.SetOptStr(s)
+	if err != nil {
+		return err
+	}
+	o.st.Dispatch(AnalyticsOptAction{choice})
+	return nil
+}

--- a/internal/hud/server/analytics_opt.go
+++ b/internal/hud/server/analytics_opt.go
@@ -7,7 +7,6 @@ import (
 )
 
 type AnalyticsOpter interface {
-	// OptStatus() (analytics.Opt, error)
 	SetOptStr(s string) error
 }
 
@@ -25,10 +24,6 @@ var _ AnalyticsOpter = &WriteToFileOpter{}
 
 func ProvideAnalyticsOpter(st store.RStore) AnalyticsOpter {
 	return &WriteToFileOpter{st: st}
-}
-
-func (*WriteToFileOpter) OptStatus() (analytics.Opt, error) {
-	return analytics.OptStatus()
 }
 
 func (o *WriteToFileOpter) SetOptStr(s string) error {

--- a/internal/hud/server/analytics_opt.go
+++ b/internal/hud/server/analytics_opt.go
@@ -22,8 +22,9 @@ func ProvideAnalyticsOpter(st store.RStore) AnalyticsOpter {
 	return &WriteToFileOpter{st: st}
 }
 
-// SetOptStr takes the string of the user's choice (should correspond to "opt-in" or "opt-out")
-// and records that choice on disk as dictated by the `analytics` package.
+// SetOptStr takes the string of the user's choice in re: sending analytics
+// (should correspond to "opt-in" or "opt-out") and records that choice on
+// disk as dictated by the `analytics` package.
 func (o *WriteToFileOpter) SetOptStr(s string) error {
 	if !webview.NewAnalyticsOn() {
 		return nil

--- a/internal/hud/server/analytics_opt.go
+++ b/internal/hud/server/analytics_opt.go
@@ -6,15 +6,11 @@ import (
 	"github.com/windmilleng/wmclient/pkg/analytics"
 )
 
+// An AnalyticsOpter can record a user's choice (opt-in or opt-out)
+// in re: Tilt recording analytics.
 type AnalyticsOpter interface {
 	SetOptStr(s string) error
 }
-
-type AnalyticsOptAction struct {
-	Opt analytics.Opt
-}
-
-func (AnalyticsOptAction) Action() {}
 
 type WriteToFileOpter struct {
 	st store.RStore
@@ -26,6 +22,8 @@ func ProvideAnalyticsOpter(st store.RStore) AnalyticsOpter {
 	return &WriteToFileOpter{st: st}
 }
 
+// SetOptStr takes the string of the user's choice (should correspond to "opt-in" or "opt-out")
+// and records that choice on disk as dictated by the `analytics` package.
 func (o *WriteToFileOpter) SetOptStr(s string) error {
 	if !webview.NewAnalyticsOn() {
 		return nil
@@ -35,6 +33,6 @@ func (o *WriteToFileOpter) SetOptStr(s string) error {
 	if err != nil {
 		return err
 	}
-	o.st.Dispatch(AnalyticsOptAction{choice})
+	o.st.Dispatch(store.AnalyticsOptAction{Opt: choice})
 	return nil
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -33,16 +33,18 @@ type HeadsUpServer struct {
 	router            *mux.Router
 	a                 analytics.Analytics
 	sailCli           client.SailClient
+	opter             AnalyticsOpter
 	numWebsocketConns int32
 }
 
-func ProvideHeadsUpServer(store *store.Store, assetServer assets.Server, analytics analytics.Analytics, sailCli client.SailClient) *HeadsUpServer {
+func ProvideHeadsUpServer(store *store.Store, assetServer assets.Server, analytics analytics.Analytics, sailCli client.SailClient, opter AnalyticsOpter) *HeadsUpServer {
 	r := mux.NewRouter().UseEncodedPath()
 	s := &HeadsUpServer{
 		store:   store,
 		router:  r,
 		a:       analytics,
 		sailCli: sailCli,
+		opter:   opter,
 	}
 
 	r.HandleFunc("/api/view", s.ViewJSON)

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -91,7 +91,7 @@ func (s *HeadsUpServer) HandleAnalyticsOpt(w http.ResponseWriter, req *http.Requ
 
 	err = s.opter.SetOptStr(payload.Opt)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("error setting opt '%s': %v", payload.Opt, err), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("error setting opt '%s': %v", payload.Opt, err), http.StatusInternalServerError)
 		return
 	}
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -89,8 +89,11 @@ func (s *HeadsUpServer) HandleAnalyticsOpt(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	// TODO(maia): record user choice
-	_, _ = fmt.Fprintf(w, "👍 you sent: %s", payload.Opt)
+	err = s.opter.SetOptStr(payload.Opt)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error setting opt '%s': %v", payload.Opt, err), http.StatusBadRequest)
+		return
+	}
 }
 
 func (s *HeadsUpServer) HandleAnalytics(w http.ResponseWriter, req *http.Request) {

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -121,6 +122,97 @@ func TestHandleAnalyticsErrorsIfNotIncr(t *testing.T) {
 	}
 }
 
+func TestHandleAnalyticsOptIn(t *testing.T) {
+	f := newTestFixture(t)
+
+	var jsonStr = []byte(`{"opt": "opt-in"}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/analytics_opt", bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(f.s.HandleAnalyticsOpt)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	if assert.Len(t, f.o.callStrs, 1) {
+		assert.Equal(t, "opt-in", f.o.callStrs[0])
+	}
+}
+
+func TestHandleAnalyticsOptNonPost(t *testing.T) {
+	f := newTestFixture(t)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/analytics_opt", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(f.s.HandleAnalyticsOpt)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+}
+
+func TestHandleAnalyticsOptMalformedPayload(t *testing.T) {
+	f := newTestFixture(t)
+
+	var jsonStr = []byte(`{"opt":`)
+	req, err := http.NewRequest(http.MethodPost, "/api/analytics_opt", bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(f.s.HandleAnalyticsOpt)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+}
+
+func TestHandleAnalyticsOptSetError(t *testing.T) {
+	f := newTestFixture(t)
+	f.o.nextErr = fmt.Errorf("oh nooooooooes")
+	var jsonStr = []byte(`{"opt": "opt-in"}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/analytics_opt", bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(f.s.HandleAnalyticsOpt)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusInternalServerError {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusInternalServerError)
+	}
+
+	if assert.Len(t, f.o.callStrs, 1) {
+		assert.Equal(t, "opt-in", f.o.callStrs[0])
+	}
+}
+
 func TestHandleSail(t *testing.T) {
 	f := newTestFixture(t)
 
@@ -188,19 +280,22 @@ type serverFixture struct {
 	s       *server.HeadsUpServer
 	a       *analytics.MemoryAnalytics
 	sailCli *client.FakeSailClient
+	o       *testOpter
 }
 
 func newTestFixture(t *testing.T) *serverFixture {
 	st := store.NewStore(engine.UpperReducer, store.LogActionsFlag(false))
 	a := analytics.NewMemoryAnalytics()
 	sailCli := client.NewFakeSailClient()
-	s := server.ProvideHeadsUpServer(st, assets.NewFakeServer(), a, sailCli, newTestOpter(t))
+	o := newTestOpter()
+	s := server.ProvideHeadsUpServer(st, assets.NewFakeServer(), a, sailCli, o)
 
 	return &serverFixture{
 		t:       t,
 		s:       s,
 		a:       a,
 		sailCli: sailCli,
+		o:       o,
 	}
 }
 
@@ -216,14 +311,13 @@ func (f *serverFixture) assertIncrement(name string, count int) {
 }
 
 type testOpter struct {
-	t        *testing.T
 	nextErr  error
 	callStrs []string
 }
 
 var _ server.AnalyticsOpter = &testOpter{}
 
-func newTestOpter(t *testing.T) *testOpter { return &testOpter{t: t} }
+func newTestOpter() *testOpter { return &testOpter{} }
 
 func (o *testOpter) SetOptStr(s string) error {
 	o.callStrs = append(o.callStrs, s)

--- a/internal/hud/webview/analytics_nudge.go
+++ b/internal/hud/webview/analytics_nudge.go
@@ -14,6 +14,40 @@ func NewAnalyticsOn() bool {
 	return os.Getenv(newAnalyticsFlag) != ""
 }
 
+type Opter interface {
+	// OptStatus() (analytics.Opt, error)
+	SetOptStr(s string) (analytics.Opt, error)
+}
+
+type AnalyticsOptAction struct {
+	Opt analytics.Opt
+}
+
+func (AnalyticsOptAction) Action() {}
+
+type WriteToFileOpter struct {
+	st store.RStore
+}
+
+var _ Opter = &WriteToFileOpter{}
+
+func (*WriteToFileOpter) OptStatus() (analytics.Opt, error) {
+	return analytics.OptStatus()
+}
+
+func (o *WriteToFileOpter) SetOptStr(s string) (analytics.Opt, error) {
+	if !NewAnalyticsOn() {
+		return analytics.OptDefault, nil
+	}
+
+	choice, err := analytics.SetOptStr(s)
+	if err != nil {
+		return choice, err
+	}
+	o.st.Dispatch(AnalyticsOptAction{choice})
+	return choice, nil
+}
+
 func NeedsNudge(st store.EngineState) bool {
 	if !NewAnalyticsOn() {
 		return false

--- a/internal/hud/webview/analytics_nudge.go
+++ b/internal/hud/webview/analytics_nudge.go
@@ -14,40 +14,6 @@ func NewAnalyticsOn() bool {
 	return os.Getenv(newAnalyticsFlag) != ""
 }
 
-type Opter interface {
-	// OptStatus() (analytics.Opt, error)
-	SetOptStr(s string) (analytics.Opt, error)
-}
-
-type AnalyticsOptAction struct {
-	Opt analytics.Opt
-}
-
-func (AnalyticsOptAction) Action() {}
-
-type WriteToFileOpter struct {
-	st store.RStore
-}
-
-var _ Opter = &WriteToFileOpter{}
-
-func (*WriteToFileOpter) OptStatus() (analytics.Opt, error) {
-	return analytics.OptStatus()
-}
-
-func (o *WriteToFileOpter) SetOptStr(s string) (analytics.Opt, error) {
-	if !NewAnalyticsOn() {
-		return analytics.OptDefault, nil
-	}
-
-	choice, err := analytics.SetOptStr(s)
-	if err != nil {
-		return choice, err
-	}
-	o.st.Dispatch(AnalyticsOptAction{choice})
-	return choice, nil
-}
-
 func NeedsNudge(st store.EngineState) bool {
 	if !NewAnalyticsOn() {
 		return false

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/wmclient/pkg/analytics"
 )
 
 type ErrorAction struct {
@@ -53,3 +54,9 @@ func NewResetRestartsAction(name model.ManifestName) ResetRestartsAction {
 		ManifestName: name,
 	}
 }
+
+type AnalyticsOptAction struct {
+	Opt analytics.Opt
+}
+
+func (AnalyticsOptAction) Action() {}

--- a/vendor/github.com/windmilleng/wmclient/pkg/analytics/cli.go
+++ b/vendor/github.com/windmilleng/wmclient/pkg/analytics/cli.go
@@ -34,7 +34,7 @@ func analyticsOpt(_ *cobra.Command, args []string) (outerErr error) {
 		return fmt.Errorf("no choice given; pass it as first arg: <tool> analytics opt <choice>")
 	}
 	choiceStr := args[0]
-	err := SetOptStr(choiceStr)
+	_, err := SetOptStr(choiceStr)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/windmilleng/wmclient/pkg/analytics/opt.go
+++ b/vendor/github.com/windmilleng/wmclient/pkg/analytics/opt.go
@@ -46,7 +46,9 @@ func OptStatus() (Opt, error) {
 	return OptDefault, nil
 }
 
-func SetOptStr(s string) error {
+// SetOptStr converts the given string into an Opt enum, and records that choice
+// as the users analytics decision, returning the Opt set (and any errors).
+func SetOptStr(s string) (Opt, error) {
 	choice := OptDefault
 	for k, v := range Choices {
 		if v == s {
@@ -58,7 +60,7 @@ func SetOptStr(s string) error {
 		}
 	}
 
-	return SetOpt(choice)
+	return choice, SetOpt(choice)
 }
 
 func SetOpt(c Opt) error {


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/record-opt:

4782d0bc60e11074abe299205d24fc687920563c (2019-05-15 15:29:34 -0400)
tests

22eb8ac21f44adaf2719ae98d82d71f686fa8711 (2019-05-15 15:06:09 -0400)
put functionality in http handler

08d4fa94f388a4277038182e2125e0c58fd99bd9 (2019-05-15 14:58:36 -0400)
test opter

02dffc057f9c21c88e05ffd13ac6b33ebab29fb4 (2019-05-15 14:41:27 -0400)
skeleton opter and events

624a508e87ea47c8de2af0bbe250978e7233b2f7 (2019-05-15 14:27:19 -0400)
update wmclient

7cb4127815c0cb47f20b0634886349ae847eeae1 (2019-05-15 14:11:30 -0400)
vendor: run dep ensure

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics