### PR TITLE
engine: only inject images into env vars when that image so configured

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -248,9 +248,10 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 				}
 
 				selector := iTargetMap[depID].ConfigurationRef
+				matchInEnvVars := iTargetMap[depID].MatchInEnvVars
 
 				var replaced bool
-				e, replaced, err = k8s.InjectImageDigest(e, selector, ref, policy)
+				e, replaced, err = k8s.InjectImageDigest(e, selector, ref, matchInEnvVars, policy)
 				if err != nil {
 					return err
 				}

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -80,6 +80,20 @@ func NewSanchoFastBuildManifestWithCache(fixture pather, paths []string) model.M
 	return manifest
 }
 
+func NewSanchoManifestWithImageInEnvVar(f pather) model.Manifest {
+	it2 := model.NewImageTarget(container.MustParseSelector(SanchoRef.String() + "2")).WithBuildDetails(model.DockerBuild{
+		Dockerfile: SanchoDockerfile,
+		BuildPath:  f.Path(),
+	})
+	it2.MatchInEnvVars = true
+	return assembleK8sManifest(
+		model.Manifest{Name: "sancho"},
+		model.K8sTarget{YAML: testyaml.SanchoImageInEnvYAML},
+		NewSanchoDockerBuildImageTarget(f),
+		it2,
+	)
+}
+
 func NewSanchoCustomBuildManifest(fixture pather) model.Manifest {
 	return NewSanchoCustomBuildManifestWithTag(fixture, "")
 }

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -34,7 +34,7 @@ func InjectImagePullPolicy(entity K8sEntity, policy v1.PullPolicy) (K8sEntity, e
 //   to ensure that k8s fails hard if the image is missing from docker.
 //
 // Returns: the new entity, whether the image was replaced, and an error.
-func InjectImageDigest(entity K8sEntity, selector container.RefSelector, injectRef reference.Named, policy v1.PullPolicy) (K8sEntity, bool, error) {
+func InjectImageDigest(entity K8sEntity, selector container.RefSelector, injectRef reference.Named, matchInEnvVars bool, policy v1.PullPolicy) (K8sEntity, bool, error) {
 	entity = entity.DeepCopy()
 
 	// NOTE(nick): For some reason, if you have a reference with a digest,
@@ -62,12 +62,14 @@ func InjectImageDigest(entity K8sEntity, selector container.RefSelector, injectR
 		replaced = true
 	}
 
-	entity, r, err = injectImageDigestInEnvVars(entity, selector, injectRef)
-	if err != nil {
-		return K8sEntity{}, false, err
-	}
-	if r {
-		replaced = true
+	if matchInEnvVars {
+		entity, r, err = injectImageDigestInEnvVars(entity, selector, injectRef)
+		if err != nil {
+			return K8sEntity{}, false, err
+		}
+		if r {
+			replaced = true
+		}
 	}
 
 	entity, r, err = injectImageDigestInUnstructured(entity, injectRef)

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -294,6 +294,8 @@ spec:
         env:
           - name: foo
             value: gcr.io/some-project-162817/sancho2
+          - name: bar
+            value: gcr.io/some-project-162817/sancho
 `
 
 const TracerYAML = `

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -16,6 +16,7 @@ type ImageTarget struct {
 	ConfigurationRef container.RefSelector
 	DeploymentRef    reference.Named
 	BuildDetails     BuildDetails
+	MatchInEnvVars   bool
 
 	cachePaths []string
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -895,6 +895,7 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 		iTarget := model.ImageTarget{
 			ConfigurationRef: image.configurationRef,
 			DeploymentRef:    image.deploymentRef,
+			MatchInEnvVars:   image.matchInEnvVars,
 		}.WithCachePaths(image.cachePaths)
 
 		lu := image.liveUpdate

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2149,7 +2149,7 @@ docker_build('gcr.io/foo-fetcher', 'foo-fetcher', match_in_env_vars=True)
 			image("gcr.io/foo"),
 		),
 		db(
-			image("gcr.io/foo-fetcher"),
+			image("gcr.io/foo-fetcher").withMatchInEnvVars(),
 		),
 	)
 }
@@ -3797,6 +3797,8 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 				f.t.FailNow()
 			}
 
+			assert.Equal(f.t, opt.image.matchInEnvVars, image.MatchInEnvVars)
+
 			if opt.cache != "" {
 				assert.Contains(f.t, image.CachePaths(), opt.cache,
 					"manifest %v cache paths don't include expected value", m.Name)
@@ -4179,8 +4181,9 @@ func fileChangeFilters(path string) matchPathHelper {
 }
 
 type imageHelper struct {
-	ref           string
-	deploymentRef string
+	ref            string
+	deploymentRef  string
+	matchInEnvVars bool
 }
 
 func image(ref string) imageHelper {
@@ -4193,6 +4196,11 @@ func imageNormalized(ref string) imageHelper {
 
 func (ih imageHelper) withInjectedRef(injectedRef string) imageHelper {
 	ih.deploymentRef = injectedRef
+	return ih
+}
+
+func (ih imageHelper) withMatchInEnvVars() imageHelper {
+	ih.matchInEnvVars = true
 	return ih
 }
 


### PR DESCRIPTION
This fixes #1793 

### Problem
#1603 made it configurable whether we match images in env vars for the purposes of workload assembly, but the backend still always injected in any env vars it found.

### Solution
Store match_in_env_vars into the ImageTarget when parsing the Tiltfile, and only inject images into env vars when that value is set for a given target.