### PR TITLE
upper: log 'detected a container change' message to ms.CombinedLog

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -8,16 +8,14 @@ import (
 	"strconv"
 	"time"
 
-	tiltanalytics "github.com/windmilleng/tilt/internal/analytics"
-	"github.com/windmilleng/wmclient/pkg/analytics"
-
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/windmilleng/wmclient/pkg/analytics"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	tiltanalytics "github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud"
@@ -743,6 +741,7 @@ func checkForPodCrash(ctx context.Context, state *store.EngineState, ms *store.M
 		ms.BuildHistory[0].Log = model.AppendLog(ms.BuildHistory[0].Log, le, state.LogTimestamps)
 	}
 	ms.CurrentBuild.Log = model.AppendLog(ms.CurrentBuild.Log, le, state.LogTimestamps)
+	ms.CombinedLog = model.AppendLog(ms.CombinedLog, le, state.LogTimestamps)
 	logger.Get(ctx).Infof("%s", msg)
 }
 


### PR DESCRIPTION
## Problem
When one:
1. deploys a change to a tilt resource via live_update
2. triggers a crash in that resource

One observes:
1. "Detected a container change for docs-site. We could be running stale code. Rebuilding and deploying a new image." is logged in the "all resources" log
2. The same message is not logged in the resource-specific (e.g., `fortune`) log, so that log just shows builds happening without reason

## Solution
Also log the "detected a container change" message to the resource-specific log.

(There's probably some logging api cleanup we should do here, like having a clear hierarchy of logs (all -> resource-specific -> resource+build-specific), and writing to a lower log also writes to its ancestors, or something)