### PR TITLE
engine: store feature flags on engine state

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -156,6 +156,7 @@ type ConfigsReloadedAction struct {
 	FinishTime time.Time
 	Err        error
 	Warnings   []string
+	Features   map[string]bool
 }
 
 func (ConfigsReloadedAction) Action() {}

--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -85,6 +85,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 		FinishTime:         cc.clock(),
 		Err:                err,
 		Warnings:           tlr.Warnings,
+		Features:           tlr.NewFeatureFlags,
 	})
 }
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -510,6 +510,8 @@ func handleConfigsReloaded(
 	state.ConfigFiles = event.ConfigFiles
 	state.TiltIgnoreContents = event.TiltIgnoreContents
 
+	state.Features = event.Features
+
 	// Remove pending file changes that were consumed by this build.
 	for file, modTime := range state.PendingConfigFileChanges {
 		if modTime.Before(status.StartTime) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2423,6 +2423,25 @@ func TestSetAnalyticsOpt(t *testing.T) {
 	assert.Equal(t, []analytics.Opt{analytics.OptOut, analytics.OptIn}, f.opter.Calls())
 }
 
+func TestFeatureFlagsStoredOnState(t *testing.T) {
+	f := newTestFixture(t)
+
+	f.Start([]model.Manifest{}, true)
+	time.Sleep(10 * time.Millisecond)
+
+	f.store.Dispatch(ConfigsReloadedAction{Manifests: []model.Manifest{}, Features: map[string]bool{"foo": true}})
+
+	f.WaitUntil("feature is enabled", func(state store.EngineState) bool {
+		return state.Features["foo"] == true
+	})
+
+	f.store.Dispatch(ConfigsReloadedAction{Manifests: []model.Manifest{}, Features: map[string]bool{"foo": false}})
+
+	f.WaitUntil("feature is disabled", func(state store.EngineState) bool {
+		return state.Features["foo"] == false
+	})
+}
+
 type fakeTimerMaker struct {
 	restTimerLock *sync.Mutex
 	maxTimerLock  *sync.Mutex

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -16,6 +16,7 @@ type Feature interface {
 	IsEnabled(flag string) bool
 	Enable(flag string) error
 	Disable(flag string) error
+	GetAllFlags() map[string]bool
 }
 
 func ProvideFeature() Feature {
@@ -74,4 +75,17 @@ func (f *staticMapFeature) Disable(flag string) error {
 
 	f.flags[flag] = false
 	return nil
+}
+
+// GetAllFlags make a copy of the feature flags map and returns it
+func (f *staticMapFeature) GetAllFlags() map[string]bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	newFlags := make(map[string]bool, len(f.flags))
+
+	for k, v := range f.flags {
+		newFlags[k] = v
+	}
+
+	return newFlags
 }

--- a/internal/feature/flags_test.go
+++ b/internal/feature/flags_test.go
@@ -47,3 +47,13 @@ func TestDisable(t *testing.T) {
 	enabled := m.IsEnabled("foo")
 	assert.False(t, enabled)
 }
+
+func TestGetAllFlags(t *testing.T) {
+	defaults := map[string]bool{"foo": true}
+	f := newStaticMapFeature(defaults)
+	actual := f.GetAllFlags()
+
+	assert.Equal(t, defaults, actual)
+	// should be a new reference, so the pointers should not be equal.
+	assert.False(t, &defaults == &actual)
+}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -83,6 +83,8 @@ type EngineState struct {
 	// Analytics Info
 	AnalyticsOpt           analytics.Opt // changes to this field will propagate into the TiltAnalytics subscriber + we'll record them as user choice
 	AnalyticsNudgeSurfaced bool          // this flag is set the first time we show the analytics nudge to the user.
+
+	Features map[string]bool
 }
 
 func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.ManifestName {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -33,6 +33,7 @@ type TiltfileLoadResult struct {
 	ConfigFiles        []string
 	Warnings           []string
 	TiltIgnoreContents string
+	NewFeatureFlags    map[string]bool
 }
 
 func (r TiltfileLoadResult) Orchestrator() model.Orchestrator {
@@ -176,6 +177,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	printedWarnings = true
 
 	s.logger.Infof("Successfully loaded Tiltfile")
+	newFeature := s.f.GetAllFlags()
 
 	tfl.reportTiltfileLoaded(s.builtinCallCounts)
 
@@ -187,7 +189,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 		return TiltfileLoadResult{}, errors.Wrapf(err, "error reading %s", tiltIgnorePath(filename))
 	}
 
-	return TiltfileLoadResult{manifests, s.configFiles, s.warnings, string(tiltIgnoreContents)}, err
+	return TiltfileLoadResult{manifests, s.configFiles, s.warnings, string(tiltIgnoreContents), newFeature}, err
 }
 
 // .tiltignore sits next to Tiltfile


### PR DESCRIPTION
This is so OnChange events will be called when feature flags change.

There might be a better way to do this. I'm all ears!