### PR TITLE
engine: get logs from pods if succeeded or failed (as well as if running) so we can get logs for short-lived pods (jobs, etc.) -- addresses #1669

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -1,4 +1,4 @@
-//+build integration
+// +build integration
 
 package integration
 
@@ -172,15 +172,18 @@ func (f *fixture) StartTearDown() {
 	f.tearingDown = true
 }
 
-func (f *fixture) TearDown() {
-	f.StartTearDown()
-
+func (f *fixture) KillProcs() {
 	for _, cmd := range f.cmds {
 		process := cmd.Process
 		if process != nil {
 			process.Kill()
 		}
 	}
+}
+func (f *fixture) TearDown() {
+	f.StartTearDown()
+
+	f.KillProcs()
 
 	cmd := f.tiltCmd([]string{"down"}, os.Stdout)
 	err := cmd.Run()

--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 )
 
 type k8sFixture struct {
@@ -54,12 +55,16 @@ func (f *k8sFixture) CurlUntil(ctx context.Context, url string, expectedContents
 	}, expectedContents)
 }
 
-// Waits until all pods matching the selector are ready.
+// Waits until all pods matching the selector are ready (i.e. phase = "Running")
 // At least one pod must match.
 // Returns the names of the ready pods.
 func (f *k8sFixture) WaitForAllPodsReady(ctx context.Context, selector string) []string {
+	return f.WaitForAllPodsInPhase(ctx, selector, []v1.PodPhase{v1.PodRunning})
+}
+
+func (f *k8sFixture) WaitForAllPodsInPhase(ctx context.Context, selector string, phases []v1.PodPhase) []string {
 	for {
-		allPodsReady, output, podNames := f.AllPodsReady(ctx, selector)
+		allPodsReady, output, podNames := f.AllPodsInPhase(ctx, selector, phases)
 		if allPodsReady {
 			return podNames
 		}
@@ -72,8 +77,9 @@ func (f *k8sFixture) WaitForAllPodsReady(ctx context.Context, selector string) [
 	}
 }
 
-// Returns the output (for diagnostics) and the name of the ready pods.
-func (f *k8sFixture) AllPodsReady(ctx context.Context, selector string) (bool, string, []string) {
+// Checks that all pods are in one of the given phases.
+// Returns the output (for diagnostics) and the name of the pods in one of the given phases.
+func (f *k8sFixture) AllPodsInPhase(ctx context.Context, selector string, phases []v1.PodPhase) (bool, string, []string) {
 	cmd := exec.Command("kubectl", "get", "pods",
 		namespaceFlag, "--selector="+selector, "-o=template",
 		"--template", "{{range .items}}{{.metadata.name}} {{.status.phase}}{{println}}{{end}}")
@@ -85,7 +91,7 @@ func (f *k8sFixture) AllPodsReady(ctx context.Context, selector string) (bool, s
 	outStr := string(out)
 	lines := strings.Split(outStr, "\n")
 	podNames := []string{}
-	hasOneRunningPod := false
+	hasOneMatchingPod := false
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -98,15 +104,21 @@ func (f *k8sFixture) AllPodsReady(ctx context.Context, selector string) (bool, s
 		}
 
 		name, phase := elements[0], elements[1]
-		if phase == "Running" {
-			hasOneRunningPod = true
-		} else {
+		var matchedPhase bool
+		for _, ph := range phases {
+			if phase == string(ph) {
+				matchedPhase = true
+				hasOneMatchingPod = true
+			}
+		}
+
+		if !matchedPhase {
 			return false, outStr, nil
 		}
 
 		podNames = append(podNames, name)
 	}
-	return hasOneRunningPod, outStr, podNames
+	return hasOneMatchingPod, outStr, podNames
 }
 
 func (f *k8sFixture) ForwardPort(name string, portMap string) {

--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -78,7 +78,7 @@ func (f *k8sFixture) WaitForAllPodsInPhase(ctx context.Context, selector string,
 }
 
 // Checks that all pods are in the given phase
-// Returns the output (for diagnostics) and the name of the pods in one of the given phases.
+// Returns the output (for diagnostics) and the name of the pods in the given phase.
 func (f *k8sFixture) AllPodsInPhase(ctx context.Context, selector string, phase v1.PodPhase) (bool, string, []string) {
 	cmd := exec.Command("kubectl", "get", "pods",
 		namespaceFlag, "--selector="+selector, "-o=template",

--- a/integration/shortlived_pods/Tiltfile
+++ b/integration/shortlived_pods/Tiltfile
@@ -1,0 +1,6 @@
+# -*- mode: Python -*-
+
+default_registry(read_json('tilt_option.json', {})
+                 .get('default_registry', 'gcr.io/windmill-test-containers/servantes'))
+
+k8s_yaml('shortlived_pods.yaml')

--- a/integration/shortlived_pods/shortlived_pods.yaml
+++ b/integration/shortlived_pods/shortlived_pods.yaml
@@ -4,12 +4,12 @@ metadata:
   name: shortlived-pod-success
   namespace: tilt-integration
   labels:
-    app: shortlived-pod
+    app: shortlived-pod-success
 spec:
   template:
     metadata:
       labels:
-        app: shortlived-pod
+        app: shortlived-pod-success
     spec:
       containers:
         - name: echohi
@@ -24,12 +24,12 @@ metadata:
   name: shortlived-pod-fail
   namespace: tilt-integration
   labels:
-    app: shortlived-pod
+    app: shortlived-pod-fail
 spec:
   template:
     metadata:
       labels:
-        app: shortlived-pod
+        app: shortlived-pod-fail
     spec:
       containers:
         - name: echohi

--- a/integration/shortlived_pods/shortlived_pods.yaml
+++ b/integration/shortlived_pods/shortlived_pods.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: shortlived-pod
+  namespace: tilt-integration
+  labels:
+    app: shortlived-pod
+spec:
+  template:
+    metadata:
+      labels:
+        app: shortlived-pod
+    spec:
+      containers:
+        - name: echohi
+          image: alpine
+          command: ["sh", "-c", "echo this is a successful job"]
+      restartPolicy: Never
+  backoffLimit: 4
+

--- a/integration/shortlived_pods/shortlived_pods.yaml
+++ b/integration/shortlived_pods/shortlived_pods.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: shortlived-pod
+  name: shortlived-pod-success
   namespace: tilt-integration
   labels:
     app: shortlived-pod
@@ -15,6 +15,26 @@ spec:
         - name: echohi
           image: alpine
           command: ["sh", "-c", "echo this is a successful job"]
+      restartPolicy: Never
+  backoffLimit: 4
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: shortlived-pod-fail
+  namespace: tilt-integration
+  labels:
+    app: shortlived-pod
+spec:
+  template:
+    metadata:
+      labels:
+        app: shortlived-pod
+    spec:
+      containers:
+        - name: echohi
+          image: alpine
+          command: ["sh", "-c", "echo this job will fail && false"]
       restartPolicy: Never
   backoffLimit: 4
 

--- a/integration/shortlived_pods_test.go
+++ b/integration/shortlived_pods_test.go
@@ -19,8 +19,10 @@ func TestShortlivedPods(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
-	f.WaitForAllPodsInPhase(ctx, "app=shortlived-pod", []v1.PodPhase{v1.PodSucceeded})
+	f.WaitForAllPodsInPhase(ctx, "app=shortlived-pod", []v1.PodPhase{v1.PodSucceeded, v1.PodFailed})
 	f.KillProcs()
 
-	assert.Contains(t, f.logs.String(), "this is a successful job")
+	out := f.logs.String()
+	assert.Contains(t, out, "this is a successful job")
+	assert.Contains(t, out, "this job will fail")
 }

--- a/integration/shortlived_pods_test.go
+++ b/integration/shortlived_pods_test.go
@@ -19,7 +19,8 @@ func TestShortlivedPods(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
-	f.WaitForAllPodsInPhase(ctx, "app=shortlived-pod", []v1.PodPhase{v1.PodSucceeded, v1.PodFailed})
+	f.WaitForAllPodsInPhase(ctx, "app=shortlived-pod-fail", v1.PodFailed)
+	f.WaitForAllPodsInPhase(ctx, "app=shortlived-pod-success", v1.PodSucceeded)
 	f.KillProcs()
 
 	out := f.logs.String()

--- a/integration/shortlived_pods_test.go
+++ b/integration/shortlived_pods_test.go
@@ -1,0 +1,26 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestShortlivedPods(t *testing.T) {
+	f := newK8sFixture(t, "shortlived_pods")
+	defer f.TearDown()
+
+	f.TiltWatch()
+
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.WaitForAllPodsInPhase(ctx, "app=shortlived-pod", []v1.PodPhase{v1.PodSucceeded})
+	f.KillProcs()
+
+	assert.Contains(t, f.logs.String(), "this is a successful job")
+}

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
-
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
+	"k8s.io/api/core/v1"
 )
 
 // Collects logs from deployed containers.
@@ -59,9 +58,9 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 				continue
 			}
 
-			// Only fetch pod logs if the pod is running.
-			// Otherwise it will reject our connection.
-			if pod.Phase != v1.PodRunning {
+			// Don't try to fetch logs if pod is pending or state unknown;
+			// it may reject our connection.
+			if pod.Phase == v1.PodPending || pod.Phase == v1.PodUnknown {
 				continue
 			}
 

--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -58,9 +58,10 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 				continue
 			}
 
-			// Don't try to fetch logs if pod is pending or state unknown;
-			// it may reject our connection.
-			if pod.Phase == v1.PodPending || pod.Phase == v1.PodUnknown {
+			// Only try to fetch logs if pod is in a state that can handle it;
+			// otherwise, it may reject our connection.
+			if !(pod.Phase == v1.PodRunning || pod.Phase == v1.PodSucceeded ||
+				pod.Phase == v1.PodFailed) {
 				continue
 			}
 

--- a/internal/engine/podlogmanager_test.go
+++ b/internal/engine/podlogmanager_test.go
@@ -199,6 +199,45 @@ func TestContainerPrefixes(t *testing.T) {
 	f.AssertOutputDoesNotContain(cNameNoPrefix.String())
 }
 
+func TestLogsByPodPhase(t *testing.T) {
+	for _, test := range []struct {
+		phase      v1.PodPhase
+		expectLogs bool
+	}{
+		{v1.PodPending, false},
+		{v1.PodRunning, true},
+		{v1.PodSucceeded, true},
+		{v1.PodFailed, true},
+		{v1.PodUnknown, false},
+	} {
+		t.Run(string(test.phase), func(t *testing.T) {
+			f := newPLMFixture(t)
+			defer f.TearDown()
+
+			f.kClient.SetLogsForPodContainer(podID, cName, "hello world!")
+
+			state := f.store.LockMutableStateForTesting()
+			state.WatchFiles = true
+			state.UpsertManifestTarget(newManifestTargetWithPod(
+				model.Manifest{Name: "server"},
+				store.Pod{
+					PodID:         podID,
+					ContainerName: cName,
+					ContainerID:   cID,
+					Phase:         test.phase,
+				}))
+			f.store.UnlockMutableState()
+
+			f.plm.OnChange(f.ctx, f.store)
+			if test.expectLogs {
+				f.AssertOutputContains("hello world!")
+			} else {
+				f.AssertOutputDoesNotContain("hello world!")
+			}
+		})
+	}
+}
+
 type plmFixture struct {
 	*tempdir.TempDirFixture
 	ctx     context.Context
@@ -271,6 +310,7 @@ func (f *plmFixture) AssertOutputContains(s string) {
 }
 
 func (f *plmFixture) AssertOutputDoesNotContain(s string) {
+	time.Sleep(10 * time.Millisecond)
 	assert.NotContains(f.T(), f.out.String(), s)
 }
 


### PR DESCRIPTION
addresses #1669 