### PR TITLE
engine/k8s: ibad can inject OverrideCommand into k8s yaml [ch2886]

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -247,8 +247,9 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 					return fmt.Errorf("Internal error: missing build result for dependency ID: %s", depID)
 				}
 
-				selector := iTargetMap[depID].ConfigurationRef
-				matchInEnvVars := iTargetMap[depID].MatchInEnvVars
+				iTarget := iTargetMap[depID]
+				selector := iTarget.ConfigurationRef
+				matchInEnvVars := iTarget.MatchInEnvVars
 
 				var replaced bool
 				e, replaced, err = k8s.InjectImageDigest(e, selector, ref, matchInEnvVars, policy)
@@ -257,6 +258,13 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 				}
 				if replaced {
 					injectedDepIDs[depID] = true
+
+					if !iTarget.OverrideCmd.Empty() {
+						e, err = k8s.InjectCommand(e, ref, iTarget.OverrideCmd)
+						if err != nil {
+							return err
+						}
+					}
 
 					if ibd.injectSynclet && needsSynclet && !injectedSynclet {
 						injectedRefSelector := container.NewRefSelector(ref).WithExactMatch()

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -27,9 +27,9 @@ type pather interface {
 	MkdirAll(p string)
 }
 
-var SanchoRef = container.MustParseSelector("gcr.io/some-project-162817/sancho")
+var SanchoRef = container.MustParseSelector(testyaml.SanchoImage)
 var SanchoBaseRef = container.MustParseSelector("sancho-base")
-var SanchoSidecarRef = container.MustParseSelector("gcr.io/some-project-162817/sancho-sidecar")
+var SanchoSidecarRef = container.MustParseSelector(testyaml.SanchoSidecarImage)
 
 func NewSanchoFastBuild(fixture pather) model.FastBuild {
 	return model.FastBuild{
@@ -197,9 +197,13 @@ func NewSanchoSidecarLiveUpdateImageTarget(f pather) (model.ImageTarget, error) 
 }
 
 func NewSanchoDockerBuildManifest(f pather) model.Manifest {
+	return NewSanchoDockerBuildManifestWithYaml(f, SanchoYAML)
+}
+
+func NewSanchoDockerBuildManifestWithYaml(f pather, yaml string) model.Manifest {
 	return assembleK8sManifest(
 		model.Manifest{Name: "sancho"},
-		model.K8sTarget{YAML: SanchoYAML},
+		model.K8sTarget{YAML: yaml},
 		NewSanchoDockerBuildImageTarget(f))
 }
 

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
-	"github.com/windmilleng/tilt/internal/model"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/windmilleng/tilt/internal/model"
 
 	"github.com/windmilleng/tilt/internal/container"
 )

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
+	"github.com/windmilleng/tilt/internal/model"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -174,6 +175,48 @@ func injectImageDigestInUnstructured(entity K8sEntity, injectRef reference.Named
 
 	entity.Obj = u
 	return entity, replaced, nil
+}
+
+func InjectCommand(entity K8sEntity, ref reference.Named, cmd model.Cmd) (K8sEntity, error) {
+	entity = entity.DeepCopy()
+
+	selector := container.NewRefSelector(ref)
+	e, injected, err := injectCommandInContainers(entity, selector, cmd)
+	if err != nil {
+		return e, err
+	}
+	if !injected {
+		// NOTE(maia): currently we only support injecting commands into containers (i.e. the
+		// k8s yaml `container` block). This means we don't support injecting commands into CRDs.
+		return e, fmt.Errorf("could not inject command %v into entity: %s. No container found matching ref: %s. "+
+			"Note: command overrides only supported on containers with images, not on CRDs",
+			cmd.Argv, entity.Name(), ref.String())
+	}
+
+	return e, nil
+}
+
+func injectCommandInContainers(entity K8sEntity, selector container.RefSelector, cmd model.Cmd) (K8sEntity, bool, error) {
+	var injected bool
+	containers, err := extractContainers(&entity)
+	if err != nil {
+		return K8sEntity{}, injected, err
+	}
+
+	for _, c := range containers {
+		existingRef, err := container.ParseNamed(c.Image)
+		if err != nil {
+			return K8sEntity{}, injected, err
+		}
+
+		if selector.Matches(existingRef) {
+			c.Command = cmd.Argv
+			c.Args = nil // clear the "args" param.
+
+			injected = true
+		}
+	}
+	return entity, injected, nil
 }
 
 // HasImage indicates whether the given entity is tagged with the given image.

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -72,6 +72,8 @@ spec:
   backoffLimit: 4
 `
 
+const SanchoImage = "gcr.io/some-project-162817/sancho"
+
 const SanchoYAML = `
 apiVersion: apps/v1
 kind: Deployment
@@ -99,6 +101,31 @@ spec:
               secretKeyRef:
                 name: slacktoken
                 key: token
+`
+
+const SanchoYAMLWithCommand = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sancho
+  namespace: sancho-ns
+  labels:
+    app: sancho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sancho
+  template:
+    metadata:
+      labels:
+        app: sancho
+    spec:
+      containers:
+      - name: sancho
+        image: gcr.io/some-project-162817/sancho
+        command: ["foo.sh"]
+        args: ["something", "something_else"]
 `
 
 const SanchoBeta1YAML = `
@@ -238,6 +265,7 @@ spec:
       - name: sancho-sidecar
         image: gcr.io/some-project-162817/sancho-sidecar
 `
+const SanchoSidecarImage = "gcr.io/some-project-162817/sancho-sidecar"
 
 const SanchoRedisSidecarYAML = `
 apiVersion: apps/v1
@@ -1174,6 +1202,8 @@ metadata:
 spec:
   replicas: 1
 `
+
+const CRDImage = "docker.io/bitnami/minideb:latest"
 
 const MyNamespaceYAML = `apiVersion: v1
 kind: Namespace

--- a/internal/model/docker_info.go
+++ b/internal/model/docker_info.go
@@ -18,6 +18,10 @@ type ImageTarget struct {
 	BuildDetails     BuildDetails
 	MatchInEnvVars   bool
 
+	// User-supplied command to run when the container runs
+	// (i.e. overrides k8s yaml "command", container ENTRYPOINT, etc.)
+	OverrideCmd Cmd
+
 	cachePaths []string
 
 	// TODO(nick): It might eventually make sense to represent
@@ -174,6 +178,11 @@ func (i ImageTarget) WithRepos(repos []LocalGitRepo) ImageTarget {
 
 func (i ImageTarget) WithDockerignores(dockerignores []Dockerignore) ImageTarget {
 	i.dockerignores = append(append([]Dockerignore{}, i.dockerignores...), dockerignores...)
+	return i
+}
+
+func (i ImageTarget) WithOverrideCommand(cmd Cmd) ImageTarget {
+	i.OverrideCmd = cmd
 	return i
 }
 


### PR DESCRIPTION
For "user can override image entrypoint" (note that this is only the backend changes -- tiltfile changes to follow)