### PR TITLE
ui: use crashlog for crashes

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -713,6 +713,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, pod *v
 	checkForPodCrash(ctx, state, ms, *podInfo)
 
 	if int(cStatus.RestartCount) > podInfo.ContainerRestarts {
+		ms.CrashLog = podInfo.CurrentLog
 		podInfo.CurrentLog = model.Log{}
 	}
 	podInfo.ContainerRestarts = int(cStatus.RestartCount)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1587,6 +1587,7 @@ func TestUpperPodLogInCrashLoopThirdInstanceStillUp(t *testing.T) {
 		assert.Equal(t, "third string\n", ms.MostRecentPod().Log().String())
 		assert.Contains(t, ms.CombinedLog.String(), "second string\n")
 		assert.Contains(t, ms.CombinedLog.String(), "third string\n")
+		assert.Equal(t, ms.CrashLog.String(), "second string\n")
 	})
 
 	err := f.Stop()

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -84,6 +84,7 @@ func StateToWebView(s store.EngineState) View {
 			ResourceInfo:       resourceInfoView(mt),
 			ShowBuildStatus:    len(mt.Manifest.ImageTargets) > 0 || mt.Manifest.IsDC(),
 			CombinedLog:        ms.CombinedLog,
+			CrashLog:           ms.CrashLog,
 		}
 
 		r.RuntimeStatus = runtimeStatus(r.ResourceInfo)

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -110,6 +110,7 @@ type Resource struct {
 	IsTiltfile      bool
 	ShowBuildStatus bool // if true, we show status & time in 'Build Status'; else, "N/A"
 	CombinedLog     model.Log
+	CrashLog        model.Log
 }
 
 func (r Resource) LastBuild() BuildRecord {

--- a/web/src/ErrorPane.test.tsx
+++ b/web/src/ErrorPane.test.tsx
@@ -205,30 +205,3 @@ it("renders multiple lines of a crash log", () => {
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
-
-it("renders multiple lines of a crash log", () => {
-  const ts = "1,555,970,585,039"
-  const resources = [
-    {
-      Name: "foo",
-      CrashLog: "Eeeeek the container crashed\nno but really it crashed",
-      BuildHistory: [
-        {
-          Log: "laa dee daa I'm not an error\nseriously",
-          FinishTime: ts,
-          Error: null,
-          IsCrashRebuild: true,
-        },
-      ],
-      ResourceInfo: {
-        PodCreationTime: ts,
-        PodStatus: "ok",
-      },
-    },
-  ]
-
-  const tree = renderer
-    .create(<AlertPane resources={resources.map(r => new AlertResource(r))} />)
-    .toJSON()
-  expect(tree).toMatchSnapshot()
-})

--- a/web/src/ErrorPane.test.tsx
+++ b/web/src/ErrorPane.test.tsx
@@ -78,6 +78,7 @@ it("renders one container start error", () => {
   let resources = [
     {
       Name: "foo",
+      CrashLog: "Eeeeek there is a problem",
       BuildHistory: [
         {
           Log: "laa dee daa I'm an error\nI'm serious",
@@ -89,7 +90,6 @@ it("renders one container start error", () => {
         PodCreationTime: ts,
         PodStatus: "Error",
         PodRestarts: 2,
-        PodLog: "Eeeeek there is a problem",
       },
     },
   ]
@@ -103,6 +103,7 @@ it("renders one container start error", () => {
   resources = [
     {
       Name: "foo",
+      CrashLog: "Eeeeek there is a problem",
       BuildHistory: [
         {
           Log: "laa dee daa I'm not an error\nI'm serious",
@@ -114,7 +115,6 @@ it("renders one container start error", () => {
         PodCreationTime: ts,
         PodStatus: "CrashLoopBackOff",
         PodRestarts: 3,
-        PodLog: "Eeeeek there is a problem",
       },
     },
   ]
@@ -130,6 +130,7 @@ it("shows that a container has restarted", () => {
   const resources = [
     {
       Name: "foo",
+      CrashLog: "Eeeeek the container crashed",
       BuildHistory: [
         {
           Log: "laa dee daa I'm not an error\nseriously",
@@ -141,7 +142,6 @@ it("shows that a container has restarted", () => {
         PodCreationTime: ts,
         PodStatus: "ok",
         PodRestarts: 1,
-        PodLog: "Eeeeek the container crashed",
       },
     },
   ]
@@ -157,6 +157,7 @@ it("shows that a crash rebuild has occurred", () => {
   const resources = [
     {
       Name: "foo",
+      CrashLog: "Eeeeek the container crashed",
       BuildHistory: [
         {
           Log: "laa dee daa I'm not an error\nseriously",
@@ -168,7 +169,6 @@ it("shows that a crash rebuild has occurred", () => {
       ResourceInfo: {
         PodCreationTime: ts,
         PodStatus: "ok",
-        PodLog: "Eeeeek the container crashed",
       },
     },
   ]
@@ -184,6 +184,7 @@ it("renders multiple lines of a crash log", () => {
   const resources = [
     {
       Name: "foo",
+      CrashLog: "Eeeeek the container crashed\nno but really it crashed",
       BuildHistory: [
         {
           Log: "laa dee daa I'm not an error\nseriously",
@@ -195,7 +196,33 @@ it("renders multiple lines of a crash log", () => {
       ResourceInfo: {
         PodCreationTime: ts,
         PodStatus: "ok",
-        PodLog: "Eeeeek the container crashed\nno but really it crashed",
+      },
+    },
+  ]
+
+  const tree = renderer
+    .create(<AlertPane resources={resources.map(r => new AlertResource(r))} />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it("renders multiple lines of a crash log", () => {
+  const ts = "1,555,970,585,039"
+  const resources = [
+    {
+      Name: "foo",
+      CrashLog: "Eeeeek the container crashed\nno but really it crashed",
+      BuildHistory: [
+        {
+          Log: "laa dee daa I'm not an error\nseriously",
+          FinishTime: ts,
+          Error: null,
+          IsCrashRebuild: true,
+        },
+      ],
+      ResourceInfo: {
+        PodCreationTime: ts,
+        PodStatus: "ok",
       },
     },
   ]

--- a/web/src/ErrorPane.tsx
+++ b/web/src/ErrorPane.tsx
@@ -11,23 +11,23 @@ class AlertResource {
   public name: string
   public buildHistory: Array<Build>
   public resourceInfo: ResourceInfo
+  public crashLog: string
 
   constructor(resource: any) {
     this.name = resource.Name
     this.buildHistory = resource.BuildHistory
+    this.crashLog = resource.CrashLog
     if (resource.ResourceInfo) {
       this.resourceInfo = {
         podCreationTime: resource.ResourceInfo.PodCreationTime,
         podStatus: resource.ResourceInfo.PodStatus,
         podRestarts: resource.ResourceInfo.PodRestarts,
-        podLog: resource.ResourceInfo.PodLog,
       }
     } else {
       this.resourceInfo = {
         podCreationTime: zeroTime,
         podStatus: "",
         podRestarts: 0,
-        podLog: "",
       }
     }
   }
@@ -72,7 +72,6 @@ type ResourceInfo = {
   podCreationTime: string
   podStatus: string
   podRestarts: number
-  podLog: string
 }
 
 type AlertsProps = {
@@ -106,7 +105,7 @@ class AlertPane extends PureComponent<AlertsProps> {
                 />
               </p>
             </header>
-            <section>{logToLines(r.resourceInfo.podLog)}</section>
+            <section>{logToLines(r.crashLog)}</section>
           </li>
         )
       } else if (r.podRestarted()) {
@@ -116,7 +115,7 @@ class AlertPane extends PureComponent<AlertsProps> {
               <p>{r.name}</p>
               <p>{`Restarts: ${r.resourceInfo.podRestarts}`}</p>
             </header>
-            <section>{logToLines(r.resourceInfo.podLog)}</section>
+            <section>{logToLines(r.crashLog)}</section>
           </li>
         )
       } else if (r.crashRebuild()) {
@@ -129,7 +128,7 @@ class AlertPane extends PureComponent<AlertsProps> {
               <p>{r.name}</p>
               <p>Pod crashed!</p>
             </header>
-            <section>{logToLines(r.resourceInfo.podLog)}</section>
+            <section>{logToLines(r.crashLog)}</section>
           </li>
         )
       }

--- a/web/src/__snapshots__/ErrorPane.test.tsx.snap
+++ b/web/src/__snapshots__/ErrorPane.test.tsx.snap
@@ -39,45 +39,6 @@ exports[`renders multiple lines of a crash log 1`] = `
 </section>
 `;
 
-exports[`renders multiple lines of a crash log 2`] = `
-<section
-  className="ErrorPane"
->
-  <ul>
-    <li
-      className="ErrorPane-item"
-    >
-      <header>
-        <p>
-          foo
-        </p>
-        <p>
-          Pod crashed!
-        </p>
-      </header>
-      <section>
-        <code>
-          <span
-            className={null}
-            style={null}
-          >
-            Eeeeek the container crashed
-          </span>
-        </code>
-        <code>
-          <span
-            className={null}
-            style={null}
-          >
-            no but really it crashed
-          </span>
-        </code>
-      </section>
-    </li>
-  </ul>
-</section>
-`;
-
 exports[`renders no errors 1`] = `
 <section
   className="ErrorPane"

--- a/web/src/__snapshots__/ErrorPane.test.tsx.snap
+++ b/web/src/__snapshots__/ErrorPane.test.tsx.snap
@@ -39,6 +39,45 @@ exports[`renders multiple lines of a crash log 1`] = `
 </section>
 `;
 
+exports[`renders multiple lines of a crash log 2`] = `
+<section
+  className="ErrorPane"
+>
+  <ul>
+    <li
+      className="ErrorPane-item"
+    >
+      <header>
+        <p>
+          foo
+        </p>
+        <p>
+          Pod crashed!
+        </p>
+      </header>
+      <section>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Eeeeek the container crashed
+          </span>
+        </code>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            no but really it crashed
+          </span>
+        </code>
+      </section>
+    </li>
+  </ul>
+</section>
+`;
+
 exports[`renders no errors 1`] = `
 <section
   className="ErrorPane"


### PR DESCRIPTION
1. We were only populating `CrashLog` in the crash rebuild case. We now also populate it when the restart count increases.
2. We were not using `CrashLog` at all in the web UI, so the web UI was just showing post-restart logs, and it's pretty frustrating for an alert to pull your attention to that tab just to show you logs that are not actually relevant.

on web:
![image](https://user-images.githubusercontent.com/7453991/58122072-cdf34200-7bd6-11e9-870e-b4c6ecdd0ec0.png)

in TUI:
![image](https://user-images.githubusercontent.com/7453991/58122085-d3e92300-7bd6-11e9-8d1b-0bed5110f8c8.png)
