### PR TITLE
model: changes to a manifest's TriggerMode via config change actually make it into engine state [ch2703]

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -495,18 +495,14 @@ func handleConfigsReloaded(
 
 		configFilesThatChanged := state.LastTiltfileBuild.Edits
 		old := mt.Manifest
-		if !m.Equal(old) {
-			old := mt.Manifest
-			mt.Manifest = m
-
-			if model.ChangesInvalidateBuild(old, m) {
-				// Manifest has changed such that the current build is invalid;
-				// ensure we do an image build so that we apply the changes
-				state := mt.State
-				state.BuildStatuses = make(map[model.TargetID]*store.BuildStatus)
-				state.PendingManifestChange = time.Now()
-				state.ConfigFilesThatCausedChange = configFilesThatChanged
-			}
+		mt.Manifest = m
+		if model.ChangesInvalidateBuild(old, m) {
+			// Manifest has changed such that the current build is invalid;
+			// ensure we do an image build so that we apply the changes
+			state := mt.State
+			state.BuildStatuses = make(map[model.TargetID]*store.BuildStatus)
+			state.PendingManifestChange = time.Now()
+			state.ConfigFilesThatCausedChange = configFilesThatChanged
 		}
 		state.UpsertManifestTarget(mt)
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -494,14 +494,19 @@ func handleConfigsReloaded(
 		newDefOrder[i] = m.ManifestName()
 
 		configFilesThatChanged := state.LastTiltfileBuild.Edits
-		if !m.Equal(mt.Manifest) {
+		old := mt.Manifest
+		if !m.Equal(old) {
+			old := mt.Manifest
 			mt.Manifest = m
 
-			// Manifest has changed, ensure we do an image build so that we apply the changes
-			state := mt.State
-			state.BuildStatuses = make(map[model.TargetID]*store.BuildStatus)
-			state.PendingManifestChange = time.Now()
-			state.ConfigFilesThatCausedChange = configFilesThatChanged
+			if model.ChangesInvalidateBuild(old, m) {
+				// Manifest has changed such that the current build is invalid;
+				// ensure we do an image build so that we apply the changes
+				state := mt.State
+				state.BuildStatuses = make(map[model.TargetID]*store.BuildStatus)
+				state.PendingManifestChange = time.Now()
+				state.ConfigFilesThatCausedChange = configFilesThatChanged
+			}
 		}
 		state.UpsertManifestTarget(mt)
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -691,17 +691,13 @@ k8s_resource('doggos', new_name='quux')  # rename "doggos" --> "quux"
 	f.assertAllBuildsConsumed()
 }
 
-func TestNoOpChangeToDockerfile(t *testing.T) {
+func TestConfigChange_NoOpChange(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
 	f.WriteFile("Tiltfile", `
-k8s_resource_assembly_version(2)
-r = local_git_repo('.')
-fast_build('gcr.io/windmill-public-containers/servantes/snack', 'Dockerfile') \
-  .add(r.path('src'), '.')
-k8s_yaml('snack.yaml')
-k8s_resource('snack', new_name='foobar')`)
+docker_build('gcr.io/windmill-public-containers/servantes/snack', './src', dockerfile='Dockerfile') 
+k8s_yaml('snack.yaml')`)
 	f.WriteFile("Dockerfile", `FROM iron/go:dev1`)
 	f.WriteFile("snack.yaml", simpleYAML)
 	f.WriteFile("src/main.go", "hello")
@@ -709,83 +705,40 @@ k8s_resource('snack', new_name='foobar')`)
 	f.loadAndStart()
 
 	// First call: with the old manifests
-	call := f.nextCall("old manifests")
-	assert.Equal(t, "FROM iron/go:dev1", call.image().TopFastBuildInfo().BaseDockerfile)
-	assert.Equal(t, "foobar", string(call.k8s().Name))
+	call := f.nextCall("initial call")
+	assert.Equal(t, "FROM iron/go:dev1", call.image().DockerBuildInfo().Dockerfile)
+	assert.Equal(t, "snack", string(call.k8s().Name))
 
+	// Write same contents to Dockerfile -- an "edit" event for a config file,
+	// but it doesn't change the manifest at all.
 	f.WriteConfigFiles("Dockerfile", `FROM iron/go:dev1`)
-
-	// The dockerfile hasn't changed, so there shouldn't be any builds.
-	f.assertNoCall()
-
-	changed := f.WriteFile("src/main.go", "goodbye")
-	f.fsWatcher.events <- watch.FileEvent{Path: changed}
+	f.assertNoCall("Dockerfile hasn't changed, so there shouldn't be any builds")
 
 	// Second call: Editing the Dockerfile means we have to reevaluate the Tiltfile.
 	// Editing the random file means we have to do a rebuild. BUT! The Dockerfile
 	// hasn't changed, so the manifest hasn't changed, so we can do an incremental build.
-	call = f.nextCall("incremental build despite edited config file")
-	assert.Equal(t, "foobar", string(call.k8s().Name))
+	changed := f.WriteFile("src/main.go", "goodbye")
+	f.fsWatcher.events <- watch.FileEvent{Path: changed}
+
+	call = f.nextCall("build from file change")
+	assert.Equal(t, "snack", string(call.k8s().Name))
 	assert.ElementsMatch(t, []string{
 		f.JoinPath("src/main.go"),
 	}, call.oneState().FilesChanged())
-
-	// Unchanged manifest --> we do NOT clear the build state
-	assert.True(t, call.oneState().HasImage())
+	assert.True(t, call.oneState().HasImage(), "Unchanged manifest --> we do NOT clear the build state")
 
 	err := f.Stop()
 	assert.Nil(t, err)
 	f.assertAllBuildsConsumed()
 }
 
-func TestRebuildDockerfileFailed(t *testing.T) {
-	f := newTestFixture(t)
-	defer f.TearDown()
-
-	f.WriteFile("Tiltfile", simpleTiltfile)
-	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
-	f.WriteFile("snack.yaml", simpleYAML)
-
-	f.loadAndStart()
-
-	// First call: init
-	call := f.nextCall("old manifest")
-	assert.Equal(t, `FROM iron/go:dev`, call.image().TopFastBuildInfo().BaseDockerfile)
-
-	// Second call: error!
-	f.WriteConfigFiles("Tiltfile", "borken")
-	f.assertNoCall("Tiltfile error should prevent BuildAndDeploy from being called")
-
-	// Third call: fix
-	f.WriteConfigFiles("Tiltfile", simpleTiltfile,
-		"Dockerfile", `FROM iron/go:dev2`)
-
-	call = f.nextCall("fixed broken config")
-	assert.Equal(t, "FROM iron/go:dev2", call.image().TopFastBuildInfo().BaseDockerfile)
-	assert.False(t, call.oneState().HasImage()) // we cleared the previous build state to force an image build
-	f.WaitUntil("manifest definition order hasn't changed", func(state store.EngineState) bool {
-		return len(state.ManifestDefinitionOrder) == 1
-	})
-	f.WaitUntilManifestState("LastError was cleared", "snack", func(ms store.ManifestState) bool {
-		return ms.LastBuild().Error == nil
-	})
-
-	err := f.Stop()
-	assert.Nil(t, err)
-	f.assertAllBuildsConsumed()
-}
-
-func TestBreakManifest(t *testing.T) {
+func TestConfigChange_TiltfileErrorAndFixWithNoChanges(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
 	origTiltfile := `
-k8s_resource_assembly_version(2)
-fast_build('gcr.io/windmill-public-containers/servantes/snack', 'Dockerfile') \
-	.add(local_git_repo('./nested'), '.')  # Tiltfile is not synced
+docker_build('gcr.io/windmill-public-containers/servantes/snack', './src', dockerfile='Dockerfile') 
 k8s_yaml('snack.yaml')`
-
-	f.MkdirAll("nested/.git") // Spoof a git directory -- this is what we'll sync.
 	f.WriteFile("Tiltfile", origTiltfile)
 	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
 	f.WriteFile("snack.yaml", simpleYAML)
@@ -797,45 +750,14 @@ k8s_yaml('snack.yaml')`
 
 	// Second call: change Tiltfile, break manifest
 	f.WriteConfigFiles("Tiltfile", "borken")
+	f.WaitUntil("tiltfile error set", func(st store.EngineState) bool {
+		return st.LastTiltfileError() != nil
+	})
 	f.assertNoCall("Tiltfile error should prevent BuildAndDeploy from being called")
-
-	f.WaitUntil("error set", func(st store.EngineState) bool {
-		return st.LastTiltfileError() != nil
-	})
-
-	f.withState(func(es store.EngineState) {
-		assert.Equal(t, "", nextManifestNameToBuild(es).String())
-	})
-}
-
-func TestBreakAndUnbreakManifestWithNoChange(t *testing.T) {
-	f := newTestFixture(t)
-	defer f.TearDown()
-
-	origTiltfile := `
-k8s_resource_assembly_version(2)
-fast_build('gcr.io/windmill-public-containers/servantes/snack', 'Dockerfile') \
-	.add(local_git_repo('./nested'), '.')  # Tiltfile is not synced
-k8s_yaml('snack.yaml')`
-	f.MkdirAll("nested/.git") // Spoof a git directory -- this is what we'll sync.
-	f.WriteFile("Tiltfile", origTiltfile)
-	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
-	f.WriteFile("snack.yaml", simpleYAML)
-
-	f.loadAndStart()
-
-	// First call: all is well
-	_ = f.nextCall("first call")
-
-	// Second call: change Tiltfile, break manifest
-	f.WriteConfigFiles("Tiltfile", "borken")
-	f.WaitUntil("state is broken", func(st store.EngineState) bool {
-		return st.LastTiltfileError() != nil
-	})
 
 	// Third call: put Tiltfile back. No change to manifest or to synced files, so expect no build.
 	f.WriteConfigFiles("Tiltfile", origTiltfile)
-	f.WaitUntil("state is restored", func(st store.EngineState) bool {
+	f.WaitUntil("tiltfile error cleared", func(st store.EngineState) bool {
 		return st.LastTiltfileError() == nil
 	})
 
@@ -844,60 +766,63 @@ k8s_yaml('snack.yaml')`
 	})
 }
 
-func TestBreakAndUnbreakManifestWithChange(t *testing.T) {
+func TestConfigChange_TiltfileErrorAndFixWithFileChange(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
-	tiltfileString := func(cmd string) string {
+	tiltfileWithCmd := func(cmd string) string {
 		return fmt.Sprintf(`
-k8s_resource_assembly_version(2)
-fast_build('gcr.io/windmill-public-containers/servantes/snack', 'Dockerfile') \
-	.add(local_git_repo('./nested'), '.') \
-  .run('%s')
+docker_build('gcr.io/windmill-public-containers/servantes/snack', './src', dockerfile='Dockerfile',
+    live_update=[
+        sync('./src', '/src'),
+        run('%s')
+    ]
+)
 k8s_yaml('snack.yaml')
 `, cmd)
 	}
 
-	f.MkdirAll("nested/.git") // Spoof a git directory -- this is what we'll sync.
-	f.WriteFile("Tiltfile", tiltfileString("original"))
+	f.WriteFile("Tiltfile", tiltfileWithCmd("original"))
 	f.WriteFile("Dockerfile", `FROM iron/go:dev`)
 	f.WriteFile("snack.yaml", simpleYAML)
 
 	f.loadAndStart()
 
-	f.WaitUntil("first build finished", func(state store.EngineState) bool {
-		return state.CompletedBuildCount == 1
-	})
+	// First call: all is well
+	_ = f.nextCall("first call")
 
-	name := model.ManifestName("snack")
 	// Second call: change Tiltfile, break manifest
 	f.WriteConfigFiles("Tiltfile", "borken")
-	f.WaitUntil("manifest load error", func(st store.EngineState) bool {
+	f.WaitUntil("tiltfile error set", func(st store.EngineState) bool {
 		return st.LastTiltfileError() != nil
 	})
 
-	f.withState(func(state store.EngineState) {
-		assert.Equal(t, 1, state.CompletedBuildCount)
-	})
+	f.assertNoCall("Tiltfile error should prevent BuildAndDeploy from being called")
 
 	// Third call: put Tiltfile back. manifest changed, so expect a build
-	f.WriteConfigFiles("Tiltfile", tiltfileString("changed"))
+	f.WriteConfigFiles("Tiltfile", tiltfileWithCmd("changed"))
 
-	f.WaitUntil("second build finished", func(state store.EngineState) bool {
-		return state.CompletedBuildCount == 2
+	call := f.nextCall("fixed broken config and rebuilt manifest")
+	assert.False(t, call.oneState().HasImage(),
+		"expected this call to have NO image (since we should have cleared it to force an image build)")
+
+	f.WaitUntil("tiltfile error cleared", func(state store.EngineState) bool {
+		return state.LastTiltfileError() == nil
 	})
 
-	f.withState(func(state store.EngineState) {
-		assert.Equal(t, "", nextManifestNameToBuild(state).String())
-		assert.NoError(t, state.LastTiltfileError())
+	f.withManifestTarget("snack", func(mt store.ManifestTarget) {
+		expectedCmd := model.ToShellCmd("changed")
+		assert.Equal(t, expectedCmd, mt.Manifest.ImageTargetAt(0).AnyLiveUpdateInfo().RunSteps()[0].Cmd,
+			"Tiltfile change should have propagated to manifest")
 	})
 
-	f.withManifestTarget(name, func(mt store.ManifestTarget) {
-		expectedRuns := []model.Run{{
-			Cmd: model.ToShellCmd("changed"),
-		}}
-		assert.Equal(t, expectedRuns, mt.Manifest.ImageTargetAt(0).TopFastBuildInfo().Runs)
-	})
+	err := f.Stop()
+	assert.Nil(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestConfigChange_TriggerModeChangePropagatesButDoesntInvalidateBuild(t *testing.T) {
+	// TODO
 }
 
 func TestDockerRebuildWithChangedFiles(t *testing.T) {

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -177,7 +177,7 @@ func (m Manifest) Validate() error {
 }
 
 func (m1 Manifest) Equal(m2 Manifest) bool {
-	primitivesMatch := m1.Name == m2.Name
+	primitivesMatch := m1.Name == m2.Name && m1.TriggerMode == m2.TriggerMode
 	dockerEqual := DeepEqual(m1.ImageTargets, m2.ImageTargets)
 
 	dc1 := m1.DockerComposeTarget()

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -177,6 +177,22 @@ func (m Manifest) Validate() error {
 }
 
 func (m1 Manifest) Equal(m2 Manifest) bool {
+	primitivesEq, dockerEq, k8sEq, dcEq := m1.fieldGroupsEqual(m2)
+	return primitivesEq && dockerEq && k8sEq && dcEq
+}
+
+// ChangesInvalidateBuild checks whether the changes from old => new manifest
+// invalidate our build of the old one; i.e. if we're replacing `old` with `new`,
+// should we perform a full rebuild?
+func ChangesInvalidateBuild(old, new Manifest) bool {
+	_, dockerEq, k8sEq, dcEq := old.fieldGroupsEqual(new)
+
+	// We only need to update for this manifest if any of the field-groups
+	// affecting build+deploy have changed (i.e. a change in primitives doesn't matter)
+	return !dockerEq || !k8sEq || !dcEq
+
+}
+func (m1 Manifest) fieldGroupsEqual(m2 Manifest) (primitivesEq, dockerEq, k8sEq, dcEq bool) {
 	primitivesMatch := m1.Name == m2.Name && m1.TriggerMode == m2.TriggerMode
 	dockerEqual := DeepEqual(m1.ImageTargets, m2.ImageTargets)
 
@@ -188,10 +204,7 @@ func (m1 Manifest) Equal(m2 Manifest) bool {
 	k8s2 := m2.K8sTarget()
 	k8sEqual := DeepEqual(k8s1, k8s2)
 
-	return primitivesMatch &&
-		dockerEqual &&
-		dockerComposeEqual &&
-		k8sEqual
+	return primitivesMatch, dockerEqual, dockerComposeEqual, k8sEqual
 }
 
 func (m Manifest) ManifestName() ManifestName {

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -311,6 +311,16 @@ var equalitytests = []struct {
 		}),
 		false,
 	},
+	{
+		Manifest{TriggerMode: TriggerModeManual},
+		Manifest{TriggerMode: TriggerModeManual},
+		true,
+	},
+	{
+		Manifest{TriggerMode: TriggerModeAuto},
+		Manifest{TriggerMode: TriggerModeManual},
+		false,
+	},
 }
 
 func TestManifestEquality(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan, @yuindustries,

Please review the following commits I made in branch maiamcc/set-trigger-mode-from-tiltfile:

0dce522f86a002503d75a0b8aed6cbfa51eb06ed (2019-06-12 16:07:37 -0400)
actually test this code change

b315ef613b6db748286d0aa9c926058cb440b8ae (2019-06-12 16:01:24 -0400)
clean up some existing config change tests

f32a355fd79311fa5c7b3e30e4b3d71d99e27d3e (2019-06-11 16:27:43 -0400)
check triggerMode when checking manifest equality (so we attach the new manifest to the state if we only change triggerMode)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics