### PR TITLE
upper test: fix flaky tests

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2059,6 +2059,8 @@ func TestNewSyncsAreWatched(t *testing.T) {
 	})
 
 	f.PollUntil("watches set up", func() bool {
+		f.fwm.mu.Lock()
+		defer f.fwm.mu.Unlock()
 		watches, ok := f.fwm.targetWatches[m2.ImageTargetAt(0).ID()]
 		if !ok {
 			return false
@@ -2740,6 +2742,8 @@ func (f *testFixture) Init(action InitAction) {
 	})
 
 	f.PollUntil("watches set up", func() bool {
+		f.fwm.mu.Lock()
+		defer f.fwm.mu.Unlock()
 		return !watchFiles || len(f.fwm.targetWatches) == len(watchableTargetsForManifests(manifests))
 	})
 }

--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -104,6 +105,7 @@ type WatchManager struct {
 	timerMaker         timerMaker
 	tiltIgnoreContents string
 	disabledForTesting bool
+	mu                 sync.Mutex
 }
 
 func NewWatchManager(watcherMaker FsWatcherMaker, timerMaker timerMaker) *WatchManager {
@@ -168,6 +170,9 @@ func watchRulesMatch(w1, w2 WatchableTarget) bool {
 }
 
 func (w *WatchManager) OnChange(ctx context.Context, st store.RStore) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	setup, teardown := w.diff(ctx, st)
 
 	state := st.RLockState()


### PR DESCRIPTION
there are occasional test failures with `fatal error: concurrent map read and map write` due to tests accessing `WatchManager.targetWatches` while the manager is writing to it.