### PR TITLE
engine: check if images still exist when deciding whether to build

### DIFF
--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -77,6 +77,8 @@ type FakeClient struct {
 	BuildOutput       string
 	BuildErrorToThrow error // next call to Build will throw this err (after which we clear the error)
 
+	ImageListCount int
+
 	TagCount  int
 	TagSource string
 	TagTarget string
@@ -204,7 +206,7 @@ func (c *FakeClient) ImageInspectWithRaw(ctx context.Context, imageID string) (t
 }
 
 func (c *FakeClient) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error) {
-	summaries := make([]types.ImageSummary, c.BuildCount)
+	summaries := make([]types.ImageSummary, c.ImageListCount)
 	for i := range summaries {
 		summaries[i] = types.ImageSummary{
 			ID:      fmt.Sprintf("build-id-%d", i),

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -66,7 +66,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	span.SetTag("target", dcTargets[0].Name)
 	defer span.Finish()
 
-	q, err := NewImageTargetQueue(iTargets, currentState)
+	q, err := NewImageTargetQueue(ctx, iTargets, currentState, bd.icb.ib.ImageExists)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -137,6 +137,7 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 	result := store.NewImageBuildResult(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
 	state := store.NewBuildState(result, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
+	f.dCli.ImageListCount = 1
 	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -105,7 +105,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		ibd.analytics.Timer("build.image", time.Since(startTime), tags)
 	}()
 
-	q, err := NewImageTargetQueue(iTargets, stateSet)
+	q, err := NewImageTargetQueue(ctx, iTargets, stateSet, ibd.ib.ImageExists)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -224,6 +224,8 @@ func TestImageIsClean(t *testing.T) {
 	iTargetID1 := manifest.ImageTargets[0].ID()
 	result1 := store.NewImageBuildResult(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
 
+	f.docker.ImageListCount = 1
+
 	stateSet := store.BuildStateSet{
 		iTargetID1: store.NewBuildState(result1, []string{}),
 	}
@@ -337,6 +339,8 @@ func TestMultiStageDockerBuildWithSecondImageDirty(t *testing.T) {
 	result2 := store.NewImageBuildResult(iTargetID2, container.MustParseNamedTagged("sancho:tilt-prebuilt2"))
 
 	newFile := f.WriteFile("sancho/message.txt", "message")
+
+	f.docker.ImageListCount = 1
 
 	stateSet := store.BuildStateSet{
 		iTargetID1: store.NewBuildState(result1, nil),

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -941,7 +941,7 @@ func TestReapOldBuilds(t *testing.T) {
 	sync := model.Sync{LocalPath: "/go", ContainerPath: "/go"}
 	manifest := f.newManifest("foobar", []model.Sync{sync})
 
-	f.docker.BuildCount++
+	f.docker.ImageListCount++
 
 	f.Start([]model.Manifest{manifest}, true)
 

--- a/internal/testutils/tar.go
+++ b/internal/testutils/tar.go
@@ -3,8 +3,11 @@ package testutils
 import (
 	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const expectedUidAndGid = 0
@@ -106,9 +109,8 @@ func AssertFilesInTar(t testing.TB, tr *tar.Reader, expectedFiles []ExpectedFile
 				t.Fatalf("Error reading tar file: %v", err)
 			}
 
-			if contents.String() != expected.Contents {
-				t.Errorf("Wrong contents in %q. Expected: %q. Actual: %q",
-					expected.Path, expected.Contents, contents.String())
+			if !assert.Equal(t, expected.Contents, contents.String()) {
+				fmt.Printf("wrong contents in %q\n", expected.Path)
 				continue
 			}
 		}


### PR DESCRIPTION
This fixes #1768

### Problem
When Tilt decides whether an image needs to build, it basically just checks whether it knows the id of a previous build that hasn't been invalidated. This only works on the assumption that it's a closed system. In reality, kubelet can come in and delete images to free up disk space, or the user could have manually deleted the image, or whatever. This leads to a build error when we try to use a ref that no longer exists.

### Solution
When determining whether to build an image, check both whether we have an image id and whether that id points at an image that still exists.