### PR TITLE
start.sh: fix quoting, kill underlying process on exit

### DIFF
--- a/integration/onewatch/start.sh
+++ b/integration/onewatch/start.sh
@@ -11,10 +11,22 @@
 #   To restart the container:
 #   ./restart.sh
 
+set -euo pipefail
+
+process_id=""
+
+trap quit TERM INT
+
+quit() {
+  if [ -n "$process_id" ]; then
+    kill $process_id
+  fi
+}
+
 while true; do
     rm -f restart.txt
-    
-    $* &
+
+    "$@" &
     process_id=$!
     echo "$process_id" > process.txt
     wait $process_id

--- a/integration/onewatch/start.sh
+++ b/integration/onewatch/start.sh
@@ -29,8 +29,7 @@ while true; do
     "$@" &
     process_id=$!
     echo "$process_id" > process.txt
-    wait $process_id
-    EXIT_CODE=$?
+    wait $process_id && EXIT_CODE=$? || EXIT_CODE=$?
     if [ ! -f restart.txt ]; then
         exit $EXIT_CODE
     fi

--- a/integration/onewatch/start.sh
+++ b/integration/onewatch/start.sh
@@ -29,7 +29,10 @@ while true; do
     "$@" &
     process_id=$!
     echo "$process_id" > process.txt
-    wait $process_id && EXIT_CODE=$? || EXIT_CODE=$?
+    set +e
+    wait $process_id
+    EXIT_CODE=$?
+    set -e
     if [ ! -f restart.txt ]; then
         exit $EXIT_CODE
     fi

--- a/integration/start.sh
+++ b/integration/start.sh
@@ -15,11 +15,10 @@ set -euo pipefail
 
 process_id=""
 
-trap quit SIGINT
-trap quit SIGTERM
+trap quit TERM INT
 
-function quit {
-  if [[ -n $process_id ]]; then
+quit() {
+  if [ -n "$process_id" ]; then
     kill $process_id
   fi
 }

--- a/integration/start.sh
+++ b/integration/start.sh
@@ -11,10 +11,23 @@
 #   To restart the container:
 #   ./restart.sh
 
+set -euo pipefail
+
+process_id=""
+
+trap quit SIGINT
+trap quit SIGTERM
+
+function quit {
+  if [[ -n $process_id ]]; then
+    kill $process_id
+  fi
+}
+
 while true; do
     rm -f restart.txt
-    
-    $* &
+
+    "$@" &
     process_id=$!
     echo "$process_id" > process.txt
     wait $process_id

--- a/integration/start.sh
+++ b/integration/start.sh
@@ -29,8 +29,7 @@ while true; do
     "$@" &
     process_id=$!
     echo "$process_id" > process.txt
-    wait $process_id
-    EXIT_CODE=$?
+    wait $process_id && EXIT_CODE=$? || EXIT_CODE=$?
     if [ ! -f restart.txt ]; then
         exit $EXIT_CODE
     fi

--- a/integration/start.sh
+++ b/integration/start.sh
@@ -29,7 +29,10 @@ while true; do
     "$@" &
     process_id=$!
     echo "$process_id" > process.txt
-    wait $process_id && EXIT_CODE=$? || EXIT_CODE=$?
+    set +e
+    wait $process_id
+    EXIT_CODE=$?
+    set -e
     if [ ! -f restart.txt ]; then
         exit $EXIT_CODE
     fi


### PR DESCRIPTION
1. we want `"$@"` instead of `$*` to ensure that we run the command with the same quotes as the original command
2. while I was testing that, it turned out that killing the script didn't kill the underlying process, which might not matter for k8s purposes, but is nice to do for local testing