### PR TITLE
engine/web: remove kubecon demo features

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -160,8 +160,6 @@ var UpperReducer = store.Reducer(func(ctx context.Context, state *store.EngineSt
 		handleBuildLogAction(state, action)
 	case BuildCompleteAction:
 		err = handleBuildCompleted(ctx, state, action)
-	case store.ResetRestartsAction:
-		handleResetRestarts(ctx, state, action)
 	case BuildStartedAction:
 		handleBuildStarted(ctx, state, action)
 	case DeployIDAction:
@@ -243,19 +241,6 @@ func handleBuildStarted(ctx context.Context, state *store.EngineState, action Bu
 
 	state.CurrentlyBuilding = mn
 	removeFromTriggerQueue(state, mn)
-}
-
-func handleResetRestarts(ctx context.Context, engineState *store.EngineState, a store.ResetRestartsAction) {
-	mt, ok := engineState.ManifestTargets[a.ManifestName]
-	if !ok {
-		return
-	}
-
-	ms := mt.State
-	for _, pod := range ms.PodSet.Pods {
-		// # of pod restarts from old code (shouldn't be reflected in HUD)
-		pod.OldRestarts = pod.ContainerRestarts
-	}
 }
 
 func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, cb BuildCompleteAction) error {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2372,31 +2372,6 @@ func TestTiltVersionCheck(t *testing.T) {
 		return state.LatestTiltBuild == versions[1]
 	})
 }
-func TestResetRestarts(t *testing.T) {
-	f := newTestFixture(t)
-	defer f.TearDown()
-
-	sync := model.Sync{LocalPath: "/go", ContainerPath: "/go"}
-	name := model.ManifestName("foobar")
-	manifest := f.newManifest(name.String(), []model.Sync{sync})
-
-	f.Start([]model.Manifest{manifest}, true)
-	f.waitForCompletedBuildCount(1)
-
-	f.startPod(name)
-	f.restartPod()
-	f.WaitUntilManifest("records restart count", name, func(st store.ManifestTarget) bool {
-		return st.State.MostRecentPod().ContainerRestarts == 1
-	})
-
-	f.store.Dispatch(store.NewResetRestartsAction(name))
-	f.WaitUntilManifest("records restart count", name, func(st store.ManifestTarget) bool {
-		return st.State.MostRecentPod().OldRestarts == 1 && st.State.MostRecentPod().ContainerRestarts == 1
-	})
-
-	err := f.Stop()
-	assert.NoError(t, err)
-}
 
 func TestSetAnalyticsOpt(t *testing.T) {
 	f := newTestFixture(t)

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/logger"
-	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/sail/client"
 	"github.com/windmilleng/tilt/internal/store"
 )
@@ -52,7 +51,6 @@ func ProvideHeadsUpServer(store *store.Store, assetServer assets.Server, analyti
 	r.HandleFunc("/api/analytics", s.HandleAnalytics)
 	r.HandleFunc("/api/analytics_opt", s.HandleAnalyticsOpt)
 	r.HandleFunc("/api/sail", s.HandleSail)
-	r.HandleFunc("/api/control/reset_restarts", s.HandleResetRestarts)
 	r.HandleFunc("/ws/view", s.ViewWebsocket)
 	r.PathPrefix("/").Handler(assetServer)
 
@@ -147,19 +145,4 @@ func (s *HeadsUpServer) HandleSail(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-}
-
-func (s *HeadsUpServer) HandleResetRestarts(w http.ResponseWriter, req *http.Request) {
-	names, ok := req.URL.Query()["name"]
-	if !ok || len(names[0]) < 1 {
-		http.Error(w, "Must contain name parameter", http.StatusBadRequest)
-		return
-	}
-
-	// Query()["name"] will return an array of items,
-	// we only want the single item.
-	name := names[0]
-
-	s.store.Dispatch(store.NewResetRestartsAction(model.ManifestName(name)))
-	w.WriteHeader(http.StatusOK)
 }

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -210,47 +210,6 @@ func TestHandleSail(t *testing.T) {
 	assert.Equal(f.t, 1, f.sailCli.ConnectCalls)
 }
 
-func TestResetRestarts(t *testing.T) {
-	f := newTestFixture(t)
-
-	req, err := http.NewRequest(http.MethodGet, "/api/control/reset_restarts", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	q := req.URL.Query()
-	q.Add("name", "foo")
-	req.URL.RawQuery = q.Encode()
-
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(f.s.HandleResetRestarts)
-
-	handler.ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusOK)
-	}
-}
-
-func TestResetRestartsNoParam(t *testing.T) {
-	f := newTestFixture(t)
-
-	req, err := http.NewRequest(http.MethodGet, "/api/control/reset_restarts", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(f.s.HandleResetRestarts)
-
-	handler.ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusBadRequest {
-		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusBadRequest)
-	}
-}
-
 type serverFixture struct {
 	t          *testing.T
 	s          *server.HeadsUpServer

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/wmclient/pkg/analytics"
 	v1 "k8s.io/api/core/v1"
 )
@@ -74,18 +73,6 @@ func objRefHumanReadable(obj v1.ObjectReference) string {
 		s += fmt.Sprintf(" (ns: %s)", obj.Namespace)
 	}
 	return s
-}
-
-type ResetRestartsAction struct {
-	ManifestName model.ManifestName
-}
-
-func (ResetRestartsAction) Action() {}
-
-func NewResetRestartsAction(name model.ManifestName) ResetRestartsAction {
-	return ResetRestartsAction{
-		ManifestName: name,
-	}
 }
 
 type AnalyticsOptAction struct {

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,6 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-helmet": "^5.2.0",
-    "react-hotkeys": "^1.1.4",
     "react-router-dom": "^4.3.1",
     "react-scripts": "3.0.0",
     "react-select": "^2.4.2",
@@ -48,15 +47,17 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "prettier": "1.16.4",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
-    "enzyme-to-json": "^3.3.5"
+    "enzyme-to-json": "^3.3.5",
+    "prettier": "1.16.4"
   },
   "engines": {
     "node": ">=11.0.0"
   },
   "jest": {
-    "snapshotSerializers": ["enzyme-to-json/serializer"]
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   }
 }

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -155,28 +155,6 @@ class HUD extends Component<HudProps, HudState> {
     return this.pathBuilder.path(relPath)
   }
 
-  keymap() {
-    return {
-      clearSnackRestarts: "\\",
-    }
-  }
-
-  handlers() {
-    return {
-      clearSnackRestarts: (event: KeyboardEvent | undefined) => {
-        if (this.state.View) {
-          this.state.View.Resources.forEach(r => {
-            fetch(
-              this.pathBuilder.path(
-                `/api/control/reset_restarts?name=${r.Name}`
-              )
-            )
-          })
-        }
-      },
-    }
-  }
-
   render() {
     let view = this.state.View
     let sailEnabled = view && view.SailEnabled ? view.SailEnabled : false
@@ -305,100 +283,98 @@ class HUD extends Component<HudProps, HudState> {
     let latestVersion = view && view.LatestTiltBuild
 
     return (
-      <HotKeys keyMap={this.keymap()} handlers={this.handlers()}>
-        <div className="HUD">
-          <AnalyticsNudge needsNudge={needsNudge} />
-          <Switch>
-            <Route
-              path={this.path("/r/:name/alerts")}
-              render={topBarRoute.bind(null, ResourceView.Alerts)}
-            />
-            <Route
-              path={this.path("/r/:name/preview")}
-              render={topBarRoute.bind(null, ResourceView.Preview)}
-            />
-            <Route
-              path={this.path("/preview")}
-              render={topBarRoute.bind(null, ResourceView.Preview)}
-            />
-            <Route
-              path={this.path("/r/:name")}
-              render={topBarRoute.bind(null, ResourceView.Log)}
-            />
-            <Route
-              path={this.path("/alerts")}
-              render={topBarRoute.bind(null, ResourceView.Alerts)}
-            />
-            <Route render={topBarRoute.bind(null, ResourceView.Log)} />
-          </Switch>
-          <Switch>
-            <Route
-              path={this.path("/r/:name/alerts")}
-              render={sidebarRoute.bind(null, ResourceView.Alerts)}
-            />
-            <Route
-              path={this.path("/alerts")}
-              render={sidebarRoute.bind(null, ResourceView.Alerts)}
-            />
-            <Route
-              path={this.path("/r/:name/preview")}
-              render={sidebarRoute.bind(null, ResourceView.Preview)}
-            />
-            <Route
-              path={this.path("/preview")}
-              render={sidebarRoute.bind(null, ResourceView.Preview)}
-            />
-            <Route
-              path={this.path("/r/:name")}
-              render={sidebarRoute.bind(null, ResourceView.Log)}
-            />
-            <Route render={sidebarRoute.bind(null, ResourceView.Log)} />
-          </Switch>
-          <Statusbar
-            items={statusItems}
-            alertsUrl={this.path("/alerts")}
-            runningVersion={runningVersion}
-            latestVersion={latestVersion}
+      <div className="HUD">
+        <AnalyticsNudge needsNudge={needsNudge} />
+        <Switch>
+          <Route
+            path={this.path("/r/:name/alerts")}
+            render={topBarRoute.bind(null, ResourceView.Alerts)}
           />
-          <Switch>
-            <Route
-              exact
-              path={this.path("/")}
-              render={() => (
-                <LogPane
-                  log={combinedLog}
-                  isExpanded={isSidebarClosed}
-                  podID={""}
-                  endpoints={[]}
-                />
-              )}
-            />
-            <Route
-              exact
-              path={this.path("/alerts")}
-              render={() => <AlertPane resources={alertResources} />}
-            />
-            <Route exact path={this.path("/preview")} render={previewRoute} />
-            <Route exact path={this.path("/r/:name")} render={logsRoute} />
-            <Route
-              exact
-              path={this.path("/r/:name/k8s")}
-              render={() => <K8sViewPane />}
-            />
-            <Route
-              exact
-              path={this.path("/r/:name/alerts")}
-              render={errorRoute}
-            />
-            <Route
-              exact
-              path={this.path("/r/:name/preview")}
-              render={previewRoute}
-            />
-            <Route component={NoMatch} />
-          </Switch>
-        </div>
-      </HotKeys>
+          <Route
+            path={this.path("/r/:name/preview")}
+            render={topBarRoute.bind(null, ResourceView.Preview)}
+          />
+          <Route
+            path={this.path("/preview")}
+            render={topBarRoute.bind(null, ResourceView.Preview)}
+          />
+          <Route
+            path={this.path("/r/:name")}
+            render={topBarRoute.bind(null, ResourceView.Log)}
+          />
+          <Route
+            path={this.path("/alerts")}
+            render={topBarRoute.bind(null, ResourceView.Alerts)}
+          />
+          <Route render={topBarRoute.bind(null, ResourceView.Log)} />
+        </Switch>
+        <Switch>
+          <Route
+            path={this.path("/r/:name/alerts")}
+            render={sidebarRoute.bind(null, ResourceView.Alerts)}
+          />
+          <Route
+            path={this.path("/alerts")}
+            render={sidebarRoute.bind(null, ResourceView.Alerts)}
+          />
+          <Route
+            path={this.path("/r/:name/preview")}
+            render={sidebarRoute.bind(null, ResourceView.Preview)}
+          />
+          <Route
+            path={this.path("/preview")}
+            render={sidebarRoute.bind(null, ResourceView.Preview)}
+          />
+          <Route
+            path={this.path("/r/:name")}
+            render={sidebarRoute.bind(null, ResourceView.Log)}
+          />
+          <Route render={sidebarRoute.bind(null, ResourceView.Log)} />
+        </Switch>
+        <Statusbar
+          items={statusItems}
+          alertsUrl={this.path("/alerts")}
+          runningVersion={runningVersion}
+          latestVersion={latestVersion}
+        />
+        <Switch>
+          <Route
+            exact
+            path={this.path("/")}
+            render={() => (
+              <LogPane
+                log={combinedLog}
+                isExpanded={isSidebarClosed}
+                podID={""}
+                endpoints={[]}
+              />
+            )}
+          />
+          <Route
+            exact
+            path={this.path("/alerts")}
+            render={() => <AlertPane resources={alertResources} />}
+          />
+          <Route exact path={this.path("/preview")} render={previewRoute} />
+          <Route exact path={this.path("/r/:name")} render={logsRoute} />
+          <Route
+            exact
+            path={this.path("/r/:name/k8s")}
+            render={() => <K8sViewPane />}
+          />
+          <Route
+            exact
+            path={this.path("/r/:name/alerts")}
+            render={errorRoute}
+          />
+          <Route
+            exact
+            path={this.path("/r/:name/preview")}
+            render={previewRoute}
+          />
+          <Route component={NoMatch} />
+        </Switch>
+      </div>
     )
   }
 }

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -17,7 +17,6 @@ import "./HUD.scss"
 import { TiltBuild, ResourceView } from "./types"
 import AlertPane, { AlertResource } from "./AlertPane"
 import PreviewList from "./PreviewList"
-import { HotKeys } from "react-hotkeys"
 import AnalyticsNudge from "./AnalyticsNudge"
 
 type HudProps = {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6439,20 +6439,10 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.isboolean@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
-  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
-
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -6829,11 +6819,6 @@ moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
   integrity sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==
-
-mousetrap@^1.5.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.3.tgz#80fee49665fd478bccf072c9d46bdf1bfed3558a"
-  integrity sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -8698,17 +8683,6 @@ react-helmet@^5.2.0:
     prop-types "^15.5.4"
     react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
-
-react-hotkeys@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-1.1.4.tgz#a0712aa2e0c03a759fd7885808598497a4dace72"
-  integrity sha1-oHEqouDAOnWf14hYCFmEl6TaznI=
-  dependencies:
-    lodash.isboolean "^3.0.3"
-    lodash.isequal "^4.5.0"
-    lodash.isobject "^3.0.2"
-    mousetrap "^1.5.2"
-    prop-types "^15.6.0"
 
 react-input-autosize@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This PR removes two things, under the assumption that we won't need them going forward:

1. Web shortcut to reset restart count for all resources
2. API endpoint that resets the restart count for a resource