### PR TITLE
engine: better err message if restart_container step not supported [ch2865]

### DIFF
--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -200,7 +200,11 @@ func (sbd *SyncletBuildAndDeployer) updateViaExec(ctx context.Context,
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncletBuildAndDeployer-updateViaExec")
 	defer span.Finish()
 	if !hotReload {
-		return fmt.Errorf("kubectl exec syncing is only supported on resources that don't use container_restart")
+		// If we're using kubectl exec syncing, it implies a non-Docker runtime,
+		// which probably doesn't support container restart. User will have to use
+		// our wrapper script to hack around it.
+		return fmt.Errorf("your container runtime does not support the `restart_container()` step. " +
+			"For a workaround, see https://github.com/windmilleng/rerun-process-wrapper")
 	}
 	l := logger.Get(ctx)
 	w := l.Writer(logger.InfoLvl)


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/better-err-msg-no-restart:

66b24c26f06910f8187b4b3c8d98ab9b78742e10 (2019-07-08 17:32:40 -0400)
engine: better err message if restart_container step not supported [ch2865]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics