### PR TITLE
engine: fix exec syncing on busybox

### DIFF
--- a/integration/live_update_base_image/app/Dockerfile
+++ b/integration/live_update_base_image/app/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:alpine
 
-# TODO(nick): remove this when we have fixed GNU/busybox tar incompatibilites
-RUN apk add tar
-
 COPY --from=gcr.io/windmill-test-containers/live-update-base-image-common /usr/src/common/regular /app/message.txt
 
 WORKDIR /app

--- a/integration/onewatch_exec/Dockerfile
+++ b/integration/onewatch_exec/Dockerfile
@@ -1,3 +1,1 @@
 FROM python:alpine
-# TODO(dmiller): remove this when we have fixed GNU/busybox tar incompatibilites
-RUN apk add tar

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -227,7 +227,7 @@ func (sbd *SyncletBuildAndDeployer) updateViaExec(ctx context.Context,
 		}
 		l.Infof("updating %v files %v", len(archivePaths), filesToShow)
 		if err := sbd.kCli.Exec(ctx, podID, container, namespace,
-			[]string{"tar", "-C", "/", "-x", "-f", "/dev/stdin"}, archive, w, w); err != nil {
+			[]string{"tar", "-C", "/", "-x", "-f", "-"}, archive, w, w); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/tarballs2:

dfa81af83362ddabb0465e48499ad24a9edca99b (2019-06-27 15:36:04 -0700)
engine: fix exec syncing on busybox
Fixes https://github.com/windmilleng/tilt/issues/1611