### PR TITLE
docker: disable buildkit on minikube. Fixes https://github.com/windmilleng/tilt/issues/1681

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -49,8 +49,9 @@ func (c fakeClock) Now() time.Time { return c.now }
 
 func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 	ctx := output.CtxForTest()
+	env := k8s.EnvGKE
 
-	dEnv, err := docker.ProvideEnv(ctx, k8s.EnvGKE, wmcontainer.RuntimeDocker, minikube.FakeClient{})
+	dEnv, err := docker.ProvideEnv(ctx, env, wmcontainer.RuntimeDocker, minikube.FakeClient{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +66,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 		t.Fatal(err)
 	}
 
-	builderVersion, err := docker.ProvideDockerBuilderVersion(version)
+	builderVersion, err := docker.ProvideDockerBuilderVersion(version, env)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -95,7 +95,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	if err != nil {
 		return demo.Script{}, err
 	}
-	builderVersion, err := docker.ProvideDockerBuilderVersion(version)
+	builderVersion, err := docker.ProvideDockerBuilderVersion(version, env)
 	if err != nil {
 		return demo.Script{}, err
 	}
@@ -227,7 +227,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	if err != nil {
 		return Threads{}, err
 	}
-	builderVersion, err := docker.ProvideDockerBuilderVersion(version)
+	builderVersion, err := docker.ProvideDockerBuilderVersion(version, env)
 	if err != nil {
 		return Threads{}, err
 	}
@@ -483,7 +483,7 @@ func wireDockerBuilderVersion(ctx context.Context) (types.BuilderVersion, error)
 	if err != nil {
 		return "", err
 	}
-	builderVersion, err := docker.ProvideDockerBuilderVersion(typesVersion)
+	builderVersion, err := docker.ProvideDockerBuilderVersion(typesVersion, env)
 	if err != nil {
 		return "", err
 	}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -15,25 +15,27 @@ import (
 
 type buildkitTestCase struct {
 	v        types.Version
+	env      k8s.Env
 	expected bool
 }
 
 func TestSupportsBuildkit(t *testing.T) {
 	cases := []buildkitTestCase{
-		{types.Version{APIVersion: "1.37", Experimental: true}, false},
-		{types.Version{APIVersion: "1.37", Experimental: false}, false},
-		{types.Version{APIVersion: "1.38", Experimental: true}, true},
-		{types.Version{APIVersion: "1.38", Experimental: false}, false},
-		{types.Version{APIVersion: "1.39", Experimental: true}, true},
-		{types.Version{APIVersion: "1.39", Experimental: false}, true},
-		{types.Version{APIVersion: "1.40", Experimental: true}, true},
-		{types.Version{APIVersion: "1.40", Experimental: false}, true},
-		{types.Version{APIVersion: "garbage", Experimental: false}, false},
+		{types.Version{APIVersion: "1.37", Experimental: true}, k8s.EnvGKE, false},
+		{types.Version{APIVersion: "1.37", Experimental: false}, k8s.EnvGKE, false},
+		{types.Version{APIVersion: "1.38", Experimental: true}, k8s.EnvGKE, true},
+		{types.Version{APIVersion: "1.38", Experimental: false}, k8s.EnvGKE, false},
+		{types.Version{APIVersion: "1.39", Experimental: true}, k8s.EnvGKE, true},
+		{types.Version{APIVersion: "1.39", Experimental: false}, k8s.EnvGKE, true},
+		{types.Version{APIVersion: "1.40", Experimental: true}, k8s.EnvGKE, true},
+		{types.Version{APIVersion: "1.40", Experimental: false}, k8s.EnvGKE, true},
+		{types.Version{APIVersion: "garbage", Experimental: false}, k8s.EnvGKE, false},
+		{types.Version{APIVersion: "1.39", Experimental: true}, k8s.EnvMinikube, false},
 	}
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
-			assert.Equal(t, c.expected, SupportsBuildkit(c.v))
+			assert.Equal(t, c.expected, SupportsBuildkit(c.v, c.env))
 		})
 	}
 }
@@ -60,15 +62,20 @@ func TestProvideBuilderVersion(t *testing.T) {
 			defer os.Setenv("DOCKER_BUILDKIT", "")
 
 			v, err := ProvideDockerBuilderVersion(
-				types.Version{APIVersion: c.v})
+				types.Version{APIVersion: c.v}, k8s.EnvGKE)
 			assert.NoError(t, err)
 			assert.Equal(t, c.expected, v)
 		})
 	}
 }
 
+type versionTestCase struct {
+	v        types.Version
+	expected bool
+}
+
 func TestSupported(t *testing.T) {
-	cases := []buildkitTestCase{
+	cases := []versionTestCase{
 		{types.Version{APIVersion: "1.22"}, false},
 		{types.Version{APIVersion: "1.23"}, true},
 		{types.Version{APIVersion: "1.39"}, true},

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -29,7 +29,7 @@ func WireSynclet(ctx context.Context, env k8s.Env, runtime container.Runtime) (*
 	if err != nil {
 		return nil, err
 	}
-	builderVersion, err := docker.ProvideDockerBuilderVersion(version)
+	builderVersion, err := docker.ProvideDockerBuilderVersion(version, env)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/issue1681:

beb1954ab826bbe85f045146083ff7c288bbaa80 (2019-05-24 13:50:11 +0100)
docker: disable buildkit on minikube. Fixes https://github.com/windmilleng/tilt/issues/1681

2247f5f2aff9fcf7aa1cdc7b5de709a0861051d3 (2019-05-24 13:36:43 +0100)
cli: add 'tilt docker' and let the user manually enable/disable buildkit