### PR TITLE
web: use build error formatting for other errors too

### DIFF
--- a/web/src/ErrorPane.test.tsx
+++ b/web/src/ErrorPane.test.tsx
@@ -178,3 +178,30 @@ it("shows that a crash rebuild has occurred", () => {
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+it("renders multiple lines of a crash log", () => {
+  const ts = "1,555,970,585,039"
+  const resources = [
+    {
+      Name: "foo",
+      BuildHistory: [
+        {
+          Log: "laa dee daa I'm not an error\nseriously",
+          FinishTime: ts,
+          Error: null,
+          IsCrashRebuild: true,
+        },
+      ],
+      ResourceInfo: {
+        PodCreationTime: ts,
+        PodStatus: "ok",
+        PodLog: "Eeeeek the container crashed\nno but really it crashed",
+      },
+    },
+  ]
+
+  const tree = renderer
+    .create(<AlertPane resources={resources.map(r => new AlertResource(r))} />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/web/src/ErrorPane.tsx
+++ b/web/src/ErrorPane.tsx
@@ -79,6 +79,10 @@ type AlertsProps = {
   resources: Array<AlertResource>
 }
 
+function logToLines(s: string) {
+  return s.split("\n").map((l, i) => <AnsiLine key={"logLine" + i} line={l} />)
+}
+
 class AlertPane extends PureComponent<AlertsProps> {
   render() {
     let formatter = timeAgoFormatter
@@ -102,7 +106,7 @@ class AlertPane extends PureComponent<AlertsProps> {
                 />
               </p>
             </header>
-            <section>{r.resourceInfo.podLog}</section>
+            <section>{logToLines(r.resourceInfo.podLog)}</section>
           </li>
         )
       } else if (r.podRestarted()) {
@@ -112,9 +116,7 @@ class AlertPane extends PureComponent<AlertsProps> {
               <p>{r.name}</p>
               <p>{`Restarts: ${r.resourceInfo.podRestarts}`}</p>
             </header>
-            <section>
-              <p>{`Last log line: ${r.resourceInfo.podLog}`}</p>
-            </section>
+            <section>{logToLines(r.resourceInfo.podLog)}</section>
           </li>
         )
       } else if (r.crashRebuild()) {
@@ -127,9 +129,7 @@ class AlertPane extends PureComponent<AlertsProps> {
               <p>{r.name}</p>
               <p>Pod crashed!</p>
             </header>
-            <section>
-              <p>{`Last log line: ${r.resourceInfo.podLog}`}</p>
-            </section>
+            <section>{logToLines(r.resourceInfo.podLog)}</section>
           </li>
         )
       }
@@ -143,11 +143,7 @@ class AlertPane extends PureComponent<AlertsProps> {
                 <TimeAgo date={lastBuild.FinishTime} formatter={formatter} />
               </p>
             </header>
-            <section>
-              {lastBuild.Log.split("\n").map((l, i) => (
-                <AnsiLine key={"logLine" + i} line={l} />
-              ))}
-            </section>
+            <section>{logToLines(lastBuild.Log)}</section>
           </li>
         )
       }

--- a/web/src/__snapshots__/ErrorPane.test.tsx.snap
+++ b/web/src/__snapshots__/ErrorPane.test.tsx.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders multiple lines of a crash log 1`] = `
+<section
+  className="ErrorPane"
+>
+  <ul>
+    <li
+      className="ErrorPane-item"
+    >
+      <header>
+        <p>
+          foo
+        </p>
+        <p>
+          Pod crashed!
+        </p>
+      </header>
+      <section>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Eeeeek the container crashed
+          </span>
+        </code>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            no but really it crashed
+          </span>
+        </code>
+      </section>
+    </li>
+  </ul>
+</section>
+`;
+
 exports[`renders no errors 1`] = `
 <section
   className="ErrorPane"
@@ -83,7 +122,14 @@ exports[`renders one container start error 1`] = `
         </p>
       </header>
       <section>
-        Eeeeek there is a problem
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Eeeeek there is a problem
+          </span>
+        </code>
       </section>
     </li>
   </ul>
@@ -112,7 +158,14 @@ exports[`renders one container start error 2`] = `
         </p>
       </header>
       <section>
-        Eeeeek there is a problem
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Eeeeek there is a problem
+          </span>
+        </code>
       </section>
     </li>
   </ul>
@@ -180,9 +233,14 @@ exports[`shows that a container has restarted 1`] = `
         </p>
       </header>
       <section>
-        <p>
-          Last log line: Eeeeek the container crashed
-        </p>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Eeeeek the container crashed
+          </span>
+        </code>
       </section>
     </li>
   </ul>
@@ -206,9 +264,14 @@ exports[`shows that a crash rebuild has occurred 1`] = `
         </p>
       </header>
       <section>
-        <p>
-          Last log line: Eeeeek the container crashed
-        </p>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Eeeeek the container crashed
+          </span>
+        </code>
       </section>
     </li>
   </ul>


### PR DESCRIPTION
The styling for errors in ErrorPane.scss applies to `<code>` elements.
For most of the types of error items we can show in ErrorPanes, we put them in `<p>` elements and *not* `<code>` elements!
It turns out that `<code>` elements are generated by the `AnsiLine` splitting we do for build errors.
This means we get all kinds of fun things, like if a pod crashes with two log lines, we display them both and ignore the newline, so they're concatenated horizontally.

Since build errors have been styled (i.e., we actually define styles for them in the scss) and the other types haven't, I'm assuming we should make everything else match build error styling.

Note this also means I'm dropping the "Last log line" copy, because:
1. we don't have it for build errors, and it's fine
2. it's a lie - we don't truncate to the last line
3. I tried changing it to "Log tail" but it felt weird to have it there with the same styling as the log itself. Given that its absence seemed fine for build errors, I figured it wasn't worth keeping.

![image](https://user-images.githubusercontent.com/7453991/58121741-19f1b700-7bd6-11e9-94b3-a01af606a780.png)
