### PR TITLE
upper test: don't use assert.FailNow b/c its type signature doesn't make sense

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2334,7 +2334,7 @@ func (to *testOpter) waitUntilCount(t *testing.T, expectedCount int) {
 			to.mu.Lock()
 			actualCount := len(to.calls)
 			to.mu.Unlock()
-			assert.FailNow(t, "waiting for opt setting count to be %d. opt setting count is currently %d", expectedCount, actualCount)
+			t.Errorf("waiting for opt setting count to be %d. opt setting count is currently %d", expectedCount, actualCount)
 		}
 	}
 }
@@ -2419,24 +2419,24 @@ func newTestFixture(t *testing.T) *testFixture {
 	sc := &client.FakeSailClient{}
 
 	ret := &testFixture{
-		TempDirFixture:        f,
-		ctx:                   ctx,
-		cancel:                cancel,
-		b:                     b,
-		fsWatcher:             watcher,
-		timerMaker:            &timerMaker,
-		docker:                dockerClient,
-		hud:                   fakeHud,
-		log:                   log,
-		store:                 st,
-		bc:                    bc,
-		onchangeCh:            fSub.ch,
-		fwm:                   fwm,
-		cc:                    cc,
-		dcc:                   fakeDcc,
-		tfl:                   tfl,
-		ghc:                   ghc,
-		opter:                 to,
+		TempDirFixture: f,
+		ctx:            ctx,
+		cancel:         cancel,
+		b:              b,
+		fsWatcher:      watcher,
+		timerMaker:     &timerMaker,
+		docker:         dockerClient,
+		hud:            fakeHud,
+		log:            log,
+		store:          st,
+		bc:             bc,
+		onchangeCh:     fSub.ch,
+		fwm:            fwm,
+		cc:             cc,
+		dcc:            fakeDcc,
+		tfl:            tfl,
+		ghc:            ghc,
+		opter:          to,
 		tiltVersionCheckDelay: versionCheckInterval,
 	}
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2335,6 +2335,7 @@ func (to *testOpter) waitUntilCount(t *testing.T, expectedCount int) {
 			actualCount := len(to.calls)
 			to.mu.Unlock()
 			t.Errorf("waiting for opt setting count to be %d. opt setting count is currently %d", expectedCount, actualCount)
+			t.FailNow()
 		}
 	}
 }
@@ -2419,24 +2420,24 @@ func newTestFixture(t *testing.T) *testFixture {
 	sc := &client.FakeSailClient{}
 
 	ret := &testFixture{
-		TempDirFixture: f,
-		ctx:            ctx,
-		cancel:         cancel,
-		b:              b,
-		fsWatcher:      watcher,
-		timerMaker:     &timerMaker,
-		docker:         dockerClient,
-		hud:            fakeHud,
-		log:            log,
-		store:          st,
-		bc:             bc,
-		onchangeCh:     fSub.ch,
-		fwm:            fwm,
-		cc:             cc,
-		dcc:            fakeDcc,
-		tfl:            tfl,
-		ghc:            ghc,
-		opter:          to,
+		TempDirFixture:        f,
+		ctx:                   ctx,
+		cancel:                cancel,
+		b:                     b,
+		fsWatcher:             watcher,
+		timerMaker:            &timerMaker,
+		docker:                dockerClient,
+		hud:                   fakeHud,
+		log:                   log,
+		store:                 st,
+		bc:                    bc,
+		onchangeCh:            fSub.ch,
+		fwm:                   fwm,
+		cc:                    cc,
+		dcc:                   fakeDcc,
+		tfl:                   tfl,
+		ghc:                   ghc,
+		opter:                 to,
 		tiltVersionCheckDelay: versionCheckInterval,
 	}
 


### PR DESCRIPTION
Idk why this test hit this case on master at all, but when it did, we got this nonsensical error b/c of the weird args of `assert.FailNow`:
```
=== FAIL: internal/engine TestSetAnalyticsOpt (14.44s)
panic: interface conversion: interface {} is int, not string [recovered]
	panic: interface conversion: interface {} is int, not string

goroutine 1671 [running]:
testing.tRunner.func1(0xc000156400)
	/usr/local/go/src/testing/testing.go:830 +0x388
panic(0x24b5ca0, 0xc000746450)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/windmilleng/tilt/vendor/github.com/stretchr/testify/assert.messageFromMsgAndArgs(0xc000dafe88, 0x2, 0x2, 0x2, 0x3)
	/go/src/github.com/windmilleng/tilt/vendor/github.com/stretchr/testify/assert/assertions.go:189 +0x177
github.com/windmilleng/tilt/vendor/github.com/stretchr/testify/assert.Fail(0x2a208c0, 0xc000156400, 0x278ba7a, 0x49, 0xc000dafe88, 0x2, 0x2, 0xc00061e038)
	/go/src/github.com/windmilleng/tilt/vendor/github.com/stretchr/testify/assert/assertions.go:255 +0x188
github.com/windmilleng/tilt/vendor/github.com/stretchr/testify/assert.FailNow(0x2a208c0, 0xc000156400, 0x278ba7a, 0x49, 0xc000dafe88, 0x2, 0x2, 0x0)
	/go/src/github.com/windmilleng/tilt/vendor/github.com/stretchr/testify/assert/assertions.go:222 +0xa7
github.com/windmilleng/tilt/internal/engine.(*testOpter).waitUntilCount(0xc000668880, 0xc000156400, 0x2)
	/go/src/github.com/windmilleng/tilt/internal/engine/upper_test.go:2337 +0x1dd
github.com/windmilleng/tilt/internal/engine.TestSetAnalyticsOpt(0xc000156400)
	/go/src/github.com/windmilleng/tilt/internal/engine/upper_test.go:2263 +0x1d7
testing.tRunner(0xc000156400, 0x27d5978)
	/usr/local/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:916 +0x357
FAIL	github.com/windmilleng/tilt/internal/engine	14.436s
```