### PR TITLE
bug: Docker compose supporting multiple files

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -37,6 +37,7 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 	defer a.Flush(time.Second)
 
 	downDeps, err := wireDownDeps(ctx, a)
+
 	if err != nil {
 		return err
 	}
@@ -56,27 +57,17 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 		logger.Get(ctx).Infof("error deleting k8s entities: %v", err)
 	}
 
-	var dcConfigPath []string
+	var dcConfigPaths []string
 	for _, m := range tlr.Manifests {
 		if m.IsDC() {
-			// TODO(maia): when we support up-ing from multiple docker-compose files, we'll
-			// need to support down-ing as well. For now, we `down` the first one we find.
-			dcConfigPath = m.DockerComposeTarget().ConfigPath
+			dcConfigPaths = m.DockerComposeTarget().ConfigPaths
 			break
 		}
 	}
-
-	for _, config := range dcConfigPath {
-		if config != "" {
-			// TODO(maia): when we support up-ing from multiple docker-compose files, we'll need to support down-ing as well
-			// TODO(maia): a way to `down` specific services?
-			// downing the first one
-			dcc := downDeps.dcClient
-			err = dcc.Down(ctx, dcConfigPath, logger.Get(ctx).Writer(logger.InfoLvl), logger.Get(ctx).Writer(logger.InfoLvl))
-			if err != nil {
-				logger.Get(ctx).Infof("error running `docker-compose down`: %v", err)
-			}
-		}
+	dcc := downDeps.dcClient
+	err = dcc.Down(ctx, dcConfigPaths, logger.Get(ctx).Writer(logger.InfoLvl), logger.Get(ctx).Writer(logger.InfoLvl))
+	if err != nil {
+		logger.Get(ctx).Infof("error running `docker-compose down`: %v", err)
 	}
 	return nil
 }

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -56,7 +56,7 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 		logger.Get(ctx).Infof("error deleting k8s entities: %v", err)
 	}
 
-	var dcConfigPath string
+	var dcConfigPath []string
 	for _, m := range tlr.Manifests {
 		if m.IsDC() {
 			// TODO(maia): when we support up-ing from multiple docker-compose files, we'll
@@ -66,14 +66,16 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 		}
 	}
 
-	if dcConfigPath != "" {
-		// TODO(maia): when we support up-ing from multiple docker-compose files, we'll need to support down-ing as well
-		// TODO(maia): a way to `down` specific services?
-
-		dcc := downDeps.dcClient
-		err = dcc.Down(ctx, dcConfigPath, logger.Get(ctx).Writer(logger.InfoLvl), logger.Get(ctx).Writer(logger.InfoLvl))
-		if err != nil {
-			logger.Get(ctx).Infof("error running `docker-compose down`: %v", err)
+	for _, config := range dcConfigPath {
+		if config != "" {
+			// TODO(maia): when we support up-ing from multiple docker-compose files, we'll need to support down-ing as well
+			// TODO(maia): a way to `down` specific services?
+			// downing the first one
+			dcc := downDeps.dcClient
+			err = dcc.Down(ctx, dcConfigPath, logger.Get(ctx).Writer(logger.InfoLvl), logger.Get(ctx).Writer(logger.InfoLvl))
+			if err != nil {
+				logger.Get(ctx).Infof("error running `docker-compose down`: %v", err)
+			}
 		}
 	}
 	return nil

--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -19,13 +19,13 @@ import (
 )
 
 type DockerComposeClient interface {
-	Up(ctx context.Context, configPath []string, serviceName model.TargetName, shouldBuild bool, stdout, stderr io.Writer) error
-	Down(ctx context.Context, configPath []string, stdout, stderr io.Writer) error
-	StreamLogs(ctx context.Context, configPath []string, serviceName model.TargetName) (io.ReadCloser, error)
-	StreamEvents(ctx context.Context, configPath []string) (<-chan string, error)
-	Config(ctx context.Context, configPath []string) (string, error)
-	Services(ctx context.Context, configPath []string) (string, error)
-	ContainerID(ctx context.Context, configPath []string, serviceName model.TargetName) (container.ID, error)
+	Up(ctx context.Context, configPaths []string, serviceName model.TargetName, shouldBuild bool, stdout, stderr io.Writer) error
+	Down(ctx context.Context, configPaths []string, stdout, stderr io.Writer) error
+	StreamLogs(ctx context.Context, configPaths []string, serviceName model.TargetName) (io.ReadCloser, error)
+	StreamEvents(ctx context.Context, configPaths []string) (<-chan string, error)
+	Config(ctx context.Context, configPaths []string) (string, error)
+	Services(ctx context.Context, configPaths []string) (string, error)
+	ContainerID(ctx context.Context, configPaths []string, serviceName model.TargetName) (container.ID, error)
 }
 
 type cmdDCClient struct {
@@ -168,8 +168,8 @@ func (c *cmdDCClient) Config(ctx context.Context, configPath []string) (string, 
 	return c.dcOutput(ctx, configPath, "config")
 }
 
-func (c *cmdDCClient) Services(ctx context.Context, configPath []string) (string, error) {
-	return c.dcOutput(ctx, configPath, "config", "--services")
+func (c *cmdDCClient) Services(ctx context.Context, configPaths []string) (string, error) {
+	return c.dcOutput(ctx, configPaths, "config", "--services")
 }
 
 func (c *cmdDCClient) ContainerID(ctx context.Context, configPath []string, serviceName model.TargetName) (container.ID, error) {

--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -19,13 +19,13 @@ import (
 )
 
 type DockerComposeClient interface {
-	Up(ctx context.Context, configPath string, serviceName model.TargetName, shouldBuild bool, stdout, stderr io.Writer) error
-	Down(ctx context.Context, configPath string, stdout, stderr io.Writer) error
-	StreamLogs(ctx context.Context, configPath string, serviceName model.TargetName) (io.ReadCloser, error)
-	StreamEvents(ctx context.Context, configPath string) (<-chan string, error)
-	Config(ctx context.Context, configPath string) (string, error)
-	Services(ctx context.Context, configPath string) (string, error)
-	ContainerID(ctx context.Context, configPath string, serviceName model.TargetName) (container.ID, error)
+	Up(ctx context.Context, configPath []string, serviceName model.TargetName, shouldBuild bool, stdout, stderr io.Writer) error
+	Down(ctx context.Context, configPath []string, stdout, stderr io.Writer) error
+	StreamLogs(ctx context.Context, configPath []string, serviceName model.TargetName) (io.ReadCloser, error)
+	StreamEvents(ctx context.Context, configPath []string) (<-chan string, error)
+	Config(ctx context.Context, configPath []string) (string, error)
+	Services(ctx context.Context, configPath []string) (string, error)
+	ContainerID(ctx context.Context, configPath []string, serviceName model.TargetName) (container.ID, error)
 }
 
 type cmdDCClient struct {
@@ -40,13 +40,18 @@ func NewDockerComposeClient(env docker.LocalEnv) DockerComposeClient {
 	}
 }
 
-func (c *cmdDCClient) Up(ctx context.Context, configPath string, serviceName model.TargetName, shouldBuild bool, stdout, stderr io.Writer) error {
+func (c *cmdDCClient) Up(ctx context.Context, configPath []string, serviceName model.TargetName, shouldBuild bool, stdout, stderr io.Writer) error {
 	var args []string
 	if logger.Get(ctx).Level() >= logger.VerboseLvl {
 		args = []string{"--verbose"}
 	}
 
-	args = append(args, "-f", configPath, "up", "--no-deps", "-d")
+	for _, config := range configPath {
+		args = append(args, "-f", config)
+	}
+
+	args = append(args, "up", "--no-deps", "-d")
+
 	if shouldBuild {
 		args = append(args, "--build")
 	} else {
@@ -65,12 +70,16 @@ func (c *cmdDCClient) Up(ctx context.Context, configPath string, serviceName mod
 	return FormatError(cmd, nil, cmd.Run())
 }
 
-func (c *cmdDCClient) Down(ctx context.Context, configPath string, stdout, stderr io.Writer) error {
+func (c *cmdDCClient) Down(ctx context.Context, configPath []string, stdout, stderr io.Writer) error {
 	var args []string
 	if logger.Get(ctx).Level() >= logger.VerboseLvl {
 		args = []string{"--verbose"}
 	}
-	args = append(args, "-f", configPath, "down")
+	for _, config := range configPath {
+		args = append(args, "-f", config)
+	}
+
+	args = append(args, "down")
 	cmd := c.dcCommand(ctx, args)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -83,10 +92,14 @@ func (c *cmdDCClient) Down(ctx context.Context, configPath string, stdout, stder
 	return nil
 }
 
-func (c *cmdDCClient) StreamLogs(ctx context.Context, configPath string, serviceName model.TargetName) (io.ReadCloser, error) {
+func (c *cmdDCClient) StreamLogs(ctx context.Context, configPath []string, serviceName model.TargetName) (io.ReadCloser, error) {
 	// TODO(maia): --since time
 	// (may need to implement with `docker log <cID>` instead since `d-c log` doesn't support `--since`
-	args := []string{"-f", configPath, "logs", "-f", "-t", serviceName.String()}
+	var args []string
+	for _, config := range configPath {
+		args = append(args, "-f", config)
+	}
+	args = append(args, "logs", "-f", "-t", serviceName.String())
 	cmd := c.dcCommand(ctx, args)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -112,10 +125,14 @@ func (c *cmdDCClient) StreamLogs(ctx context.Context, configPath string, service
 	return stdout, nil
 }
 
-func (c *cmdDCClient) StreamEvents(ctx context.Context, configPath string) (<-chan string, error) {
+func (c *cmdDCClient) StreamEvents(ctx context.Context, configPath []string) (<-chan string, error) {
 	ch := make(chan string)
 
-	args := []string{"-f", configPath, "events", "--json"}
+	var args []string
+	for _, config := range configPath {
+		args = append(args, "-f", config)
+	}
+	args = append(args, "events", "--json")
 	cmd := c.dcCommand(ctx, args)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -140,21 +157,22 @@ func (c *cmdDCClient) StreamEvents(ctx context.Context, configPath string) (<-ch
 		err = cmd.Wait()
 		if err != nil {
 			logger.Get(ctx).Infof("[DOCKER-COMPOSE WATCHER] exited with error: %v", err)
+			logger.Get(ctx).Infof("command running %v", cmd)
 		}
 	}()
 
 	return ch, nil
 }
 
-func (c *cmdDCClient) Config(ctx context.Context, configPath string) (string, error) {
+func (c *cmdDCClient) Config(ctx context.Context, configPath []string) (string, error) {
 	return c.dcOutput(ctx, configPath, "config")
 }
 
-func (c *cmdDCClient) Services(ctx context.Context, configPath string) (string, error) {
+func (c *cmdDCClient) Services(ctx context.Context, configPath []string) (string, error) {
 	return c.dcOutput(ctx, configPath, "config", "--services")
 }
 
-func (c *cmdDCClient) ContainerID(ctx context.Context, configPath string, serviceName model.TargetName) (container.ID, error) {
+func (c *cmdDCClient) ContainerID(ctx context.Context, configPath []string, serviceName model.TargetName) (container.ID, error) {
 	id, err := c.dcOutput(ctx, configPath, "ps", "-q", serviceName.String())
 	if err != nil {
 		return container.ID(""), err
@@ -169,8 +187,13 @@ func (c *cmdDCClient) dcCommand(ctx context.Context, args []string) *exec.Cmd {
 	return cmd
 }
 
-func (c *cmdDCClient) dcOutput(ctx context.Context, configPath string, args ...string) (string, error) {
-	args = append([]string{"-f", configPath}, args...)
+func (c *cmdDCClient) dcOutput(ctx context.Context, configPath []string, args ...string) (string, error) {
+
+	var tempArgs []string
+	for _, config := range configPath {
+		tempArgs = append(tempArgs, "-f", config)
+	}
+	args = append(tempArgs, args...)
 	cmd := c.dcCommand(ctx, args)
 
 	output, err := cmd.Output()

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -40,17 +40,17 @@ func NewFakeDockerComposeClient(t *testing.T, ctx context.Context) *FakeDCClient
 	}
 }
 
-func (c *FakeDCClient) Up(ctx context.Context, pathToConfig []string, serviceName model.TargetName,
+func (c *FakeDCClient) Up(ctx context.Context, configPaths []string, serviceName model.TargetName,
 	shouldBuild bool, stdout, stderr io.Writer) error {
-	c.UpCalls = append(c.UpCalls, UpCall{pathToConfig, serviceName, shouldBuild})
+	c.UpCalls = append(c.UpCalls, UpCall{configPaths, serviceName, shouldBuild})
 	return nil
 }
 
-func (c *FakeDCClient) Down(ctx context.Context, pathToConfig []string, stdout, stderr io.Writer) error {
+func (c *FakeDCClient) Down(ctx context.Context, configPaths []string, stdout, stderr io.Writer) error {
 	return nil
 }
 
-func (c *FakeDCClient) StreamLogs(ctx context.Context, pathToConfig []string, serviceName model.TargetName) (io.ReadCloser, error) {
+func (c *FakeDCClient) StreamLogs(ctx context.Context, configPaths []string, serviceName model.TargetName) (io.ReadCloser, error) {
 	output := c.RunLogOutput[serviceName]
 	reader, writer := io.Pipe()
 	go func() {
@@ -72,7 +72,7 @@ func (c *FakeDCClient) StreamLogs(ctx context.Context, pathToConfig []string, se
 	return reader, nil
 }
 
-func (c *FakeDCClient) StreamEvents(ctx context.Context, pathToConfig []string) (<-chan string, error) {
+func (c *FakeDCClient) StreamEvents(ctx context.Context, configPaths []string) (<-chan string, error) {
 	events := make(chan string, 10)
 	go func() {
 		for {
@@ -102,7 +102,7 @@ func (c *FakeDCClient) SendEvent(evt Event) error {
 	return nil
 }
 
-func (c *FakeDCClient) Config(ctx context.Context, pathToConfig []string) (string, error) {
+func (c *FakeDCClient) Config(ctx context.Context, configPaths []string) (string, error) {
 	return c.ConfigOutput, nil
 }
 
@@ -110,6 +110,6 @@ func (c *FakeDCClient) Services(ctx context.Context, configPaths []string) (stri
 	return c.ServicesOutput, nil
 }
 
-func (c *FakeDCClient) ContainerID(ctx context.Context, pathToConfig []string, serviceName model.TargetName) (container.ID, error) {
+func (c *FakeDCClient) ContainerID(ctx context.Context, configPaths []string, serviceName model.TargetName) (container.ID, error) {
 	return c.ContainerIdOutput, nil
 }

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -106,7 +106,7 @@ func (c *FakeDCClient) Config(ctx context.Context, pathToConfig []string) (strin
 	return c.ConfigOutput, nil
 }
 
-func (c *FakeDCClient) Services(ctx context.Context, pathToConfig []string) (string, error) {
+func (c *FakeDCClient) Services(ctx context.Context, configPaths []string) (string, error) {
 	return c.ServicesOutput, nil
 }
 

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -26,7 +26,7 @@ type FakeDCClient struct {
 
 // Represents a single call to Up
 type UpCall struct {
-	PathToConfig string
+	PathToConfig []string
 	ServiceName  model.TargetName
 	ShouldBuild  bool
 }
@@ -40,17 +40,17 @@ func NewFakeDockerComposeClient(t *testing.T, ctx context.Context) *FakeDCClient
 	}
 }
 
-func (c *FakeDCClient) Up(ctx context.Context, pathToConfig string, serviceName model.TargetName,
+func (c *FakeDCClient) Up(ctx context.Context, pathToConfig []string, serviceName model.TargetName,
 	shouldBuild bool, stdout, stderr io.Writer) error {
 	c.UpCalls = append(c.UpCalls, UpCall{pathToConfig, serviceName, shouldBuild})
 	return nil
 }
 
-func (c *FakeDCClient) Down(ctx context.Context, pathToConfig string, stdout, stderr io.Writer) error {
+func (c *FakeDCClient) Down(ctx context.Context, pathToConfig []string, stdout, stderr io.Writer) error {
 	return nil
 }
 
-func (c *FakeDCClient) StreamLogs(ctx context.Context, pathToConfig string, serviceName model.TargetName) (io.ReadCloser, error) {
+func (c *FakeDCClient) StreamLogs(ctx context.Context, pathToConfig []string, serviceName model.TargetName) (io.ReadCloser, error) {
 	output := c.RunLogOutput[serviceName]
 	reader, writer := io.Pipe()
 	go func() {
@@ -72,7 +72,7 @@ func (c *FakeDCClient) StreamLogs(ctx context.Context, pathToConfig string, serv
 	return reader, nil
 }
 
-func (c *FakeDCClient) StreamEvents(ctx context.Context, pathToConfig string) (<-chan string, error) {
+func (c *FakeDCClient) StreamEvents(ctx context.Context, pathToConfig []string) (<-chan string, error) {
 	events := make(chan string, 10)
 	go func() {
 		for {
@@ -102,14 +102,14 @@ func (c *FakeDCClient) SendEvent(evt Event) error {
 	return nil
 }
 
-func (c *FakeDCClient) Config(ctx context.Context, pathToConfig string) (string, error) {
+func (c *FakeDCClient) Config(ctx context.Context, pathToConfig []string) (string, error) {
 	return c.ConfigOutput, nil
 }
 
-func (c *FakeDCClient) Services(ctx context.Context, pathToConfig string) (string, error) {
+func (c *FakeDCClient) Services(ctx context.Context, pathToConfig []string) (string, error) {
 	return c.ServicesOutput, nil
 }
 
-func (c *FakeDCClient) ContainerID(ctx context.Context, pathToConfig string, serviceName model.TargetName) (container.ID, error) {
+func (c *FakeDCClient) ContainerID(ctx context.Context, pathToConfig []string, serviceName model.TargetName) (container.ID, error) {
 	return c.ContainerIdOutput, nil
 }

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -113,14 +113,14 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 
 	stdout := logger.Get(ctx).Writer(logger.InfoLvl)
 	stderr := logger.Get(ctx).Writer(logger.InfoLvl)
-	err = bd.dcc.Up(ctx, dcTarget.ConfigPath, dcTarget.Name, !haveImage, stdout, stderr)
+	err = bd.dcc.Up(ctx, dcTarget.ConfigPaths, dcTarget.Name, !haveImage, stdout, stderr)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
 
 	// NOTE(dmiller): right now we only need this the first time. In the future
 	// it might be worth it to move this somewhere else
-	cid, err := bd.dcc.ContainerID(ctx, dcTarget.ConfigPath, dcTarget.Name)
+	cid, err := bd.dcc.ContainerID(ctx, dcTarget.ConfigPaths, dcTarget.Name)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var expectedContainer = container.ID("dc-cont")
-var confPath = "/whales/are/big/dc.yml"
+var confPath = []string{"/whales/are/big/dc.yml"}
 var dcName = model.TargetName("MobyDick")
 var dcTarg = model.DockerComposeTarget{Name: dcName, ConfigPaths: confPath}
 

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -23,7 +23,7 @@ import (
 var expectedContainer = container.ID("dc-cont")
 var confPath = "/whales/are/big/dc.yml"
 var dcName = model.TargetName("MobyDick")
-var dcTarg = model.DockerComposeTarget{Name: dcName, ConfigPath: confPath}
+var dcTarg = model.DockerComposeTarget{Name: dcName, ConfigPaths: confPath}
 
 var imgRef = "gcr.io/some/image"
 var imgTarg = model.NewImageTarget(container.MustParseSelector(imgRef)).

--- a/internal/engine/docker_compose_event_watcher.go
+++ b/internal/engine/docker_compose_event_watcher.go
@@ -36,7 +36,7 @@ func (w *DockerComposeEventWatcher) OnChange(ctx context.Context, st store.RStor
 	configPath := state.DockerComposeConfigPath()
 	st.RUnlockState()
 
-	if configPath == "" {
+	if configPath == nil {
 		// No DC manifests to watch
 		return
 	}
@@ -52,7 +52,7 @@ func (w *DockerComposeEventWatcher) OnChange(ctx context.Context, st store.RStor
 	go dispatchDockerComposeEventLoop(ctx, ch, st)
 }
 
-func (w *DockerComposeEventWatcher) startWatch(ctx context.Context, configPath string) (<-chan string, error) {
+func (w *DockerComposeEventWatcher) startWatch(ctx context.Context, configPath []string) (<-chan string, error) {
 	return w.dcc.StreamEvents(ctx, configPath)
 }
 

--- a/internal/engine/docker_compose_event_watcher.go
+++ b/internal/engine/docker_compose_event_watcher.go
@@ -33,16 +33,16 @@ func (w *DockerComposeEventWatcher) OnChange(ctx context.Context, st store.RStor
 	}
 
 	state := st.RLockState()
-	configPath := state.DockerComposeConfigPath()
+	configPaths := state.DockerComposeConfigPath()
 	st.RUnlockState()
 
-	if configPath == nil {
+	if len(configPaths) == 0 {
 		// No DC manifests to watch
 		return
 	}
 
 	w.watching = true
-	ch, err := w.startWatch(ctx, configPath)
+	ch, err := w.startWatch(ctx, configPaths)
 	if err != nil {
 		err = errors.Wrap(err, "Subscribing to docker-compose events")
 		st.Dispatch(NewErrorAction(err))

--- a/internal/engine/docker_compose_log_manager.go
+++ b/internal/engine/docker_compose_log_manager.go
@@ -111,7 +111,7 @@ func (m *DockerComposeLogManager) consumeLogs(watch dockerComposeLogWatch, st st
 	}()
 
 	name := watch.name
-	readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPath, watch.dc.Name)
+	readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPath, watch.dc.Name) //todo(maria)
 	if err != nil {
 		logger.Get(watch.ctx).Debugf("Error streaming %s logs: %v", name, err)
 		return

--- a/internal/engine/docker_compose_log_manager.go
+++ b/internal/engine/docker_compose_log_manager.go
@@ -111,7 +111,7 @@ func (m *DockerComposeLogManager) consumeLogs(watch dockerComposeLogWatch, st st
 	}()
 
 	name := watch.name
-	readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPath, watch.dc.Name) //todo(maria)
+	readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPaths, watch.dc.Name)
 	if err != nil {
 		logger.Get(watch.ctx).Debugf("Error streaming %s logs: %v", name, err)
 		return

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2938,9 +2938,9 @@ func (f *testFixture) newDCManifest(name string, DCYAMLRaw string, dockerfileCon
 	return model.Manifest{
 		Name: model.ManifestName(name),
 	}.WithDeployTarget(model.DockerComposeTarget{
-		ConfigPath: f.JoinPath("docker-compose.yml"),
-		YAMLRaw:    []byte(DCYAMLRaw),
-		DfRaw:      []byte(dockerfileContents),
+		ConfigPaths: f.JoinPath("docker-compose.yml"),
+		YAMLRaw:     []byte(DCYAMLRaw),
+		DfRaw:       []byte(dockerfileContents),
 	})
 }
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2044,6 +2044,7 @@ func TestDockerComposeUp(t *testing.T) {
 	assert.Equal(t, server.DockerComposeTarget().ID(), call.dc().ID())
 }
 
+//TODO (maria) tests for dockercompose mulltiple files
 func TestDockerComposeRedeployFromFileChange(t *testing.T) {
 	f := newTestFixture(t)
 	_, m := f.setupDCFixture()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2044,7 +2044,6 @@ func TestDockerComposeUp(t *testing.T) {
 	assert.Equal(t, server.DockerComposeTarget().ID(), call.dc().ID())
 }
 
-//TODO (maria) tests for dockercompose mulltiple files
 func TestDockerComposeRedeployFromFileChange(t *testing.T) {
 	f := newTestFixture(t)
 	_, m := f.setupDCFixture()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2938,7 +2938,7 @@ func (f *testFixture) newDCManifest(name string, DCYAMLRaw string, dockerfileCon
 	return model.Manifest{
 		Name: model.ManifestName(name),
 	}.WithDeployTarget(model.DockerComposeTarget{
-		ConfigPaths: f.JoinPath("docker-compose.yml"),
+		ConfigPaths: []string{f.JoinPath("docker-compose.yml")},
 		YAMLRaw:     []byte(DCYAMLRaw),
 		DfRaw:       []byte(dockerfileContents),
 	})

--- a/internal/hud/renderer_test.go
+++ b/internal/hud/renderer_test.go
@@ -580,7 +580,7 @@ func TestDockerComposeUpExpanded(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name:         "snack",
-				ResourceInfo: view.NewDCResourceInfo("foo", dockercompose.StatusUp, testCID, model.NewLog("hellllo"), now.Add(-5*time.Second)),
+				ResourceInfo: view.NewDCResourceInfo([]string{"foo"}, dockercompose.StatusUp, testCID, model.NewLog("hellllo"), now.Add(-5*time.Second)),
 				Endpoints:    []string{"http://localhost:3000"},
 				CurrentBuild: model.BuildRecord{
 					StartTime: now.Add(-5 * time.Second),
@@ -602,7 +602,7 @@ func TestStatusBarDCRebuild(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name:         "snack",
-				ResourceInfo: view.NewDCResourceInfo("foo", dockercompose.StatusDown, testCID, model.NewLog("hellllo"), now.Add(-5*time.Second)),
+				ResourceInfo: view.NewDCResourceInfo([]string{"foo"}, dockercompose.StatusDown, testCID, model.NewLog("hellllo"), now.Add(-5*time.Second)),
 				CurrentBuild: model.BuildRecord{
 					StartTime: now.Add(-5 * time.Second),
 					Reason:    model.BuildReasonFlagChangedFiles,
@@ -623,7 +623,7 @@ func TestDetectDCCrashExpanded(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name:         "snack",
-				ResourceInfo: view.NewDCResourceInfo("foo", dockercompose.StatusCrash, testCID, model.NewLog("hi im a crash"), now.Add(-5*time.Second)),
+				ResourceInfo: view.NewDCResourceInfo([]string{"foo"}, dockercompose.StatusCrash, testCID, model.NewLog("hi im a crash"), now.Add(-5*time.Second)),
 			},
 		},
 	}
@@ -640,7 +640,7 @@ func TestDetectDCCrashNotExpanded(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name:         "snack",
-				ResourceInfo: view.NewDCResourceInfo("foo", dockercompose.StatusCrash, testCID, model.NewLog("hi im a crash"), now.Add(-5*time.Second)),
+				ResourceInfo: view.NewDCResourceInfo([]string{"foo"}, dockercompose.StatusCrash, testCID, model.NewLog("hi im a crash"), now.Add(-5*time.Second)),
 			},
 		},
 	}
@@ -657,7 +657,7 @@ func TestDetectDCCrashAutoExpand(t *testing.T) {
 		Resources: []view.Resource{
 			{
 				Name:         "snack",
-				ResourceInfo: view.NewDCResourceInfo("foo", dockercompose.StatusCrash, testCID, model.NewLog("hi im a crash"), now.Add(-5*time.Second)),
+				ResourceInfo: view.NewDCResourceInfo([]string{"foo"}, dockercompose.StatusCrash, testCID, model.NewLog("hi im a crash"), now.Add(-5*time.Second)),
 			},
 		},
 	}

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -24,9 +24,9 @@ type DCResourceInfo struct {
 	StartTime       time.Time
 }
 
-func NewDCResourceInfo(configPath []string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
+func NewDCResourceInfo(configPaths []string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
 	return DCResourceInfo{
-		ConfigPaths:     configPath,
+		ConfigPaths:     configPaths,
 		ContainerStatus: status,
 		ContainerID:     cID,
 		Log:             log,

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -17,7 +17,7 @@ type ResourceInfoView interface {
 }
 
 type DCResourceInfo struct {
-	ConfigPath      []string
+	ConfigPaths     []string
 	ContainerStatus dockercompose.Status
 	ContainerID     container.ID
 	Log             model.Log
@@ -26,7 +26,7 @@ type DCResourceInfo struct {
 
 func NewDCResourceInfo(configPath []string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
 	return DCResourceInfo{
-		ConfigPath:      configPath,
+		ConfigPaths:     configPath,
 		ContainerStatus: status,
 		ContainerID:     cID,
 		Log:             log,

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -17,14 +17,14 @@ type ResourceInfoView interface {
 }
 
 type DCResourceInfo struct {
-	ConfigPath      string
+	ConfigPath      []string
 	ContainerStatus dockercompose.Status
 	ContainerID     container.ID
 	Log             model.Log
 	StartTime       time.Time
 }
 
-func NewDCResourceInfo(configPath string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
+func NewDCResourceInfo(configPath []string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
 	return DCResourceInfo{
 		ConfigPath:      configPath,
 		ContainerStatus: status,

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -137,7 +137,7 @@ func resourceInfoView(mt *store.ManifestTarget) ResourceInfoView {
 		}
 	}
 	if dcState, ok := mt.State.ResourceState.(dockercompose.State); ok {
-		return NewDCResourceInfo(mt.Manifest.DockerComposeTarget().ConfigPath, dcState.Status, dcState.ContainerID, dcState.Log(), dcState.StartTime)
+		return NewDCResourceInfo(mt.Manifest.DockerComposeTarget().ConfigPaths, dcState.Status, dcState.ContainerID, dcState.Log(), dcState.StartTime)
 	} else {
 		pod := mt.State.MostRecentPod()
 		return K8sResourceInfo{

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -16,14 +16,14 @@ type ResourceInfoView interface {
 }
 
 type DCResourceInfo struct {
-	ConfigPath      string
+	ConfigPath      []string
 	ContainerStatus dockercompose.Status
 	ContainerID     container.ID
 	Log             model.Log
 	StartTime       time.Time
 }
 
-func NewDCResourceInfo(configPath string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
+func NewDCResourceInfo(configPath []string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
 	return DCResourceInfo{
 		ConfigPath:      configPath,
 		ContainerStatus: status,

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -16,16 +16,16 @@ type ResourceInfoView interface {
 }
 
 type DCResourceInfo struct {
-	ConfigPath      []string
+	ConfigPaths     []string
 	ContainerStatus dockercompose.Status
 	ContainerID     container.ID
 	Log             model.Log
 	StartTime       time.Time
 }
 
-func NewDCResourceInfo(configPath []string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
+func NewDCResourceInfo(configPaths []string, status dockercompose.Status, cID container.ID, log model.Log, startTime time.Time) DCResourceInfo {
 	return DCResourceInfo{
-		ConfigPath:      configPath,
+		ConfigPaths:     configPaths,
 		ContainerStatus: status,
 		ContainerID:     cID,
 		Log:             log,

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -22,7 +22,7 @@ func (dID DeployID) String() string { return strconv.Itoa(int(dID)) }
 
 type DockerComposeTarget struct {
 	Name       TargetName
-	ConfigPath string
+	ConfigPath []string
 
 	// The docker context, like in DockerBuild
 	buildPath string
@@ -136,7 +136,7 @@ func (dc DockerComposeTarget) Validate() error {
 		return fmt.Errorf("[Validate] DockerCompose resource missing name:\n%s", dc.YAMLRaw)
 	}
 
-	if dc.ConfigPath == "" {
+	if dc.ConfigPath == nil {
 		return fmt.Errorf("[Validate] DockerCompose resource %s missing config path", dc.Name)
 	}
 

--- a/internal/model/deploy_info.go
+++ b/internal/model/deploy_info.go
@@ -21,8 +21,8 @@ func NewDeployID() DeployID {
 func (dID DeployID) String() string { return strconv.Itoa(int(dID)) }
 
 type DockerComposeTarget struct {
-	Name       TargetName
-	ConfigPath []string
+	Name        TargetName
+	ConfigPaths []string
 
 	// The docker context, like in DockerBuild
 	buildPath string
@@ -136,7 +136,7 @@ func (dc DockerComposeTarget) Validate() error {
 		return fmt.Errorf("[Validate] DockerCompose resource missing name:\n%s", dc.YAMLRaw)
 	}
 
-	if dc.ConfigPath == nil {
+	if len(dc.ConfigPaths) == 0 {
 		return fmt.Errorf("[Validate] DockerCompose resource %s missing config path", dc.Name)
 	}
 

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -317,15 +317,15 @@ var equalitytests = []struct {
 	},
 	{
 		"DockerCompose.ConfigPaths equal",
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose.yml"}),
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose.yml"}),
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose.yml"}}),
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose.yml"}}),
 		true,
 		false,
 	},
 	{
 		"DockerCompose.ConfigPaths unequal",
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose1.yml"}),
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose2.yml"}),
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose1.yml"}}),
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose2.yml"}}),
 		false,
 		true,
 	},
@@ -468,7 +468,7 @@ func TestManifestValidateSyncRelativePath(t *testing.T) {
 func TestDCTargetValidate(t *testing.T) {
 	targ := DockerComposeTarget{
 		Name:        "blah",
-		ConfigPaths: "docker-compose.yml",
+		ConfigPaths: []string{"docker-compose.yml"},
 	}
 	err := targ.Validate()
 	assert.NoError(t, err)
@@ -479,7 +479,7 @@ func TestDCTargetValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "missing config path")
 	}
 
-	noName := DockerComposeTarget{ConfigPaths: "docker-compose.yml"}
+	noName := DockerComposeTarget{ConfigPaths: []string{"docker-compose.yml"}}
 	err = noName.Validate()
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "missing name")

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -316,16 +316,16 @@ var equalitytests = []struct {
 		false,
 	},
 	{
-		"DockerCompose.ConfigPath equal",
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPath: "/src/docker-compose.yml"}),
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPath: "/src/docker-compose.yml"}),
+		"DockerCompose.ConfigPaths equal",
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose.yml"}),
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose.yml"}),
 		true,
 		false,
 	},
 	{
-		"DockerCompose.ConfigPath unequal",
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPath: "/src/docker-compose1.yml"}),
-		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPath: "/src/docker-compose2.yml"}),
+		"DockerCompose.ConfigPaths unequal",
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose1.yml"}),
+		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: "/src/docker-compose2.yml"}),
 		false,
 		true,
 	},
@@ -467,8 +467,8 @@ func TestManifestValidateSyncRelativePath(t *testing.T) {
 
 func TestDCTargetValidate(t *testing.T) {
 	targ := DockerComposeTarget{
-		Name:       "blah",
-		ConfigPath: "docker-compose.yml",
+		Name:        "blah",
+		ConfigPaths: "docker-compose.yml",
 	}
 	err := targ.Validate()
 	assert.NoError(t, err)
@@ -479,7 +479,7 @@ func TestDCTargetValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "missing config path")
 	}
 
-	noName := DockerComposeTarget{ConfigPath: "docker-compose.yml"}
+	noName := DockerComposeTarget{ConfigPaths: "docker-compose.yml"}
 	err = noName.Validate()
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "missing name")

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -704,7 +704,7 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 	}
 
 	if dcState, ok := mt.State.ResourceState.(dockercompose.State); ok {
-		return view.NewDCResourceInfo(mt.Manifest.DockerComposeTarget().ConfigPath, dcState.Status, dcState.ContainerID, dcState.Log(), dcState.StartTime)
+		return view.NewDCResourceInfo(mt.Manifest.DockerComposeTarget().ConfigPaths, dcState.Status, dcState.ContainerID, dcState.Log(), dcState.StartTime)
 	} else {
 		pod := mt.State.MostRecentPod()
 		return view.K8sResourceInfo{
@@ -726,8 +726,8 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 func (s EngineState) DockerComposeConfigPath() []string {
 	for _, mt := range s.ManifestTargets {
 		if mt.Manifest.IsDC() {
-			return mt.Manifest.DockerComposeTarget().ConfigPath
+			return mt.Manifest.DockerComposeTarget().ConfigPaths
 		}
 	}
-	return nil
+	return []string{}
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -723,11 +723,11 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 // docker-compose manifests on this EngineState.
 // NOTE(maia): current assumption is only one d-c.yaml per run, so we take the
 // path from the first d-c manifest we see.
-func (s EngineState) DockerComposeConfigPath() string {
+func (s EngineState) DockerComposeConfigPath() []string {
 	for _, mt := range s.ManifestTargets {
 		if mt.Manifest.IsDC() {
 			return mt.Manifest.DockerComposeTarget().ConfigPath
 		}
 	}
-	return ""
+	return nil
 }

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -420,9 +420,9 @@ func getConfigAndServiceNames(ctx context.Context, dcc dockercompose.DockerCompo
 func (s *tiltfileState) dcServiceToManifest(service *dcService, dcConfigPath []string) (manifest model.Manifest,
 	configFiles []string, err error) {
 	dcInfo := model.DockerComposeTarget{
-		ConfigPath: dcConfigPath,
-		YAMLRaw:    service.ServiceConfig,
-		DfRaw:      service.DfContents,
+		ConfigPaths: dcConfigPath,
+		YAMLRaw:     service.ServiceConfig,
+		DfRaw:       service.DfContents,
 	}.WithDependencyIDs(service.DependencyIDs).
 		WithPublishedPorts(service.PublishedPorts).
 		WithIgnoredLocalDirectories(service.MountedLocalDirs)

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -39,12 +39,11 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	} // parsing args
 
-	//see if its single value or not, can be refactored into a function
 	pathSlice := starlarkValueOrSequenceToSlice(configPathsValue)
 	var configPaths []string
-	for _, v := range pathSlice { // parsing slice of strings
+	for _, v := range pathSlice {
 		switch val := v.(type) {
-		case starlark.String: //for singular string
+		case starlark.String:
 			goString := val.GoString()
 			configPaths = append(configPaths, goString)
 		default:
@@ -54,11 +53,11 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 	var services []*dcService
 
 	for _, path := range configPaths {
-		path = s.absPath(path) //get absolute paths for each element in configpath slice
+		path = s.absPath(path)
 
 	}
 
-	tempServices, err := parseDCConfig(s.ctx, s.dcCli, configPaths) // getting services from config files
+	tempServices, err := parseDCConfig(s.ctx, s.dcCli, configPaths)
 	services = append(services, tempServices...)
 	if err != nil {
 		return nil, err

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -23,7 +23,7 @@ import (
 
 // dcResourceSet represents a single docker-compose config file and all its associated services
 type dcResourceSet struct {
-	configPath string
+	configPath []string
 
 	services []*dcService
 }
@@ -32,25 +32,42 @@ func (dc dcResourceSet) Empty() bool { return reflect.DeepEqual(dc, dcResourceSe
 
 func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var configPath string
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "configPath", &configPath)
+	var configPathsValue starlark.Value
+
+	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "configPaths", &configPathsValue)
 	if err != nil {
 		return nil, err
+	} // parsing args
+
+	//see if its single value or not, can be refactored into a function
+	pathSlice := starlarkValueOrSequenceToSlice(configPathsValue)
+	var configPaths []string
+	for _, v := range pathSlice { // parsing slice of strings
+		switch val := v.(type) {
+		case starlark.String: //for singular string
+			goString := val.GoString()
+			configPaths = append(configPaths, goString)
+		default:
+			return nil, fmt.Errorf("docker_compose files must be a string or a sequence of strings; found a %T", val)
+		}
 	}
-	configPath = s.absPath(configPath)
-	if err != nil {
-		return nil, err
+	var services []*dcService
+
+	for _, path := range configPaths {
+		path = s.absPath(path) //get absolute paths for each element in configpath slice
+
 	}
 
-	services, err := parseDCConfig(s.ctx, s.dcCli, configPath)
+	tempServices, err := parseDCConfig(s.ctx, s.dcCli, configPaths) // getting services from config files
+	services = append(services, tempServices...)
 	if err != nil {
 		return nil, err
 	}
-
 	if !s.dc.Empty() {
 		return starlark.None, fmt.Errorf("already have a docker-compose resource declared (%s), cannot declare another (%s)", s.dc.configPath, configPath)
 	}
 
-	s.dc = dcResourceSet{configPath: configPath, services: services}
+	s.dc = dcResourceSet{configPath: configPaths, services: services}
 
 	return starlark.None, nil
 }
@@ -330,7 +347,7 @@ func (c dcConfig) GetService(name string) (dcService, error) {
 	return svc, nil
 }
 
-func serviceNames(ctx context.Context, dcc dockercompose.DockerComposeClient, configPath string) ([]string, error) {
+func serviceNames(ctx context.Context, dcc dockercompose.DockerComposeClient, configPath []string) ([]string, error) {
 	servicesText, err := dcc.Services(ctx, configPath)
 	if err != nil {
 		return nil, err
@@ -350,7 +367,8 @@ func serviceNames(ctx context.Context, dcc dockercompose.DockerComposeClient, co
 	return result, nil
 }
 
-func parseDCConfig(ctx context.Context, dcc dockercompose.DockerComposeClient, configPath string) ([]*dcService, error) {
+func parseDCConfig(ctx context.Context, dcc dockercompose.DockerComposeClient, configPath []string) ([]*dcService, error) {
+
 	config, svcNames, err := getConfigAndServiceNames(ctx, dcc, configPath)
 	if err != nil {
 		return nil, err
@@ -369,7 +387,7 @@ func parseDCConfig(ctx context.Context, dcc dockercompose.DockerComposeClient, c
 }
 
 func getConfigAndServiceNames(ctx context.Context, dcc dockercompose.DockerComposeClient,
-	configPath string) (conf dcConfig, svcNames []string, err error) {
+	configPath []string) (conf dcConfig, svcNames []string, err error) {
 	// calls to `docker-compose config` take a bit, and we need two,
 	// so do them in parallel to make things faster
 	g, ctx := errgroup.WithContext(ctx)
@@ -400,7 +418,7 @@ func getConfigAndServiceNames(ctx context.Context, dcc dockercompose.DockerCompo
 	return conf, svcNames, err
 }
 
-func (s *tiltfileState) dcServiceToManifest(service *dcService, dcConfigPath string) (manifest model.Manifest,
+func (s *tiltfileState) dcServiceToManifest(service *dcService, dcConfigPath []string) (manifest model.Manifest,
 	configFiles []string, err error) {
 	dcInfo := model.DockerComposeTarget{
 		ConfigPath: dcConfigPath,
@@ -426,7 +444,11 @@ func (s *tiltfileState) dcServiceToManifest(service *dcService, dcConfigPath str
 
 	dcInfo = dcInfo.WithBuildPath(service.BuildContext)
 
-	paths := []string{path.Dir(service.DfPath), path.Dir(dcConfigPath)}
+	var paths []string
+	for _, configPath := range dcConfigPath {
+		paths = append(paths, path.Dir(configPath))
+	}
+	paths = append([]string{path.Dir(service.DfPath)}, paths...)
 	paths = append(paths, dcInfo.LocalPaths()...)
 	paths = append(paths, path.Dir(s.filename.path))
 

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -358,6 +358,7 @@ func serviceNames(ctx context.Context, dcc dockercompose.DockerComposeClient, co
 
 	for _, name := range serviceNames {
 		if name == "" {
+			continue
 		}
 		result = append(result, name)
 	}

--- a/internal/tiltfile/docker_compose_test.go
+++ b/internal/tiltfile/docker_compose_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 // ParseConfig must return services topologically sorted wrt dependencies.
+
 func TestParseConfigPreservesServiceOrder(t *testing.T) {
 	f := newDCFixture(t)
 
@@ -61,6 +62,7 @@ version: '3.2'
 	if assert.Len(t, services, 1) {
 		assert.Equal(t, []int{3000}, services[0].PublishedPorts)
 	}
+
 }
 
 func TestPortMapSame(t *testing.T) {

--- a/internal/tiltfile/docker_compose_test.go
+++ b/internal/tiltfile/docker_compose_test.go
@@ -142,7 +142,7 @@ func (f dcFixture) parse(configOutput, servicesOutput string) []*dcService {
 	f.dcCli.ConfigOutput = configOutput
 	f.dcCli.ServicesOutput = servicesOutput
 
-	services, err := parseDCConfig(f.ctx, f.dcCli, "doesn't-matter.yml")
+	services, err := parseDCConfig(f.ctx, f.dcCli, []string{"doesn't-matter.yml"})
 	if err != nil {
 		f.t.Fatalf("dcFixture.Parse: %v", err)
 	}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -437,12 +437,12 @@ func starlarkValuesToJSONPaths(values []starlark.Value) ([]k8s.JSONPath, error) 
 	for _, v := range values {
 		s, ok := v.(starlark.String)
 		if !ok {
-			return nil, fmt.Errorf("path must be a string or list of strings, found a list containing value '%+v' of type '%T'", v, v)
+			return nil, fmt.Errorf("paths must be a string or list of strings, found a list containing value '%+v' of type '%T'", v, v)
 		}
 
 		jp, err := k8s.NewJSONPath(s.String())
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing json path '%s'", s.String())
+			return nil, errors.Wrapf(err, "error parsing json paths '%s'", s.String())
 		}
 
 		paths = append(paths, jp)
@@ -455,7 +455,7 @@ func (s *tiltfileState) k8sImageJsonPath(thread *starlark.Thread, fn *starlark.B
 	var apiVersion, kind, name, namespace string
 	var imageJSONPath starlark.Value
 	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
-		"path", &imageJSONPath,
+		"paths", &imageJSONPath,
 		"api_version?", &apiVersion,
 		"kind?", &kind,
 		"name?", &name,

--- a/internal/tiltfile/text_test.go
+++ b/internal/tiltfile/text_test.go
@@ -163,7 +163,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - paths: /
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -106,7 +106,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	absFilename, err := ospath.RealAbs(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return TiltfileLoadResult{ConfigFiles: []string{filename}}, fmt.Errorf("No Tiltfile found at path '%s'. Check out https://docs.tilt.dev/tutorial.html", filename)
+			return TiltfileLoadResult{ConfigFiles: []string{filename}}, fmt.Errorf("No Tiltfile found at paths '%s'. Check out https://docs.tilt.dev/tutorial.html", filename)
 		}
 		absFilename, _ = filepath.Abs(filename)
 		return TiltfileLoadResult{ConfigFiles: []string{absFilename}}, err

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -61,7 +61,7 @@ ports:
 - 12312:80/tcp`, f.JoinPath("foo"))
 }
 
-func TestDockerComposeManifest(t *testing.T) {
+func TestDockerComposeManifest(t *testing.T) { //TODO MARIA
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -324,7 +324,7 @@ dc_resource('foo', 'gcr.io/foo')
 	assert.True(t, iTarget.AnyLiveUpdateInfo().Empty())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, m.DockerComposeTarget().ConfigPath, configPath)
+	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, configPath)
 }
 
 // I.e. make sure that we handle de/normalization between `fooimage` <--> `docker.io/library/fooimage`
@@ -346,7 +346,7 @@ dc_resource('foo', 'fooimage')
 	assert.False(t, m.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, m.DockerComposeTarget().ConfigPath, configPath)
+	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, configPath)
 }
 
 func TestDockerComposeWithFastBuild(t *testing.T) {
@@ -368,7 +368,7 @@ dc_resource('foo', 'gcr.io/foo')
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi"), hotReload(false)))
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, m.DockerComposeTarget().ConfigPath, configPath)
+	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, configPath)
 }
 
 func TestMultipleDockerComposeWithDockerBuild(t *testing.T) {
@@ -396,8 +396,8 @@ dc_resource('bar', 'gcr.io/bar')
 	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, foo.DockerComposeTarget().ConfigPath, configPath)
-	assert.Equal(t, bar.DockerComposeTarget().ConfigPath, configPath)
+	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, configPath)
 }
 
 func TestMultipleDockerComposeWithDockerBuildImageNames(t *testing.T) {
@@ -430,8 +430,8 @@ docker_compose('docker-compose.yml')
 	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, foo.DockerComposeTarget().ConfigPath, configPath)
-	assert.Equal(t, bar.DockerComposeTarget().ConfigPath, configPath)
+	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, configPath)
 }
 
 func TestDCImageRefSuggestion(t *testing.T) {
@@ -473,8 +473,8 @@ dc_resource('foo', img_name)
 	assert.Empty(t, bar.ImageTargets)
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, foo.DockerComposeTarget().ConfigPath, configPath)
-	assert.Equal(t, bar.DockerComposeTarget().ConfigPath, configPath)
+	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, configPath)
 }
 
 func TestDockerComposeResourceNoImageMatch(t *testing.T) {
@@ -501,7 +501,7 @@ func (f *fixture) assertDcManifest(name string, opts ...interface{}) model.Manif
 	for _, opt := range opts {
 		switch opt := opt.(type) {
 		case dcConfigPathHelper:
-			assert.Equal(f.t, opt.path, dcInfo.ConfigPath)
+			assert.Equal(f.t, opt.path, dcInfo.ConfigPaths)
 		case dcLocalPathsHelper:
 			assert.ElementsMatch(f.t, opt.paths, dcInfo.LocalPaths())
 		case dcYAMLRawHelper:

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -72,7 +72,7 @@ func TestDockerComposeManifest(t *testing.T) { //TODO MARIA
 	f.load("foo")
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
 	f.assertDcManifest("foo",
-		dcConfigPath(configPath),
+		dcConfigPath([]string{configPath}),
 		dcYAMLRaw(f.simpleConfigFooYAML()),
 		dcDfRaw(simpleDockerfile),
 		dcPublishedPorts(12312),
@@ -96,7 +96,7 @@ services:
 	f.load("bar")
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
 	f.assertDcManifest("bar",
-		dcConfigPath(configPath),
+		dcConfigPath([]string{configPath}),
 		dcYAMLRaw("image: redis:alpine"),
 		dcDfRaw(""),
 		// TODO(maia): assert m.tiltFilename
@@ -127,7 +127,7 @@ services:
 	f.load("baz")
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
 	f.assertDcManifest("baz",
-		dcConfigPath(configPath),
+		dcConfigPath([]string{configPath}),
 		dcYAMLRaw(dcYAML),
 		dcDfRaw(simpleDockerfile),
 		// TODO(maia): assert m.tiltFilename
@@ -184,7 +184,7 @@ services:
 	f.file("Tiltfile", fmt.Sprintf("docker_compose('%s')", configPath))
 
 	f.load("foo")
-	f.assertDcManifest("foo", dcConfigPath(configPath))
+	f.assertDcManifest("foo", dcConfigPath([]string{configPath}))
 }
 
 func TestDockerComposeManifestComputesLocalPaths(t *testing.T) {
@@ -204,7 +204,7 @@ RUN echo hi`
 	f.load("foo")
 	configPath := f.JoinPath("docker-compose.yml")
 	f.assertDcManifest("foo",
-		dcConfigPath(configPath),
+		dcConfigPath([]string{configPath}),
 		dcYAMLRaw(f.simpleConfigFooYAML()),
 		dcDfRaw(df),
 		dcLocalPaths([]string{f.JoinPath("foo")}),
@@ -239,7 +239,7 @@ services:
 	f.load("foo")
 	configPath := f.JoinPath("foo/docker-compose.yml")
 	f.assertDcManifest("foo",
-		dcConfigPath(configPath),
+		dcConfigPath([]string{configPath}),
 		dcYAMLRaw(f.simpleConfigFooYAML()),
 		dcDfRaw(df),
 		dcLocalPaths([]string{f.JoinPath("foo")}),
@@ -324,7 +324,7 @@ dc_resource('foo', 'gcr.io/foo')
 	assert.True(t, iTarget.AnyLiveUpdateInfo().Empty())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, []string{configPath})
 }
 
 // I.e. make sure that we handle de/normalization between `fooimage` <--> `docker.io/library/fooimage`
@@ -346,7 +346,7 @@ dc_resource('foo', 'fooimage')
 	assert.False(t, m.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, []string{configPath})
 }
 
 func TestDockerComposeWithFastBuild(t *testing.T) {
@@ -368,7 +368,7 @@ dc_resource('foo', 'gcr.io/foo')
 		fb(image("gcr.io/foo"), add("foo", "src/"), run("echo hi"), hotReload(false)))
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, []string{configPath})
 }
 
 func TestMultipleDockerComposeWithDockerBuild(t *testing.T) {
@@ -396,8 +396,8 @@ dc_resource('bar', 'gcr.io/bar')
 	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, configPath)
-	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, []string{configPath})
+	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, []string{configPath})
 }
 
 func TestMultipleDockerComposeWithDockerBuildImageNames(t *testing.T) {
@@ -430,8 +430,8 @@ docker_compose('docker-compose.yml')
 	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, configPath)
-	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, []string{configPath})
+	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, []string{configPath})
 }
 
 func TestDCImageRefSuggestion(t *testing.T) {
@@ -473,8 +473,8 @@ dc_resource('foo', img_name)
 	assert.Empty(t, bar.ImageTargets)
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
-	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, configPath)
-	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, configPath)
+	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, []string{configPath})
+	assert.Equal(t, bar.DockerComposeTarget().ConfigPaths, []string{configPath})
 }
 
 func TestDockerComposeResourceNoImageMatch(t *testing.T) {
@@ -518,10 +518,10 @@ func (f *fixture) assertDcManifest(name string, opts ...interface{}) model.Manif
 }
 
 type dcConfigPathHelper struct {
-	path string
+	path []string
 }
 
-func dcConfigPath(path string) dcConfigPathHelper {
+func dcConfigPath(path []string) dcConfigPathHelper {
 	return dcConfigPathHelper{path}
 }
 

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -61,7 +61,7 @@ ports:
 - 12312:80/tcp`, f.JoinPath("foo"))
 }
 
-func TestDockerComposeManifest(t *testing.T) { //TODO MARIA
+func TestDockerComposeManifest(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -357,7 +357,7 @@ func TestDockerComposeWithFastBuild(t *testing.T) {
 	f.file("docker-compose.yml", simpleConfig)
 	f.file("Tiltfile", `repo = local_git_repo('.')
 fast_build('gcr.io/foo', 'foo/Dockerfile') \
-  .add(repo.path('foo'), 'src/') \
+  .add(repo.paths('foo'), 'src/') \
   .run("echo hi")
 docker_compose('docker-compose.yml')
 dc_resource('foo', 'gcr.io/foo')
@@ -501,7 +501,7 @@ func (f *fixture) assertDcManifest(name string, opts ...interface{}) model.Manif
 	for _, opt := range opts {
 		switch opt := opt.(type) {
 		case dcConfigPathHelper:
-			assert.Equal(f.t, opt.path, dcInfo.ConfigPaths)
+			assert.Equal(f.t, opt.paths, dcInfo.ConfigPaths)
 		case dcLocalPathsHelper:
 			assert.ElementsMatch(f.t, opt.paths, dcInfo.LocalPaths())
 		case dcYAMLRawHelper:
@@ -518,11 +518,11 @@ func (f *fixture) assertDcManifest(name string, opts ...interface{}) model.Manif
 }
 
 type dcConfigPathHelper struct {
-	path []string
+	paths []string
 }
 
-func dcConfigPath(path []string) dcConfigPathHelper {
-	return dcConfigPathHelper{path}
+func dcConfigPath(paths []string) dcConfigPathHelper {
+	return dcConfigPathHelper{paths}
 }
 
 type dcYAMLRawHelper struct {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -981,37 +981,7 @@ func (s *tiltfileState) translateDC(dc dcResourceSet) ([]model.Manifest, error) 
 
 		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, dc.configPath...))
 	}
-	//var result []model.Manifest
-	//for _, configPath := range dc.configPath {
-	//	for _, svc := range dc.services { // for each services
-	//		m, configFiles, err := s.dcServiceToManifest(svc, configPath)
-	//		if err != nil {
-	//			return nil, err
-	//		}
-	//
-	//		iTargets, err := s.imgTargetsForDependencyIDs(svc.DependencyIDs)
-	//		if err != nil {
-	//			return nil, errors.Wrapf(err, "getting image build info for %s", svc.Name)
-	//		}
-	//		m = m.WithImageTargets(iTargets)
-	//
-	//		err = s.checkForImpossibleLiveUpdates(m)
-	//		if err != nil {
-	//			return nil, err
-	//		}
-	//
-	//		result = append(result, m)
-	//
-	//		// TODO(maia): might get config files from dc.yml that are overridden by imageTarget :-/
-	//		// e.g. dc.yml specifies one Dockerfile but the imageTarget specifies another
-	//		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configFiles...))
-	//
-	//	}
-	//	if configPath != "" {
-	//		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configPath))
-	//	}
-	//}
-	//
+
 	return result, nil
 }
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -847,7 +847,7 @@ func (s *tiltfileState) validateLiveUpdate(iTarget model.ImageTarget, g model.Ta
 		return err
 	}
 
-	// Verify that all a) sync step src's and b) fall_back_on files are children of a watched path.
+	// Verify that all a) sync step src's and b) fall_back_on files are children of a watched paths.
 	// (If not, we'll never even get "file changed" events for them--they're nonsensical input, throw an error.)
 	for _, sync := range lu.SyncSteps() {
 		if !ospath.IsChildOfOne(watchedPaths, sync.LocalPath) {
@@ -859,7 +859,7 @@ func (s *tiltfileState) validateLiveUpdate(iTarget model.ImageTarget, g model.Ta
 	for _, path := range lu.FallBackOnFiles().Paths {
 		absPath := s.absPath(path)
 		if !ospath.IsChildOfOne(watchedPaths, absPath) {
-			return fmt.Errorf("fall_back_on path '%s' is not a child of any watched filepaths (%v)",
+			return fmt.Errorf("fall_back_on paths '%s' is not a child of any watched filepaths (%v)",
 				absPath, watchedPaths)
 		}
 
@@ -977,7 +977,7 @@ func (s *tiltfileState) translateDC(dc dcResourceSet) ([]model.Manifest, error) 
 		// e.g. dc.yml specifies one Dockerfile but the imageTarget specifies another
 		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configFiles...))
 	}
-	if dc.configPaths != nil {
+	if len(dc.configPaths) != 0 {
 
 		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, dc.configPaths...))
 	}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -955,7 +955,7 @@ func (s *tiltfileState) translateDC(dc dcResourceSet) ([]model.Manifest, error) 
 	var result []model.Manifest
 
 	for _, svc := range dc.services {
-		m, configFiles, err := s.dcServiceToManifest(svc, dc.configPath)
+		m, configFiles, err := s.dcServiceToManifest(svc, dc.configPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -977,9 +977,9 @@ func (s *tiltfileState) translateDC(dc dcResourceSet) ([]model.Manifest, error) 
 		// e.g. dc.yml specifies one Dockerfile but the imageTarget specifies another
 		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configFiles...))
 	}
-	if dc.configPath != nil {
+	if dc.configPaths != nil {
 
-		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, dc.configPath...))
+		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, dc.configPaths...))
 	}
 
 	return result, nil

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -953,6 +953,7 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 
 func (s *tiltfileState) translateDC(dc dcResourceSet) ([]model.Manifest, error) {
 	var result []model.Manifest
+
 	for _, svc := range dc.services {
 		m, configFiles, err := s.dcServiceToManifest(svc, dc.configPath)
 		if err != nil {
@@ -976,9 +977,41 @@ func (s *tiltfileState) translateDC(dc dcResourceSet) ([]model.Manifest, error) 
 		// e.g. dc.yml specifies one Dockerfile but the imageTarget specifies another
 		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configFiles...))
 	}
-	if dc.configPath != "" {
-		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, dc.configPath))
+	if dc.configPath != nil {
+
+		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, dc.configPath...))
 	}
+	//var result []model.Manifest
+	//for _, configPath := range dc.configPath {
+	//	for _, svc := range dc.services { // for each services
+	//		m, configFiles, err := s.dcServiceToManifest(svc, configPath)
+	//		if err != nil {
+	//			return nil, err
+	//		}
+	//
+	//		iTargets, err := s.imgTargetsForDependencyIDs(svc.DependencyIDs)
+	//		if err != nil {
+	//			return nil, errors.Wrapf(err, "getting image build info for %s", svc.Name)
+	//		}
+	//		m = m.WithImageTargets(iTargets)
+	//
+	//		err = s.checkForImpossibleLiveUpdates(m)
+	//		if err != nil {
+	//			return nil, err
+	//		}
+	//
+	//		result = append(result, m)
+	//
+	//		// TODO(maia): might get config files from dc.yml that are overridden by imageTarget :-/
+	//		// e.g. dc.yml specifies one Dockerfile but the imageTarget specifies another
+	//		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configFiles...))
+	//
+	//	}
+	//	if configPath != "" {
+	//		s.configFiles = sliceutils.DedupedAndSorted(append(s.configFiles, configPath))
+	//	}
+	//}
+	//
 	return result, nil
 }
 


### PR DESCRIPTION
As a response to  #1782 the docker_compose() function on the tiltfile should support multiple files.  
i.e: 
`docker_compose(["docker-compose1.yml", "docker-compose2.yml"]`


