### PR TITLE
Revert "engine/integration: remove k8s events feature flag (#1708)"

### DIFF
--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -195,6 +195,7 @@ func (f *k8sFixture) setupNewKubeConfig() {
 
 	f.tempDir.WriteFile("config", string(current))
 	f.fixture.tiltEnviron["KUBECONFIG"] = f.tempDir.JoinPath("config")
+	f.fixture.tiltEnviron["TILT_K8S_EVENTS"] = "true"
 	f.usingOverriddenConfig = true
 }
 

--- a/internal/engine/event_watch_manager.go
+++ b/internal/engine/event_watch_manager.go
@@ -22,6 +22,10 @@ func NewEventWatchManager(kClient k8s.Client) *EventWatchManager {
 }
 
 func (m *EventWatchManager) needsWatch(st store.RStore) bool {
+	if !k8sEventsFeatureFlagOn() {
+		return false
+	}
+
 	state := st.RLockState()
 	defer st.RUnlockState()
 

--- a/internal/engine/k8s_events_feature.go
+++ b/internal/engine/k8s_events_feature.go
@@ -1,0 +1,12 @@
+package engine
+
+import "os"
+
+// TODO(maia): remove this when feature is merged
+
+const k8sEventsFeatureFlag = "TILT_K8S_EVENTS"
+
+// TEMPORARY: check env to see if feature flag is set
+func k8sEventsFeatureFlagOn() bool {
+	return os.Getenv(k8sEventsFeatureFlag) != ""
+}

--- a/internal/engine/uid_map_manager.go
+++ b/internal/engine/uid_map_manager.go
@@ -21,6 +21,10 @@ func NewUIDMapManager(kCli k8s.Client) *UIDMapManager {
 }
 
 func (m *UIDMapManager) needsWatch(st store.RStore) bool {
+	if !k8sEventsFeatureFlagOn() {
+		return false
+	}
+
 	state := st.RLockState()
 	defer st.RUnlockState()
 


### PR DESCRIPTION
A user reported #1744 affecting `Deployment`, so hiding the events feature behind a flag until we've fixed that.