### PR TITLE
tiltfile: deprecation warning for FastBuild

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -14,6 +14,11 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 )
 
+const fastBuildDeprecationWarning = "FastBuild (`fast_build`; `add_fast_build`; " +
+	"`docker_build(...).add(...)`, etc.) will be deprecated soon; you can use Live " +
+	"Update instead! See https://docs.tilt.dev/live_update_tutorial.html for more " +
+	"information. If Live Update doesn't fit your use case, let us know."
+
 type dockerImage struct {
 	baseDockerfilePath localPath
 	baseDockerfile     dockerfile.Dockerfile
@@ -603,4 +608,16 @@ func (s *tiltfileState) dockerignoresForImage(image *dockerImage) []model.Docker
 	paths = append(paths, image.dbBuildPath.path)
 
 	return s.dockerignoresForPaths(paths)
+}
+
+func (s *tiltfileState) checkForFastBuilds(manifests []model.Manifest) {
+Loop:
+	for _, m := range manifests {
+		for _, iTarg := range m.ImageTargets {
+			if !iTarg.AnyFastBuildInfo().Empty() {
+				s.warnings = append(s.warnings, fastBuildDeprecationWarning)
+				break Loop
+			}
+		}
+	}
 }

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -611,12 +611,11 @@ func (s *tiltfileState) dockerignoresForImage(image *dockerImage) []model.Docker
 }
 
 func (s *tiltfileState) checkForFastBuilds(manifests []model.Manifest) {
-Loop:
 	for _, m := range manifests {
 		for _, iTarg := range m.ImageTargets {
 			if !iTarg.AnyFastBuildInfo().Empty() {
 				s.warnings = append(s.warnings, fastBuildDeprecationWarning)
-				break Loop
+				return
 			}
 		}
 	}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -130,6 +130,8 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		return TiltfileLoadResult{}, err
 	}
 
+	s.checkForFastBuilds(manifests)
+
 	manifests, err = match(manifests, matching)
 	if err != nil {
 		return TiltfileLoadResult{}, err

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -363,7 +363,7 @@ docker_compose('docker-compose.yml')
 dc_resource('foo', 'gcr.io/foo')
 `)
 
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	m := f.assertNextManifest("foo",
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi"), hotReload(false)))
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -249,7 +249,7 @@ fast_build('gcr.io/foo', 'foo/Dockerfile') \
   .run("echo hi")
 k8s_yaml('foo.yaml')
 `)
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo",
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi"), hotReload(false)),
 		deployment("foo"),
@@ -269,7 +269,7 @@ fast_build('gcr.io/foo', 'foo/Dockerfile') \
   .hot_reload()
 k8s_yaml('foo.yaml')
 `)
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo",
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi"), hotReload(true)),
 		deployment("foo"),
@@ -288,7 +288,7 @@ fb = fast_build('gcr.io/foo', 'foo/Dockerfile') \
   .run("echo hi")
 k8s_yaml('foo.yaml')
 `)
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo",
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi")),
 		deployment("foo"),
@@ -342,7 +342,7 @@ fastbar.add('local/path', 'remote/path')
 fastbar.run('echo hi')
 `)
 
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo",
 		db(image("gcr.io/foo")),
 		deployment("foo"))
@@ -363,7 +363,7 @@ fast_build('gcr.io/foo', 'foo/Dockerfile') \
   .run("echo again", trigger='c')
 k8s_yaml('foo.yaml')
 `)
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo",
 		fb(image("gcr.io/foo"),
 			add("foo", "src/"),
@@ -483,7 +483,7 @@ func TestFastBuildCache(t *testing.T) {
 k8s_yaml('foo.yaml')
 fast_build("gcr.io/foo", 'foo/Dockerfile', cache='/path/to/cache')
 `)
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo", fbWithCache(image("gcr.io/foo"), "/path/to/cache"))
 }
 
@@ -544,7 +544,7 @@ fast_build('gcr.io/foo', 'foo/Dockerfile').add('./foo', '/foo')
 fast_build('gcr.io/bar', 'foo/Dockerfile').add('%s', '/bar')
 `, f.JoinPath("./bar")))
 
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo", fb(image("gcr.io/foo"), add("foo", "/foo")))
 	f.assertNextManifest("bar", fb(image("gcr.io/bar"), add("bar", "/bar")))
 }
@@ -560,7 +560,7 @@ k8s_yaml('foo.yaml')
 fast_build('gcr.io/foo', 'foo/Dockerfile').add(repo.path('foo'), '/foo')
 `)
 
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo", fb(image("gcr.io/foo"), add("foo", "/foo")))
 }
 
@@ -577,7 +577,7 @@ k8s_yaml('foo.yaml')
 fast_build('gcr.io/foo', 'foo/Dockerfile').add(repo, '/whole_repo')
 `)
 
-	f.load()
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo", fb(image("gcr.io/foo"), add(".", "/whole_repo")))
 }
 
@@ -995,7 +995,7 @@ fast_build('gcr.io/foo', 'foo/Dockerfile') \
   .run("echo hi")
 k8s_yaml('foo.yaml')
 `)
-	f.load("foo")
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo",
 		buildFilters("foo/a.txt"),
 		fileChangeFilters("foo/a.txt"),
@@ -1014,7 +1014,7 @@ fast_build('gcr.io/foo', 'foo/Dockerfile') \
   .run("echo hi")
 k8s_yaml('foo.yaml')
 `)
-	f.load("foo")
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNextManifest("foo",
 		buildFilters("foo/a.txt"),
 		fileChangeFilters("foo/a.txt"),
@@ -1861,7 +1861,7 @@ k8s_yaml(blob('hi'))
 	f.loadErrString("from Tiltfile blob() call")
 }
 
-func TestCustomBuild(t *testing.T) {
+func TestCustomBuildWithFastBuild(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1878,7 +1878,7 @@ hfb.hot_reload()`
 	f.setupFoo()
 	f.file("Tiltfile", tiltfile)
 
-	f.load("foo")
+	f.loadAssertWarnings(fastBuildDeprecationWarning)
 	f.assertNumManifests(1)
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml", "foo/.dockerignore")
 	f.assertNextManifest("foo",


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/fast-build-deprecation-warn:

873ed75d9d799615774dace32223edb6041111b2 (2019-05-22 17:51:28 -0400)
tiltfile: deprecation warning for FastBuild

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics