### PR TITLE
k8s: add a bunch of unit tests around watch and namespace restrictions

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -46,6 +46,8 @@ func (pID PodID) String() string { return string(pID) }
 
 func (nID NodeID) String() string { return string(nID) }
 
+func (n Namespace) Empty() bool { return n == "" }
+
 func (n Namespace) String() string {
 	if n == "" {
 		return string(DefaultNamespace)

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -24,6 +24,20 @@ import (
 	"github.com/windmilleng/tilt/internal/testutils/output"
 )
 
+func TestEmptyNamespace(t *testing.T) {
+	var emptyNamespace Namespace
+	assert.True(t, emptyNamespace.Empty())
+	assert.True(t, emptyNamespace == "")
+	assert.Equal(t, "default", emptyNamespace.String())
+}
+
+func TestNotEmptyNamespace(t *testing.T) {
+	var ns Namespace = "x"
+	assert.False(t, ns.Empty())
+	assert.False(t, ns == "")
+	assert.Equal(t, "x", ns.String())
+}
+
 func TestUpsert(t *testing.T) {
 	f := newClientTestFixture(t)
 	postgres, err := ParseYAMLFromString(testyaml.PostgresYAML)


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/watchnamespace:

628e37317d8d9899642f0e2ed585321d789aff5d (2019-05-16 18:38:35 -0400)
k8s: add a bunch of unit tests around watch and namespace restrictions