### PR TITLE
web: disambiguate k8s status from Tilt status

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -71,7 +71,7 @@ it("doesn't re-render the sidebar when the logs change", async () => {
   let resourceView = oneResourceView()
   hud.setState({ View: resourceView })
   let oldDOMNode = root.find(".Sidebar").getDOMNode()
-  resourceView.Resources[0].PodLog += "hello world\n"
+  resourceView.Resources[0].ResourceInfo.PodLog += "hello world\n"
   hud.setState({ View: resourceView })
   let newDOMNode = root.find(".Sidebar").getDOMNode()
 

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -10,46 +10,17 @@ import PreviewPane from "./PreviewPane"
 import PathBuilder from "./PathBuilder"
 import { Map } from "immutable"
 import { Route, Switch, RouteComponentProps } from "react-router-dom"
-import { createBrowserHistory, History, UnregisterCallback } from "history"
+import { History, UnregisterCallback } from "history"
 import { incr, pathToTag } from "./analytics"
 import TopBar from "./TopBar"
 import "./HUD.scss"
-import { TiltBuild, ResourceView, TriggerMode } from "./types"
+import { TiltBuild, ResourceView, Resource } from "./types"
 import AlertPane, { AlertResource } from "./AlertPane"
 import PreviewList from "./PreviewList"
 import AnalyticsNudge from "./AnalyticsNudge"
 
 type HudProps = {
   history: History
-}
-
-type Resource = {
-  Name: string
-  CombinedLog: string
-  BuildHistory: Array<any>
-  CrashLog: string
-  CurrentBuild: any
-  DirectoriesWatched: Array<any>
-  Endpoints: Array<string>
-  PodID: string
-  IsTiltfile: boolean
-  LastDeployTime: string
-  PathsWatched: Array<string>
-  PendingBuildEdits: Array<string>
-  PendingBuildReason: number
-  ResourceInfo: {
-    PodCreationTime: string
-    PodLog: string
-    PodName: string
-    PodRestarts: number
-    PodUpdateStartTime: string
-    YAML: string
-    PodStatus: string
-  }
-  RuntimeStatus: string
-  ShowBuildStatus: boolean
-  TriggerMode: TriggerMode
-  HasPendingChanges: boolean
 }
 
 type HudState = {

--- a/web/src/Sidebar.test.tsx
+++ b/web/src/Sidebar.test.tsx
@@ -10,7 +10,7 @@ import {
   oneResourceManualTriggerDirty,
 } from "./testdata.test"
 import { mount } from "enzyme"
-import { ResourceView, TriggerMode } from "./types"
+import { ResourceView, TriggerMode, Resource } from "./types"
 import PathBuilder from "./PathBuilder"
 
 let pathBuilder = new PathBuilder("localhost", "/")
@@ -44,7 +44,7 @@ describe("sidebar", () => {
   })
 
   it("renders list of resources", () => {
-    let items = twoResourceView().Resources.map((res: any) => {
+    let items = twoResourceView().Resources.map((res: Resource) => {
       res.BuildHistory[0].Error = ""
       return new SidebarItem(res)
     })
@@ -70,7 +70,7 @@ describe("sidebar", () => {
     let items = [4, 9, 19, 29, 39, 49, 54].map(d => {
       let res = oneResource()
       res.Name = `resource${d}`
-      res.LastDeployTime = Date.now() - d * 1000
+      res.LastDeployTime = new Date(Date.now() - d * 1000).toISOString()
       return new SidebarItem(res)
     })
 

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -3,7 +3,7 @@ import { ReactComponent as ChevronSvg } from "./assets/svg/chevron.svg"
 import { Link } from "react-router-dom"
 import { combinedStatus, warnings } from "./status"
 import "./Sidebar.scss"
-import { ResourceView, TriggerMode, ResourceStatus, Build } from "./types"
+import { ResourceView, TriggerMode, RuntimeStatus, Build } from "./types"
 import TimeAgo from "react-timeago"
 import { isZeroTime } from "./time"
 import PathBuilder from "./PathBuilder"
@@ -14,7 +14,7 @@ import SidebarTriggerButton from "./SidebarTriggerButton"
 
 class SidebarItem {
   name: string
-  status: ResourceStatus
+  status: RuntimeStatus
   hasWarnings: boolean
   hasEndpoints: boolean
   lastDeployTime: string
@@ -30,7 +30,7 @@ class SidebarItem {
    */
   constructor(res: any) {
     this.name = res.Name
-    this.status = combinedStatus(res)
+    this.status = combinedStatus(res.RuntimeStatus)
     this.hasWarnings = warnings(res).length > 0
     this.hasEndpoints = (res.Endpoints || []).length
     this.lastDeployTime = res.LastDeployTime

--- a/web/src/SidebarIcon.test.tsx
+++ b/web/src/SidebarIcon.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { mount } from "enzyme"
 import SidebarIcon, { IconType } from "./SidebarIcon"
-import { ResourceStatus, TriggerMode, Build } from "./types"
+import { RuntimeStatus, TriggerMode, Build } from "./types"
 import { Color } from "./constants"
 
 type Ignore = boolean
@@ -19,7 +19,7 @@ const buildWithError = {
 const cases: Array<
   [
     string,
-    ResourceStatus,
+    RuntimeStatus,
     boolean,
     boolean,
     TriggerMode,
@@ -31,7 +31,7 @@ const cases: Array<
 > = [
   [
     "auto mode, building with any status or warning state → small loader",
-    ResourceStatus.Pending,
+    RuntimeStatus.Pending,
     false,
     true,
     TriggerMode.TriggerModeAuto,
@@ -42,7 +42,7 @@ const cases: Array<
   ],
   [
     "manual mode, building with any status or warning state → loader",
-    ResourceStatus.Ok,
+    RuntimeStatus.Ok,
     false,
     true,
     TriggerMode.TriggerModeAuto,
@@ -53,7 +53,7 @@ const cases: Array<
   ],
   [
     "auto mode, status ok and no warning → small green dot",
-    ResourceStatus.Ok,
+    RuntimeStatus.Ok,
     false,
     false,
     TriggerMode.TriggerModeAuto,
@@ -64,7 +64,7 @@ const cases: Array<
   ],
   [
     "manual mode, status ok and no warning → green ring",
-    ResourceStatus.Ok,
+    RuntimeStatus.Ok,
     false,
     false,
     TriggerMode.TriggerModeManual,
@@ -75,7 +75,7 @@ const cases: Array<
   ],
   [
     "auto mode, status error and no warning → small red dot",
-    ResourceStatus.Error,
+    RuntimeStatus.Error,
     false,
     false,
     TriggerMode.TriggerModeAuto,
@@ -86,7 +86,7 @@ const cases: Array<
   ],
   [
     "manual mode, status error and no warning → red ring",
-    ResourceStatus.Error,
+    RuntimeStatus.Error,
     false,
     false,
     TriggerMode.TriggerModeManual,
@@ -97,7 +97,7 @@ const cases: Array<
   ],
   [
     "auto mode, status error with warnings → small red dot",
-    ResourceStatus.Error,
+    RuntimeStatus.Error,
     true,
     false,
     TriggerMode.TriggerModeAuto,
@@ -108,7 +108,7 @@ const cases: Array<
   ],
   [
     "manual mode, status error with warnings → red ring",
-    ResourceStatus.Error,
+    RuntimeStatus.Error,
     true,
     false,
     TriggerMode.TriggerModeManual,
@@ -119,7 +119,7 @@ const cases: Array<
   ],
   [
     "auto mode, status ok with warning → small yellow dot",
-    ResourceStatus.Ok,
+    RuntimeStatus.Ok,
     true,
     false,
     TriggerMode.TriggerModeAuto,
@@ -130,7 +130,7 @@ const cases: Array<
   ],
   [
     "manual mode, status ok with warning → yellow ring",
-    ResourceStatus.Ok,
+    RuntimeStatus.Ok,
     true,
     false,
     TriggerMode.TriggerModeManual,
@@ -141,7 +141,7 @@ const cases: Array<
   ],
   [
     "auto mode, status pending and no warnings → small glowing ring",
-    ResourceStatus.Pending,
+    RuntimeStatus.Pending,
     false,
     false,
     TriggerMode.TriggerModeAuto,
@@ -152,7 +152,7 @@ const cases: Array<
   ],
   [
     "auto mode, status pending with warnings → small glowing ring",
-    ResourceStatus.Pending,
+    RuntimeStatus.Pending,
     true,
     false,
     TriggerMode.TriggerModeAuto,
@@ -163,7 +163,7 @@ const cases: Array<
   ],
   [
     "manual mode, status pending and no warnings → glowing ring",
-    ResourceStatus.Pending,
+    RuntimeStatus.Pending,
     false,
     false,
     TriggerMode.TriggerModeManual,
@@ -174,7 +174,7 @@ const cases: Array<
   ],
   [
     "manual mode, status pending with warnings → glowing ring",
-    ResourceStatus.Pending,
+    RuntimeStatus.Pending,
     true,
     false,
     TriggerMode.TriggerModeManual,
@@ -185,7 +185,7 @@ const cases: Array<
   ],
   [
     "manual mode, status pending with last build in error → red ring",
-    ResourceStatus.Pending,
+    RuntimeStatus.Pending,
     false,
     false,
     TriggerMode.TriggerModeManual,

--- a/web/src/SidebarIcon.tsx
+++ b/web/src/SidebarIcon.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react"
-import { TriggerMode, ResourceStatus, Build } from "./types"
+import { TriggerMode, RuntimeStatus, Build } from "./types"
 import { Color } from "./constants"
 import { ReactComponent as ManualSvg } from "./assets/svg/indicator-manual.svg"
 import { ReactComponent as ManualBuildingSvg } from "./assets/svg/indicator-manual-building.svg"
@@ -9,7 +9,7 @@ import { ReactComponent as AutoBuildingSvg } from "./assets/svg/indicator-auto-b
 
 type SidebarIconProps = {
   triggerMode: TriggerMode
-  status: ResourceStatus
+  status: RuntimeStatus
   hasWarning: boolean
   isBuilding: boolean
   isDirty: boolean
@@ -32,7 +32,7 @@ export default class SidebarIcon extends PureComponent<SidebarIconProps> {
     let dirtyBuildWithError =
       props.isDirty && props.lastBuild && props.lastBuild.Error
 
-    if (props.status === ResourceStatus.Error) {
+    if (props.status === RuntimeStatus.Error) {
       fill = Color.red
     } else if (props.hasWarning) {
       fill = Color.yellow
@@ -53,7 +53,7 @@ export default class SidebarIcon extends PureComponent<SidebarIconProps> {
       return this.dotAutoBuilding()
     }
 
-    if (props.status === ResourceStatus.Pending) {
+    if (props.status === RuntimeStatus.Pending) {
       return this.dotAutoPending()
     }
 
@@ -70,7 +70,7 @@ export default class SidebarIcon extends PureComponent<SidebarIconProps> {
       return this.dotManual(fill)
     }
 
-    if (props.status === ResourceStatus.Pending) {
+    if (props.status === RuntimeStatus.Pending) {
       return this.dotManualPending()
     }
 

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -48,14 +48,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -72,7 +64,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           >
             <time
               dateTime="2017-12-21T15:36:03.000Z"
-              title="2017-12-21 15:36"
+              title="2017-12-21T15:36:03.000Z"
             >
               &lt;5s
             </time>
@@ -102,14 +94,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -126,7 +110,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:58.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:58.000Z"
             >
               &lt;15s
             </time>
@@ -156,14 +140,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -180,7 +156,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:48.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:48.000Z"
             >
               &lt;30s
             </time>
@@ -210,14 +186,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -234,7 +202,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:38.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:38.000Z"
             >
               &lt;30s
             </time>
@@ -264,14 +232,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -288,7 +248,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:28.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:28.000Z"
             >
               &lt;45s
             </time>
@@ -318,14 +278,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -342,7 +294,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:18.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:18.000Z"
             >
               &lt;1m
             </time>
@@ -372,14 +324,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -396,7 +340,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:13.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:13.000Z"
             >
               &lt;1m
             </time>
@@ -643,14 +587,6 @@ exports[`sidebar renders list of resources 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -667,7 +603,7 @@ exports[`sidebar renders list of resources 1`] = `
           >
             <time
               dateTime="2017-12-21T15:36:07.000Z"
-              title="2017-12-21 15:36"
+              title="2017-12-21T15:36:07.000Z"
             >
               &lt;5s
             </time>
@@ -697,14 +633,6 @@ exports[`sidebar renders list of resources 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -721,7 +649,7 @@ exports[`sidebar renders list of resources 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:57.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:57.000Z"
             >
               &lt;15s
             </time>
@@ -798,14 +726,6 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -847,14 +767,6 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             >
               indicator-auto-building.svg
             </svg>
-            <button
-              className="SidebarTriggerButton "
-              onClick={[Function]}
-            >
-              <svg>
-                trigger.svg
-              </svg>
-            </button>
           </div>
           <span
             className="resLink-name"
@@ -967,7 +879,7 @@ exports[`sidebar renders resources with manual trigger mode 1`] = `
           >
             <time
               dateTime="2017-12-21T15:36:07.000Z"
-              title="2017-12-21 15:36"
+              title="2017-12-21T15:36:07.000Z"
             >
               &lt;5s
             </time>
@@ -1021,7 +933,7 @@ exports[`sidebar renders resources with manual trigger mode 1`] = `
           >
             <time
               dateTime="2017-12-21T15:35:57.000Z"
-              title="2017-12-21 15:35"
+              title="2017-12-21T15:35:57.000Z"
             >
               &lt;15s
             </time>

--- a/web/src/status.tsx
+++ b/web/src/status.tsx
@@ -1,12 +1,12 @@
 import { isZeroTime } from "./time"
-import { ResourceStatus } from "./types"
+import { RuntimeStatus, ResourceStatus, Resource } from "./types"
 
 // A combination of runtime status and build status over a resource view.
 // 1) If there's a current or pending build, this is "pending".
 // 2) Otherwise, if there's a build error or runtime error, this is "error".
 // 3) Otherwise, we fallback to runtime status.
-function combinedStatus(res: any): ResourceStatus {
-  let runtimeStatus: ResourceStatus = res.RuntimeStatus
+function combinedStatus(res: any): RuntimeStatus {
+  let runtimeStatus: RuntimeStatus = res.RuntimeStatus
   let currentBuild = res.CurrentBuild
   let hasCurrentBuild = Boolean(
     currentBuild && !isZeroTime(currentBuild.StartTime)
@@ -17,10 +17,10 @@ function combinedStatus(res: any): ResourceStatus {
   let lastBuildError = lastBuild ? lastBuild.Error : ""
 
   if (hasCurrentBuild || hasPendingBuild) {
-    return ResourceStatus.Pending
+    return RuntimeStatus.Pending
   }
   if (lastBuildError) {
-    return ResourceStatus.Error
+    return RuntimeStatus.Error
   }
   return runtimeStatus
 }
@@ -38,4 +38,8 @@ function warnings(res: any): string[] {
   return warnings
 }
 
-export { combinedStatus, warnings }
+function tiltStatus(res: Resource): ResourceStatus {
+  return ResourceStatus.Building
+}
+
+export { combinedStatus, warnings, tiltStatus }

--- a/web/src/testdata.test.tsx
+++ b/web/src/testdata.test.tsx
@@ -1,6 +1,11 @@
 import { RouteComponentProps } from "react-router-dom"
 import { UnregisterCallback, Href } from "history"
 import { podStatusImagePullBackOff, podStatusErrImgPull } from "./constants"
+import { Resource, TriggerMode } from "./types"
+
+type view = {
+  Resources: Array<Resource>
+}
 
 // NOTE(dmiller) 4-02-19 this function is currently unused but I'm going to keep it around.
 // I have a feeling that it will come in handy later.
@@ -49,9 +54,9 @@ function getMockRouterProps<P>(data: P) {
   return props
 }
 
-function oneResource(): any {
-  const ts = Date.now().valueOf()
-  const resource = {
+function oneResource(): Resource {
+  const ts = new Date(Date.now()).toISOString()
+  const resource: Resource = {
     Name: "vigoda",
     DirectoriesWatched: ["foo", "bar"],
     LastDeployTime: ts,
@@ -65,6 +70,7 @@ function oneResource(): any {
     ],
     PendingBuildEdits: ["main.go", "cli.go", "vigoda.go"],
     PendingBuildSince: ts,
+    PendingBuildReason: 0,
     CurrentBuild: {
       Edits: ["main.go"],
       StartTime: ts,
@@ -76,8 +82,18 @@ function oneResource(): any {
       PodRestarts: 0,
       Endpoints: ["1.2.3.4:8080"],
       PodLog: "1\n2\n3\n4\nabe vigoda is now dead\n5\n6\n7\n8\n",
+      PodUpdateStartTime: ts,
+      YAML: "",
     },
     RuntimeStatus: "ok",
+    CombinedLog: "",
+    CrashLog: "",
+    TriggerMode: TriggerMode.TriggerModeAuto,
+    HasPendingChanges: false,
+    Endpoints: [],
+    PodID: "",
+    IsTiltfile: false,
+    PathsWatched: [],
   }
   return resource
 }
@@ -172,19 +188,19 @@ function oneResourceErrImgPull(): any {
   return resource
 }
 
-function oneResourceView(): any {
+function oneResourceView(): view {
   return { Resources: [oneResource()] }
 }
 
-function twoResourceView(): any {
+function twoResourceView(): view {
   const time = Date.now()
-  const ts = time.valueOf()
+  const ts = new Date(time).toISOString()
   const vigoda = oneResource()
 
-  const snack = {
+  const snack: Resource = {
     Name: "snack",
     DirectoriesWatched: ["foo", "bar"],
-    LastDeployTime: (time - 10000).valueOf(),
+    LastDeployTime: new Date(time - 10000).toISOString(),
     BuildHistory: [
       {
         Edits: ["main.go", "cli.go"],
@@ -199,13 +215,26 @@ function twoResourceView(): any {
       Edits: ["main.go"],
       StartTime: ts,
     },
-    PodName: "snack-pod",
-    PodCreationTime: ts,
-    PodStatus: "Running",
-    PodRestarts: 0,
     Endpoints: ["1.2.3.4:8080"],
-    PodLog: "1\n2\n3\n4\nsnacks are great\n5\n6\n7\n8\n",
     RuntimeStatus: "ok",
+    TriggerMode: TriggerMode.TriggerModeAuto,
+    CombinedLog: "",
+    CrashLog: "",
+    IsTiltfile: false,
+    PodID: "",
+    PathsWatched: [],
+    PendingBuildReason: 0,
+    ResourceInfo: {
+      PodStatus: "Running",
+      PodRestarts: 0,
+      PodCreationTime: "",
+      PodLog: "",
+      PodName: "snack",
+      PodUpdateStartTime: "",
+      YAML: "",
+      Endpoints: [],
+    },
+    HasPendingChanges: false,
   }
   return { Resources: [vigoda, snack] }
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -25,8 +25,49 @@ export type TiltBuild = {
   Dev: boolean
 }
 
-export enum ResourceStatus {
+// what is the status of the resource in the cluster
+export enum RuntimeStatus {
   Ok = "ok",
   Pending = "pending",
   Error = "error",
+}
+
+// What is the status of the resource with respect to Tilt
+export enum ResourceStatus {
+  BuildQueued, // in auto, if you have changed a file but an affected build hasn't started yet. In manual after you have clicked build, before it has started building
+  Building,
+  Error,
+  Warning,
+  Deploying,
+  Deployed, // defer to RuntimeStatus
+}
+
+export type Resource = {
+  Name: string
+  CombinedLog: string
+  BuildHistory: Array<any>
+  CrashLog: string
+  CurrentBuild: any
+  DirectoriesWatched: Array<any>
+  Endpoints: Array<string>
+  PodID: string
+  IsTiltfile: boolean
+  LastDeployTime: string
+  PathsWatched: Array<string>
+  PendingBuildEdits: Array<string>
+  PendingBuildReason: number
+  PendingBuildSince: string
+  ResourceInfo: {
+    PodCreationTime: string
+    PodLog: string
+    PodName: string
+    PodRestarts: number
+    PodUpdateStartTime: string
+    YAML: string
+    PodStatus: string
+    Endpoints: Array<string>
+  }
+  RuntimeStatus: string
+  TriggerMode: TriggerMode
+  HasPendingChanges: boolean
 }


### PR DESCRIPTION
This lays the groundwork for a series of changes that will disentangle the idea of "the status in kubernetes" from "where is this resource in Tilt's flow", in to two different statuses: `RuntimeStatus` (for k8s) and `ResourceStatus` (for Tilt).

In a future PR I will remove the `combinedStatus` function and call two different functions: `runtimeStatus` and `resourceStatus` as appropriate in the various places that `combinedStatus` is used.

All this PR does is:
1. Introduce `RuntimeStatus` and `ResoruceStatus`
2. Refactor tests to use the appropriate types
