### PR TITLE
engine: k8s_events feature flag casing should match the one we set in integration tests

### DIFF
--- a/internal/engine/k8s_events_feature.go
+++ b/internal/engine/k8s_events_feature.go
@@ -4,7 +4,7 @@ import "os"
 
 // TODO(maia): remove this when feature is merged
 
-const k8sEventsFeatureFlag = "TILT_K8s_EVENTS"
+const k8sEventsFeatureFlag = "TILT_K8S_EVENTS"
 
 // TEMPORARY: check env to see if feature flag is set
 func k8sEventsFeatureFlagOn() bool {


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/events-feature-test:

f8b077f4e3a157dffd69555ce61f3e2830c7acda (2019-06-11 11:24:43 -0400)
engine: k8s_events feature flag casing should match the one we set in integration tests

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics