### PR TITLE
engine: build_controller respects manifest trigger mode [ch2355]

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -79,6 +79,11 @@ func nextTargetToBuild(state store.EngineState) *store.ManifestTarget {
 	for _, mt := range targets {
 		ok, newTime := mt.State.HasPendingChangesBefore(earliest)
 		if ok {
+			if mt.Manifest.TriggerMode == model.TriggerModeManual {
+				// Don't trigger update of a manual manifest just b/c if has
+				// pending changes; must come through the TriggerQueue, above.
+				continue
+			}
 			choice = mt
 			earliest = newTime
 		}

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/tilt/internal/container"
+	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/watch"
@@ -154,6 +155,48 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	assert.NoError(t, err)
 	f.assertAllBuildsConsumed()
 }
+
+func TestBuildControllerManualTrigger(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+	mName := model.ManifestName("foobar")
+
+	sync := model.Sync{LocalPath: f.Path(), ContainerPath: "/go"}
+	manifest := f.newManifest(mName.String(), []model.Sync{sync}).WithTriggerMode(model.TriggerModeManual)
+	f.Init(InitAction{
+		Manifests:       []model.Manifest{manifest},
+		WatchFiles:      true,
+		ExecuteTiltfile: true,
+	})
+
+	f.nextCall()
+	f.waitForCompletedBuildCount(1)
+
+	f.store.Dispatch(view.AppendToTriggerQueueAction{Name: mName})
+	f.assertNoCall("manifest has no pending changes, so shouldn't build even if we try to trigger it")
+
+	f.fsWatcher.events <- watch.FileEvent{Path: f.JoinPath("main.go")}
+	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
+		return len(st.BuildStatus(manifest.ImageTargetAt(0).ID()).PendingFileChanges) > 0
+	})
+	f.assertNoCall("even tho there are pending changes, manual manifest shouldn't build w/o explicit trigger")
+
+	f.store.Dispatch(view.AppendToTriggerQueueAction{Name: mName})
+	call := f.nextCall()
+	assert.Equal(t, []string{f.JoinPath("main.go")}, call.oneState().FilesChanged())
+	f.waitForCompletedBuildCount(2)
+
+	f.WaitUntil("manifest removed from queue", func(st store.EngineState) bool {
+		for _, mn := range st.TriggerQueue {
+			if mn == mName {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// Test with some manual and some auto
 
 // any manifests without image targets should be deployed before any manifests WITH image targets
 func TestBuildControllerNoBuildManifestsFirst(t *testing.T) {

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -116,6 +116,11 @@ func (m Manifest) WithDeployTarget(t TargetSpec) Manifest {
 	return m
 }
 
+func (m Manifest) WithTriggerMode(mode TriggerMode) Manifest {
+	m.TriggerMode = mode
+	return m
+}
+
 func (m Manifest) TargetSpecs() []TargetSpec {
 	result := []TargetSpec{}
 	for _, t := range m.ImageTargets {


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch maiamcc/respect-trigger-mode:

4795e241e95a607f1d5a0b8d2d0ecb2c4c062723 (2019-06-07 15:45:56 -0400)
engine: build_controller respects manifest trigger mode [ch2355]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics