### PR TITLE
k8s: better error reporting when tilt doesn't have permission to read nodes

### DIFF
--- a/internal/k8s/errors.go
+++ b/internal/k8s/errors.go
@@ -1,0 +1,18 @@
+package k8s
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newForbiddenError() *errors.StatusError {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "unknown",
+			Reason:  "Forbidden",
+			Code:    http.StatusForbidden,
+		},
+	}
+}

--- a/internal/k8s/runtime_test.go
+++ b/internal/k8s/runtime_test.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/windmilleng/tilt/internal/container"
+	"github.com/windmilleng/tilt/internal/logger"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestRuntimeForbidden(t *testing.T) {
+	cs := &fake.Clientset{}
+	cs.AddReactor("*", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, newForbiddenError()
+	})
+
+	core := cs.CoreV1()
+	runtimeAsync := newRuntimeAsync(core)
+
+	out := &bytes.Buffer{}
+	l := logger.NewLogger(logger.InfoLvl, out)
+	ctx := logger.WithLogger(context.Background(), l)
+	runtime := runtimeAsync.Runtime(ctx)
+	assert.Equal(t, container.RuntimeUnknown, runtime)
+	assert.Contains(t, out.String(), "Tilt could not read your node configuration")
+}

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/windmilleng/tilt/internal/model"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -83,13 +82,7 @@ func TestK8sClient_WatchServicesLabelsPassed(t *testing.T) {
 
 func TestK8sClient_WatchPodsError(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	tf.watchErr = &errors.StatusError{
-		ErrStatus: metav1.Status{
-			Message: "unknown",
-			Reason:  "Forbidden",
-			Code:    http.StatusForbidden,
-		},
-	}
+	tf.watchErr = newForbiddenError()
 	_, err := tf.kCli.WatchPods(tf.ctx, labels.Set{}.AsSelector())
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Forbidden")


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/node-error:

46e8f237c9de53436845bf49883191f62732924d (2019-06-03 11:06:13 -0400)
k8s: better error reporting when tilt doesn't have permission to read nodes