### PR TITLE
tiltfile: k8s_context returns the name of the k8s context Tilt locked

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -119,7 +119,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics, dockerComposeClient)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics, dockerComposeClient, kubeContext)
 	configsController := engine.NewConfigsController(tiltfileLoader)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
@@ -250,7 +250,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics, dockerComposeClient)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics, dockerComposeClient, kubeContext)
 	configsController := engine.NewConfigsController(tiltfileLoader)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
@@ -463,7 +463,7 @@ func wireDownDeps(ctx context.Context) (DownDeps, error) {
 		return DownDeps{}, err
 	}
 	dockerComposeClient := dockercompose.NewDockerComposeClient(dockerEnv)
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics, dockerComposeClient)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics, dockerComposeClient, kubeContext)
 	downDeps := ProvideDownDeps(tiltfileLoader, dockerComposeClient, k8sClient)
 	return downDeps, nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2342,7 +2342,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	fakeDcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	realDcc := dockercompose.NewDockerComposeClient(docker.Env{})
 
-	tfl := tiltfile.ProvideTiltfileLoader(an, realDcc)
+	tfl := tiltfile.ProvideTiltfileLoader(an, realDcc, "fake-context")
 	cc := NewConfigsController(tfl)
 	dcw := NewDockerComposeEventWatcher(fakeDcc)
 	dclm := NewDockerComposeLogManager(fakeDcc)

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -924,3 +924,7 @@ func uniqueResourceNames(es []k8s.K8sEntity) ([]string, error) {
 
 	return ret, nil
 }
+
+func (s *tiltfileState) k8sContext(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.String(s.kubeContext), nil
+}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -60,13 +60,14 @@ func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, matchi
 	}, tfl.Err
 }
 
-func ProvideTiltfileLoader(analytics analytics.Analytics, dcCli dockercompose.DockerComposeClient) TiltfileLoader {
-	return tiltfileLoader{analytics: analytics, dcCli: dcCli}
+func ProvideTiltfileLoader(analytics analytics.Analytics, dcCli dockercompose.DockerComposeClient, kubeContext k8s.KubeContext) TiltfileLoader {
+	return tiltfileLoader{analytics: analytics, dcCli: dcCli, kubeContext: kubeContext}
 }
 
 type tiltfileLoader struct {
-	analytics analytics.Analytics
-	dcCli     dockercompose.DockerComposeClient
+	analytics   analytics.Analytics
+	dcCli       dockercompose.DockerComposeClient
+	kubeContext k8s.KubeContext
 }
 
 var _ TiltfileLoader = &tiltfileLoader{}
@@ -88,7 +89,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		return TiltfileLoadResult{ConfigFiles: []string{absFilename}}, err
 	}
 
-	s := newTiltfileState(ctx, tfl.dcCli, absFilename)
+	s := newTiltfileState(ctx, tfl.dcCli, absFilename, tfl.kubeContext)
 	printedWarnings := false
 	defer func() {
 		tlr.ConfigFiles = s.configFiles

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -29,9 +29,10 @@ type resourceSet struct {
 
 type tiltfileState struct {
 	// set at creation
-	ctx      context.Context
-	filename localPath
-	dcCli    dockercompose.DockerComposeClient
+	ctx         context.Context
+	filename    localPath
+	dcCli       dockercompose.DockerComposeClient
+	kubeContext k8s.KubeContext
 
 	// added to during execution
 	configFiles        []string
@@ -83,12 +84,13 @@ const (
 	k8sResourceAssemblyVersionReasonExplicit
 )
 
-func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClient, filename string) *tiltfileState {
+func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClient, filename string, kubeContext k8s.KubeContext) *tiltfileState {
 	lp := localPath{path: filename}
 	s := &tiltfileState{
 		ctx:                        ctx,
 		filename:                   localPath{path: filename},
 		dcCli:                      dcCli,
+		kubeContext:                kubeContext,
 		buildIndex:                 newBuildIndex(),
 		k8sByName:                  make(map[string]*k8sResource),
 		k8sImageJSONPaths:          make(map[k8sObjectSelector][]k8s.JSONPath),
@@ -140,6 +142,7 @@ const (
 	k8sKindN                    = "k8s_kind"
 	k8sImageJSONPathN           = "k8s_image_json_path"
 	workloadToResourceFunctionN = "workload_to_resource_function"
+	k8sContextN                 = "k8s_context"
 
 	// file functions
 	localGitRepoN = "local_git_repo"
@@ -262,6 +265,7 @@ func (s *tiltfileState) predeclared() starlark.StringDict {
 	addBuiltin(r, k8sKindN, s.k8sKind)
 	addBuiltin(r, k8sImageJSONPathN, s.k8sImageJsonPath)
 	addBuiltin(r, workloadToResourceFunctionN, s.workloadToResourceFunctionFn)
+	addBuiltin(r, k8sContextN, s.k8sContext)
 	addBuiltin(r, localGitRepoN, s.localGitRepo)
 	addBuiltin(r, kustomizeN, s.kustomize)
 	addBuiltin(r, helmN, s.helm)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3168,6 +3168,27 @@ k8s_yaml(yml)
 	)
 }
 
+func TestK8sContext(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+
+	f.file("Tiltfile", `
+if k8s_context() != 'fake-context':
+  fail('bad context')
+k8s_yaml('foo.yaml')
+docker_build('gcr.io/foo', 'foo')
+`)
+
+	f.load()
+	f.assertNextManifest("foo",
+		db(image("gcr.io/foo")),
+		deployment("foo"))
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo/.dockerignore", "foo.yaml")
+
+}
+
 type fixture struct {
 	ctx context.Context
 	t   *testing.T
@@ -3185,7 +3206,7 @@ func newFixture(t *testing.T) *fixture {
 	f := tempdir.NewTempDirFixture(t)
 	an := analytics.NewMemoryAnalytics()
 	dcc := dockercompose.NewDockerComposeClient(docker.Env{})
-	tfl := ProvideTiltfileLoader(an, dcc)
+	tfl := ProvideTiltfileLoader(an, dcc, "fake-context")
 
 	r := &fixture{
 		ctx:            ctx,


### PR DESCRIPTION
This is useful to allow you to set a different registry when iterating against microk8s. e.g.,

if k8s_context() == 'microk8s': #microk8s uses a local registry
  default_registry('localhost:32000')