### PR TITLE
web: warnings count as alerts

### DIFF
--- a/web/src/AlertPane.test.tsx
+++ b/web/src/AlertPane.test.tsx
@@ -205,3 +205,31 @@ it("renders multiple lines of a crash log", () => {
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+it("renders warnings", () => {
+  const ts = "1,555,970,585,039"
+  const resources = [
+    {
+      Name: "foo",
+      CrashLog: "Eeeeek the container crashed",
+      BuildHistory: [
+        {
+          Log: "laa dee daa I'm not an error\nseriously",
+          FinishTime: ts,
+          Error: null,
+          IsCrashRebuild: true,
+          Warnings: ["Hi I'm a warning"],
+        },
+      ],
+      ResourceInfo: {
+        PodCreationTime: ts,
+        PodStatus: "ok",
+      },
+    },
+  ]
+
+  const tree = renderer
+    .create(<AlertPane resources={resources.map(r => new AlertResource(r))} />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -170,7 +170,7 @@ class AlertPane extends PureComponent<AlertsProps> {
                 <TimeAgo date={lastBuild.FinishTime} formatter={formatter} />
               </p>
             </header>
-            <section>{w}</section>
+            <section>{logToLines(w)}</section>
           </li>
         )
       })

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -32,6 +32,7 @@ class AlertResource {
     }
   }
 
+  // TODO(dmiller): unify this and the render path in to one codepath, `getAlertElements`, and just use the length of that here
   public hasAlert() {
     return (
       this.podStatusIsError() ||
@@ -76,7 +77,7 @@ class AlertResource {
 
   public warnings(): Array<string> {
     if (this.buildHistory.length > 0) {
-      return this.buildHistory[0].Warnings ? this.buildHistory[0].Warnings : []
+      return this.buildHistory[0].Warnings || []
     }
 
     return []

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -260,7 +260,14 @@ exports[`renders warnings 1`] = `
         </p>
       </header>
       <section>
-        Hi I'm a warning
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Hi I'm a warning
+          </span>
+        </code>
       </section>
     </li>
   </ul>

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -216,6 +216,57 @@ exports[`renders the last build with an error 1`] = `
 </section>
 `;
 
+exports[`renders warnings 1`] = `
+<section
+  className="AlertPane"
+>
+  <ul>
+    <li
+      className="AlertPane-item"
+    >
+      <header>
+        <p>
+          foo
+        </p>
+        <p>
+          Pod crashed!
+        </p>
+      </header>
+      <section>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            Eeeeek the container crashed
+          </span>
+        </code>
+      </section>
+    </li>
+    <li
+      className="AlertPane-item"
+    >
+      <header>
+        <p>
+          foo
+        </p>
+        <p>
+          <time
+            dateTime="1949-11-18T09:39:00.000Z"
+            title="1,555,970,585,039"
+          >
+            67yr
+          </time>
+        </p>
+      </header>
+      <section>
+        Hi I'm a warning
+      </section>
+    </li>
+  </ul>
+</section>
+`;
+
 exports[`shows that a container has restarted 1`] = `
 <section
   className="AlertPane"

--- a/web/src/mostRecentBuild.test.ts
+++ b/web/src/mostRecentBuild.test.ts
@@ -16,6 +16,7 @@ it("returns the most recent build if there are no pending builds", () => {
     FinishTime: "2019-04-24T13:08:42.926608-04:00",
     Log: "",
     IsCrashRebuild: false,
+    Warnings: [],
   }
   let expectedTuple = {
     name: "snack",
@@ -32,6 +33,7 @@ it("returns the most recent build if there are no pending builds", () => {
         FinishTime: "2019-04-24T13:08:40.926608-04:00",
         Log: "",
         IsCrashRebuild: false,
+        Warnings: [],
       },
       recent,
     ],
@@ -52,6 +54,7 @@ it("returns null if there are no pending builds and the most recent build has no
     FinishTime: "2019-04-24T13:08:42.926608-04:00",
     Log: "",
     IsCrashRebuild: false,
+    Warnings: [],
   }
   let expectedTuple = {
     name: "snack",
@@ -68,6 +71,7 @@ it("returns null if there are no pending builds and the most recent build has no
         FinishTime: "2019-04-24T13:08:40.926608-04:00",
         Log: "",
         IsCrashRebuild: false,
+        Warnings: [],
       },
       recent,
     ],
@@ -96,6 +100,7 @@ it("returns the pending build if there is one", () => {
         FinishTime: "2019-04-24T13:08:40.926608-04:00",
         Log: "",
         IsCrashRebuild: false,
+        Warnings: [],
       },
     ],
     pendingBuildEdits: ["bar"],

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -11,6 +11,7 @@ export type Build = {
   FinishTime: string
   Edits: Array<string> | null
   IsCrashRebuild: boolean
+  Warnings: Array<string> | null
 }
 
 export type TiltBuild = {


### PR DESCRIPTION
Addresses parts of #1713

Alerts now show up in the UI like this:

<img width="1263" alt="Screen Shot 2019-06-06 at 2 27 32 PM" src="https://user-images.githubusercontent.com/452453/59056996-66d8bd00-8867-11e9-93a3-15d0bdf14356.png">
