### PR TITLE
tiltfile: track the current orchestator, so that we can run integration tests on microk8s

### DIFF
--- a/internal/model/orchestrator.go
+++ b/internal/model/orchestrator.go
@@ -1,0 +1,8 @@
+package model
+
+// The current orchestrator we're running with (K8s or DockerCompose)
+type Orchestrator string
+
+const OrchestratorUnknown = Orchestrator("")
+const OrchestratorK8s = Orchestrator("Kubernetes")
+const OrchestratorDC = Orchestrator("DockerCompose")

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -295,6 +295,17 @@ func (s *tiltfileState) predeclared() starlark.StringDict {
 	return r
 }
 
+// Returns the current orchestrator.
+//
+// Note that assemble() will eventually error out if this has
+// both DC and K8s resources.
+func (s *tiltfileState) orchestrator() model.Orchestrator {
+	if !s.dc.Empty() {
+		return model.OrchestratorDC
+	}
+	return model.OrchestratorK8s
+}
+
 func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 	err := s.assembleImages()
 	if err != nil {
@@ -334,7 +345,7 @@ func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 
 func (s *tiltfileState) assembleImages() error {
 	registry := s.defaultRegistryHost
-	if s.privateRegistry != "" {
+	if s.orchestrator() == model.OrchestratorK8s && s.privateRegistry != "" {
 		// If we've found a private registry in the cluster at run-time,
 		// use that instead of the one in the tiltfile
 		s.logger.Infof("Auto-detected private registry from environment: %s", s.privateRegistry)


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/microk8s:

2e1b0a8fc8a4639c85be23881e09ed23b06da32b (2019-06-21 12:10:38 -0400)
tiltfile: track the current orchestator, so that we can run integration tests on microk8s