### PR TITLE
web: when user opts in/out via nudge, acknowledge it, and vanish the notification [ch2590]

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,8 +16,6 @@
     "@types/react-test-renderer": "^16.8.1",
     "@types/react-timeago": "^4.1.0",
     "ansi-to-react": "^5.0.0",
-    "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.11.2",
     "history": "^4.9.0",
     "immutable": "^4.0.0-rc.12",
     "node-sass": "^4.12.0",
@@ -50,9 +48,15 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "prettier": "1.16.4"
+    "prettier": "1.16.4",
+    "enzyme": "^3.9.0",
+    "enzyme-adapter-react-16": "^1.11.2",
+    "enzyme-to-json": "^3.3.5"
   },
   "engines": {
     "node": ">=11.0.0"
+  },
+  "jest": {
+    "snapshotSerializers": ["enzyme-to-json/serializer"]
   }
 }

--- a/web/src/AnalyticsNudge.test.tsx
+++ b/web/src/AnalyticsNudge.test.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import AnalyticsNudge from "./AnalyticsNudge"
+import { shallow } from "enzyme"
+
+it("hides nudge if !needsNudge and no state", () => {
+  const component = shallow(<AnalyticsNudge needsNudge={false} />)
+
+  expect(component).toMatchSnapshot()
+})
+
+it("shows nudge if needsNudge", () => {
+  const component = shallow(<AnalyticsNudge needsNudge={true} />)
+
+  expect(component).toMatchSnapshot()
+})
+
+it("shows request-in-progress message", () => {
+  const component = shallow(<AnalyticsNudge needsNudge={false} />)
+
+  component.setState({ requestMade: true })
+
+  expect(component).toMatchSnapshot()
+})
+
+it("shows success message", () => {
+  const component = shallow(<AnalyticsNudge needsNudge={false} />)
+
+  component.setState({ requestMade: true, responseCode: 200 })
+
+  expect(component).toMatchSnapshot()
+})
+
+it("shows failure message", () => {
+  const component = shallow(<AnalyticsNudge needsNudge={false} />)
+
+  component.setState({ requestMade: true, responseCode: 418 })
+
+  expect(component).toMatchSnapshot()
+})
+
+it("hidden if dismissed", () => {
+  const component = shallow(<AnalyticsNudge needsNudge={false} />)
+
+  component.setState({ requestMade: true, responseCode: 200, dismissed: true })
+
+  expect(component).toMatchSnapshot()
+})

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react"
 import "./AnalyticsNudge.scss"
-import { ResourceView } from "./types"
 
 type AnalyticsNudgeProps = {
   needsNudge: boolean
@@ -49,13 +48,24 @@ class AnalyticsNudge extends Component<
   messageElem(): JSX.Element {
     if (this.state && this.state.responseCode) {
       if (this.state.responseCode == 200) {
-        return <span>Okay yay!</span>
+        // Successfully called opt endpt.
+        return <span>Cool, got it! 👍</span>
       } else {
-        return <span>Oh no, something went wrong! hi@windmill.engineering</span>
+        return (
+          // error calling the opt endpt.
+          <span>
+            Oh no, something went wrong!{" "}
+            <a href="https://tilt.dev/contact" target="_blank">
+              Get in touch
+            </a>
+            .
+          </span>
+        )
       }
     }
 
     if (this.state && this.state.requestMade) {
+      // request in progress
       return <span>Okay, we'll inform the robots...</span>
     }
     return (

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -1,6 +1,8 @@
 import React, { Component } from "react"
 import "./AnalyticsNudge.scss"
 
+const nudgeTimeoutMs = 3000 // 3 seconds
+
 type AnalyticsNudgeProps = {
   needsNudge: boolean
 }
@@ -48,7 +50,7 @@ class AnalyticsNudge extends Component<
       // after 3s, dismiss the nudge
       setTimeout(() => {
         this.setState({ dismissed: true })
-      }, 3000)
+      }, nudgeTimeoutMs)
     })
   }
 

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react"
+import React, { Component } from "react"
 import "./AnalyticsNudge.scss"
 import { ResourceView } from "./types"
 
@@ -6,28 +6,60 @@ type AnalyticsNudgeProps = {
   needsNudge: boolean
 }
 
-class AnalyticsNudge extends PureComponent<AnalyticsNudgeProps> {
-  static analyticsOpt(optIn: boolean) {
+type AnalyticsNudgeState = {
+  requestMade: boolean
+  responseCode: number
+  dismissed: boolean
+}
+
+// constructor for defaults?
+
+class AnalyticsNudge extends Component<
+  AnalyticsNudgeProps,
+  AnalyticsNudgeState
+> {
+  shouldShow(): boolean {
+    return (
+      this.props.needsNudge ||
+      (this.state && this.state.requestMade && !this.state.dismissed)
+    )
+  }
+  analyticsOpt(optIn: boolean) {
     let url = `//${window.location.host}/api/analytics_opt`
 
     let payload = { opt: optIn ? "opt-in" : "opt-out" }
 
+    this.setState({ requestMade: true })
+
     fetch(url, {
       method: "post",
       body: JSON.stringify(payload),
-    }).then(function(response) {
-      console.log("got response -->", response.status) // returns 200
+    }).then((response: Response) => {
+      this.setState({
+        responseCode: response.status,
+      })
+
+      // after 3s, dismiss the nudge
+      setTimeout(() => {
+        this.setState({ dismissed: true })
+      }, 3000)
     })
   }
-  render() {
-    let classes = ["AnalyticsNudge"]
-    if (this.props.needsNudge) {
-      // or if  already visible...
-      classes.push("is-visible")
+
+  messageElem(): JSX.Element {
+    if (this.state && this.state.responseCode) {
+      if (this.state.responseCode == 200) {
+        return <span>Okay yay!</span>
+      } else {
+        return <span>Oh no, something went wrong! hi@windmill.engineering</span>
+      }
     }
 
+    if (this.state && this.state.requestMade) {
+      return <span>Okay, we'll inform the robots...</span>
+    }
     return (
-      <div className={classes.join(" ")}>
+      <div>
         <span>
           Congrats on your first Tilt resource 🎉 Opt into analytics? (Read more{" "}
           <a href="https://github.com/windmilleng/tilt#privacy" target="_blank">
@@ -36,15 +68,20 @@ class AnalyticsNudge extends PureComponent<AnalyticsNudgeProps> {
           .)&nbsp;
         </span>
         <span className="AnalyticsNudge-buttons">
-          <button onClick={() => AnalyticsNudge.analyticsOpt(true)}>
-            Yes!
-          </button>
-          <button onClick={() => AnalyticsNudge.analyticsOpt(false)}>
-            Nope!
-          </button>
+          <button onClick={() => this.analyticsOpt(true)}>Yes!</button>
+          <button onClick={() => this.analyticsOpt(false)}>Nope!</button>
         </span>
       </div>
     )
+  }
+  render() {
+    let classes = ["AnalyticsNudge"]
+    if (this.shouldShow()) {
+      // or if already visible...
+      classes.push("is-visible")
+    }
+
+    return <div className={classes.join(" ")}>{this.messageElem()}</div>
   }
 }
 

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -11,16 +11,23 @@ type AnalyticsNudgeState = {
   dismissed: boolean
 }
 
-// constructor for defaults?
-
 class AnalyticsNudge extends Component<
   AnalyticsNudgeProps,
   AnalyticsNudgeState
 > {
+  constructor(props: AnalyticsNudgeProps) {
+    super(props)
+
+    this.state = {
+      requestMade: false,
+      responseCode: 0,
+      dismissed: false,
+    }
+  }
+
   shouldShow(): boolean {
     return (
-      this.props.needsNudge ||
-      (this.state && this.state.requestMade && !this.state.dismissed)
+      this.props.needsNudge || (this.state.requestMade && !this.state.dismissed)
     )
   }
   analyticsOpt(optIn: boolean) {
@@ -46,7 +53,7 @@ class AnalyticsNudge extends Component<
   }
 
   messageElem(): JSX.Element {
-    if (this.state && this.state.responseCode) {
+    if (this.state.responseCode) {
       if (this.state.responseCode == 200) {
         // Successfully called opt endpt.
         return <span>Cool, got it! 👍</span>
@@ -64,7 +71,7 @@ class AnalyticsNudge extends Component<
       }
     }
 
-    if (this.state && this.state.requestMade) {
+    if (this.state.requestMade) {
       // request in progress
       return <span>Okay, we'll inform the robots...</span>
     }

--- a/web/src/__snapshots__/AnalyticsNudge.test.tsx.snap
+++ b/web/src/__snapshots__/AnalyticsNudge.test.tsx.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hidden if dismissed 1`] = `
+<div
+  className="AnalyticsNudge"
+>
+  <span>
+    Cool, got it! 👍
+  </span>
+</div>
+`;
+
+exports[`hides nudge if !needsNudge and no state 1`] = `
+<div
+  className="AnalyticsNudge"
+>
+  <div>
+    <span>
+      Congrats on your first Tilt resource 🎉 Opt into analytics? (Read more
+       
+      <a
+        href="https://github.com/windmilleng/tilt#privacy"
+        target="_blank"
+      >
+        here
+      </a>
+      .) 
+    </span>
+    <span
+      className="AnalyticsNudge-buttons"
+    >
+      <button
+        onClick={[Function]}
+      >
+        Yes!
+      </button>
+      <button
+        onClick={[Function]}
+      >
+        Nope!
+      </button>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`shows failure message 1`] = `
+<div
+  className="AnalyticsNudge is-visible"
+>
+  <span>
+    Oh no, something went wrong!
+     
+    <a
+      href="https://tilt.dev/contact"
+      target="_blank"
+    >
+      Get in touch
+    </a>
+    .
+  </span>
+</div>
+`;
+
+exports[`shows nudge if needsNudge 1`] = `
+<div
+  className="AnalyticsNudge is-visible"
+>
+  <div>
+    <span>
+      Congrats on your first Tilt resource 🎉 Opt into analytics? (Read more
+       
+      <a
+        href="https://github.com/windmilleng/tilt#privacy"
+        target="_blank"
+      >
+        here
+      </a>
+      .) 
+    </span>
+    <span
+      className="AnalyticsNudge-buttons"
+    >
+      <button
+        onClick={[Function]}
+      >
+        Yes!
+      </button>
+      <button
+        onClick={[Function]}
+      >
+        Nope!
+      </button>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`shows request-in-progress message 1`] = `
+<div
+  className="AnalyticsNudge is-visible"
+>
+  <span>
+    Okay, we'll inform the robots...
+  </span>
+</div>
+`;
+
+exports[`shows success message 1`] = `
+<div
+  className="AnalyticsNudge is-visible"
+>
+  <span>
+    Cool, got it! 👍
+  </span>
+</div>
+`;

--- a/web/src/__snapshots__/TopBar.test.tsx.snap
+++ b/web/src/__snapshots__/TopBar.test.tsx.snap
@@ -7,31 +7,33 @@ exports[`shows sail share button 1`] = `
   <div
     className="AnalyticsNudge"
   >
-    <span>
-      Congrats on your first Tilt resource 🎉 Opt into analytics? (Read more
-       
-      <a
-        href="https://github.com/windmilleng/tilt#privacy"
-        target="_blank"
+    <div>
+      <span>
+        Congrats on your first Tilt resource 🎉 Opt into analytics? (Read more
+         
+        <a
+          href="https://github.com/windmilleng/tilt#privacy"
+          target="_blank"
+        >
+          here
+        </a>
+        .) 
+      </span>
+      <span
+        className="AnalyticsNudge-buttons"
       >
-        here
-      </a>
-      .) 
-    </span>
-    <span
-      className="AnalyticsNudge-buttons"
-    >
-      <button
-        onClick={[Function]}
-      >
-        Yes!
-      </button>
-      <button
-        onClick={[Function]}
-      >
-        Nope!
-      </button>
-    </span>
+        <button
+          onClick={[Function]}
+        >
+          Yes!
+        </button>
+        <button
+          onClick={[Function]}
+        >
+          Nope!
+        </button>
+      </span>
+    </div>
   </div>
   <div
     className="TopBar-row"
@@ -97,31 +99,33 @@ exports[`shows sail url 1`] = `
   <div
     className="AnalyticsNudge"
   >
-    <span>
-      Congrats on your first Tilt resource 🎉 Opt into analytics? (Read more
-       
-      <a
-        href="https://github.com/windmilleng/tilt#privacy"
-        target="_blank"
+    <div>
+      <span>
+        Congrats on your first Tilt resource 🎉 Opt into analytics? (Read more
+         
+        <a
+          href="https://github.com/windmilleng/tilt#privacy"
+          target="_blank"
+        >
+          here
+        </a>
+        .) 
+      </span>
+      <span
+        className="AnalyticsNudge-buttons"
       >
-        here
-      </a>
-      .) 
-    </span>
-    <span
-      className="AnalyticsNudge-buttons"
-    >
-      <button
-        onClick={[Function]}
-      >
-        Yes!
-      </button>
-      <button
-        onClick={[Function]}
-      >
-        Nope!
-      </button>
-    </span>
+        <button
+          onClick={[Function]}
+        >
+          Yes!
+        </button>
+        <button
+          onClick={[Function]}
+        >
+          Nope!
+        </button>
+      </span>
+    </div>
   </div>
   <div
     className="TopBar-row"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3790,6 +3790,13 @@ enzyme-adapter-utils@^1.11.0:
     prop-types "^15.7.2"
     semver "^5.6.0"
 
+enzyme-to-json@^3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz#f8eb82bd3d5941c9d8bc6fd9140030777d17d0af"
+  integrity sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==
+  dependencies:
+    lodash "^4.17.4"
+
 enzyme@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.9.0.tgz#2b491f06ca966eb56b6510068c7894a7e0be3909"
@@ -6487,7 +6494,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch maiamcc/acknowledge-opt:

d79f671082f9b2c739d80b725b368dcb63f9daec (2019-05-16 18:37:45 -0400)
add enzyme-to-json, test analyticsNudge

7d5497fecac9d32896fd75ef154d0ebcc21659a6 (2019-05-16 17:54:32 -0400)
web: store state on analyticsNudge, reflect endpoint result, disappear after 3s

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics