### PR TITLE
[analytics] close loop on transporting analytics around on the context by removing global

### DIFF
--- a/internal/cli/analytics.go
+++ b/internal/cli/analytics.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"crypto/md5"
 	"encoding/base64"
 	"os"
@@ -120,8 +119,4 @@ func normalizeGitRemote(s string) string {
 
 func isAnalyticsDisabledFromEnv() bool {
 	return os.Getenv(disableAnalyticsEnvVar) != ""
-}
-
-func provideAnalytics(ctx context.Context) *tiltanalytics.TiltAnalytics {
-	return tiltanalytics.Get(ctx)
 }

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/demo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -28,8 +29,8 @@ func (c *demoCmd) register() *cobra.Command {
 }
 
 func (c *demoCmd) run(ctx context.Context, args []string) error {
-	analyticsService.Incr("cmd.demo", map[string]string{})
-	defer analyticsService.Flush(time.Second)
+	analytics.Get(ctx).Incr("cmd.demo", map[string]string{})
+	defer analytics.Get(ctx).Flush(time.Second)
 
 	demo, err := wireDemo(ctx, demo.RepoBranch(c.branch))
 	if err != nil {

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/windmilleng/tilt/internal/analytics"
-	"github.com/windmilleng/tilt/internal/demo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/windmilleng/tilt/internal/analytics"
+	"github.com/windmilleng/tilt/internal/demo"
 )
 
 type demoCmd struct {
@@ -29,10 +30,11 @@ func (c *demoCmd) register() *cobra.Command {
 }
 
 func (c *demoCmd) run(ctx context.Context, args []string) error {
-	analytics.Get(ctx).Incr("cmd.demo", map[string]string{})
-	defer analytics.Get(ctx).Flush(time.Second)
+	a := analytics.Get(ctx)
+	a.Incr("cmd.demo", map[string]string{})
+	defer a.Flush(time.Second)
 
-	demo, err := wireDemo(ctx, demo.RepoBranch(c.branch))
+	demo, err := wireDemo(ctx, demo.RepoBranch(c.branch), a)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/windmilleng/tilt/internal/analytics"
 )
 
 type doctorCmd struct {
@@ -21,8 +22,8 @@ func (c *doctorCmd) register() *cobra.Command {
 }
 
 func (c *doctorCmd) run(ctx context.Context, args []string) error {
-	analyticsService.Incr("cmd.doctor", map[string]string{})
-	defer analyticsService.Flush(time.Second)
+	analytics.Get(ctx).Incr("cmd.doctor", map[string]string{})
+	defer analytics.Get(ctx).Flush(time.Second)
 
 	fmt.Printf("Tilt: %s\n", buildStamp())
 	fmt.Printf("System: %s-%s\n", runtime.GOOS, runtime.GOARCH)

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/tiltfile"
@@ -29,10 +30,10 @@ func (c *downCmd) register() *cobra.Command {
 }
 
 func (c *downCmd) run(ctx context.Context, args []string) error {
-	analyticsService.Incr("cmd.down", map[string]string{
+	analytics.Get(ctx).Incr("cmd.down", map[string]string{
 		"count": fmt.Sprintf("%d", len(args)),
 	})
-	defer analyticsService.Flush(time.Second)
+	defer analytics.Get(ctx).Flush(time.Second)
 
 	downDeps, err := wireDownDeps(ctx)
 	if err != nil {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -30,12 +30,13 @@ func (c *downCmd) register() *cobra.Command {
 }
 
 func (c *downCmd) run(ctx context.Context, args []string) error {
-	analytics.Get(ctx).Incr("cmd.down", map[string]string{
+	a := analytics.Get(ctx)
+	a.Incr("cmd.down", map[string]string{
 		"count": fmt.Sprintf("%d", len(args)),
 	})
-	defer analytics.Get(ctx).Flush(time.Second)
+	defer a.Flush(time.Second)
 
-	downDeps, err := wireDownDeps(ctx)
+	downDeps, err := wireDownDeps(ctx, a)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -97,7 +97,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		span.SetTag(k, v)
 	}
 
-	threads, err := wireThreads(ctx)
+	threads, err := wireThreads(ctx, a)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/analytics"
+
 	"github.com/docker/docker/api/types"
 	"github.com/google/wire"
 	"k8s.io/apimachinery/pkg/version"
@@ -83,7 +85,6 @@ var BaseWireSet = wire.NewSet(
 	provideTiltInfo,
 	engine.ProvideSubscribers,
 	engine.NewUpper,
-	provideAnalytics,
 	engine.NewTiltAnalyticsSubscriber,
 	engine.ProvideAnalyticsReporter,
 	provideUpdateModeFlag,
@@ -108,12 +109,12 @@ var BaseWireSet = wire.NewSet(
 	engine.NewKINDPusher,
 )
 
-func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) {
+func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics *analytics.TiltAnalytics) (demo.Script, error) {
 	wire.Build(BaseWireSet, demo.NewScript, build.ProvideClock)
 	return demo.Script{}, nil
 }
 
-func wireThreads(ctx context.Context) (Threads, error) {
+func wireThreads(ctx context.Context, analytics *analytics.TiltAnalytics) (Threads, error) {
 	wire.Build(BaseWireSet, build.ProvideClock)
 	return Threads{}, nil
 }
@@ -172,7 +173,7 @@ func wireDockerEnv(ctx context.Context) (docker.Env, error) {
 	return docker.Env{}, nil
 }
 
-func wireDownDeps(ctx context.Context) (DownDeps, error) {
+func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (DownDeps, error) {
 	wire.Build(BaseWireSet, ProvideDownDeps)
 	return DownDeps{}, nil
 }

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/docker/docker/api/types"
 	"github.com/google/wire"
+	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/container"
@@ -32,7 +33,7 @@ import (
 
 // Injectors from wire.go:
 
-func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) {
+func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics.TiltAnalytics) (demo.Script, error) {
 	reducer := _wireReducerValue
 	storeLogActionsFlag := provideLogActions()
 	storeStore := store.NewStore(reducer, storeLogActionsFlag)
@@ -43,8 +44,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	if err != nil {
 		return demo.Script{}, err
 	}
-	tiltAnalytics := provideAnalytics(ctx)
-	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer, webURL, tiltAnalytics)
+	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer, webURL, analytics2)
 	if err != nil {
 		return demo.Script{}, err
 	}
@@ -100,7 +100,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 		return demo.Script{}, err
 	}
 	containerUpdater := build.NewContainerUpdater(cli)
-	localContainerBuildAndDeployer := engine.NewLocalContainerBuildAndDeployer(containerUpdater, tiltAnalytics, env)
+	localContainerBuildAndDeployer := engine.NewLocalContainerBuildAndDeployer(containerUpdater, analytics2, env)
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(cli, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
@@ -108,7 +108,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	clock := build.ProvideClock()
 	execCustomBuilder := build.NewExecCustomBuilder(cli, dockerEnv, clock)
 	kindPusher := engine.NewKINDPusher()
-	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, execCustomBuilder, k8sClient, env, tiltAnalytics, updateMode, clock, runtime, kindPusher)
+	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, execCustomBuilder, k8sClient, env, analytics2, updateMode, clock, runtime, kindPusher)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(dockerEnv)
 	imageAndCacheBuilder := engine.NewImageAndCacheBuilder(imageBuilder, cacheBuilder, execCustomBuilder, updateMode)
 	dockerComposeBuildAndDeployer := engine.NewDockerComposeBuildAndDeployer(dockerComposeClient, cli, imageAndCacheBuilder, clock)
@@ -117,12 +117,12 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, dockerComposeClient, kubeContext)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, dockerComposeClient, kubeContext)
 	configsController := engine.NewConfigsController(tiltfileLoader)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
-	analyticsReporter := engine.ProvideAnalyticsReporter(tiltAnalytics, storeStore)
+	analyticsReporter := engine.ProvideAnalyticsReporter(analytics2, storeStore)
 	tiltBuild := provideTiltInfo()
 	webMode, err := provideWebMode(tiltBuild)
 	if err != nil {
@@ -145,11 +145,11 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	sailRoomer := client.ProvideSailRoomer(sailURL)
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, tiltAnalytics, sailClient)
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient)
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL)
 	githubClientFactory := engine.NewGithubClientFactory()
 	tiltVersionChecker := engine.NewTiltVersionChecker(githubClientFactory, timerMaker)
-	tiltAnalyticsSubscriber := engine.NewTiltAnalyticsSubscriber(tiltAnalytics)
+	tiltAnalyticsSubscriber := engine.NewTiltAnalyticsSubscriber(analytics2)
 	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, imageController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, sailClient, tiltVersionChecker, tiltAnalyticsSubscriber)
 	upper := engine.NewUpper(ctx, storeStore, v2)
 	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, storeStore, branch, runtime, tiltfileLoader)
@@ -161,7 +161,7 @@ var (
 	_wireLabelsValue  = dockerfile.Labels{}
 )
 
-func wireThreads(ctx context.Context) (Threads, error) {
+func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Threads, error) {
 	v := provideClock()
 	renderer := hud.NewRenderer(v)
 	modelWebPort := provideWebPort()
@@ -169,8 +169,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	if err != nil {
 		return Threads{}, err
 	}
-	tiltAnalytics := provideAnalytics(ctx)
-	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer, webURL, tiltAnalytics)
+	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer, webURL, analytics2)
 	if err != nil {
 		return Threads{}, err
 	}
@@ -229,7 +228,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 		return Threads{}, err
 	}
 	containerUpdater := build.NewContainerUpdater(cli)
-	localContainerBuildAndDeployer := engine.NewLocalContainerBuildAndDeployer(containerUpdater, tiltAnalytics, env)
+	localContainerBuildAndDeployer := engine.NewLocalContainerBuildAndDeployer(containerUpdater, analytics2, env)
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(cli, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
@@ -237,7 +236,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	clock := build.ProvideClock()
 	execCustomBuilder := build.NewExecCustomBuilder(cli, dockerEnv, clock)
 	kindPusher := engine.NewKINDPusher()
-	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, execCustomBuilder, k8sClient, env, tiltAnalytics, updateMode, clock, runtime, kindPusher)
+	imageBuildAndDeployer := engine.NewImageBuildAndDeployer(imageBuilder, cacheBuilder, execCustomBuilder, k8sClient, env, analytics2, updateMode, clock, runtime, kindPusher)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(dockerEnv)
 	imageAndCacheBuilder := engine.NewImageAndCacheBuilder(imageBuilder, cacheBuilder, execCustomBuilder, updateMode)
 	dockerComposeBuildAndDeployer := engine.NewDockerComposeBuildAndDeployer(dockerComposeClient, cli, imageAndCacheBuilder, clock)
@@ -246,12 +245,12 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(cli)
 	imageController := engine.NewImageController(imageReaper)
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, dockerComposeClient, kubeContext)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, dockerComposeClient, kubeContext)
 	configsController := engine.NewConfigsController(tiltfileLoader)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
-	analyticsReporter := engine.ProvideAnalyticsReporter(tiltAnalytics, storeStore)
+	analyticsReporter := engine.ProvideAnalyticsReporter(analytics2, storeStore)
 	tiltBuild := provideTiltInfo()
 	webMode, err := provideWebMode(tiltBuild)
 	if err != nil {
@@ -274,11 +273,11 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	sailRoomer := client.ProvideSailRoomer(sailURL)
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, tiltAnalytics, sailClient)
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient)
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL)
 	githubClientFactory := engine.NewGithubClientFactory()
 	tiltVersionChecker := engine.NewTiltVersionChecker(githubClientFactory, timerMaker)
-	tiltAnalyticsSubscriber := engine.NewTiltAnalyticsSubscriber(tiltAnalytics)
+	tiltAnalyticsSubscriber := engine.NewTiltAnalyticsSubscriber(analytics2)
 	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, imageController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, sailClient, tiltVersionChecker, tiltAnalyticsSubscriber)
 	upper := engine.NewUpper(ctx, storeStore, v2)
 	threads := provideThreads(headsUpDisplay, upper, tiltBuild, sailMode)
@@ -418,8 +417,7 @@ func wireDockerEnv(ctx context.Context) (docker.Env, error) {
 	return dockerEnv, nil
 }
 
-func wireDownDeps(ctx context.Context) (DownDeps, error) {
-	tiltAnalytics := provideAnalytics(ctx)
+func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (DownDeps, error) {
 	clientConfig := k8s.ProvideClientConfig()
 	config, err := k8s.ProvideKubeConfig(clientConfig)
 	if err != nil {
@@ -453,7 +451,7 @@ var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideKubeCo
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,
-	provideKubectlLogLevel, docker.ProvideDockerClient, docker.ProvideDockerVersion, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, tiltfile.ProvideTiltfileLoader, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, provideAnalytics, engine.NewTiltAnalyticsSubscriber, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
+	provideKubectlLogLevel, docker.ProvideDockerClient, docker.ProvideDockerVersion, docker.DefaultClient, wire.Bind(new(docker.Client), new(docker.Cli)), dockercompose.NewDockerComposeClient, build.NewImageReaper, tiltfile.ProvideTiltfileLoader, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, engine.NewPodWatcher, engine.NewServiceWatcher, engine.NewImageController, engine.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, engine.NewTiltAnalyticsSubscriber, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -43,10 +43,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch) (demo.Script, error) 
 	if err != nil {
 		return demo.Script{}, err
 	}
-	tiltAnalytics, err := provideAnalytics()
-	if err != nil {
-		return demo.Script{}, err
-	}
+	tiltAnalytics := provideAnalytics(ctx)
 	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer, webURL, tiltAnalytics)
 	if err != nil {
 		return demo.Script{}, err
@@ -172,10 +169,7 @@ func wireThreads(ctx context.Context) (Threads, error) {
 	if err != nil {
 		return Threads{}, err
 	}
-	tiltAnalytics, err := provideAnalytics()
-	if err != nil {
-		return Threads{}, err
-	}
+	tiltAnalytics := provideAnalytics(ctx)
 	headsUpDisplay, err := hud.NewDefaultHeadsUpDisplay(renderer, webURL, tiltAnalytics)
 	if err != nil {
 		return Threads{}, err
@@ -425,10 +419,7 @@ func wireDockerEnv(ctx context.Context) (docker.Env, error) {
 }
 
 func wireDownDeps(ctx context.Context) (DownDeps, error) {
-	tiltAnalytics, err := provideAnalytics()
-	if err != nil {
-		return DownDeps{}, err
-	}
+	tiltAnalytics := provideAnalytics(ctx)
 	clientConfig := k8s.ProvideClientConfig()
 	config, err := k8s.ProvideKubeConfig(clientConfig)
 	if err != nil {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/analytics-on-context:

a4c4436dff2a0abf76c77a8da9f9eb5124b9f7d7 (2019-05-23 13:43:34 -0400)
[analytics] close loop on transporting analytics around on the context by removing global

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics