### PR TITLE
integration: run tests on Kind

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -25,42 +25,21 @@ RUN apt update && apt install -y apt-transport-https \
   && touch /etc/apt/sources.list.d/kubernetes.list \
   && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \
   && apt update && apt install -y kubectl
-
-# Install gcloud.
-# Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/Dockerfile
-ENV CLOUD_SDK_VERSION=219.0.1
-RUN apt-get -qqy update && apt-get install -qqy \
-        curl \
-        gcc \
-        python-dev \
-        python-setuptools \
-        apt-transport-https \
-        lsb-release \
-        openssh-client \
-        git \
-        gnupg \
-    && easy_install -U pip && \
-    pip install -U crcmod   && \
-    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && \
-    apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 && \
-    gcloud config set core/disable_usage_reporting true && \
-    gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment github_docker_image && \
-    gcloud --version
-
-# Install cluster script, which downloads the necessary containers.
-# The dind-based kubernetes cluster uses socat to do port-forwarding
+  # Install cluster script, which downloads the necessary containers.
+  
+# Grab a script from the DIND kubernetes cluster that uses socat to do port-forwarding
 ENV KUBEADM_SHA=30a2033581adf53161fe1cdc76f1550193927db4
-ADD https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/${KUBEADM_SHA}/fixed/dind-cluster-v1.12.sh ./dind-cluster.sh
 ADD https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/${KUBEADM_SHA}/build/portforward.sh .
 RUN apt install -y curl ca-certificates git liblz4-tool rsync socat \
-  && chmod a+x /go/dind-cluster.sh \
   && chmod a+x /go/portforward.sh
 
 # install gotestsum
 RUN go get gotest.tools/gotestsum
 
-RUN apt install -y jq
+# install jq
+RUN apt update && apt install -y jq
+
+# install Kind (Kubernetes in Docker)
+RUN curl -Lo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 \
+  && chmod +x ./kind-linux-amd64 \
+  && mv ./kind-linux-amd64 /go/bin/kind

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,32 +22,23 @@ jobs:
 
   build-integration:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:38635a2b7f755340f8e3bf1b635d465e39cc574fc8fd60e44a87ffc1a4e66e69
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:e5170fc182c0284a57d9bdbc18ee39548ff053c5152b68089d2d60a503774cd5
     working_directory: /go/src/github.com/windmilleng/tilt
     steps:
       - checkout
       - run: echo 'export PATH=~/go/bin:$PATH' >> $BASH_ENV
       - setup_remote_docker
-      - run: if [[ -z ${GCLOUD_SERVICE_KEY} ]]; then echo "Integration tests only run for users with commit access (since they use gcloud creds)"; false; fi
-      - run: echo ${GCLOUD_SERVICE_KEY} > ${HOME}/gcloud-service-key.json
-      # NOTE(nick): Integration tests currently push images to windmill-test-containers,
-      # so we need to use a gcloud service account.
-      # I'm not super happy with this solution. I'd prefer we ran a local registry.
-      # But this is hard to coordinate effectively.
-      - run: |
-          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-          gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-          gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-          gcloud auth configure-docker
-      # Cleaning is helpful when running with the local circleci toolchain
-      - run: /go/dind-cluster.sh clean
+      # Delete any existing clusters, for `circleci local execute` mode
+      - run: kind delete cluster || exit 0 
       - run: docker kill portforward || exit 0
       - run: docker rm portforward || exit 0
       - run: /go/portforward.sh start
-      - run: DIND_PORT_FORWARDER_WAIT=1 DIND_PORT_FORWARDER="/go/portforward.sh" NUM_NODES=1 /go/dind-cluster.sh up
-      - run: /go/portforward.sh -wait $(/go/dind-cluster.sh apiserver-port) &&
+      - run: kind create cluster
+      - run: "export KUBECONFIG=$(kind get kubeconfig-path) &&
+             export APISERVER_PORT=$(kubectl config view -o jsonpath='{.clusters[].cluster.server}' | cut -d: -f 3 -) &&
+             /go/portforward.sh -wait $APISERVER_PORT &&
              kubectl get nodes &&
-             make integration
+             make integration"
       - store_test_results:
           path: test-results
 


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/kind3:

d4a708a37501b94f42003271beaa7d2d71040437 (2019-06-25 18:51:51 -0400)
integration: run tests on Kind
Should make the tests faster and more robust, because
we no longer need to push to a remote registry

eac18bf14334d01fcc760c8d32ffa7aeba1741d6 (2019-06-25 18:51:51 -0400)
integration: all tests pass on containerd/KIND
- we can delete live_update_test.go, because now it's just a duplicate of onewatch
- live_update_base_image needed the busybox tar workaround