### PR TITLE
k8s: clean up serializers so that they ever print status objects

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -284,7 +284,7 @@ func (k K8sClient) actOnEntities(ctx context.Context, cmdArgs []string, entities
 	args := append([]string{}, cmdArgs...)
 	args = append(args, "-f", "-")
 
-	rawYAML, err := SerializeYAML(entities)
+	rawYAML, err := SerializeSpecYAML(entities)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "serializeYaml for kubectl %s", cmdArgs)
 	}

--- a/internal/k8s/encoder.go
+++ b/internal/k8s/encoder.go
@@ -1,0 +1,126 @@
+package k8s
+
+import (
+	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var defaultJSONIterator = createDefaultJSONIterator()
+var specJSONIterator = createSpecJSONIterator()
+
+func createDefaultJSONConfig() jsoniter.Config {
+	return jsoniter.Config{
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+		CaseSensitive:          true,
+	}
+}
+
+func createDefaultJSONIterator() jsoniter.API {
+	return createDefaultJSONConfig().Froze()
+}
+
+// Create a JSON iterator that:
+// - encodes "zero" metav1.Time values as empty instead of nil
+// - encodes all status values as empty
+func createSpecJSONIterator() jsoniter.API {
+	config := createDefaultJSONConfig().Froze()
+	config.RegisterExtension(newTimeExtension())
+	config.RegisterExtension(alwaysEmptyExtension{
+		typeIndex: createTypeIndex(allStatusTypes()),
+	})
+	return config
+}
+
+func allStatusTypes() []reflect2.Type {
+	result := []reflect2.Type{}
+	for _, typ := range scheme.Scheme.AllKnownTypes() {
+		typ2 := reflect2.Type2(typ)
+
+		sTyp2, ok := typ2.(reflect2.StructType)
+		if !ok {
+			continue
+		}
+
+		statusField := sTyp2.FieldByName("Status")
+		if statusField == nil {
+			continue
+		}
+
+		result = append(result, statusField.Type())
+	}
+	return result
+}
+
+type TypeIndex map[reflect2.Type]bool
+
+func (idx TypeIndex) Contains(typ reflect2.Type) bool {
+	_, ok := idx[typ]
+	return ok
+}
+
+func createTypeIndex(ts []reflect2.Type) TypeIndex {
+	result := make(map[reflect2.Type]bool)
+	for _, t := range ts {
+		result[t] = true
+	}
+	return TypeIndex(result)
+}
+
+// Any type that matches this extension is considered empty,
+// and skipped during json serialization.
+type alwaysEmptyExtension struct {
+	*jsoniter.DummyExtension
+	typeIndex TypeIndex
+}
+
+func (e alwaysEmptyExtension) CreateEncoder(typ reflect2.Type) jsoniter.ValEncoder {
+	if e.typeIndex.Contains(typ) {
+		return alwaysEmptyEncoder{}
+	}
+	return nil
+}
+
+type alwaysEmptyEncoder struct {
+}
+
+func (alwaysEmptyEncoder) IsEmpty(ptr unsafe.Pointer) bool                    { return true }
+func (alwaysEmptyEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {}
+
+type timeExtension struct {
+	*jsoniter.DummyExtension
+	timeType reflect2.Type
+}
+
+func newTimeExtension() timeExtension {
+	return timeExtension{
+		// memoize the type lookup
+		timeType: reflect2.TypeOf(metav1.Time{}),
+	}
+}
+
+func (e timeExtension) CreateEncoder(typ reflect2.Type) jsoniter.ValEncoder {
+	if e.timeType == typ {
+		return timeEncoder{delegate: defaultJSONIterator.EncoderOf(typ)}
+	}
+	return nil
+}
+
+type timeEncoder struct {
+	delegate jsoniter.ValEncoder
+}
+
+// Returns true if the time value is the zero value.
+func (e timeEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	t := *((*metav1.Time)(ptr))
+	return t == metav1.Time{} || e.delegate.IsEmpty(ptr)
+}
+
+func (e timeEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	e.delegate.Encode(ptr, stream)
+}

--- a/internal/k8s/entity_benchmark_test.go
+++ b/internal/k8s/entity_benchmark_test.go
@@ -13,7 +13,7 @@ func BenchmarkParseUnparseSingle(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		_, err = SerializeYAML(entities)
+		_, err = SerializeSpecYAML(entities)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -30,7 +30,7 @@ func BenchmarkParseUnparseLonger(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		_, err = SerializeYAML(entities)
+		_, err = SerializeSpecYAML(entities)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -48,7 +48,7 @@ func BenchmarkParseUnparseLongest(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		_, err = SerializeYAML(entities)
+		_, err = SerializeSpecYAML(entities)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -121,7 +121,7 @@ func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity) error 
 	if c.UpsertError != nil {
 		return c.UpsertError
 	}
-	yaml, err := SerializeYAML(entities)
+	yaml, err := SerializeSpecYAML(entities)
 	if err != nil {
 		return errors.Wrap(err, "kubectl apply")
 	}
@@ -130,7 +130,7 @@ func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity) error 
 }
 
 func (c *FakeK8sClient) Delete(ctx context.Context, entities []K8sEntity) error {
-	yaml, err := SerializeYAML(entities)
+	yaml, err := SerializeSpecYAML(entities)
 	if err != nil {
 		return errors.Wrap(err, "kubectl delete")
 	}

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -37,7 +37,7 @@ func TestInjectDigestSanchoYAML(t *testing.T) {
 		t.Errorf("Expected replaced: true. Actual: %v", replaced)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestInjectDigestDoesNotMutateOriginal(t *testing.T) {
 		t.Errorf("Expected replaced: true. Actual: %v", replaced)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{entity})
+	result, err := SerializeSpecYAML([]K8sEntity{entity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestInjectImagePullPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestInjectImagePullPolicy(t *testing.T) {
 		t.Errorf("image does not have correct pull policy: %s", result)
 	}
 
-	serializedOrigEntity, err := SerializeYAML([]K8sEntity{entity})
+	serializedOrigEntity, err := SerializeSpecYAML([]K8sEntity{entity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestInjectImagePullPolicyDoesNotMutateOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{entity})
+	result, err := SerializeSpecYAML([]K8sEntity{entity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestInjectDigestBlorgBackendYAML(t *testing.T) {
 		t.Errorf("Expected replaced: true. Actual: %v", replaced)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestInjectSyncletImage(t *testing.T) {
 		t.Errorf("Expected replacement in:\n%s", testyaml.SyncletYAML)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,7 @@ func TestInjectDigestEnvVar(t *testing.T) {
 		t.Errorf("Expected replaced: true. Actual: %v", replaced)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func testInjectDigestCRD(t *testing.T, yaml string, expectedDigestPrefix string)
 		t.Errorf("Expected replaced: true. Actual: %v", replaced)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/k8s/label_test.go
+++ b/internal/k8s/label_test.go
@@ -24,7 +24,7 @@ func TestInjectLabelPod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestInjectLabelDeployment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestInjectLabelDeploymentBeta1(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestInjectLabelDeploymentBeta2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestInjectLabelExtDeploymentBeta1(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestInjectStatefulSet(t *testing.T) {
 	assert.Equal(t, "deadbeef", podTmpl.ObjectMeta.Labels["tilt-runid"])
 	assert.Equal(t, "", vcTmpl.ObjectMeta.Labels["tilt-runid"])
 
-	result, err := SerializeYAML([]K8sEntity{newEntity})
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -12,7 +12,7 @@ func NewTarget(
 	portForwards []model.PortForward,
 	extraPodSelectors []labels.Selector,
 	dependencyIDs []model.TargetID) (model.K8sTarget, error) {
-	yaml, err := SerializeYAML(entities)
+	yaml, err := SerializeSpecYAML(entities)
 	if err != nil {
 		return model.K8sTarget{}, err
 	}

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -694,7 +694,6 @@ const (
 const SnackYAMLPostConfig = `apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     app: snack
   name: snack
@@ -705,7 +704,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: snack
     spec:
@@ -715,7 +713,6 @@ spec:
         image: gcr.io/windmill-public-containers/servantes/snack
         name: snack
         resources: {}
-status: {}
 `
 
 const SecretName = "mysecret"
@@ -1312,3 +1309,19 @@ spec:
 	result = strings.Replace(result, "IMAGE", imageName, -1)
 	return result
 }
+
+const PodDisruptionBudgetYAML = `
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: zookeeper
+  name: infra-kafka-zookeeper
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+      component: server
+      release: infra-kafka
+`

--- a/internal/synclet/sidecar/sidecar_test.go
+++ b/internal/synclet/sidecar/sidecar_test.go
@@ -26,7 +26,7 @@ func TestInjectSyncletSidecar(t *testing.T) {
 		t.Errorf("Expected replacement in:\n%s", testyaml.SanchoYAML)
 	}
 
-	result, err := k8s.SerializeYAML([]k8s.K8sEntity{newEntity})
+	result, err := k8s.SerializeSpecYAML([]k8s.K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestInjectSyncletSidecarMultipleContainers(t *testing.T) {
 		t.Errorf("Expected replacement in:\n%s", testyaml.MultipleContainersDeploymentYAML)
 	}
 
-	result, err := k8s.SerializeYAML([]k8s.K8sEntity{newEntity})
+	result, err := k8s.SerializeSpecYAML([]k8s.K8sEntity{newEntity})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -171,11 +171,11 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		rest = append(rest, r...)
 	}
 
-	matchingStr, err := k8s.SerializeYAML(match)
+	matchingStr, err := k8s.SerializeSpecYAML(match)
 	if err != nil {
 		return nil, err
 	}
-	restStr, err := k8s.SerializeYAML(rest)
+	restStr, err := k8s.SerializeSpecYAML(rest)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3352,7 +3352,7 @@ func (f *fixture) yaml(path string, entities ...k8sOpts) {
 		}
 	}
 
-	s, err := k8s.SerializeYAML(entityObjs)
+	s, err := k8s.SerializeSpecYAML(entityObjs)
 	if err != nil {
 		f.t.Fatal(err)
 	}


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/poddisruption:

5b4b73e027e0d372fc4b24008671b53aa37ef647 (2019-05-28 10:44:19 -0400)
k8s: clean up serializers so that they ever print status objects
Fixes https://github.com/windmilleng/tilt/issues/1667