### PR TITLE
tiltfile/model: old UpdateModeAuto | Manual -> TriggerMode to match existing code, disambiguate with engine.UpdateMode [ch2701]

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -142,9 +142,9 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		})
 	}
 
-	triggerMode := model.TriggerAuto
+	triggerMode := model.TriggerModeAuto
 	if !c.autoDeploy {
-		triggerMode = model.TriggerManual
+		triggerMode = model.TriggerModeManual
 	}
 
 	g.Go(func() error {

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -68,7 +68,7 @@ func nextTargetToBuild(state store.EngineState) *store.ManifestTarget {
 		}
 	}
 
-	if state.TriggerMode == model.TriggerManual && len(state.TriggerQueue) > 0 {
+	if state.TriggerMode == model.TriggerModeManual && len(state.TriggerQueue) > 0 {
 		mn := state.TriggerQueue[0]
 		mt, ok := state.ManifestTargets[mn]
 		if ok {
@@ -76,7 +76,7 @@ func nextTargetToBuild(state store.EngineState) *store.ManifestTarget {
 		}
 	}
 
-	if state.TriggerMode == model.TriggerAuto {
+	if state.TriggerMode == model.TriggerModeAuto {
 		for _, mt := range targets {
 			ok, newTime := mt.State.HasPendingChangesBefore(earliest)
 			if ok {

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -165,7 +165,7 @@ func TestBuildControllerManualTrigger(t *testing.T) {
 	f.Init(InitAction{
 		Manifests:       []model.Manifest{manifest},
 		WatchFiles:      true,
-		TriggerMode:     model.TriggerManual,
+		TriggerMode:     model.TriggerModeManual,
 		ExecuteTiltfile: true,
 	})
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -360,7 +360,7 @@ func handleDeployIDAction(ctx context.Context, state *store.EngineState, action 
 }
 
 func appendToTriggerQueue(state *store.EngineState, mn model.ManifestName) {
-	if state.TriggerMode != model.TriggerManual {
+	if state.TriggerMode != model.TriggerModeManual {
 		return
 	}
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2338,7 +2338,7 @@ func TestDockerComposeBuildCompletedDoesntSetStatusIfNotSuccessful(t *testing.T)
 func TestEmptyTiltfile(t *testing.T) {
 	f := newTestFixture(t)
 	f.WriteFile("Tiltfile", "")
-	go f.upper.Start(f.ctx, []string{}, model.TiltBuild{}, false, model.TriggerAuto, f.JoinPath("Tiltfile"), true, model.SailModeDisabled, analytics.OptIn)
+	go f.upper.Start(f.ctx, []string{}, model.TiltBuild{}, false, model.TriggerModeAuto, f.JoinPath("Tiltfile"), true, model.SailModeDisabled, analytics.OptIn)
 	f.WaitUntil("build is set", func(st store.EngineState) bool {
 		return !st.LastTiltfileBuild.Empty()
 	})

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -7,6 +7,7 @@ package engine
 
 import (
 	"context"
+
 	"github.com/google/wire"
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/build"

--- a/internal/hud/buildstatus.go
+++ b/internal/hud/buildstatus.go
@@ -45,7 +45,7 @@ func makeBuildStatus(res view.Resource, triggerMode model.TriggerMode) buildStat
 		reason = res.CurrentBuild.Reason
 	} else if !res.PendingBuildSince.IsZero() && !res.PendingBuildReason.IsCrashOnly() {
 		status = "Pending"
-		if triggerMode == model.TriggerAuto {
+		if triggerMode == model.TriggerModeAuto {
 			duration = time.Since(res.PendingBuildSince)
 		}
 		edits = res.PendingBuildEdits

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -193,7 +193,7 @@ func keyLegend(v view.View, vs view.ViewState) string {
 	defaultKeys := "Browse (↓ ↑), Expand (→) ┊ (enter) log, (b)rowser ┊ (ctrl-C) quit  "
 	if vs.AlertMessage != "" {
 		return "Tilt (l)og ┊ (esc) close alert "
-	} else if v.TriggerMode == model.TriggerManual {
+	} else if v.TriggerMode == model.TriggerModeManual {
 		return "Build (space) ┊ " + defaultKeys
 	}
 	return defaultKeys

--- a/internal/hud/renderer_test.go
+++ b/internal/hud/renderer_test.go
@@ -361,14 +361,14 @@ func TestPodPending(t *testing.T) {
 	vs := fakeViewState(1, view.CollapseAuto)
 
 	rtf.run("pending pod no status", 80, 20, v, vs)
-	assert.Equal(t, cPending, statusColor(v.Resources[0], model.TriggerAuto))
+	assert.Equal(t, cPending, statusColor(v.Resources[0], model.TriggerModeAuto))
 
 	v.Resources[0].ResourceInfo = view.K8SResourceInfo{
 		PodCreationTime: ts,
 		PodStatus:       "Pending",
 	}
 	rtf.run("pending pod pending status", 80, 20, v, vs)
-	assert.Equal(t, cPending, statusColor(v.Resources[0], model.TriggerAuto))
+	assert.Equal(t, cPending, statusColor(v.Resources[0], model.TriggerModeAuto))
 }
 
 func TestCrashingPodInlineCrashLog(t *testing.T) {
@@ -524,7 +524,7 @@ func TestPendingBuildInManualTriggerMode(t *testing.T) {
 	rtf := newRendererTestFixture(t)
 	ts := time.Now().Add(-30 * time.Second)
 	v := view.View{
-		TriggerMode: model.TriggerManual,
+		TriggerMode: model.TriggerModeManual,
 		Resources: []view.Resource{
 			{
 				Name:              "vigoda",

--- a/internal/hud/resourceview.go
+++ b/internal/hud/resourceview.go
@@ -81,7 +81,7 @@ func statusColor(res view.Resource, triggerMode model.TriggerMode) tcell.Color {
 	if !res.CurrentBuild.Empty() && !res.CurrentBuild.Reason.IsCrashOnly() {
 		return cPending
 	} else if !res.PendingBuildSince.IsZero() && !res.PendingBuildReason.IsCrashOnly() {
-		if triggerMode == model.TriggerAuto {
+		if triggerMode == model.TriggerModeAuto {
 			return cPending
 		} else {
 			return cLightText

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -32,7 +32,10 @@ type Manifest struct {
 	// Info needed to deploy. Can be k8s yaml, docker compose, etc.
 	deployTarget TargetSpec
 
-	UpdateMode UpdateMode
+	// How updates are triggered:
+	// - automatically, when we detect a change
+	// - manually, when the user tells us to
+	TriggerMode TriggerMode
 }
 
 func (m Manifest) ID() TargetID {
@@ -359,10 +362,3 @@ func DeepEqual(x, y interface{}) bool {
 		selectorAllowUnexported,
 		dockerRefEqual)
 }
-
-type UpdateMode int
-
-const (
-	UpdateModeAuto   UpdateMode = iota
-	UpdateModeManual UpdateMode = iota
-)

--- a/internal/model/trigger_mode.go
+++ b/internal/model/trigger_mode.go
@@ -2,7 +2,10 @@ package model
 
 type TriggerMode int
 
+// How builds are triggered (per manifest or globally):
 const (
-	TriggerAuto TriggerMode = iota
-	TriggerManual
+	// Automatically, whenever we detect a change, or
+	TriggerModeAuto TriggerMode = iota
+	// Manually (i.e. only when the user tells us to update)
+	TriggerModeManual
 )

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -60,12 +60,12 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var name string
 	var imageVal starlark.Value
-	var updateMode updateMode
+	var triggerMode triggerMode
 
 	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
 		"image", &imageVal, // in future this will be optional
-		"update_mode?", &updateMode,
+		"trigger_mode?", &triggerMode,
 	); err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 		return nil, err
 	}
 
-	svc.UpdateMode = updateMode
+	svc.TriggerMode = triggerMode
 
 	normalized, err := container.ParseNamed(imageRefAsStr)
 	if err != nil {
@@ -268,7 +268,7 @@ type dcService struct {
 	DependencyIDs  []model.TargetID
 	PublishedPorts []int
 
-	UpdateMode updateMode
+	TriggerMode triggerMode
 }
 
 func (c dcConfig) GetService(name string) (dcService, error) {
@@ -410,7 +410,7 @@ func (s *tiltfileState) dcServiceToManifest(service *dcService, dcConfigPath str
 		WithPublishedPorts(service.PublishedPorts).
 		WithIgnoredLocalDirectories(service.MountedLocalDirs)
 
-	um, err := starlarkUpdateModeToModel(s.updateModeForResource(service.UpdateMode))
+	um, err := starlarkTriggerModeToModel(s.triggerModeForResource(service.TriggerMode))
 	if err != nil {
 		return model.Manifest{}, nil, err
 	}

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -415,8 +415,8 @@ func (s *tiltfileState) dcServiceToManifest(service *dcService, dcConfigPath str
 		return model.Manifest{}, nil, err
 	}
 	m := model.Manifest{
-		Name:       model.ManifestName(service.Name),
-		UpdateMode: um,
+		Name:        model.ManifestName(service.Name),
+		TriggerMode: um,
 	}.WithDeployTarget(dcInfo)
 
 	if service.DfPath == "" {

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -48,7 +48,7 @@ type k8sResource struct {
 
 	dependencyIDs []model.TargetID
 
-	updateMode updateMode
+	triggerMode triggerMode
 }
 
 const deprecatedResourceAssemblyV1Warning = "This Tiltfile is using k8s resource assembly version 1, which has been " +
@@ -60,7 +60,7 @@ type k8sResourceOptions struct {
 	newName           string
 	portForwards      []portForward
 	extraPodSelectors []labels.Selector
-	updateMode        updateMode
+	triggerMode       triggerMode
 	tiltfilePosition  syntax.Position
 	consumed          bool
 }
@@ -328,14 +328,14 @@ func (s *tiltfileState) k8sResourceV2(thread *starlark.Thread, fn *starlark.Buil
 	var newName string
 	var portForwardsVal starlark.Value
 	var extraPodSelectorsVal starlark.Value
-	var updateMode updateMode
+	var triggerMode triggerMode
 
 	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"workload", &workload,
 		"new_name?", &newName,
 		"port_forwards?", &portForwardsVal,
 		"extra_pod_selectors?", &extraPodSelectorsVal,
-		"update_mode?", &updateMode,
+		"trigger_mode?", &triggerMode,
 	); err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (s *tiltfileState) k8sResourceV2(thread *starlark.Thread, fn *starlark.Buil
 		portForwards:      portForwards,
 		extraPodSelectors: extraPodSelectors,
 		tiltfilePosition:  thread.Caller().Position(),
-		updateMode:        updateMode,
+		triggerMode:       triggerMode,
 	}
 
 	return starlark.None, nil

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -220,12 +220,12 @@ func (s *tiltfileState) triggerModeForResource(resourceTriggerMode triggerMode) 
 	}
 }
 
-func starlarkTriggerModeToModel(triggerMode triggerMode) (model.UpdateMode, error) {
+func starlarkTriggerModeToModel(triggerMode triggerMode) (model.TriggerMode, error) {
 	switch triggerMode {
 	case TriggerModeManual:
-		return model.UpdateModeManual, nil
+		return model.TriggerModeManual, nil
 	case TriggerModeAuto:
-		return model.UpdateModeAuto, nil
+		return model.TriggerModeAuto, nil
 	default:
 		return 0, fmt.Errorf("unknown triggerMode %v", triggerMode)
 	}
@@ -717,13 +717,13 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 	var result []model.Manifest
 	for _, r := range resources {
 		mn := model.ManifestName(r.name)
-		um, err := starlarkTriggerModeToModel(s.triggerModeForResource(r.triggerMode))
+		tm, err := starlarkTriggerModeToModel(s.triggerModeForResource(r.triggerMode))
 		if err != nil {
 			return nil, err
 		}
 		m := model.Manifest{
-			Name:       mn,
-			UpdateMode: um,
+			Name:        mn,
+			TriggerMode: tm,
 		}
 
 		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities, s.portForwardsToDomain(r), r.extraPodSelectors, r.dependencyIDs)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -67,9 +67,12 @@ type tiltfileState struct {
 	// with the same hashcode (like, all restartcontainer steps)
 	unconsumedLiveUpdateSteps map[string]liveUpdateStep
 
-	updateMode updateMode
+	// global trigger mode -- will be the default for all manifests (tho user can still explicitly set
+	// triggerMode for a specific manifest)
+	triggerMode triggerMode
+
 	// for error reporting in case it's called twice
-	updateModeCallPosition syntax.Position
+	triggerModeCallPosition syntax.Position
 
 	logger   logger.Logger
 	warnings []string
@@ -101,7 +104,7 @@ func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClie
 		unconsumedLiveUpdateSteps:  make(map[string]liveUpdateStep),
 		k8sResourceAssemblyVersion: 2,
 		k8sResourceOptions:         make(map[string]k8sResourceOptions),
-		updateMode:                 UpdateModeAuto,
+		triggerMode:                TriggerModeAuto,
 	}
 	s.filename = s.maybeAttachGitRepo(lp, filepath.Dir(lp.path))
 	return s
@@ -162,69 +165,69 @@ const (
 	runN              = "run"
 	restartContainerN = "restart_container"
 
-	// update mode
-	updateModeN       = "update_mode"
-	updateModeAutoN   = "UPDATE_MODE_AUTO"
-	updateModeManualN = "UPDATE_MODE_MANUAL"
+	// trigger mode
+	triggerModeN       = "trigger_mode"
+	triggerModeAutoN   = "TRIGGER_MODE_AUTO"
+	triggerModeManualN = "TRIGGER_MODE_MANUAL"
 
 	// other functions
 	failN = "fail"
 	blobN = "blob"
 )
 
-type updateMode int
+type triggerMode int
 
-func (u updateMode) String() string {
-	switch u {
-	case UpdateModeManual:
-		return updateModeManualN
-	case UpdateModeAuto:
-		return updateModeAutoN
+func (m triggerMode) String() string {
+	switch m {
+	case TriggerModeManual:
+		return triggerModeManualN
+	case TriggerModeAuto:
+		return triggerModeAutoN
 	default:
-		return fmt.Sprintf("unknown update mode with value %d", u)
+		return fmt.Sprintf("unknown trigger mode with value %d", m)
 	}
 }
 
-func (u updateMode) Type() string {
-	return "UpdateMode"
+func (t triggerMode) Type() string {
+	return "TriggerMode"
 }
 
-func (u updateMode) Freeze() {
+func (t triggerMode) Freeze() {
 	// noop
 }
 
-func (u updateMode) Truth() starlark.Bool {
-	return starlark.MakeInt(int(u)).Truth()
+func (t triggerMode) Truth() starlark.Bool {
+	return starlark.MakeInt(int(t)).Truth()
 }
 
-func (u updateMode) Hash() (uint32, error) {
-	return starlark.MakeInt(int(u)).Hash()
+func (t triggerMode) Hash() (uint32, error) {
+	return starlark.MakeInt(int(t)).Hash()
 }
 
-var _ starlark.Value = updateMode(0)
+var _ starlark.Value = triggerMode(0)
 
 const (
-	UpdateModeUnset  updateMode = iota
-	UpdateModeAuto   updateMode = iota
-	UpdateModeManual updateMode = iota
+	TriggerModeUnset  triggerMode = iota
+	TriggerModeAuto   triggerMode = iota
+	TriggerModeManual triggerMode = iota
 )
 
-func (s *tiltfileState) updateModeForResource(resourceUpdateMode updateMode) updateMode {
-	if resourceUpdateMode != UpdateModeUnset {
-		return resourceUpdateMode
+func (s *tiltfileState) triggerModeForResource(resourceTriggerMode triggerMode) triggerMode {
+	if resourceTriggerMode != TriggerModeUnset {
+		return resourceTriggerMode
 	} else {
-		return s.updateMode
+		return s.triggerMode
 	}
 }
 
-func starlarkUpdateModeToModel(updateMode updateMode) (model.UpdateMode, error) {
-	switch updateMode {
-	case UpdateModeManual:
+func starlarkTriggerModeToModel(triggerMode triggerMode) (model.UpdateMode, error) {
+	switch triggerMode {
+	case TriggerModeManual:
 		return model.UpdateModeManual, nil
-	case UpdateModeAuto:
+	case TriggerModeAuto:
 		return model.UpdateModeAuto, nil
 	default:
-		return 0, fmt.Errorf("unknown updateMode %v", updateMode)
+		return 0, fmt.Errorf("unknown triggerMode %v", triggerMode)
 	}
 }
 
@@ -276,9 +279,9 @@ func (s *tiltfileState) predeclared() starlark.StringDict {
 	addBuiltin(r, readJSONN, s.readJson)
 	addBuiltin(r, readYAMLN, s.readYaml)
 
-	addBuiltin(r, updateModeN, s.updateModeFn)
-	r[updateModeAutoN] = UpdateModeAuto
-	r[updateModeManualN] = UpdateModeManual
+	addBuiltin(r, triggerModeN, s.triggerModeFn)
+	r[triggerModeAutoN] = TriggerModeAuto
+	r[triggerModeManualN] = TriggerModeManual
 
 	addBuiltin(r, fallBackOnN, s.liveUpdateFallBackOn)
 	addBuiltin(r, syncN, s.liveUpdateSync)
@@ -407,7 +410,7 @@ func (s *tiltfileState) assembleK8sV2() error {
 		if r, ok := s.k8sByName[workload]; ok {
 			r.extraPodSelectors = opts.extraPodSelectors
 			r.portForwards = opts.portForwards
-			r.updateMode = opts.updateMode
+			r.triggerMode = opts.triggerMode
 			if opts.newName != "" && opts.newName != r.name {
 				if _, ok := s.k8sByName[opts.newName]; ok {
 					return fmt.Errorf("k8s_resource at %s specified to rename '%s' to '%s', but there is already a resource with that name", opts.tiltfilePosition.String(), r.name, opts.newName)
@@ -714,7 +717,7 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 	var result []model.Manifest
 	for _, r := range resources {
 		mn := model.ManifestName(r.name)
-		um, err := starlarkUpdateModeToModel(s.updateModeForResource(r.updateMode))
+		um, err := starlarkTriggerModeToModel(s.triggerModeForResource(r.triggerMode))
 		if err != nil {
 			return nil, err
 		}
@@ -1022,19 +1025,19 @@ func (k k8sObjectSelector) matches(e k8s.K8sEntity) bool {
 		k.namespace.MatchString(e.Namespace().String())
 }
 
-func (s *tiltfileState) updateModeFn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var updateMode updateMode
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "update_mode", &updateMode)
+func (s *tiltfileState) triggerModeFn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var triggerMode triggerMode
+	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "trigger_mode", &triggerMode)
 	if err != nil {
 		return nil, err
 	}
 
-	if s.updateModeCallPosition.IsValid() {
-		return starlark.None, fmt.Errorf("%s can only be called once. It was already called at %s", fn.Name(), s.updateModeCallPosition.String())
+	if s.triggerModeCallPosition.IsValid() {
+		return starlark.None, fmt.Errorf("%s can only be called once. It was already called at %s", fn.Name(), s.triggerModeCallPosition.String())
 	}
 
-	s.updateMode = updateMode
-	s.updateModeCallPosition = thread.Caller().Position()
+	s.triggerMode = triggerMode
+	s.triggerModeCallPosition = thread.Caller().Position()
 
 	return starlark.None, nil
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3061,12 +3061,12 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', './sidecar')
 	f.load()
 }
 
-func TestUpdateModeK8S(t *testing.T) {
+func TestTriggerModeK8S(t *testing.T) {
 	for _, testCase := range []struct {
-		name               string
-		globalSetting      triggerMode
-		k8sResourceSetting triggerMode
-		expectedUpdateMode model.UpdateMode
+		name                string
+		globalSetting       triggerMode
+		k8sResourceSetting  triggerMode
+		expectedTriggerMode model.UpdateMode
 	}{
 		{"default", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
 		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.UpdateModeAuto},
@@ -3082,14 +3082,14 @@ func TestUpdateModeK8S(t *testing.T) {
 
 			f.setupFoo()
 
-			var globalUpdateModeDirective string
+			var globalTriggerModeDirective string
 			switch testCase.globalSetting {
 			case TriggerModeUnset:
-				globalUpdateModeDirective = ""
+				globalTriggerModeDirective = ""
 			case TriggerModeManual:
-				globalUpdateModeDirective = "update_mode(UPDATE_MODE_MANUAL)"
+				globalTriggerModeDirective = "trigger_mode(TRIGGER_MODE_MANUAL)"
 			case TriggerModeAuto:
-				globalUpdateModeDirective = "update_mode(UPDATE_MODE_AUTO)"
+				globalTriggerModeDirective = "trigger_mode(TRIGGER_MODE_AUTO)"
 			}
 
 			var k8sResourceDirective string
@@ -3097,9 +3097,9 @@ func TestUpdateModeK8S(t *testing.T) {
 			case TriggerModeUnset:
 				k8sResourceDirective = ""
 			case TriggerModeManual:
-				k8sResourceDirective = "k8s_resource('foo', update_mode=UPDATE_MODE_MANUAL)"
+				k8sResourceDirective = "k8s_resource('foo', trigger_mode=TRIGGER_MODE_MANUAL)"
 			case TriggerModeAuto:
-				k8sResourceDirective = "k8s_resource('foo', update_mode=UPDATE_MODE_AUTO)"
+				k8sResourceDirective = "k8s_resource('foo', trigger_mode=TRIGGER_MODE_AUTO)"
 			}
 
 			f.file("Tiltfile", fmt.Sprintf(`
@@ -3107,22 +3107,22 @@ func TestUpdateModeK8S(t *testing.T) {
 docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
 %s
-`, globalUpdateModeDirective, k8sResourceDirective))
+`, globalTriggerModeDirective, k8sResourceDirective))
 
 			f.load()
 
 			f.assertNumManifests(1)
-			f.assertNextManifest("foo", testCase.expectedUpdateMode)
+			f.assertNextManifest("foo", testCase.expectedTriggerMode)
 		})
 	}
 }
 
-func TestUpdateModeDC(t *testing.T) {
+func TestTriggerModeDC(t *testing.T) {
 	for _, testCase := range []struct {
-		name               string
-		globalSetting      triggerMode
-		dcResourceSetting  triggerMode
-		expectedUpdateMode model.UpdateMode
+		name                string
+		globalSetting       triggerMode
+		dcResourceSetting   triggerMode
+		expectedTriggerMode model.UpdateMode
 	}{
 		{"default", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
 		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.UpdateModeAuto},
@@ -3139,14 +3139,14 @@ func TestUpdateModeDC(t *testing.T) {
 			f.dockerfile("foo/Dockerfile")
 			f.file("docker-compose.yml", simpleConfig)
 
-			var globalUpdateModeDirective string
+			var globalTriggerModeDirective string
 			switch testCase.globalSetting {
 			case TriggerModeUnset:
-				globalUpdateModeDirective = ""
+				globalTriggerModeDirective = ""
 			case TriggerModeManual:
-				globalUpdateModeDirective = "update_mode(UPDATE_MODE_MANUAL)"
+				globalTriggerModeDirective = "trigger_mode(TRIGGER_MODE_MANUAL)"
 			case TriggerModeAuto:
-				globalUpdateModeDirective = "update_mode(UPDATE_MODE_AUTO)"
+				globalTriggerModeDirective = "trigger_mode(TRIGGER_MODE_AUTO)"
 			}
 
 			var dcResourceDirective string
@@ -3154,44 +3154,44 @@ func TestUpdateModeDC(t *testing.T) {
 			case TriggerModeUnset:
 				dcResourceDirective = ""
 			case TriggerModeManual:
-				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', update_mode=UPDATE_MODE_MANUAL)"
+				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', trigger_mode=TRIGGER_MODE_MANUAL)"
 			case TriggerModeAuto:
-				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', update_mode=UPDATE_MODE_AUTO)"
+				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', trigger_mode=TRIGGER_MODE_AUTO)"
 			}
 
 			f.file("Tiltfile", fmt.Sprintf(`
 %s
 docker_compose('docker-compose.yml')
 %s
-`, globalUpdateModeDirective, dcResourceDirective))
+`, globalTriggerModeDirective, dcResourceDirective))
 
 			f.load()
 
 			f.assertNumManifests(1)
-			f.assertNextManifest("foo", testCase.expectedUpdateMode)
+			f.assertNextManifest("foo", testCase.expectedTriggerMode)
 		})
 	}
 }
 
-func TestUpdateModeInt(t *testing.T) {
+func TestTriggerModeInt(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-update_mode(1)
+trigger_mode(1)
 `)
 	f.loadErrString("got int, want TriggerMode")
 }
 
-func TestMultipleUpdateMode(t *testing.T) {
+func TestMultipleTriggerMode(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-update_mode(UPDATE_MODE_MANUAL)
-update_mode(UPDATE_MODE_MANUAL)
+trigger_mode(TRIGGER_MODE_MANUAL)
+trigger_mode(TRIGGER_MODE_MANUAL)
 `)
-	f.loadErrString("update_mode can only be called once")
+	f.loadErrString("trigger_mode can only be called once")
 }
 
 func TestHelmSkipsTests(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3066,15 +3066,15 @@ func TestTriggerModeK8S(t *testing.T) {
 		name                string
 		globalSetting       triggerMode
 		k8sResourceSetting  triggerMode
-		expectedTriggerMode model.UpdateMode
+		expectedTriggerMode model.TriggerMode
 	}{
-		{"default", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
-		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.UpdateModeAuto},
-		{"explicit global manual", TriggerModeManual, TriggerModeUnset, model.UpdateModeManual},
-		{"kr auto", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
-		{"kr manual", TriggerModeUnset, TriggerModeManual, model.UpdateModeManual},
-		{"kr override auto", TriggerModeManual, TriggerModeAuto, model.UpdateModeAuto},
-		{"kr override manual", TriggerModeAuto, TriggerModeManual, model.UpdateModeManual},
+		{"default", TriggerModeUnset, TriggerModeUnset, model.TriggerModeAuto},
+		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.TriggerModeAuto},
+		{"explicit global manual", TriggerModeManual, TriggerModeUnset, model.TriggerModeManual},
+		{"kr auto", TriggerModeUnset, TriggerModeUnset, model.TriggerModeAuto},
+		{"kr manual", TriggerModeUnset, TriggerModeManual, model.TriggerModeManual},
+		{"kr override auto", TriggerModeManual, TriggerModeAuto, model.TriggerModeAuto},
+		{"kr override manual", TriggerModeAuto, TriggerModeManual, model.TriggerModeManual},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := newFixture(t)
@@ -3122,15 +3122,15 @@ func TestTriggerModeDC(t *testing.T) {
 		name                string
 		globalSetting       triggerMode
 		dcResourceSetting   triggerMode
-		expectedTriggerMode model.UpdateMode
+		expectedTriggerMode model.TriggerMode
 	}{
-		{"default", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
-		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.UpdateModeAuto},
-		{"explicit global manual", TriggerModeManual, TriggerModeUnset, model.UpdateModeManual},
-		{"dc auto", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
-		{"dc manual", TriggerModeUnset, TriggerModeManual, model.UpdateModeManual},
-		{"dc override auto", TriggerModeManual, TriggerModeAuto, model.UpdateModeAuto},
-		{"dc override manual", TriggerModeAuto, TriggerModeManual, model.UpdateModeManual},
+		{"default", TriggerModeUnset, TriggerModeUnset, model.TriggerModeAuto},
+		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.TriggerModeAuto},
+		{"explicit global manual", TriggerModeManual, TriggerModeUnset, model.TriggerModeManual},
+		{"dc auto", TriggerModeUnset, TriggerModeUnset, model.TriggerModeAuto},
+		{"dc manual", TriggerModeUnset, TriggerModeManual, model.TriggerModeManual},
+		{"dc override auto", TriggerModeManual, TriggerModeAuto, model.TriggerModeAuto},
+		{"dc override manual", TriggerModeAuto, TriggerModeManual, model.TriggerModeManual},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := newFixture(t)
@@ -3884,8 +3884,8 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 
 		case []model.PortForward:
 			assert.Equal(f.t, opt, m.K8sTarget().PortForwards)
-		case model.UpdateMode:
-			assert.Equal(f.t, opt, m.UpdateMode)
+		case model.TriggerMode:
+			assert.Equal(f.t, opt, m.TriggerMode)
 		default:
 			f.t.Fatalf("unexpected arg to assertNextManifest: %T %v", opt, opt)
 		}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3064,17 +3064,17 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', './sidecar')
 func TestUpdateModeK8S(t *testing.T) {
 	for _, testCase := range []struct {
 		name               string
-		globalSetting      updateMode
-		k8sResourceSetting updateMode
+		globalSetting      triggerMode
+		k8sResourceSetting triggerMode
 		expectedUpdateMode model.UpdateMode
 	}{
-		{"default", UpdateModeUnset, UpdateModeUnset, model.UpdateModeAuto},
-		{"explicit global auto", UpdateModeAuto, UpdateModeUnset, model.UpdateModeAuto},
-		{"explicit global manual", UpdateModeManual, UpdateModeUnset, model.UpdateModeManual},
-		{"kr auto", UpdateModeUnset, UpdateModeUnset, model.UpdateModeAuto},
-		{"kr manual", UpdateModeUnset, UpdateModeManual, model.UpdateModeManual},
-		{"kr override auto", UpdateModeManual, UpdateModeAuto, model.UpdateModeAuto},
-		{"kr override manual", UpdateModeAuto, UpdateModeManual, model.UpdateModeManual},
+		{"default", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
+		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.UpdateModeAuto},
+		{"explicit global manual", TriggerModeManual, TriggerModeUnset, model.UpdateModeManual},
+		{"kr auto", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
+		{"kr manual", TriggerModeUnset, TriggerModeManual, model.UpdateModeManual},
+		{"kr override auto", TriggerModeManual, TriggerModeAuto, model.UpdateModeAuto},
+		{"kr override manual", TriggerModeAuto, TriggerModeManual, model.UpdateModeManual},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := newFixture(t)
@@ -3084,21 +3084,21 @@ func TestUpdateModeK8S(t *testing.T) {
 
 			var globalUpdateModeDirective string
 			switch testCase.globalSetting {
-			case UpdateModeUnset:
+			case TriggerModeUnset:
 				globalUpdateModeDirective = ""
-			case UpdateModeManual:
+			case TriggerModeManual:
 				globalUpdateModeDirective = "update_mode(UPDATE_MODE_MANUAL)"
-			case UpdateModeAuto:
+			case TriggerModeAuto:
 				globalUpdateModeDirective = "update_mode(UPDATE_MODE_AUTO)"
 			}
 
 			var k8sResourceDirective string
 			switch testCase.k8sResourceSetting {
-			case UpdateModeUnset:
+			case TriggerModeUnset:
 				k8sResourceDirective = ""
-			case UpdateModeManual:
+			case TriggerModeManual:
 				k8sResourceDirective = "k8s_resource('foo', update_mode=UPDATE_MODE_MANUAL)"
-			case UpdateModeAuto:
+			case TriggerModeAuto:
 				k8sResourceDirective = "k8s_resource('foo', update_mode=UPDATE_MODE_AUTO)"
 			}
 
@@ -3120,17 +3120,17 @@ k8s_yaml('foo.yaml')
 func TestUpdateModeDC(t *testing.T) {
 	for _, testCase := range []struct {
 		name               string
-		globalSetting      updateMode
-		dcResourceSetting  updateMode
+		globalSetting      triggerMode
+		dcResourceSetting  triggerMode
 		expectedUpdateMode model.UpdateMode
 	}{
-		{"default", UpdateModeUnset, UpdateModeUnset, model.UpdateModeAuto},
-		{"explicit global auto", UpdateModeAuto, UpdateModeUnset, model.UpdateModeAuto},
-		{"explicit global manual", UpdateModeManual, UpdateModeUnset, model.UpdateModeManual},
-		{"dc auto", UpdateModeUnset, UpdateModeUnset, model.UpdateModeAuto},
-		{"dc manual", UpdateModeUnset, UpdateModeManual, model.UpdateModeManual},
-		{"dc override auto", UpdateModeManual, UpdateModeAuto, model.UpdateModeAuto},
-		{"dc override manual", UpdateModeAuto, UpdateModeManual, model.UpdateModeManual},
+		{"default", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
+		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.UpdateModeAuto},
+		{"explicit global manual", TriggerModeManual, TriggerModeUnset, model.UpdateModeManual},
+		{"dc auto", TriggerModeUnset, TriggerModeUnset, model.UpdateModeAuto},
+		{"dc manual", TriggerModeUnset, TriggerModeManual, model.UpdateModeManual},
+		{"dc override auto", TriggerModeManual, TriggerModeAuto, model.UpdateModeAuto},
+		{"dc override manual", TriggerModeAuto, TriggerModeManual, model.UpdateModeManual},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := newFixture(t)
@@ -3141,21 +3141,21 @@ func TestUpdateModeDC(t *testing.T) {
 
 			var globalUpdateModeDirective string
 			switch testCase.globalSetting {
-			case UpdateModeUnset:
+			case TriggerModeUnset:
 				globalUpdateModeDirective = ""
-			case UpdateModeManual:
+			case TriggerModeManual:
 				globalUpdateModeDirective = "update_mode(UPDATE_MODE_MANUAL)"
-			case UpdateModeAuto:
+			case TriggerModeAuto:
 				globalUpdateModeDirective = "update_mode(UPDATE_MODE_AUTO)"
 			}
 
 			var dcResourceDirective string
 			switch testCase.dcResourceSetting {
-			case UpdateModeUnset:
+			case TriggerModeUnset:
 				dcResourceDirective = ""
-			case UpdateModeManual:
+			case TriggerModeManual:
 				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', update_mode=UPDATE_MODE_MANUAL)"
-			case UpdateModeAuto:
+			case TriggerModeAuto:
 				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', update_mode=UPDATE_MODE_AUTO)"
 			}
 
@@ -3180,7 +3180,7 @@ func TestUpdateModeInt(t *testing.T) {
 	f.file("Tiltfile", `
 update_mode(1)
 `)
-	f.loadErrString("got int, want UpdateMode")
+	f.loadErrString("got int, want TriggerMode")
 }
 
 func TestMultipleUpdateMode(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch maiamcc/disambiguate-update-mode:

7ac9f276c16620cfe54672d71e8f7c56633faf87 (2019-06-07 14:03:28 -0400)
fix in model

ac00de8ec2acb3c96c98073c565bd1d30649a0e7 (2019-06-07 13:39:20 -0400)
fix tiltfile tests

603bed5f3fbd00062e222a5b5f8782006c329ace (2019-06-07 12:13:45 -0400)
wip - changed in tiltfile code. TODO: tiltfile tests, model code

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics