### PR TITLE
vendor: bump tcell

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -448,15 +448,16 @@
   revision = "b23993cbb6353f0e6aa98d0ee318a34728f628b9"
 
 [[projects]]
-  digest = "1:00b9cce210566117aff926677c005aeaea6c85374e67bdcb72783af237c48f97"
+  branch = "master"
+  digest = "1:fb2c53586c4f2fd2567396caf6981514ca370d0108e996c572a98e511356f733"
   name = "github.com/gdamore/tcell"
   packages = [
     ".",
     "terminfo",
+    "terminfo/dynamic",
   ]
   pruneopts = "UT"
-  revision = "de7e78efa4a71b3f36c7154989c529dbdf9ae623"
-  version = "v1.1.0"
+  revision = "ca8fb5bcc94b37b52eb8508d3ed8753e4762e83f"
 
 [[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
@@ -1851,6 +1852,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/apps/v1beta2",
+    "k8s.io/api/authorization/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
@@ -1873,6 +1875,7 @@
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/authorization/v1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,3 +76,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/windmilleng/windmill"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/gdamore/tcell"

--- a/vendor/github.com/gdamore/tcell/.travis.yml
+++ b/vendor/github.com/gdamore/tcell/.travis.yml
@@ -1,12 +1,8 @@
 language: go
 
 go:
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
   - master
 
 before_install:

--- a/vendor/github.com/gdamore/tcell/README.adoc
+++ b/vendor/github.com/gdamore/tcell/README.adoc
@@ -1,0 +1,272 @@
+= tcell
+
+
+image:https://img.shields.io/travis/gdamore/tcell.svg?label=linux[Linux Status,link="https://travis-ci.org/gdamore/tcell"]
+image:https://img.shields.io/appveyor/ci/gdamore/tcell.svg?label=windows[Windows Status,link="https://ci.appveyor.com/project/gdamore/tcell"]
+image:https://img.shields.io/badge/license-APACHE2-blue.svg[Apache License,link="https://github.com/gdamore/tcell/blob/master/LICENSE"]
+image:https://img.shields.io/badge/gitter-join-brightgreen.svg[Gitter,link="https://gitter.im/gdamore/tcell"]
+image:https://img.shields.io/badge/godoc-reference-blue.svg[GoDoc,link="https://godoc.org/github.com/gdamore/tcell"]
+image:http://goreportcard.com/badge/gdamore/tcell[Go Report Card,link="http://goreportcard.com/report/gdamore/tcell"]
+image:https://codecov.io/gh/gdamore/tcell/branch/master/graph/badge.svg[codecov,link="https://codecov.io/gh/gdamore/tcell"]
+image:https://tidelift.com/badges/github/gdamore/tcell?style=flat[Dependencies]
+
+[cols="2",grid="none"]
+|===
+|_Tcell_ is a _Go_ package that provides a cell based view for text terminals, like _xterm_.
+It was inspired by _termbox_, but includes many additional improvements.
+a|[.right]
+image::logos/tcell.png[float="right"]
+|===
+
+## Examples
+
+* https://github.com/gdamore/proxima5[proxima5] - space shooter (https://youtu.be/jNxKTCmY_bQ[video])
+* https://github.com/gdamore/govisor[govisor] - service management UI (http://2.bp.blogspot.com/--OsvnfzSNow/Vf7aqMw3zXI/AAAAAAAAARo/uOMtOvw4Sbg/s1600/Screen%2BShot%2B2015-09-20%2Bat%2B9.08.41%2BAM.png[screenshot])
+* mouse demo - included mouse test (http://2.bp.blogspot.com/-fWvW5opT0es/VhIdItdKqJI/AAAAAAAAATE/7Ojc0L1SpB0/s1600/Screen%2BShot%2B2015-10-04%2Bat%2B11.47.13%2BPM.png[screenshot])
+* https://github.com/gdamore/gomatrix[gomatrix] - converted from Termbox
+* https://github.com/zyedidia/micro/[micro] - lightweight text editor with syntax-highlighting and themes
+* https://github.com/viktomas/godu[godu] - simple golang utility helping to discover large files/folders.
+* https://github.com/rivo/tview[tview] - rich interactive widgets for terminal UIs
+* https://github.com/marcusolsson/tui-go[tui-go] - UI library for terminal apps
+* https://github.com/rgm3/gomandelbrot[gomandelbrot] - Mandelbrot!
+* https://github.com/senorprogrammer/wtf[WTF]- Personal information dashboard for your terminal
+* https://github.com/browsh-org/browsh[browsh] - A fully-modern text-based browser, rendering to TTY and browsers (https://www.youtube.com/watch?v=HZq86XfBoRo[video])
+* https://github.com/sachaos/go-life[go-life] - Conway's Game of Life.
+* https://github.com/gcla/gowid[gowid] - compositional widgets for terminal UIs, inspired by urwid
+* https://termshark.io[termshark] - a terminal UI for tshark, inspired by Wireshark, built on gowid
+
+## Pure Go Terminfo Database
+
+_Tcell_ includes a full parser and expander for terminfo capability strings,
+so that it can avoid hard coding escape strings for formatting.  It also favors
+portability, and includes support for all POSIX systems.
+
+The database is also flexible & extensible, and can modified by either running
+a program to build the entire database, or an entry for just a single terminal.
+
+## More Portable
+
+_Tcell_ is portable to a wide variety of systems.
+_Tcell_ is believed
+to work with all of the systems officially supported by golang with
+the exception of nacl (which lacks any kind of a terminal interface).
+(Plan9 is not supported by _Tcell_, but it is experimental status only
+in golang.)  For all of these systems *except Solaris/illumos*, _Tcell_
+is pure Go, with no need for CGO.
+
+## No Async IO
+
+_Tcell_ is able to operate without requiring `SIGIO` signals (unlike _termbox_),
+or asynchronous I/O, and can instead use standard Go file
+objects and Go routines.
+This means it should be safe, especially for
+use with programs that use exec, or otherwise need to manipulate the
+tty streams.
+This model is also much closer to idiomatic Go, leading
+to fewer surprises.
+
+## Rich Unicode & non-Unicode support
+
+_Tcell_ includes enhanced support for Unicode, including wide characters and
+combining characters, provided your terminal can support them.
+Note that
+Windows terminals generally don't support the full Unicode repertoire.
+
+It will also convert to and from Unicode locales, so that the program
+can work with UTF-8 internally, and get reasonable output in other locales.
+_Tcell_ tries hard to convert to native characters on both input and output, and
+on output _Tcell_ even makes use of the alternate character set to facilitate
+drawing certain characters.
+
+## More Function Keys
+
+_Tcell_ also has richer support for a larger number of special keys that some terminals can send.
+
+## Better Color Handling
+
+_Tcell_ will respect your terminal's color space as specified within your terminfo
+entries, so that for example attempts to emit color sequences on VT100 terminals
+won't result in unintended consequences.
+
+In Windows mode, _Tcell_ supports 16 colors, bold, dim, and reverse,
+instead of just termbox's 8 colors with reverse.  (Note that there is some
+conflation with bold/dim and colors.)
+
+_Tcell_ maps 16 colors down to 8, for terminals that need it.
+(The upper 8 colors are just brighter versions of the lower 8.)
+
+## Better Mouse Support
+
+_Tcell_ supports enhanced mouse tracking mode, so your application can receive
+regular mouse motion events, and wheel events, if your terminal supports it.
+
+## _Termbox_ Compatibility
+
+A compatibility layer for _termbox_ is provided in the `compat` directory.
+To use it, try importing `github.com/gdamore/tcell/termbox`
+instead.  Most _termbox-go_ programs will probably work without further
+modification.
+
+## Working With Unicode
+
+Internally Tcell uses UTF-8, just like Go.
+However, Tcell understands how to
+convert to and from other character sets, using the capabilities of
+the `golang.org/x/text/encoding packages`.
+Your application must supply
+them, as the full set of the most common ones bloats the program by about 2MB.
+If you're lazy, and want them all anyway, see the `encoding` sub-directory.
+
+## Wide & Combining Characters
+
+The `SetContent()` API takes a primary rune, and an optional list of combining runes.
+If any of the runes is a wide (East Asian) rune occupying two cells,
+then the library will skip output from the following cell, but care must be
+taken in the application to avoid explicitly attempting to set content in the
+next cell, otherwise the results are undefined.  (Normally wide character
+is displayed, and the other character is not; do not depend on that behavior.)
+
+Experience has shown that the vanilla Windows 8 console application does not
+support any of these characters properly, but at least some options like
+_ConEmu_ do support Wide characters.
+
+## Colors
+
+_Tcell_ assumes the ANSI/XTerm color model, including the 256 color map that
+XTerm uses when it supports 256 colors.  The terminfo guidance will be
+honored, with respect to the number of colors supported.  Also, only
+terminals which expose ANSI style `setaf` and `setab` will support color;
+if you have a color terminal that only has `setf` and `setb`, please let me
+know; it wouldn't be hard to add that if there is need.
+
+## 24-bit Color
+
+_Tcell_ _supports true color_!  (That is, if your terminal can support it,
+_Tcell_ can accurately display 24-bit color.)
+
+To use 24-bit color, you need to use a terminal that supports it.  Modern
+xterm and similar teminal emulators can support this.  As terminfo lacks any
+way to describe this capability, we fabricate the capability for
+terminals with names ending in `*-truecolor`.  The stock distribution ships
+with a database that defines `xterm-truecolor`.
+To try it out, set your
+`TERM` variable to `xterm-truecolor`.
+
+When using TrueColor, programs will display the colors that the programmer
+intended, overriding any "`themes`" you may have set in your terminal
+emulator.  (For some cases, accurate color fidelity is more important
+than respecting themes.  For other cases, such as typical text apps that
+only use a few colors, its more desirable to respect the themes that
+the user has established.)
+
+If you find this undesirable, you can either use a `TERM` variable
+that lacks the `TRUECOLOR` setting, or set `TCELL_TRUECOLOR=disable` in your
+environment.
+
+## Performance
+
+Reasonable attempts have been made to minimize sending data to terminals,
+avoiding repeated sequences or drawing the same cell on refresh updates.
+
+## Terminfo
+
+(Not relevent for Windows users.)
+
+The Terminfo implementation operates with two forms of database.  The first
+is the built-in go database, which contains a number of real database entries
+that are compiled into the program directly.  This should minimize calling
+out to database file searches.
+
+The second is in the form of JSON files, that contain the same information,
+which can be located either by the `$TCELLDB` environment file, `$HOME/.tcelldb`,
+or is located in the Go source directory as `database.json`.
+
+These files (both the Go and the JSON files) can be generated using the
+mkinfo.go program.  If you need to regnerate the entire set for some reason,
+run the mkdatabase.sh file.  The generation uses the infocmp(1) program on
+the system to collect the necessary information.
+
+The `mkinfo.go` program can also be used to generate specific database entries
+for named terminals, in case your favorite terminal is missing.  (If you
+find that this is the case, please let me know and I'll try to add it!)
+
+_Tcell_ requires that the terminal support the `cup` mode of cursor addressing.
+Terminals without absolute cursor addressability are not supported.
+This is unlikely to be a problem; such terminals have not been mass produced
+since the early 1970s.
+
+## Mouse Support
+
+Mouse support is detected via the `kmous` terminfo variable, however,
+enablement/disablement and decoding mouse events is done using hard coded
+sequences based on the XTerm X11 model.  As of this writing all popular
+terminals with mouse tracking support this model.  (Full terminfo support
+is not possible as terminfo sequences are not defined.)
+
+On Windows, the mouse works normally.
+
+Mouse wheel buttons on various terminals are known to work, but the support
+in terminal emulators, as well as support for various buttons and
+live mouse tracking, varies widely.  Modern _xterm_, macOS _Terminal_, and _iTerm_ all work well.
+
+## Testablity
+
+There is a `SimulationScreen`, that can be used to simulate a real screen
+for automated testing.  The supplied tests do this.  The simulation contains
+event delivery, screen resizing support, and capabilities to inject events
+and examine "`physical`" screen contents.
+
+## Platforms
+
+### POSIX (Linux, FreeBSD, macOS, Solaris, etc.)
+
+For mainstream systems with a suitably well defined system call interface
+to tty settings, everything works using pure Go.
+
+For the remainder (right now means only Solaris/illumos) we use POSIX function
+calls to manage termios, which implies that CGO is required on those platforms.
+
+### Windows
+
+Windows console mode applications are supported.  Unfortunately _mintty_
+and other _cygwin_ style applications are not supported.
+
+Modern console applications like ConEmu, as well as the Windows 10
+console itself, support all the good features (resize, mouse tracking, etc.)
+
+I haven't figured out how to cleanly resolve the dichotomy between cygwin
+style termios and the Windows Console API; it seems that perhaps nobody else
+has either.  If anyone has suggestions, let me know!  Really, if you're
+using a Windows application, you should use the native Windows console or a
+fully compatible console implementation.
+
+### Plan9 and Native Client (Nacl)
+
+The nacl and plan9 platforms won't work, but compilation stubs are supplied
+for folks that want to include parts of this in software targetting those
+platforms.  The Simulation screen works, but as Tcell doesn't know how to
+allocate a real screen object on those platforms, `NewScreen()` will fail.
+
+If anyone has wisdom about how to improve support for either of these,
+please let me know.  PRs are especially welcome.
+
+### Commercial Support
+
+_Tcell_ is absolutely free, but if you want to obtain commercial, professional support, there are options.
+
+[cols="2",align="center",frame="none", grid="none"]
+|===
+^.^|
+image:logos/tidelift.png[100,100]
+a|
+https://tidelift.com/[Tidelift] subscriptions include support for _Tcell_, as well as many other open source packages.
+
+^.^|
+image:logos/staysail.png[100,100]
+a|
+mailto:info@staysail.tech[Staysail Systems, Inc.] offers direct support, and custom development around _Tcell_ on an hourly basis.
+
+^.^|
+image:logos/patreon.png[100,100]
+a|I also welcome donations at https://www.patreon.com/gedamore/[Patreon], if you just want to make a contribution.
+|===

--- a/vendor/github.com/gdamore/tcell/cell.go
+++ b/vendor/github.com/gdamore/tcell/cell.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The TCell Authors
+// Copyright 2019 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -15,7 +15,7 @@
 package tcell
 
 import (
-	"github.com/mattn/go-runewidth"
+	runewidth "github.com/mattn/go-runewidth"
 )
 
 type cell struct {
@@ -49,16 +49,6 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		c := &cb.cells[(y*cb.w)+x]
 
 		c.currComb = append([]rune{}, combc...)
-		i := 0
-		for i < len(c.currComb) {
-			r := c.currComb[i]
-			if runewidth.RuneWidth(r) != 0 {
-				// not a combining character, yank it
-				c.currComb = append(c.currComb[:i-1], c.currComb[i+1:]...)
-				continue
-			}
-			i++
-		}
 
 		if c.currMain != mainc {
 			c.width = runewidth.RuneWidth(mainc)
@@ -175,12 +165,13 @@ func (cb *CellBuffer) Resize(w, h int) {
 
 // Fill fills the entire cell buffer array with the specified character
 // and style.  Normally choose ' ' to clear the screen.  This API doesn't
-// support combining characters.
+// support combining characters, or characters with a width larger than one.
 func (cb *CellBuffer) Fill(r rune, style Style) {
 	for i := range cb.cells {
 		c := &cb.cells[i]
 		c.currMain = r
 		c.currComb = nil
 		c.currStyle = style
+		c.width = 1
 	}
 }

--- a/vendor/github.com/gdamore/tcell/console_win.go
+++ b/vendor/github.com/gdamore/tcell/console_win.go
@@ -1,6 +1,6 @@
 // +build windows
 
-// Copyright 2016 The TCell Authors
+// Copyright 2019 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -283,7 +283,6 @@ func (s *cScreen) doCursor() {
 	x, y := s.curx, s.cury
 
 	if x < 0 || y < 0 || x >= s.w || y >= s.h {
-		s.setCursorPos(0, 0)
 		s.hideCursor()
 	} else {
 		s.setCursorPos(x, y)
@@ -787,7 +786,9 @@ func (s *cScreen) draw() {
 			if len(combc) != 0 {
 				wcs = append(wcs, utf16.Encode(combc)...)
 			}
-			s.cells.SetDirty(x, y, false)
+			for dx := 0; dx < width; dx++ {
+				s.cells.SetDirty(x+dx, y, false)
+			}
 			x += width - 1
 		}
 		s.writeString(lx, ly, lstyle, wcs)
@@ -880,13 +881,13 @@ func (s *cScreen) resize() {
 	s.w = w
 	s.h = h
 
+	s.setBufferSize(w, h)
+
 	r := rect{0, 0, int16(w - 1), int16(h - 1)}
 	procSetConsoleWindowInfo.Call(
 		uintptr(s.out),
 		uintptr(1),
 		uintptr(unsafe.Pointer(&r)))
-
-	s.setBufferSize(w, h)
 
 	s.PostEvent(NewEventResize(w, h))
 }

--- a/vendor/github.com/gdamore/tcell/go.mod
+++ b/vendor/github.com/gdamore/tcell/go.mod
@@ -1,0 +1,10 @@
+module github.com/gdamore/tcell
+
+go 1.12
+
+require (
+	github.com/gdamore/encoding v1.0.0
+	github.com/lucasb-eyer/go-colorful v1.0.2
+	github.com/mattn/go-runewidth v0.0.4
+	golang.org/x/text v0.3.0
+)

--- a/vendor/github.com/gdamore/tcell/go.sum
+++ b/vendor/github.com/gdamore/tcell/go.sum
@@ -1,0 +1,10 @@
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
+github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/lucasb-eyer/go-colorful v1.0.2 h1:mCMFu6PgSozg9tDNMMK3g18oJBX7oYGrC09mS6CXfO4=
+github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vendor/github.com/gdamore/tcell/screen.go
+++ b/vendor/github.com/gdamore/tcell/screen.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The TCell Authors
+// Copyright 2019 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -198,14 +198,11 @@ type Screen interface {
 // NewScreen returns a default Screen suitable for the user's terminal
 // environment.
 func NewScreen() (Screen, error) {
-	// First we attempt to obtain a terminfo screen.  This should work
-	// in most places if $TERM is set.
-	if s, e := NewTerminfoScreen(); s != nil {
+	// Windows is happier if we try for a console screen first.
+	if s, _ := NewConsoleScreen(); s != nil {
 		return s, nil
-
-	} else if s, _ := NewConsoleScreen(); s != nil {
+	} else if s, e := NewTerminfoScreen(); s != nil {
 		return s, nil
-
 	} else {
 		return nil, e
 	}

--- a/vendor/github.com/gdamore/tcell/terminfo/dynamic/dynamic.go
+++ b/vendor/github.com/gdamore/tcell/terminfo/dynamic/dynamic.go
@@ -1,0 +1,425 @@
+// Copyright 2019 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The dynamic package is used to generate a terminal description dynamically,
+// using infocmp.  This is really a method of last resort, as the performance
+// will be slow, and it requires a working infocmp.  But, the hope is that it
+// will assist folks who have to deal with a terminal description that isn't
+// already built in.  This requires infocmp to be in the user's path, and to
+// support reasonably the -1 option.
+
+package dynamic
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gdamore/tcell/terminfo"
+)
+
+type termcap struct {
+	name    string
+	desc    string
+	aliases []string
+	bools   map[string]bool
+	nums    map[string]int
+	strs    map[string]string
+}
+
+func (tc *termcap) getnum(s string) int {
+	return (tc.nums[s])
+}
+
+func (tc *termcap) getflag(s string) bool {
+	return (tc.bools[s])
+}
+
+func (tc *termcap) getstr(s string) string {
+	return (tc.strs[s])
+}
+
+const (
+	none = iota
+	control
+	escaped
+)
+
+var errNotAddressable = errors.New("terminal not cursor addressable")
+
+func unescape(s string) string {
+	// Various escapes are in \x format.  Control codes are
+	// encoded as ^M (carat followed by ASCII equivalent).
+	// escapes are: \e, \E - escape
+	//  \0 NULL, \n \l \r \t \b \f \s for equivalent C escape.
+	buf := &bytes.Buffer{}
+	esc := none
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch esc {
+		case none:
+			switch c {
+			case '\\':
+				esc = escaped
+			case '^':
+				esc = control
+			default:
+				buf.WriteByte(c)
+			}
+		case control:
+			buf.WriteByte(c - 0x40)
+			esc = none
+		case escaped:
+			switch c {
+			case 'E', 'e':
+				buf.WriteByte(0x1b)
+			case '0', '1', '2', '3', '4', '5', '6', '7':
+				if i+2 < len(s) && s[i+1] >= '0' && s[i+1] <= '7' && s[i+2] >= '0' && s[i+2] <= '7' {
+					buf.WriteByte(((c - '0') * 64) + ((s[i+1] - '0') * 8) + (s[i+2] - '0'))
+					i = i + 2
+				} else if c == '0' {
+					buf.WriteByte(0)
+				}
+			case 'n':
+				buf.WriteByte('\n')
+			case 'r':
+				buf.WriteByte('\r')
+			case 't':
+				buf.WriteByte('\t')
+			case 'b':
+				buf.WriteByte('\b')
+			case 'f':
+				buf.WriteByte('\f')
+			case 's':
+				buf.WriteByte(' ')
+			default:
+				buf.WriteByte(c)
+			}
+			esc = none
+		}
+	}
+	return (buf.String())
+}
+
+func (tc *termcap) setupterm(name string) error {
+	cmd := exec.Command("infocmp", "-1", name)
+	output := &bytes.Buffer{}
+	cmd.Stdout = output
+
+	tc.strs = make(map[string]string)
+	tc.bools = make(map[string]bool)
+	tc.nums = make(map[string]int)
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Now parse the output.
+	// We get comment lines (starting with "#"), followed by
+	// a header line that looks like "<name>|<alias>|...|<desc>"
+	// then capabilities, one per line, starting with a tab and ending
+	// with a comma and newline.
+	lines := strings.Split(output.String(), "\n")
+	for len(lines) > 0 && strings.HasPrefix(lines[0], "#") {
+		lines = lines[1:]
+	}
+
+	// Ditch trailing empty last line
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	header := lines[0]
+	if strings.HasSuffix(header, ",") {
+		header = header[:len(header)-1]
+	}
+	names := strings.Split(header, "|")
+	tc.name = names[0]
+	names = names[1:]
+	if len(names) > 0 {
+		tc.desc = names[len(names)-1]
+		names = names[:len(names)-1]
+	}
+	tc.aliases = names
+	for _, val := range lines[1:] {
+		if (!strings.HasPrefix(val, "\t")) ||
+			(!strings.HasSuffix(val, ",")) {
+			return (errors.New("malformed infocmp: " + val))
+		}
+
+		val = val[1:]
+		val = val[:len(val)-1]
+
+		if k := strings.SplitN(val, "=", 2); len(k) == 2 {
+			tc.strs[k[0]] = unescape(k[1])
+		} else if k := strings.SplitN(val, "#", 2); len(k) == 2 {
+			u, err := strconv.ParseUint(k[1], 0, 0)
+			if err != nil {
+				return (err)
+			}
+			tc.nums[k[0]] = int(u)
+		} else {
+			tc.bools[val] = true
+		}
+	}
+	return nil
+}
+
+// LoadTerminfo creates a Terminfo by for named terminal by attempting to parse
+// the output from infocmp.  This returns the terminfo entry, a description of
+// the terminal, and either nil or an error.
+func LoadTerminfo(name string) (*terminfo.Terminfo, string, error) {
+	var tc termcap
+	if err := tc.setupterm(name); err != nil {
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	t := &terminfo.Terminfo{}
+	// If this is an alias record, then just emit the alias
+	t.Name = tc.name
+	if t.Name != name {
+		return t, "", nil
+	}
+	t.Aliases = tc.aliases
+	t.Colors = tc.getnum("colors")
+	t.Columns = tc.getnum("cols")
+	t.Lines = tc.getnum("lines")
+	t.Bell = tc.getstr("bel")
+	t.Clear = tc.getstr("clear")
+	t.EnterCA = tc.getstr("smcup")
+	t.ExitCA = tc.getstr("rmcup")
+	t.ShowCursor = tc.getstr("cnorm")
+	t.HideCursor = tc.getstr("civis")
+	t.AttrOff = tc.getstr("sgr0")
+	t.Underline = tc.getstr("smul")
+	t.Bold = tc.getstr("bold")
+	t.Blink = tc.getstr("blink")
+	t.Dim = tc.getstr("dim")
+	t.Reverse = tc.getstr("rev")
+	t.EnterKeypad = tc.getstr("smkx")
+	t.ExitKeypad = tc.getstr("rmkx")
+	t.SetFg = tc.getstr("setaf")
+	t.SetBg = tc.getstr("setab")
+	t.SetCursor = tc.getstr("cup")
+	t.CursorBack1 = tc.getstr("cub1")
+	t.CursorUp1 = tc.getstr("cuu1")
+	t.KeyF1 = tc.getstr("kf1")
+	t.KeyF2 = tc.getstr("kf2")
+	t.KeyF3 = tc.getstr("kf3")
+	t.KeyF4 = tc.getstr("kf4")
+	t.KeyF5 = tc.getstr("kf5")
+	t.KeyF6 = tc.getstr("kf6")
+	t.KeyF7 = tc.getstr("kf7")
+	t.KeyF8 = tc.getstr("kf8")
+	t.KeyF9 = tc.getstr("kf9")
+	t.KeyF10 = tc.getstr("kf10")
+	t.KeyF11 = tc.getstr("kf11")
+	t.KeyF12 = tc.getstr("kf12")
+	t.KeyF13 = tc.getstr("kf13")
+	t.KeyF14 = tc.getstr("kf14")
+	t.KeyF15 = tc.getstr("kf15")
+	t.KeyF16 = tc.getstr("kf16")
+	t.KeyF17 = tc.getstr("kf17")
+	t.KeyF18 = tc.getstr("kf18")
+	t.KeyF19 = tc.getstr("kf19")
+	t.KeyF20 = tc.getstr("kf20")
+	t.KeyF21 = tc.getstr("kf21")
+	t.KeyF22 = tc.getstr("kf22")
+	t.KeyF23 = tc.getstr("kf23")
+	t.KeyF24 = tc.getstr("kf24")
+	t.KeyF25 = tc.getstr("kf25")
+	t.KeyF26 = tc.getstr("kf26")
+	t.KeyF27 = tc.getstr("kf27")
+	t.KeyF28 = tc.getstr("kf28")
+	t.KeyF29 = tc.getstr("kf29")
+	t.KeyF30 = tc.getstr("kf30")
+	t.KeyF31 = tc.getstr("kf31")
+	t.KeyF32 = tc.getstr("kf32")
+	t.KeyF33 = tc.getstr("kf33")
+	t.KeyF34 = tc.getstr("kf34")
+	t.KeyF35 = tc.getstr("kf35")
+	t.KeyF36 = tc.getstr("kf36")
+	t.KeyF37 = tc.getstr("kf37")
+	t.KeyF38 = tc.getstr("kf38")
+	t.KeyF39 = tc.getstr("kf39")
+	t.KeyF40 = tc.getstr("kf40")
+	t.KeyF41 = tc.getstr("kf41")
+	t.KeyF42 = tc.getstr("kf42")
+	t.KeyF43 = tc.getstr("kf43")
+	t.KeyF44 = tc.getstr("kf44")
+	t.KeyF45 = tc.getstr("kf45")
+	t.KeyF46 = tc.getstr("kf46")
+	t.KeyF47 = tc.getstr("kf47")
+	t.KeyF48 = tc.getstr("kf48")
+	t.KeyF49 = tc.getstr("kf49")
+	t.KeyF50 = tc.getstr("kf50")
+	t.KeyF51 = tc.getstr("kf51")
+	t.KeyF52 = tc.getstr("kf52")
+	t.KeyF53 = tc.getstr("kf53")
+	t.KeyF54 = tc.getstr("kf54")
+	t.KeyF55 = tc.getstr("kf55")
+	t.KeyF56 = tc.getstr("kf56")
+	t.KeyF57 = tc.getstr("kf57")
+	t.KeyF58 = tc.getstr("kf58")
+	t.KeyF59 = tc.getstr("kf59")
+	t.KeyF60 = tc.getstr("kf60")
+	t.KeyF61 = tc.getstr("kf61")
+	t.KeyF62 = tc.getstr("kf62")
+	t.KeyF63 = tc.getstr("kf63")
+	t.KeyF64 = tc.getstr("kf64")
+	t.KeyInsert = tc.getstr("kich1")
+	t.KeyDelete = tc.getstr("kdch1")
+	t.KeyBackspace = tc.getstr("kbs")
+	t.KeyHome = tc.getstr("khome")
+	t.KeyEnd = tc.getstr("kend")
+	t.KeyUp = tc.getstr("kcuu1")
+	t.KeyDown = tc.getstr("kcud1")
+	t.KeyRight = tc.getstr("kcuf1")
+	t.KeyLeft = tc.getstr("kcub1")
+	t.KeyPgDn = tc.getstr("knp")
+	t.KeyPgUp = tc.getstr("kpp")
+	t.KeyBacktab = tc.getstr("kcbt")
+	t.KeyExit = tc.getstr("kext")
+	t.KeyCancel = tc.getstr("kcan")
+	t.KeyPrint = tc.getstr("kprt")
+	t.KeyHelp = tc.getstr("khlp")
+	t.KeyClear = tc.getstr("kclr")
+	t.AltChars = tc.getstr("acsc")
+	t.EnterAcs = tc.getstr("smacs")
+	t.ExitAcs = tc.getstr("rmacs")
+	t.EnableAcs = tc.getstr("enacs")
+	t.Mouse = tc.getstr("kmous")
+	t.KeyShfRight = tc.getstr("kRIT")
+	t.KeyShfLeft = tc.getstr("kLFT")
+	t.KeyShfHome = tc.getstr("kHOM")
+	t.KeyShfEnd = tc.getstr("kEND")
+
+	// Terminfo lacks descriptions for a bunch of modified keys,
+	// but modern XTerm and emulators often have them.  Let's add them,
+	// if the shifted right and left arrows are defined.
+	if t.KeyShfRight == "\x1b[1;2C" && t.KeyShfLeft == "\x1b[1;2D" {
+		t.KeyShfUp = "\x1b[1;2A"
+		t.KeyShfDown = "\x1b[1;2B"
+		t.KeyMetaUp = "\x1b[1;9A"
+		t.KeyMetaDown = "\x1b[1;9B"
+		t.KeyMetaRight = "\x1b[1;9C"
+		t.KeyMetaLeft = "\x1b[1;9D"
+		t.KeyAltUp = "\x1b[1;3A"
+		t.KeyAltDown = "\x1b[1;3B"
+		t.KeyAltRight = "\x1b[1;3C"
+		t.KeyAltLeft = "\x1b[1;3D"
+		t.KeyCtrlUp = "\x1b[1;5A"
+		t.KeyCtrlDown = "\x1b[1;5B"
+		t.KeyCtrlRight = "\x1b[1;5C"
+		t.KeyCtrlLeft = "\x1b[1;5D"
+		t.KeyAltShfUp = "\x1b[1;4A"
+		t.KeyAltShfDown = "\x1b[1;4B"
+		t.KeyAltShfRight = "\x1b[1;4C"
+		t.KeyAltShfLeft = "\x1b[1;4D"
+
+		t.KeyMetaShfUp = "\x1b[1;10A"
+		t.KeyMetaShfDown = "\x1b[1;10B"
+		t.KeyMetaShfRight = "\x1b[1;10C"
+		t.KeyMetaShfLeft = "\x1b[1;10D"
+
+		t.KeyCtrlShfUp = "\x1b[1;6A"
+		t.KeyCtrlShfDown = "\x1b[1;6B"
+		t.KeyCtrlShfRight = "\x1b[1;6C"
+		t.KeyCtrlShfLeft = "\x1b[1;6D"
+	}
+	// And also for Home and End
+	if t.KeyShfHome == "\x1b[1;2H" && t.KeyShfEnd == "\x1b[1;2F" {
+		t.KeyCtrlHome = "\x1b[1;5H"
+		t.KeyCtrlEnd = "\x1b[1;5F"
+		t.KeyAltHome = "\x1b[1;9H"
+		t.KeyAltEnd = "\x1b[1;9F"
+		t.KeyCtrlShfHome = "\x1b[1;6H"
+		t.KeyCtrlShfEnd = "\x1b[1;6F"
+		t.KeyAltShfHome = "\x1b[1;4H"
+		t.KeyAltShfEnd = "\x1b[1;4F"
+		t.KeyMetaShfHome = "\x1b[1;10H"
+		t.KeyMetaShfEnd = "\x1b[1;10F"
+	}
+
+	// And the same thing for rxvt and workalikes (Eterm, aterm, etc.)
+	// It seems that urxvt at least send escaped as ALT prefix for these,
+	// although some places seem to indicate a separate ALT key sesquence.
+	if t.KeyShfRight == "\x1b[c" && t.KeyShfLeft == "\x1b[d" {
+		t.KeyShfUp = "\x1b[a"
+		t.KeyShfDown = "\x1b[b"
+		t.KeyCtrlUp = "\x1b[Oa"
+		t.KeyCtrlDown = "\x1b[Ob"
+		t.KeyCtrlRight = "\x1b[Oc"
+		t.KeyCtrlLeft = "\x1b[Od"
+	}
+	if t.KeyShfHome == "\x1b[7$" && t.KeyShfEnd == "\x1b[8$" {
+		t.KeyCtrlHome = "\x1b[7^"
+		t.KeyCtrlEnd = "\x1b[8^"
+	}
+
+	// If the kmous entry is present, then we need to record the
+	// the codes to enter and exit mouse mode.  Sadly, this is not
+	// part of the terminfo databases anywhere that I've found, but
+	// is an extension.  The escapedape codes are documented in the XTerm
+	// manual, and all terminals that have kmous are expected to
+	// use these same codes, unless explicitly configured otherwise
+	// vi XM.  Note that in any event, we only known how to parse either
+	// x11 or SGR mouse events -- if your terminal doesn't support one
+	// of these two forms, you maybe out of luck.
+	t.MouseMode = tc.getstr("XM")
+	if t.Mouse != "" && t.MouseMode == "" {
+		// we anticipate that all xterm mouse tracking compatible
+		// terminals understand mouse tracking (1000), but we hope
+		// that those that don't understand any-event tracking (1003)
+		// will at least ignore it.  Likewise we hope that terminals
+		// that don't understand SGR reporting (1006) just ignore it.
+		t.MouseMode = "%?%p1%{1}%=%t%'h'%Pa%e%'l'%Pa%;" +
+			"\x1b[?1000%ga%c\x1b[?1002%ga%c\x1b[?1003%ga%c\x1b[?1006%ga%c"
+	}
+
+	// We only support colors in ANSI 8 or 256 color mode.
+	if t.Colors < 8 || t.SetFg == "" {
+		t.Colors = 0
+	}
+	if t.SetCursor == "" {
+		return nil, "", errNotAddressable
+	}
+
+	// For padding, we lookup the pad char.  If that isn't present,
+	// and npc is *not* set, then we assume a null byte.
+	t.PadChar = tc.getstr("pad")
+	if t.PadChar == "" {
+		if !tc.getflag("npc") {
+			t.PadChar = "\u0000"
+		}
+	}
+
+	// For terminals that use "standard" SGR sequences, lets combine the
+	// foreground and background together.
+	if strings.HasPrefix(t.SetFg, "\x1b[") &&
+		strings.HasPrefix(t.SetBg, "\x1b[") &&
+		strings.HasSuffix(t.SetFg, "m") &&
+		strings.HasSuffix(t.SetBg, "m") {
+		fg := t.SetFg[:len(t.SetFg)-1]
+		r := regexp.MustCompile("%p1")
+		bg := r.ReplaceAllString(t.SetBg[2:], "%p2")
+		t.SetFgBg = fg + ";" + bg
+	}
+
+	return t, tc.desc, nil
+}

--- a/vendor/github.com/gdamore/tcell/terminfo/mkinfo.go
+++ b/vendor/github.com/gdamore/tcell/terminfo/mkinfo.go
@@ -1,6 +1,6 @@
 // +build ignore
 
-// Copyright 2018 The TCell Authors
+// Copyright 2019 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -226,27 +226,9 @@ func (tc *termcap) setupterm(name string) error {
 // capabilities encoded in the program.  It should never need to be run by
 // an end user, but developers can use this to add codes for additional
 // terminal types.
-//
-// If a terminal name ending with -truecolor is given, and we cannot find
-// one, we will try to fabricate one from either the -256color (if present)
-// or the unadorned base name, adding the XTerm specific 24-bit color
-// escapes.  We believe that all 24-bit capable terminals use the same
-// escape sequences, and terminfo has yet to evolve to support this.
 func getinfo(name string) (*terminfo.Terminfo, string, error) {
 	var tc termcap
-	addTrueColor := false
 	if err := tc.setupterm(name); err != nil {
-		if strings.HasSuffix(name, "-truecolor") {
-			base := name[:len(name)-len("-truecolor")]
-			// Probably -256color is closest to what we want
-			if err = tc.setupterm(base + "-256color"); err != nil {
-				err = tc.setupterm(base)
-			}
-			if err == nil {
-				addTrueColor = true
-			}
-			tc.name = name
-		}
 		if err != nil {
 			return nil, "", err
 		}
@@ -469,15 +451,6 @@ func getinfo(name string) (*terminfo.Terminfo, string, error) {
 		if !tc.getflag("npc") {
 			t.PadChar = "\u0000"
 		}
-	}
-
-	// For some terminals we fabricate a -truecolor entry, that may
-	// not exist in terminfo.
-	if addTrueColor {
-		t.SetFgRGB = "\x1b[38;2;%p1%d;%p2%d;%p3%dm"
-		t.SetBgRGB = "\x1b[48;2;%p1%d;%p2%d;%p3%dm"
-		t.SetFgBgRGB = "\x1b[38;2;%p1%d;%p2%d;%p3%d;" +
-			"48;2;%p4%d;%p5%d;%p6%dm"
 	}
 
 	// For terminals that use "standard" SGR sequences, lets combine the

--- a/vendor/github.com/gdamore/tcell/tscreen.go
+++ b/vendor/github.com/gdamore/tcell/tscreen.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/text/transform"
 
 	"github.com/gdamore/tcell/terminfo"
+	"github.com/gdamore/tcell/terminfo/dynamic"
 )
 
 // NewTerminfoScreen returns a Screen that uses the stock TTY interface
@@ -39,7 +40,11 @@ import (
 func NewTerminfoScreen() (Screen, error) {
 	ti, e := terminfo.LookupTerminfo(os.Getenv("TERM"))
 	if e != nil {
-		return nil, e
+		ti, _, e = dynamic.LoadTerminfo(os.Getenv("TERM"))
+		if e != nil {
+			return nil, e
+		}
+		terminfo.AddTerminfo(ti)
 	}
 	t := &tScreen{ti: ti}
 
@@ -74,6 +79,8 @@ type tScreen struct {
 	cells     CellBuffer
 	in        *os.File
 	out       *os.File
+	buffering bool // true if we are collecting writes to buf instead of sending directly to out
+	buf       bytes.Buffer
 	curstyle  Style
 	style     Style
 	evch      chan Event
@@ -614,7 +621,7 @@ func (t *tScreen) drawCell(x, y int) int {
 		width = 1
 		str = " "
 	}
-	io.WriteString(t.out, str)
+	t.writeString(str)
 	t.cx += width
 	t.cells.SetDirty(x, y, false)
 	if width > 1 {
@@ -649,8 +656,26 @@ func (t *tScreen) showCursor() {
 	t.cy = y
 }
 
+// writeString sends a string to the terminal. The string is sent as-is and
+// this function does not expand inline padding indications (of the form
+// $<[delay]> where [delay] is msec). In order to have these expanded, use
+// TPuts. If the screen is "buffering", the string is collected in a buffer,
+// with the intention that the entire buffer be sent to the terminal in one
+// write operation at some point later.
+func (t *tScreen) writeString(s string) {
+	if t.buffering {
+		io.WriteString(&t.buf, s)
+	} else {
+		io.WriteString(t.out, s)
+	}
+}
+
 func (t *tScreen) TPuts(s string) {
-	t.ti.TPuts(t.out, s, t.baud)
+	if t.buffering {
+		t.ti.TPuts(&t.buf, s, t.baud)
+	} else {
+		t.ti.TPuts(t.out, s, t.baud)
+	}
 }
 
 func (t *tScreen) Show() {
@@ -686,6 +711,12 @@ func (t *tScreen) draw() {
 	t.cx = -1
 	t.cy = -1
 
+	t.buf.Reset()
+	t.buffering = true
+	defer func() {
+		t.buffering = false
+	}()
+
 	// hide the cursor while we move stuff around
 	t.hideCursor()
 
@@ -710,6 +741,8 @@ func (t *tScreen) draw() {
 
 	// restore the cursor
 	t.showCursor()
+
+	t.buf.WriteTo(t.out)
 }
 
 func (t *tScreen) EnableMouse() {
@@ -858,7 +891,10 @@ func (t *tScreen) clip(x, y int) (int, int) {
 	return x, y
 }
 
-func (t *tScreen) postMouseEvent(x, y, btn int) {
+// buildMouseEvent returns an event based on the supplied coordinates and button
+// state. Note that the screen's mouse button state is updated based on the
+// input to this function (i.e. it mutates the receiver).
+func (t *tScreen) buildMouseEvent(x, y, btn int) *EventMouse {
 
 	// XTerm mouse events only report at most one button at a time,
 	// which may include a wheel button.  Wheel motion events are
@@ -914,8 +950,7 @@ func (t *tScreen) postMouseEvent(x, y, btn int) {
 	// to the screen in that case.
 	x, y = t.clip(x, y)
 
-	ev := NewEventMouse(x, y, button, mod)
-	t.PostEvent(ev)
+	return NewEventMouse(x, y, button, mod)
 }
 
 // parseSgrMouse attempts to locate an SGR mouse record at the start of the
@@ -923,7 +958,7 @@ func (t *tScreen) postMouseEvent(x, y, btn int) {
 // be removed from the buffer.  It returns true, false if the buffer might
 // contain such an event, but more bytes are necessary (partial match), and
 // false, false if the content is definitely *not* an SGR mouse record.
-func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 
 	b := buf.Bytes()
 
@@ -1031,7 +1066,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 				buf.ReadByte()
 				i--
 			}
-			t.postMouseEvent(x, y, btn)
+			*evs = append(*evs, t.buildMouseEvent(x, y, btn))
 			return true, true
 		}
 	}
@@ -1042,7 +1077,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 
 // parseXtermMouse is like parseSgrMouse, but it parses a legacy
 // X11 mouse record.
-func (t *tScreen) parseXtermMouse(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseXtermMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 
 	b := buf.Bytes()
 
@@ -1084,14 +1119,14 @@ func (t *tScreen) parseXtermMouse(buf *bytes.Buffer) (bool, bool) {
 				buf.ReadByte()
 				i--
 			}
-			t.postMouseEvent(x, y, btn)
+			*evs = append(*evs, t.buildMouseEvent(x, y, btn))
 			return true, true
 		}
 	}
 	return true, false
 }
 
-func (t *tScreen) parseFunctionKey(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseFunctionKey(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	b := buf.Bytes()
 	partial := false
 	for e, k := range t.keycodes {
@@ -1110,8 +1145,7 @@ func (t *tScreen) parseFunctionKey(buf *bytes.Buffer) (bool, bool) {
 				mod |= ModAlt
 				t.escaped = false
 			}
-			ev := NewEventKey(k.key, r, mod)
-			t.PostEvent(ev)
+			*evs = append(*evs, NewEventKey(k.key, r, mod))
 			for i := 0; i < len(esc); i++ {
 				buf.ReadByte()
 			}
@@ -1124,7 +1158,7 @@ func (t *tScreen) parseFunctionKey(buf *bytes.Buffer) (bool, bool) {
 	return partial, false
 }
 
-func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseRune(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	b := buf.Bytes()
 	if b[0] >= ' ' && b[0] <= 0x7F {
 		// printable ASCII easy to deal with -- no encodings
@@ -1133,8 +1167,7 @@ func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
 			mod = ModAlt
 			t.escaped = false
 		}
-		ev := NewEventKey(KeyRune, rune(b[0]), mod)
-		t.PostEvent(ev)
+		*evs = append(*evs, NewEventKey(KeyRune, rune(b[0]), mod))
 		buf.ReadByte()
 		return true, true
 	}
@@ -1159,8 +1192,7 @@ func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
 					mod = ModAlt
 					t.escaped = false
 				}
-				ev := NewEventKey(KeyRune, r, mod)
-				t.PostEvent(ev)
+				*evs = append(*evs, NewEventKey(KeyRune, r, mod))
 			}
 			for nin > 0 {
 				buf.ReadByte()
@@ -1174,6 +1206,19 @@ func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
 }
 
 func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
+	evs := t.collectEventsFromInput(buf, expire)
+
+	for _, ev := range evs {
+		t.PostEventWait(ev)
+	}
+}
+
+// Return an array of Events extracted from the supplied buffer. This is done
+// while holding the screen's lock - the events can then be queued for
+// application processing with the lock released.
+func (t *tScreen) collectEventsFromInput(buf *bytes.Buffer, expire bool) []Event {
+
+	res := make([]Event, 0, 20)
 
 	t.Lock()
 	defer t.Unlock()
@@ -1182,18 +1227,18 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		b := buf.Bytes()
 		if len(b) == 0 {
 			buf.Reset()
-			return
+			return res
 		}
 
 		partials := 0
 
-		if part, comp := t.parseRune(buf); comp {
+		if part, comp := t.parseRune(buf, &res); comp {
 			continue
 		} else if part {
 			partials++
 		}
 
-		if part, comp := t.parseFunctionKey(buf); comp {
+		if part, comp := t.parseFunctionKey(buf, &res); comp {
 			continue
 		} else if part {
 			partials++
@@ -1203,13 +1248,13 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		// mouse support
 
 		if t.ti.Mouse != "" {
-			if part, comp := t.parseXtermMouse(buf); comp {
+			if part, comp := t.parseXtermMouse(buf, &res); comp {
 				continue
 			} else if part {
 				partials++
 			}
 
-			if part, comp := t.parseSgrMouse(buf); comp {
+			if part, comp := t.parseSgrMouse(buf, &res); comp {
 				continue
 			} else if part {
 				partials++
@@ -1219,8 +1264,7 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		if partials == 0 || expire {
 			if b[0] == '\x1b' {
 				if len(b) == 1 {
-					ev := NewEventKey(KeyEsc, 0, ModNone)
-					t.PostEvent(ev)
+					res = append(res, NewEventKey(KeyEsc, 0, ModNone))
 					t.escaped = false
 				} else {
 					t.escaped = true
@@ -1238,8 +1282,7 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 				t.escaped = false
 				mod = ModAlt
 			}
-			ev := NewEventKey(KeyRune, rune(by), mod)
-			t.PostEvent(ev)
+			res = append(res, NewEventKey(KeyRune, rune(by), mod))
 			continue
 		}
 
@@ -1247,6 +1290,8 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		// some more
 		break
 	}
+
+	return res
 }
 
 func (t *tScreen) mainLoop() {


### PR DESCRIPTION
This picks up a fix for #1728 from tcell.

Tested by:

export GOPATH=/tmp
export TERM=xterm-color

before the upgrade, this repro'd the error in #1728 
after the upgrade, tilt ran fine