### PR TITLE
build: change ArchiveBuilder to return io.Reader

### DIFF
--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -52,7 +52,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 	if err != nil {
 		return errors.Wrap(err, "archivePathsIfExists")
 	}
-	archive, err := ab.BytesBuffer()
+	reader, err := ab.Reader()
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 
 	// TODO(maia): catch errors -- CopyToContainer doesn't return errors if e.g. it
 	// fails to write a file b/c of permissions =(
-	err = r.dCli.CopyToContainerRoot(ctx, cID.String(), bytes.NewReader(archive.Bytes()))
+	err = r.dCli.CopyToContainerRoot(ctx, cID.String(), reader)
 	if err != nil {
 		return err
 	}

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -8,8 +8,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/dustin/go-humanize"
-
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/ignore"
@@ -302,10 +300,6 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO(Han): Extend output to print without newline
-	ps.Printf(ctx, "Created tarball (size: %s)",
-		humanize.Bytes(uint64(archive.Len())))
 
 	ps.StartBuildStep(ctx, "Building image")
 	spanBuild, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuild")


### PR DESCRIPTION
This will make it easier to refactor ArchiveBuilder to not use a
`bytes.Buffer` in the future, which should help address #1753.