### PR TITLE
docker: dynamically switch between the local docker daemon and the in-cluster daemon

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -48,7 +48,7 @@ var BaseWireSet = wire.NewSet(
 	K8sWireSet,
 	provideKubectlLogLevel,
 
-	docker.ClusterWireSet,
+	docker.SwitchWireSet,
 
 	dockercompose.NewDockerComposeClient,
 

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -65,6 +65,10 @@ type Client interface {
 
 	ServerVersion() types.Version
 
+	// Set the orchestrator we're talking to. This is only relevant to switchClient,
+	// which can talk to either the Local or in-cluster docker daemon.
+	SetOrchestrator(orc model.Orchestrator)
+
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerRestartNoWait(ctx context.Context, containerID string) error
 	CopyToContainerRoot(ctx context.Context, container string, content io.Reader) error
@@ -332,6 +336,7 @@ func (c *Cli) backgroundInit(ctx context.Context) {
 	close(c.initDone)
 }
 
+func (c *Cli) SetOrchestrator(orc model.Orchestrator) {}
 func (c *Cli) Env() Env {
 	return c.env
 }

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -106,6 +106,7 @@ func NewFakeClient() *FakeClient {
 	}
 }
 
+func (c *FakeClient) SetOrchestrator(orc model.Orchestrator) {}
 func (c *FakeClient) Env() Env {
 	return Env{}
 }

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -1,0 +1,86 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/docker/docker/api/types"
+
+	"github.com/windmilleng/tilt/internal/container"
+	"github.com/windmilleng/tilt/internal/model"
+)
+
+// A Cli implementation that lets us switch back and forth between a local
+// Docker instance and one that lives in our K8s cluster.
+
+type switchCli struct {
+	localCli   LocalClient
+	clusterCli ClusterClient
+	orc        model.Orchestrator
+	mu         sync.Mutex
+}
+
+func ProvideSwitchCli(clusterCli ClusterClient, localCli LocalClient) *switchCli {
+	return &switchCli{
+		localCli:   localCli,
+		clusterCli: clusterCli,
+		orc:        model.OrchestratorK8s,
+	}
+}
+
+func (c *switchCli) client() Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.orc == model.OrchestratorK8s {
+		return c.clusterCli
+	}
+	return c.localCli
+}
+
+func (c *switchCli) SetOrchestrator(orc model.Orchestrator) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.orc = orc
+}
+func (c *switchCli) Env() Env {
+	return c.client().Env()
+}
+func (c *switchCli) BuilderVersion() types.BuilderVersion {
+	return c.client().BuilderVersion()
+}
+func (c *switchCli) ServerVersion() types.Version {
+	return c.client().ServerVersion()
+}
+func (c *switchCli) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	return c.client().ContainerList(ctx, options)
+}
+func (c *switchCli) ContainerRestartNoWait(ctx context.Context, containerID string) error {
+	return c.client().ContainerRestartNoWait(ctx, containerID)
+}
+func (c *switchCli) CopyToContainerRoot(ctx context.Context, container string, content io.Reader) error {
+	return c.client().CopyToContainerRoot(ctx, container, content)
+}
+func (c *switchCli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error {
+	return c.client().ExecInContainer(ctx, cID, cmd, out)
+}
+func (c *switchCli) ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error) {
+	return c.client().ImagePush(ctx, image, options)
+}
+func (c *switchCli) ImageBuild(ctx context.Context, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
+	return c.client().ImageBuild(ctx, buildContext, options)
+}
+func (c *switchCli) ImageTag(ctx context.Context, source, target string) error {
+	return c.client().ImageTag(ctx, source, target)
+}
+func (c *switchCli) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	return c.client().ImageInspectWithRaw(ctx, imageID)
+}
+func (c *switchCli) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error) {
+	return c.client().ImageList(ctx, options)
+}
+func (c *switchCli) ImageRemove(ctx context.Context, imageID string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
+	return c.client().ImageRemove(ctx, imageID, options)
+}
+
+var _ Client = &switchCli{}

--- a/internal/docker/wire.go
+++ b/internal/docker/wire.go
@@ -11,6 +11,15 @@ func ProvideClusterAsDefault(cli ClusterClient) Client {
 
 // Bind a docker client that can either talk to the in-cluster
 // Docker daemon or to the local Docker daemon.
+var SwitchWireSet = wire.NewSet(
+	ProvideClusterCli,
+	ProvideLocalCli,
+	ProvideSwitchCli,
+	ProvideLocalEnv,
+	ProvideClusterEnv,
+	wire.Bind(new(Client), new(switchCli)))
+
+// Bind a docker client that talks to the in-cluster Docker daemon.
 var ClusterWireSet = wire.NewSet(
 	ProvideClusterCli,
 	ProvideLocalCli,

--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/testutils"
@@ -85,7 +86,7 @@ func newCCFixture(t *testing.T) *ccFixture {
 	f := tempdir.NewTempDirFixture(t)
 	st, getActions := store.NewStoreForTesting()
 	tfl := tiltfile.NewFakeTiltfileLoader()
-	cc := NewConfigsController(tfl)
+	cc := NewConfigsController(tfl, docker.NewFakeClient())
 	fc := testutils.NewRandomFakeClock()
 	cc.clock = fc.Clock()
 	ctx := output.CtxForTest()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2631,7 +2631,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	realDcc := dockercompose.NewDockerComposeClient(docker.LocalEnv{})
 
 	tfl := tiltfile.ProvideTiltfileLoader(ta, k8s, realDcc, "fake-context")
-	cc := NewConfigsController(tfl)
+	cc := NewConfigsController(tfl, dockerClient)
 	dcw := NewDockerComposeEventWatcher(fakeDcc)
 	dclm := NewDockerComposeLogManager(fakeDcc)
 	pm := NewProfilerManager()

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -34,6 +34,17 @@ type TiltfileLoadResult struct {
 	TiltIgnoreContents string
 }
 
+func (r TiltfileLoadResult) Orchestrator() model.Orchestrator {
+	for _, manifest := range r.Manifests {
+		if manifest.IsK8s() {
+			return model.OrchestratorK8s
+		} else if manifest.IsDC() {
+			return model.OrchestratorDC
+		}
+	}
+	return model.OrchestratorUnknown
+}
+
 type TiltfileLoader interface {
 	Load(ctx context.Context, filename string, matching map[string]bool) (TiltfileLoadResult, error)
 }


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/minikube:

f32c3ee39e5b166656e6bb56d3a73675d2fd4939 (2019-06-24 12:12:36 -0400)
docker: dynamically switch between the local docker daemon and the in-cluster daemon
fixes docker-compose integration tests on minikube