### PR TITLE
tiltfile: allow k8s_kind with no images

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -495,15 +495,9 @@ func (s *tiltfileState) k8sKind(thread *starlark.Thread, fn *starlark.Builtin, a
 	var imageJSONPath starlark.Value
 	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
 		"kind", &kind,
-		"image_json_path", &imageJSONPath,
+		"image_json_path?", &imageJSONPath,
 		"api_version?", &apiVersion,
 	); err != nil {
-		return nil, err
-	}
-
-	values := starlarkValueOrSequenceToSlice(imageJSONPath)
-	paths, err := starlarkValuesToJSONPaths(values)
-	if err != nil {
 		return nil, err
 	}
 
@@ -512,7 +506,17 @@ func (s *tiltfileState) k8sKind(thread *starlark.Thread, fn *starlark.Builtin, a
 		return nil, err
 	}
 
-	s.k8sImageJSONPaths[k] = paths
+	if imageJSONPath == nil {
+		s.workloadTypes = append(s.workloadTypes, k)
+	} else {
+		values := starlarkValueOrSequenceToSlice(imageJSONPath)
+		paths, err := starlarkValuesToJSONPaths(values)
+		if err != nil {
+			return nil, err
+		}
+
+		s.k8sImageJSONPaths[k] = paths
+	}
 
 	return starlark.None, nil
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -51,6 +51,8 @@ type tiltfileState struct {
 
 	// JSON paths to images in k8s YAML (other than Container specs)
 	k8sImageJSONPaths map[k8sObjectSelector][]k8s.JSONPath
+	// objects of these types are considered workloads, whether or not they have an image
+	workloadTypes []k8sObjectSelector
 
 	k8sResourceAssemblyVersion       int
 	k8sResourceAssemblyVersionReason k8sResourceAssemblyVersionReason
@@ -528,6 +530,12 @@ func (s *tiltfileState) envVarImages() []container.RefSelector {
 }
 
 func (s *tiltfileState) isWorkload(e k8s.K8sEntity) (bool, error) {
+	for _, sel := range s.workloadTypes {
+		if sel.matches(e) {
+			return true, nil
+		}
+	}
+
 	images, err := e.FindImages(s.imageJSONPaths(e), s.envVarImages())
 	if err != nil {
 		return false, err


### PR DESCRIPTION
This fixes #1805

### Problem

When Tilt creates workloads, it does so by looking for any k8s entities that either 1) have a ContainerSpec or 2) have an image specified by a k8s_kind image_json_path.

This leaves no mechanism by which a user can specify a CRD via k8s_kind that should be a workload, but has no image that should be built by Tilt. This is relevant for, e.g., Fission and Prometheus.

### Solution

Allow `k8s_kind` to be called with 0 args, in which case we take it to mean "anything of this kind is a workload".

### Result

I made a Tiltfile that runs a fission CRD and didn't give it any information about images, and it successfully created a resource and watched the pods specified by extra_pod_selectors.