### PR TITLE
version check: move api limit errors to verbose, don't render upgrade badge on error

### DIFF
--- a/internal/engine/version_checker.go
+++ b/internal/engine/version_checker.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/windmilleng/tilt/internal/github"
@@ -42,7 +43,11 @@ func (tvc *TiltVersionChecker) OnChange(ctx context.Context, st store.RStore) {
 		for {
 			version, err := tvc.client.GetLatestRelease(ctx, githubOrg, githubProject)
 			if err != nil {
-				logger.Get(ctx).Infof("error checking github for latest Tilt release: %s", err.Error())
+				if strings.Contains(err.Error(), "API rate limit exceeded") {
+					logger.Get(ctx).Verbosef("error checking github for latest Tilt release: %v", err)
+				} else {
+					logger.Get(ctx).Infof("error checking github for latest Tilt release: %s", err.Error())
+				}
 			} else {
 				st.Dispatch(LatestVersionAction{version})
 			}

--- a/web/src/Statusbar.test.tsx
+++ b/web/src/Statusbar.test.tsx
@@ -143,6 +143,55 @@ describe("StatusBar", () => {
 
     expect(tree).toMatchSnapshot()
   })
+
+  it("does not render an upgrade badge when there is no latestVersion", () => {
+    let view = twoResourceView()
+    view.Resources.forEach((res: any) => {
+      res.BuildHistory[0].Error = ""
+    })
+    let items = view.Resources.map((res: any) => new StatusItem(res))
+    let latestVersion = {Version: "", Date: "", Dev: false}
+    const tree = renderer
+        .create(
+            <MemoryRouter>
+              <Statusbar
+                  items={items}
+                  alertsUrl="/alerts"
+                  runningVersion={runningVersion}
+                  latestVersion={latestVersion}
+              />
+            </MemoryRouter>
+        )
+        .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("does not render an upgrade badge when runningVersion is dev", () => {
+    let view = twoResourceView()
+    view.Resources.forEach((res: any) => {
+      res.BuildHistory[0].Error = ""
+    })
+    let items = view.Resources.map((res: any) => new StatusItem(res))
+    let latestVersion = runningVersion
+    latestVersion.Version = "10.0.0"
+    let devRunningVersion = runningVersion
+    devRunningVersion.Dev = true
+    const tree = renderer
+        .create(
+            <MemoryRouter>
+              <Statusbar
+                  items={items}
+                  alertsUrl="/alerts"
+                  runningVersion={devRunningVersion}
+                  latestVersion={latestVersion}
+              />
+            </MemoryRouter>
+        )
+        .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })
 
 describe("StatusItem", () => {

--- a/web/src/Statusbar.test.tsx
+++ b/web/src/Statusbar.test.tsx
@@ -150,19 +150,19 @@ describe("StatusBar", () => {
       res.BuildHistory[0].Error = ""
     })
     let items = view.Resources.map((res: any) => new StatusItem(res))
-    let latestVersion = {Version: "", Date: "", Dev: false}
+    let latestVersion = { Version: "", Date: "", Dev: false }
     const tree = renderer
-        .create(
-            <MemoryRouter>
-              <Statusbar
-                  items={items}
-                  alertsUrl="/alerts"
-                  runningVersion={runningVersion}
-                  latestVersion={latestVersion}
-              />
-            </MemoryRouter>
-        )
-        .toJSON()
+      .create(
+        <MemoryRouter>
+          <Statusbar
+            items={items}
+            alertsUrl="/alerts"
+            runningVersion={runningVersion}
+            latestVersion={latestVersion}
+          />
+        </MemoryRouter>
+      )
+      .toJSON()
 
     expect(tree).toMatchSnapshot()
   })
@@ -178,17 +178,17 @@ describe("StatusBar", () => {
     let devRunningVersion = runningVersion
     devRunningVersion.Dev = true
     const tree = renderer
-        .create(
-            <MemoryRouter>
-              <Statusbar
-                  items={items}
-                  alertsUrl="/alerts"
-                  runningVersion={devRunningVersion}
-                  latestVersion={latestVersion}
-              />
-            </MemoryRouter>
-        )
-        .toJSON()
+      .create(
+        <MemoryRouter>
+          <Statusbar
+            items={items}
+            alertsUrl="/alerts"
+            runningVersion={devRunningVersion}
+            latestVersion={latestVersion}
+          />
+        </MemoryRouter>
+      )
+      .toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/web/src/Statusbar.tsx
+++ b/web/src/Statusbar.tsx
@@ -111,8 +111,8 @@ class Statusbar extends PureComponent<StatusBarProps> {
   tiltPanel(runningVersion: TiltBuild | null, latestVersion: TiltBuild | null) {
     let content: ReactElement = <LogoSvg className="Statusbar-logo" />
     if (
-      latestVersion &&
-      runningVersion &&
+      latestVersion && latestVersion.Version &&
+      runningVersion && runningVersion.Version &&
       !runningVersion.Dev &&
       runningVersion.Version != latestVersion.Version
     ) {

--- a/web/src/Statusbar.tsx
+++ b/web/src/Statusbar.tsx
@@ -111,8 +111,10 @@ class Statusbar extends PureComponent<StatusBarProps> {
   tiltPanel(runningVersion: TiltBuild | null, latestVersion: TiltBuild | null) {
     let content: ReactElement = <LogoSvg className="Statusbar-logo" />
     if (
-      latestVersion && latestVersion.Version &&
-      runningVersion && runningVersion.Version &&
+      latestVersion &&
+      latestVersion.Version &&
+      runningVersion &&
+      runningVersion.Version &&
       !runningVersion.Dev &&
       runningVersion.Version != latestVersion.Version
     ) {

--- a/web/src/__snapshots__/Statusbar.test.tsx.snap
+++ b/web/src/__snapshots__/Statusbar.test.tsx.snap
@@ -1,5 +1,197 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StatusBar does not render an upgrade badge when runningVersion is dev 1`] = `
+<div
+  className="Statusbar"
+>
+  <section
+    className="Statusbar-panel Statusbar-errWarnPanel"
+  >
+    <div
+      className="Statusbar-errWarnPanel-child"
+    >
+      <svg
+        className="Statusbar-errWarnPanel-icon "
+      >
+        error.svg
+      </svg>
+      <p>
+        <span
+          className="Statusbar-errWarnPanel-count Statusbar-errWarnPanel-count--error"
+        >
+          0
+        </span>
+         
+        <a
+          href="/alerts"
+          onClick={[Function]}
+        >
+          error
+          s
+        </a>
+      </p>
+    </div>
+    <div
+      className="Statusbar-errWarnPanel-child"
+    >
+      <svg
+        className="Statusbar-errWarnPanel-icon "
+      >
+        warning.svg
+      </svg>
+      <p>
+        <span
+          className="Statusbar-errWarnPanel-count"
+        >
+          0
+        </span>
+         
+        warning
+        s
+      </p>
+    </div>
+  </section>
+  <section
+    className="Statusbar-panel Statusbar-statusMsgPanel"
+  >
+    <p
+      className="Statusbar-statusMsgPanel-child"
+    >
+      Updating vigoda…
+    </p>
+    <p
+      className="Statusbar-statusMsgPanel-child Statusbar-statusMsgPanel-child--lastEdit"
+    >
+      <span
+        className="Statusbar-statusMsgPanel-label"
+      >
+        Last Edit:
+      </span>
+      <span>
+        vigoda ‣ main.go[+2 more]
+      </span>
+    </p>
+  </section>
+  <section
+    className="Statusbar-panel Statusbar-progressPanel"
+  >
+    <p>
+      <strong>
+        0
+      </strong>
+      /
+      2
+       running
+    </p>
+  </section>
+  <section
+    className="Statusbar-tiltPanel"
+  >
+    <svg
+      className="Statusbar-logo"
+    >
+      logo.svg
+    </svg>
+  </section>
+</div>
+`;
+
+exports[`StatusBar does not render an upgrade badge when there is no latestVersion 1`] = `
+<div
+  className="Statusbar"
+>
+  <section
+    className="Statusbar-panel Statusbar-errWarnPanel"
+  >
+    <div
+      className="Statusbar-errWarnPanel-child"
+    >
+      <svg
+        className="Statusbar-errWarnPanel-icon "
+      >
+        error.svg
+      </svg>
+      <p>
+        <span
+          className="Statusbar-errWarnPanel-count Statusbar-errWarnPanel-count--error"
+        >
+          0
+        </span>
+         
+        <a
+          href="/alerts"
+          onClick={[Function]}
+        >
+          error
+          s
+        </a>
+      </p>
+    </div>
+    <div
+      className="Statusbar-errWarnPanel-child"
+    >
+      <svg
+        className="Statusbar-errWarnPanel-icon "
+      >
+        warning.svg
+      </svg>
+      <p>
+        <span
+          className="Statusbar-errWarnPanel-count"
+        >
+          0
+        </span>
+         
+        warning
+        s
+      </p>
+    </div>
+  </section>
+  <section
+    className="Statusbar-panel Statusbar-statusMsgPanel"
+  >
+    <p
+      className="Statusbar-statusMsgPanel-child"
+    >
+      Updating vigoda…
+    </p>
+    <p
+      className="Statusbar-statusMsgPanel-child Statusbar-statusMsgPanel-child--lastEdit"
+    >
+      <span
+        className="Statusbar-statusMsgPanel-label"
+      >
+        Last Edit:
+      </span>
+      <span>
+        vigoda ‣ main.go[+2 more]
+      </span>
+    </p>
+  </section>
+  <section
+    className="Statusbar-panel Statusbar-progressPanel"
+  >
+    <p>
+      <strong>
+        0
+      </strong>
+      /
+      2
+       running
+    </p>
+  </section>
+  <section
+    className="Statusbar-tiltPanel"
+  >
+    <svg
+      className="Statusbar-logo"
+    >
+      logo.svg
+    </svg>
+  </section>
+</div>
+`;
+
 exports[`StatusBar renders an upgrade badge when the version is out of date 1`] = `
 <div
   className="Statusbar"


### PR DESCRIPTION
This is to make #1658 a little less bad.

The API limit issue will be addressed separately.