### PR TITLE
fix bug in file filtering for .git directory

### DIFF
--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -26,7 +26,7 @@ func (r repoIgnoreTester) Matches(f string, isDir bool) (bool, error) {
 	}
 
 	// match the .git directory itself
-	if strings.HasSuffix(absPath, ".git") {
+	if filepath.Base(absPath) == ".git" {
 		return true, nil
 	}
 

--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -18,7 +19,14 @@ func (r repoIgnoreTester) Matches(f string, isDir bool) (bool, error) {
 		return false, err
 	}
 
-	if strings.HasPrefix(absPath, filepath.Join(r.repoRoot, ".git/")) {
+	// match everything inside the .git/ directory
+	gitPath := fmt.Sprintf("%s/", filepath.Join(r.repoRoot, ".git"))
+	if strings.HasPrefix(absPath, gitPath) {
+		return true, nil
+	}
+
+	// match the .git directory itself
+	if strings.HasSuffix(absPath, ".git") {
 		return true, nil
 	}
 

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -16,6 +16,7 @@ func TestGitIgnoreTester_GitDirMatches(t *testing.T) {
 	defer tf.TearDown()
 
 	tf.AssertResult(tf.JoinPath(0, ".git", "foo", "bar"), true, false)
+	tf.AssertResult(tf.JoinPath(0, ".gitlab-ci.yml"), false, false)
 }
 
 type testFixture struct {

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -15,8 +15,35 @@ func TestGitIgnoreTester_GitDirMatches(t *testing.T) {
 	tf := newTestFixture(t)
 	defer tf.TearDown()
 
-	tf.AssertResult(tf.JoinPath(0, ".git", "foo", "bar"), true, false)
-	tf.AssertResult(tf.JoinPath(0, ".gitlab-ci.yml"), false, false)
+	tests := []struct {
+		description string
+		path        []string
+		expectMatch bool
+		expectError bool
+	}{
+		{
+			description: "a file in the .git directory",
+			path:        []string{".git", "foo", "bar"},
+			expectMatch: true,
+			expectError: false,
+		},
+		{
+			description: "a .gitlab-ci.yml file",
+			path:        []string{".gitlab-ci.yml"},
+			expectMatch: false,
+			expectError: false,
+		},
+		{
+			description: "a foo.git file",
+			path:        []string{"foo.git"},
+			expectMatch: false,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tf.AssertResult(tt.description, tf.JoinPath(0, tt.path...), tt.expectMatch, tt.expectError)
+	}
 }
 
 type testFixture struct {
@@ -52,15 +79,17 @@ func (tf *testFixture) JoinPath(repoNum int, path ...string) string {
 	return tf.repoRoots[repoNum].JoinPath(path...)
 }
 
-func (tf *testFixture) AssertResult(path string, expectedMatches bool, expectError bool) {
-	isIgnored, err := tf.tester.Matches(path, false)
-	if expectError {
-		assert.Error(tf.t, err)
-	} else {
-		if assert.NoError(tf.t, err) {
-			assert.Equal(tf.t, expectedMatches, isIgnored)
+func (tf *testFixture) AssertResult(description, path string, expectedMatches bool, expectError bool) {
+	tf.t.Run(description, func(t *testing.T) {
+		isIgnored, err := tf.tester.Matches(path, false)
+		if expectError {
+			assert.Error(t, err)
+		} else {
+			if assert.NoError(t, err) {
+				assert.Equal(t, expectedMatches, isIgnored)
+			}
 		}
-	}
+	})
 }
 
 func (tf *testFixture) TearDown() {


### PR DESCRIPTION
Files beginning with `.git` were being excluded (for example `.gitlab-ci.yml`) when tarring files for image building.

(Failed build is un-related to PR)