### PR TITLE
web: show pod status more clearly

### DIFF
--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -6,6 +6,11 @@ import "./AlertPane.scss"
 import { zeroTime } from "./time"
 import { Build } from "./types"
 import { timeAgoFormatter } from "./timeFormatters"
+import {
+  podStatusError,
+  podStatusCrashLoopBackOff,
+  podStatusImagePullBackOff,
+} from "./constants"
 
 class AlertResource {
   public name: string
@@ -41,9 +46,11 @@ class AlertResource {
   }
 
   public podStatusIsError() {
+    let podStatus = this.resourceInfo.podStatus
     return (
-      this.resourceInfo.podStatus === "Error" ||
-      this.resourceInfo.podStatus === "CrashLoopBackOff"
+      podStatus === podStatusError ||
+      podStatus === podStatusCrashLoopBackOff ||
+      podStatus === podStatusImagePullBackOff
     )
   }
 
@@ -87,6 +94,13 @@ function alertElements(resources: Array<AlertResource>) {
   let alertElements: Array<JSX.Element> = []
   resources.forEach(r => {
     if (r.podStatusIsError()) {
+      let podStatus = r.resourceInfo.podStatus
+      let msg = ""
+      if (podStatus === "Error" || podStatus === "CrashLoopBackOff") {
+        msg = r.crashLog
+      } else {
+        msg = `Pod has status ${podStatus}`
+      }
       alertElements.push(
         <li key={"resourceInfoError" + r.name} className="AlertPane-item">
           <header>
@@ -98,7 +112,7 @@ function alertElements(resources: Array<AlertResource>) {
               />
             </p>
           </header>
-          <section>{logToLines(r.crashLog || "")}</section>
+          <section>{logToLines(msg)}</section>
         </li>
       )
     } else if (r.podRestarted()) {

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -44,6 +44,7 @@ type Resource = {
     PodRestarts: number
     PodUpdateStartTime: string
     YAML: string
+    PodStatus: string
   }
   RuntimeStatus: string
   ShowBuildStatus: boolean
@@ -222,12 +223,14 @@ class HUD extends Component<HudProps, HudState> {
           : ""
       let logs = ""
       let endpoints: Array<string> = []
-      let podID: string = ""
+      let podID = ""
+      let podStatus = ""
       if (view && name !== "") {
         let r = view.Resources.find(r => r.Name === name)
         logs = (r && r.CombinedLog) || ""
         endpoints = (r && r.Endpoints) || []
         podID = (r && r.PodID) || ""
+        podStatus = (r && r.ResourceInfo && r.ResourceInfo.PodStatus) || ""
       }
       return (
         <LogPane
@@ -235,6 +238,7 @@ class HUD extends Component<HudProps, HudState> {
           isExpanded={isSidebarClosed}
           endpoints={endpoints}
           podID={podID}
+          podStatus={podStatus}
         />
       )
     }
@@ -346,6 +350,7 @@ class HUD extends Component<HudProps, HudState> {
                 isExpanded={isSidebarClosed}
                 podID={""}
                 endpoints={[]}
+                podStatus={""}
               />
             )}
           />

--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -64,6 +64,7 @@
   padding-left: $spacing-unit / 2;
 }
 .resourceInfo-label {
+  padding-left: $spacing-unit / 2;
   text-transform: uppercase;
   color: $color-gray-light;
   font-weight: bold;

--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -64,7 +64,6 @@
   padding-left: $spacing-unit / 2;
 }
 .resourceInfo-label {
-  padding-left: $spacing-unit / 2;
   text-transform: uppercase;
   color: $color-gray-light;
   font-weight: bold;

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -12,7 +12,8 @@ it("renders without crashing", () => {
       message="world"
       isExpanded={false}
       endpoints={[]}
-      podID={""}
+      podID={"foobar"}
+      podStatus={"Running"}
     />,
     div
   )
@@ -22,7 +23,15 @@ it("renders without crashing", () => {
 it("renders logs", () => {
   const log = "hello\nworld\nfoo\nbar"
   const tree = renderer
-    .create(<LogPane log={log} isExpanded={false} endpoints={[]} podID={""} />)
+    .create(
+      <LogPane
+        log={log}
+        isExpanded={false}
+        endpoints={[]}
+        podID={"foobar"}
+        podStatus={"Running"}
+      />
+    )
     .toJSON()
 
   expect(tree).toMatchSnapshot()
@@ -360,7 +369,15 @@ it("renders logs with leading whitespace and ANSI codes", () => {
         ╎ [4/5] RUN cd /app && yarn install
         ╎ [5/5] ADD src /app`
   const tree = renderer
-    .create(<LogPane log={log} isExpanded={false} endpoints={[]} podID={""} />)
+    .create(
+      <LogPane
+        log={log}
+        isExpanded={false}
+        endpoints={[]}
+        podID={"foobar"}
+        podStatus={"Running"}
+      />
+    )
     .toJSON()
 
   expect(tree).toMatchSnapshot()

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -116,12 +116,16 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
     let podID = this.props.podID
     let podStatus = this.props.podStatus
     let podIDEl = podID && (
-      <div className="resourceInfo">
-        <div className="resourceInfo-label">Pod ID:</div>
-        <div className="resourceInfo-value">{podID}</div>
-        <div className="resourceInfo-label">Pod Status:</div>
-        <div className="resourceInfo-value">{podStatus}</div>
-      </div>
+      <>
+        <div className="resourceInfo">
+          <div className="resourceInfo-label">Pod Status:</div>
+          <div className="resourceInfo-value">{podStatus}</div>
+        </div>
+        <div className="resourceInfo">
+          <div className="resourceInfo-label">Pod ID:</div>
+          <div className="resourceInfo-value">{podID}</div>
+        </div>
+      </>
     )
 
     let endpoints = this.props.endpoints

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -11,6 +11,7 @@ type LogPaneProps = {
   isExpanded: boolean
   podID: string
   endpoints: string[]
+  podStatus: string
 }
 type LogPaneState = {
   autoscroll: boolean
@@ -113,10 +114,13 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
     }
 
     let podID = this.props.podID
+    let podStatus = this.props.podStatus
     let podIDEl = podID && (
       <div className="resourceInfo">
         <div className="resourceInfo-label">Pod ID:</div>
         <div className="resourceInfo-value">{podID}</div>
+        <div className="resourceInfo-label">Pod Status:</div>
+        <div className="resourceInfo-value">{podStatus}</div>
       </div>
     )
 

--- a/web/src/__snapshots__/LogPane.test.tsx.snap
+++ b/web/src/__snapshots__/LogPane.test.tsx.snap
@@ -13,22 +13,26 @@ exports[`renders logs 1`] = `
       <div
         className="resourceInfo-label"
       >
-        Pod ID:
-      </div>
-      <div
-        className="resourceInfo-value"
-      >
-        foobar
-      </div>
-      <div
-        className="resourceInfo-label"
-      >
         Pod Status:
       </div>
       <div
         className="resourceInfo-value"
       >
         Running
+      </div>
+    </div>
+    <div
+      className="resourceInfo"
+    >
+      <div
+        className="resourceInfo-label"
+      >
+        Pod ID:
+      </div>
+      <div
+        className="resourceInfo-value"
+      >
+        foobar
       </div>
     </div>
   </section>
@@ -89,22 +93,26 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
       <div
         className="resourceInfo-label"
       >
-        Pod ID:
-      </div>
-      <div
-        className="resourceInfo-value"
-      >
-        foobar
-      </div>
-      <div
-        className="resourceInfo-label"
-      >
         Pod Status:
       </div>
       <div
         className="resourceInfo-value"
       >
         Running
+      </div>
+    </div>
+    <div
+      className="resourceInfo"
+    >
+      <div
+        className="resourceInfo-label"
+      >
+        Pod ID:
+      </div>
+      <div
+        className="resourceInfo-value"
+      >
+        foobar
       </div>
     </div>
   </section>

--- a/web/src/__snapshots__/LogPane.test.tsx.snap
+++ b/web/src/__snapshots__/LogPane.test.tsx.snap
@@ -7,7 +7,30 @@ exports[`renders logs 1`] = `
   <section
     className="resourceBar"
   >
-    
+    <div
+      className="resourceInfo"
+    >
+      <div
+        className="resourceInfo-label"
+      >
+        Pod ID:
+      </div>
+      <div
+        className="resourceInfo-value"
+      >
+        foobar
+      </div>
+      <div
+        className="resourceInfo-label"
+      >
+        Pod Status:
+      </div>
+      <div
+        className="resourceInfo-value"
+      >
+        Running
+      </div>
+    </div>
   </section>
   <section
     className="logText"
@@ -60,7 +83,30 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
   <section
     className="resourceBar"
   >
-    
+    <div
+      className="resourceInfo"
+    >
+      <div
+        className="resourceInfo-label"
+      >
+        Pod ID:
+      </div>
+      <div
+        className="resourceInfo-value"
+      >
+        foobar
+      </div>
+      <div
+        className="resourceInfo-label"
+      >
+        Pod Status:
+      </div>
+      <div
+        className="resourceInfo-value"
+      >
+        Running
+      </div>
+    </div>
   </section>
   <section
     className="logText"

--- a/web/src/combinedStatusMessage.test.ts
+++ b/web/src/combinedStatusMessage.test.ts
@@ -55,6 +55,6 @@ describe("combined status message", () => {
     resources = data.map((r: any) => new StatusItem(r))
     actual = combinedStatusMessage(resources)
 
-    expect(actual).toBe("vigoda has pod with status ErrImgPull")
+    expect(actual).toBe("vigoda has pod with status ErrImagePull")
   })
 })

--- a/web/src/combinedStatusMessage.test.ts
+++ b/web/src/combinedStatusMessage.test.ts
@@ -3,6 +3,8 @@ import {
   oneResourceFailedToBuild,
   oneResourceCrashedOnStart,
   oneResourceNoAlerts,
+  oneResourceErrImgPull,
+  oneResourceImagePullBackOff,
 } from "./testdata.test"
 import { combinedStatusMessage } from "./combinedStatusMessage"
 import { StatusItem } from "./Statusbar"
@@ -39,5 +41,20 @@ describe("combined status message", () => {
     let actual = combinedStatusMessage(resources)
 
     expect(actual).toBe("")
+  })
+
+  it("should show a pod's status message if it is image pull back off of err img pull", () => {
+    let resource = oneResourceImagePullBackOff()
+    let data = [resource]
+    let resources = data.map((r: any) => new StatusItem(r))
+    let actual = combinedStatusMessage(resources)
+
+    expect(actual).toBe("vigoda has pod with status ImagePullBackOff")
+
+    data = [oneResourceErrImgPull()]
+    resources = data.map((r: any) => new StatusItem(r))
+    actual = combinedStatusMessage(resources)
+
+    expect(actual).toBe("vigoda has pod with status ErrImgPull")
   })
 })

--- a/web/src/combinedStatusMessage.test.ts
+++ b/web/src/combinedStatusMessage.test.ts
@@ -43,7 +43,7 @@ describe("combined status message", () => {
     expect(actual).toBe("")
   })
 
-  it("should show a pod's status message if it is image pull back off of err img pull", () => {
+  it("should show a pod's status message if it is image pull back off or err img pull", () => {
     let resource = oneResourceImagePullBackOff()
     let data = [resource]
     let resources = data.map((r: any) => new StatusItem(r))

--- a/web/src/combinedStatusMessage.ts
+++ b/web/src/combinedStatusMessage.ts
@@ -1,7 +1,14 @@
 import { isZeroTime } from "./time"
 import { StatusItem } from "./Statusbar"
+import {
+  podStatusCrashLoopBackOff,
+  podStatusError,
+  podStatusImagePullBackOff,
+  podStatusErrImgPull,
+} from "./constants"
 
 const combinedStatusMessage = (resources: Array<StatusItem>): string => {
+  debugger
   let buildingResources = resources.filter(
     r => !isZeroTime(r.currentBuild.StartTime)
   )
@@ -11,7 +18,9 @@ const combinedStatusMessage = (resources: Array<StatusItem>): string => {
   }
 
   let containerCrashedResources = resources.filter(
-    r => r.podStatus === "CrashLoopBackOff"
+    r =>
+      r.podStatus === podStatusCrashLoopBackOff ||
+      r.podStatus === podStatusError
   )
   if (containerCrashedResources.length > 0) {
     return "Container crashed: " + containerCrashedResources[0].name
@@ -23,6 +32,16 @@ const combinedStatusMessage = (resources: Array<StatusItem>): string => {
 
   if (resourcesWithBuildErrors.length > 0) {
     return "Build failed: " + resourcesWithBuildErrors[0].name
+  }
+
+  let resourcesWithInterestingPodStatuses = resources.filter(
+    r =>
+      r.podStatus === podStatusImagePullBackOff ||
+      r.podStatus === podStatusErrImgPull
+  )
+  if (resourcesWithInterestingPodStatuses.length > 0) {
+    let r = resourcesWithInterestingPodStatuses[0]
+    return `${r.name} has pod with status ${r.podStatus}`
   }
 
   return ""

--- a/web/src/combinedStatusMessage.ts
+++ b/web/src/combinedStatusMessage.ts
@@ -8,7 +8,6 @@ import {
 } from "./constants"
 
 const combinedStatusMessage = (resources: Array<StatusItem>): string => {
-  debugger
   let buildingResources = resources.filter(
     r => !isZeroTime(r.currentBuild.StartTime)
   )

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -5,7 +5,7 @@ const colorGreyDark = "#606060"
 const podStatusError = "Error"
 const podStatusCrashLoopBackOff = "CrashLoopBackOff"
 const podStatusImagePullBackOff = "ImagePullBackOff"
-const podStatusErrImgPull = "ErrImgPull"
+const podStatusErrImgPull = "ErrImagePull"
 
 export {
   colorGreyDark,

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,5 +1,17 @@
 // Duplicated styles from constants.scss
+const colorGreyDarkest = "#434343"
+const colorGreyDark = "#606060"
 
-let colorGreyDarkest = "#434343"
-let colorGreyDark = "#606060"
-export { colorGreyDark, colorGreyDarkest }
+const podStatusError = "Error"
+const podStatusCrashLoopBackOff = "CrashLoopBackOff"
+const podStatusImagePullBackOff = "ImagePullBackOff"
+const podStatusErrImgPull = "ErrImgPull"
+
+export {
+  colorGreyDark,
+  colorGreyDarkest,
+  podStatusError,
+  podStatusCrashLoopBackOff,
+  podStatusImagePullBackOff,
+  podStatusErrImgPull,
+}

--- a/web/src/testdata.test.tsx
+++ b/web/src/testdata.test.tsx
@@ -1,5 +1,6 @@
 import { RouteComponentProps } from "react-router-dom"
 import { UnregisterCallback, Href } from "history"
+import { podStatusImagePullBackOff, podStatusErrImgPull } from "./constants"
 
 // NOTE(dmiller) 4-02-19 this function is currently unused but I'm going to keep it around.
 // I have a feeling that it will come in handy later.
@@ -102,6 +103,66 @@ function oneResourceNoAlerts(): any {
       PodName: "vigoda-pod",
       PodCreationTime: ts,
       PodStatus: "Running",
+      PodRestarts: 0,
+      PodLog: "1\n2\n3\n4\nabe vigoda is now dead\n5\n6\n7\n8\n",
+    },
+    Endpoints: ["1.2.3.4:8080"],
+    RuntimeStatus: "ok",
+  }
+  return resource
+}
+
+function oneResourceImagePullBackOff(): any {
+  const ts = Date.now().valueOf()
+  const resource = {
+    Name: "vigoda",
+    DirectoriesWatched: ["foo", "bar"],
+    LastDeployTime: ts,
+    BuildHistory: [
+      {
+        Edits: ["main.go", "cli.go"],
+        Error: null,
+        FinishTime: ts,
+        StartTime: ts,
+      },
+    ],
+    PendingBuildEdits: ["main.go", "cli.go", "vigoda.go"],
+    PendingBuildSince: ts,
+    CurrentBuild: {},
+    ResourceInfo: {
+      PodName: "vigoda-pod",
+      PodCreationTime: ts,
+      PodStatus: podStatusImagePullBackOff,
+      PodRestarts: 0,
+      PodLog: "1\n2\n3\n4\nabe vigoda is now dead\n5\n6\n7\n8\n",
+    },
+    Endpoints: ["1.2.3.4:8080"],
+    RuntimeStatus: "ok",
+  }
+  return resource
+}
+
+function oneResourceErrImgPull(): any {
+  const ts = Date.now().valueOf()
+  const resource = {
+    Name: "vigoda",
+    DirectoriesWatched: ["foo", "bar"],
+    LastDeployTime: ts,
+    BuildHistory: [
+      {
+        Edits: ["main.go", "cli.go"],
+        Error: null,
+        FinishTime: ts,
+        StartTime: ts,
+      },
+    ],
+    PendingBuildEdits: ["main.go", "cli.go", "vigoda.go"],
+    PendingBuildSince: ts,
+    CurrentBuild: {},
+    ResourceInfo: {
+      PodName: "vigoda-pod",
+      PodCreationTime: ts,
+      PodStatus: podStatusErrImgPull,
       PodRestarts: 0,
       PodLog: "1\n2\n3\n4\nabe vigoda is now dead\n5\n6\n7\n8\n",
     },
@@ -1240,4 +1301,6 @@ export {
   oneResourceCrashedOnStart,
   oneResourceBuilding,
   oneResourceNoAlerts,
+  oneResourceImagePullBackOff,
+  oneResourceErrImgPull,
 }


### PR DESCRIPTION
<img width="1270" alt="Screen Shot 2019-06-06 at 6 55 56 PM" src="https://user-images.githubusercontent.com/452453/59114142-87128580-8914-11e9-944d-b463a29f44f7.png">

Note the section above the logs and the message in the status bar.