### PR TITLE
engine: log k8s events to appropriate manifest log as well as global log [ch2644]

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -39,16 +39,6 @@ func NewServiceChangeAction(service *v1.Service, url *url.URL) ServiceChangeActi
 	return ServiceChangeAction{Service: service, URL: url}
 }
 
-type K8SEventAction struct {
-	Event *v1.Event
-}
-
-func (K8SEventAction) Action() {}
-
-func NewK8SEventAction(event *v1.Event) K8SEventAction {
-	return K8SEventAction{event}
-}
-
 type BuildLogAction struct {
 	store.LogEvent
 	ManifestName model.ManifestName

--- a/internal/engine/event_watch_manager.go
+++ b/internal/engine/event_watch_manager.go
@@ -63,7 +63,7 @@ func (m *EventWatchManager) dispatchEventsLoop(ctx context.Context, ch <-chan *v
 				return
 			}
 
-			st.Dispatch(NewK8SEventAction(event))
+			st.Dispatch(store.NewK8SEventAction(event))
 		case <-ctx.Done():
 			return
 		}

--- a/internal/engine/uid_map_manager_test.go
+++ b/internal/engine/uid_map_manager_test.go
@@ -48,7 +48,7 @@ func TestUIDMapManager(t *testing.T) {
 func entityWithUID(t *testing.T, yaml string, uid string) k8s.K8sEntity {
 	es, err := k8s.ParseYAMLFromString(yaml)
 	if err != nil {
-		t.Fatalf("error parsing doggos yaml: %v", err)
+		t.Fatalf("error parsing yaml: %v", err)
 	}
 
 	if len(es) != 1 {

--- a/internal/engine/uid_map_manager_test.go
+++ b/internal/engine/uid_map_manager_test.go
@@ -22,21 +22,7 @@ func TestUIDMapManager(t *testing.T) {
 	f := newUMMFixture(t)
 	defer f.TearDown()
 
-	es, err := k8s.ParseYAMLFromString(testyaml.DoggosDeploymentYaml)
-	if err != nil {
-		t.Fatalf("error parsing doggos yaml: %v", err)
-	}
-
-	e := es[0]
-	e, err = k8s.InjectLabels(e, []model.LabelPair{{
-		Key:   k8s.ManifestNameLabel,
-		Value: e.Name(),
-	}})
-	if err != nil {
-		t.Fatalf("error injecting manifest label: %v", err)
-	}
-
-	k8s.SetUIDForTest(t, &e, "foobar")
+	e := entityWithUID(t, testyaml.DoggosDeploymentYaml, "foobar")
 
 	f.addManifest(e.Name())
 
@@ -57,6 +43,30 @@ func TestUIDMapManager(t *testing.T) {
 	}
 
 	f.assertObservedUIDUpdateActions(expectedAction)
+}
+
+func entityWithUID(t *testing.T, yaml string, uid string) k8s.K8sEntity {
+	es, err := k8s.ParseYAMLFromString(yaml)
+	if err != nil {
+		t.Fatalf("error parsing doggos yaml: %v", err)
+	}
+
+	if len(es) != 1 {
+		t.Fatalf("expected exactly 1 k8s entity from yaml, got %d", len(es))
+	}
+
+	e := es[0]
+	e, err = k8s.InjectLabels(e, []model.LabelPair{{
+		Key:   k8s.ManifestNameLabel,
+		Value: e.Name(),
+	}})
+	if err != nil {
+		t.Fatalf("error injecting manifest label: %v", err)
+	}
+
+	k8s.SetUIDForTest(t, &e, uid)
+
+	return e
 }
 
 func (f *ummFixture) addManifest(manifestName string) {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -860,7 +860,7 @@ func handleK8SEvent(ctx context.Context, state *store.EngineState, action store.
 		return
 	}
 
-	if evt.Type == "Warning" {
+	if evt.Type != "Normal" {
 		ms, ok := state.ManifestState(v.Manifest)
 		if !ok {
 			return

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -869,7 +869,7 @@ func handleK8SEvent(ctx context.Context, state *store.EngineState, action store.
 		ms.CombinedLog = model.AppendLog(ms.CombinedLog, action, state.LogTimestamps)
 		logger.Get(ctx).Infof("%s%s", logPrefix(ms.Name.String()), action.MessageRaw())
 
-		// TODO(maia): ms.k8sWarnEvents = append(ms.k8sWarnEvents...)
+		ms.K8sWarnEvents = append(ms.K8sWarnEvents, k8s.NewEventWithEntity(evt, v.Entity))
 	}
 }
 

--- a/internal/k8s/events.go
+++ b/internal/k8s/events.go
@@ -1,0 +1,16 @@
+package k8s
+
+import v1 "k8s.io/api/core/v1"
+
+// A Kubernetes event and the entity to which it applies
+type EventWithEntity struct {
+	Event  *v1.Event
+	Entity K8sEntity
+}
+
+func NewEventWithEntity(evt *v1.Event, entity K8sEntity) EventWithEntity {
+	return EventWithEntity{
+		Event:  evt,
+		Entity: entity,
+	}
+}

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -90,7 +90,7 @@ func (l Log) Empty() bool {
 	return l.Len() == 0
 }
 
-func timestampPrefix(ts time.Time) []byte {
+func TimestampPrefix(ts time.Time) []byte {
 	t := ts.Format("2006/01/02 15:04:05")
 	return []byte(fmt.Sprintf("%s ", t))
 }
@@ -109,7 +109,7 @@ func AppendLog(l Log, le LogEvent, timestampsEnabled bool) Log {
 		ts := le.Time()
 		for i, line := range addedLines {
 			if i != 0 || isStartingNewLine {
-				addedLines[i] = append(timestampPrefix(ts), line...)
+				addedLines[i] = append(TimestampPrefix(ts), line...)
 			}
 		}
 	}

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -64,7 +64,7 @@ func (kEvt K8SEventAction) Message() []byte {
 }
 
 func (kEvt K8SEventAction) MessageRaw() string {
-	// todo(maia): obj reference, namespace, etc.
+	// TODO(maia): obj reference, namespace, etc.
 	return fmt.Sprintf("[K8S EVENT] %s", kEvt.Event.Message)
 }
 

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -1,10 +1,12 @@
 package store
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/wmclient/pkg/analytics"
+	v1 "k8s.io/api/core/v1"
 )
 
 type ErrorAction struct {
@@ -41,6 +43,29 @@ func NewLogEvent(b []byte) LogEvent {
 		Timestamp: time.Now(),
 		Msg:       b,
 	}
+}
+
+type K8SEventAction struct {
+	Event *v1.Event
+}
+
+func (K8SEventAction) Action() {}
+
+func NewK8SEventAction(event *v1.Event) K8SEventAction {
+	return K8SEventAction{event}
+}
+
+func (kEvt K8SEventAction) Time() time.Time {
+	return kEvt.Event.LastTimestamp.Time
+}
+
+func (kEvt K8SEventAction) Message() []byte {
+	return []byte(kEvt.MessageRaw() + "\n")
+}
+
+func (kEvt K8SEventAction) MessageRaw() string {
+	// todo(maia): obj reference, namespace, etc.
+	return fmt.Sprintf("[K8S EVENT] %s", kEvt.Event.Message)
 }
 
 type ResetRestartsAction struct {

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -64,8 +64,16 @@ func (kEvt K8SEventAction) Message() []byte {
 }
 
 func (kEvt K8SEventAction) MessageRaw() string {
-	// TODO(maia): obj reference, namespace, etc.
-	return fmt.Sprintf("[K8S EVENT] %s", kEvt.Event.Message)
+	return fmt.Sprintf("[K8S EVENT: %s] %s",
+		objRefHumanReadable(kEvt.Event.InvolvedObject), kEvt.Event.Message)
+}
+
+func objRefHumanReadable(obj v1.ObjectReference) string {
+	s := fmt.Sprintf("%s/%s %s", obj.APIVersion, obj.Kind, obj.Name)
+	if obj.Namespace != "default" {
+		s += fmt.Sprintf(" (ns: %s)", obj.Namespace)
+	}
+	return s
 }
 
 type ResetRestartsAction struct {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -265,6 +265,8 @@ type ManifestState struct {
 
 	// If this manifest was changed, which config files led to the most recent change in manifest definition
 	ConfigFilesThatCausedChange []string
+
+	K8sWarnEvents []k8s.EventWithEntity
 }
 
 func NewState() *EngineState {


### PR DESCRIPTION
Hello tbd,

Please review the following commits I made in branch maiamcc/event-in-mainfest-log:

66d790585c47b739ff76a218b2dfab83dcc206eb (2019-05-31 12:34:17 -0400)
store warn events on manifest state

37bcdbf7bb5eb595cc2c7a0fca51499f0ce24dc3 (2019-05-31 12:19:35 -0400)
test global log, only log warning events

d81501f1acbcfff3c2d1b2416448d5cda332153e (2019-05-31 12:07:40 -0400)
timestamp test

c6b0e531c678f8b602b0202f6d2019785a2ca8ba (2019-05-31 11:46:45 -0400)
tests wip

35be4adee1584ef92ad3de7f0eae04b1cc40fb0e (2019-05-30 16:52:25 -0400)
engine: log k8s events to appropriate manifest log as well as global log

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics