### PR TITLE
build: stream tar to docker

### DIFF
--- a/cmd/buildkitapi/main.go
+++ b/cmd/buildkitapi/main.go
@@ -41,20 +41,25 @@ func run() error {
 
 	d.NegotiateAPIVersion(ctx)
 
-	archive, err := build.TarPath(ctx, ".")
-	if err != nil {
-		return err
-	}
+	pr, pw := io.Pipe()
+	go func() {
+		err := build.TarPath(ctx, pw, ".")
+		if err != nil {
+			pw.CloseWithError(err)
+		} else {
+			pw.Close()
+		}
+	}()
 
 	opts := types.ImageBuildOptions{}
 	opts.Version = types.BuilderBuildKit
 	opts.Dockerfile = "Dockerfile"
-	opts.Context = archive
+	opts.Context = pr
 	if !useCache {
 		opts.NoCache = true
 	}
 
-	response, err := d.ImageBuild(ctx, archive, opts)
+	response, err := d.ImageBuild(ctx, pr, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/buildkitapi/main.go
+++ b/cmd/buildkitapi/main.go
@@ -45,9 +45,9 @@ func run() error {
 	go func() {
 		err := build.TarPath(ctx, pw, ".")
 		if err != nil {
-			pw.CloseWithError(err)
+			_ = pw.CloseWithError(err)
 		} else {
-			pw.Close()
+			_ = pw.Close()
 		}
 	}()
 

--- a/internal/build/cache_builder.go
+++ b/internal/build/cache_builder.go
@@ -109,7 +109,6 @@ func (b CacheBuilder) CreateCacheFrom(ctx context.Context, inputs CacheInputs, s
 	// Create a Dockerfile that copies directories from the sourceRef
 	// and puts them in a standalone image.
 	df := b.makeCacheDockerfile(inputs.BaseDockerfile, sourceRef, inputs.CachePaths)
-	// TODO(dmiller) do the same thing here
 	pr, pw := io.Pipe()
 	go func() {
 		err := TarDfOnly(ctx, pw, df)

--- a/internal/build/cache_builder.go
+++ b/internal/build/cache_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -108,19 +109,25 @@ func (b CacheBuilder) CreateCacheFrom(ctx context.Context, inputs CacheInputs, s
 	// Create a Dockerfile that copies directories from the sourceRef
 	// and puts them in a standalone image.
 	df := b.makeCacheDockerfile(inputs.BaseDockerfile, sourceRef, inputs.CachePaths)
-	dockerCtx, err := TarDfOnly(ctx, df)
-	if err != nil {
-		return errors.Wrap(err, "CreateCacheFrom")
-	}
+	// TODO(dmiller) do the same thing here
+	pr, pw := io.Pipe()
+	go func() {
+		err := TarDfOnly(ctx, pw, df)
+		if err != nil {
+			pw.CloseWithError(errors.Wrap(err, "CreateCacheFrom"))
+		} else {
+			pw.Close()
+		}
+	}()
 
-	options := Options(dockerCtx, buildArgs)
+	options := Options(pr, buildArgs)
 	options.Tags = []string{cacheRef.String()}
 
 	// TODO(nick): I'm not sure if we should print this, or if it should
 	// be something that happens in the background without any user-visible output.
 	writer := logger.Get(ctx).Writer(logger.DebugLvl)
 	logger.Get(ctx).Debugf("Copying cache directories (%s)", sourceRef.String())
-	res, err := b.dCli.ImageBuild(ctx, dockerCtx, options)
+	res, err := b.dCli.ImageBuild(ctx, pr, options)
 	if err != nil {
 		return errors.Wrap(err, "ImageBuild")
 	}

--- a/internal/build/cache_builder.go
+++ b/internal/build/cache_builder.go
@@ -114,9 +114,9 @@ func (b CacheBuilder) CreateCacheFrom(ctx context.Context, inputs CacheInputs, s
 	go func() {
 		err := TarDfOnly(ctx, pw, df)
 		if err != nil {
-			pw.CloseWithError(errors.Wrap(err, "CreateCacheFrom"))
+			_ = pw.CloseWithError(errors.Wrap(err, "CreateCacheFrom"))
 		} else {
-			pw.Close()
+			_ = pw.Close()
 		}
 	}()
 

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -47,15 +47,21 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 	}
 
 	// copy files to container
-	ab := NewArchiveBuilder(filter)
-	err = ab.ArchivePathsIfExist(ctx, toArchive)
-	if err != nil {
-		return errors.Wrap(err, "archivePathsIfExists")
-	}
-	reader, err := ab.Reader()
-	if err != nil {
-		return err
-	}
+	pr, pw := io.Pipe()
+	go func() {
+		ab := NewArchiveBuilder(pw, filter)
+		err = ab.ArchivePathsIfExist(ctx, toArchive)
+		if err != nil {
+			pw.CloseWithError(errors.Wrap(err, "archivePathsIfExists"))
+		} else {
+			err := ab.Close()
+			if err != nil {
+				pw.CloseWithError(err)
+			} else {
+				pw.Close()
+			}
+		}
+	}()
 
 	if len(toArchive) > 0 {
 		l.Infof("Copying %d file(s) to container: %s", len(toArchive), cID.ShortStr())
@@ -66,7 +72,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 
 	// TODO(maia): catch errors -- CopyToContainer doesn't return errors if e.g. it
 	// fails to write a file b/c of permissions =(
-	err = r.dCli.CopyToContainerRoot(ctx, cID.String(), reader)
+	err = r.dCli.CopyToContainerRoot(ctx, cID.String(), pr)
 	if err != nil {
 		return err
 	}

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -55,6 +55,7 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 			_ = pw.CloseWithError(errors.Wrap(err, "archivePathsIfExists"))
 		} else {
 			_ = ab.Close()
+			_ = pw.Close()
 		}
 	}()
 

--- a/internal/build/container_updater.go
+++ b/internal/build/container_updater.go
@@ -52,14 +52,9 @@ func (r *ContainerUpdater) UpdateInContainer(ctx context.Context, cID container.
 		ab := NewArchiveBuilder(pw, filter)
 		err = ab.ArchivePathsIfExist(ctx, toArchive)
 		if err != nil {
-			pw.CloseWithError(errors.Wrap(err, "archivePathsIfExists"))
+			_ = pw.CloseWithError(errors.Wrap(err, "archivePathsIfExists"))
 		} else {
-			err := ab.Close()
-			if err != nil {
-				pw.CloseWithError(err)
-			} else {
-				pw.Close()
-			}
+			_ = ab.Close()
 		}
 	}()
 

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -319,7 +319,6 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 
 	ps.StartBuildStep(ctx, "Building image")
 	spanBuild, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuild")
-	// pass pr here
 	imageBuildResponse, err := d.dCli.ImageBuild(
 		ctx,
 		pr,

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -311,9 +311,9 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 	go func() {
 		err := tarContextAndUpdateDf(ctx, pw, df, paths, filter)
 		if err != nil {
-			pw.CloseWithError(err)
+			_ = pw.CloseWithError(err)
 		} else {
-			pw.Close()
+			_ = pw.Close()
 		}
 	}()
 

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -29,7 +29,7 @@ func TestArchiveDf(t *testing.T) {
 		df := dockerfile.Dockerfile(dfText)
 		err := ab.archiveDf(f.ctx, df)
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 	}()
 

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/dockerignore"
 	"github.com/windmilleng/tilt/internal/model"

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -138,6 +138,7 @@ func (sbd *SyncletBuildAndDeployer) updateInCluster(ctx context.Context, iTarget
 	if err != nil {
 		return errors.Wrap(err, "archivePathsIfExists")
 	}
+	ab.Close()
 	archivePaths := ab.Paths()
 
 	if len(toArchive) > 0 {

--- a/internal/engine/synclet_build_and_deployer.go
+++ b/internal/engine/synclet_build_and_deployer.go
@@ -138,7 +138,10 @@ func (sbd *SyncletBuildAndDeployer) updateInCluster(ctx context.Context, iTarget
 	if err != nil {
 		return errors.Wrap(err, "archivePathsIfExists")
 	}
-	ab.Close()
+	err = ab.Close()
+	if err != nil {
+		return errors.Wrap(err, "ArchiveBuilder Close")
+	}
 	archivePaths := ab.Paths()
 
 	if len(toArchive) > 0 {


### PR DESCRIPTION
The basic strategy is to have the tar archiver be responsible only for _writing_ to a `io.Writer`. Whenever we call the tar archiver we need to either

1. pass in a byte buffer and [deal with it](https://gph.is/1lDpHWH)
2. wire up an `io.Pipe`, pass the writer end in to the archiver and pass the reader end to Docker

This makes the tar package API truly gross, IMO. But that's a problem for a separate PR.

Memory allocations during tar before:

```
(pprof) top
Showing nodes accounting for 1.11GB, 99.72% of 1.11GB total
Dropped 42 nodes (cum <= 0.01GB)
Showing top 10 nodes out of 20
      flat  flat%   sum%        cum   cum%
    1.11GB 99.72% 99.72%     1.11GB 99.72%  bytes.makeSlice
         0     0% 99.72%     1.11GB 99.72%  archive/tar.(*Writer).Write
         0     0% 99.72%     1.11GB 99.72%  archive/tar.(*regFileWriter).Write
         0     0% 99.72%     1.11GB 99.72%  bytes.(*Buffer).Write
         0     0% 99.72%     1.11GB 99.72%  bytes.(*Buffer).grow
         0     0% 99.72%     1.11GB 99.72%  github.com/windmilleng/tilt/internal/build.(*ArchiveBuilder).ArchivePathsIfExist
         0     0% 99.72%     1.11GB 99.72%  github.com/windmilleng/tilt/internal/build.(*ArchiveBuilder).writeEntry
         0     0% 99.72%     1.11GB 99.72%  github.com/windmilleng/tilt/internal/build.(*dockerImageBuilder).BuildDockerfile
         0     0% 99.72%     1.11GB 99.72%  github.com/windmilleng/tilt/internal/build.(*dockerImageBuilder).buildFromDf
         0     0% 99.72%     1.11GB 99.72%  github.com/windmilleng/tilt/internal/build.tarContextAndUpdateDf
```

After:

```
(pprof) top
Showing nodes accounting for 5408.26kB, 100% of 5408.26kB total
Showing top 10 nodes out of 34
      flat  flat%   sum%        cum   cum%
 2804.01kB 51.85% 51.85%  2804.01kB 51.85%  github.com/windmilleng/tilt/vendor/github.com/gdamore/tcell.(*CellBuffer).Resize
  553.04kB 10.23% 62.07%   553.04kB 10.23%  github.com/windmilleng/tilt/vendor/github.com/gogo/protobuf/proto.RegisterType
  513.56kB  9.50% 71.57%   513.56kB  9.50%  github.com/windmilleng/tilt/vendor/k8s.io/apimachinery/pkg/api/meta.(*DefaultRESTMapper).AddSpecific
  513.50kB  9.49% 81.06%   513.50kB  9.49%  github.com/windmilleng/tilt/vendor/github.com/rivo/tview.init.ializers
  512.12kB  9.47% 90.53%   512.12kB  9.47%  runtime.mcommoninit
  512.02kB  9.47%   100%   512.02kB  9.47%  fmt.Sprintf
         0     0%   100%   512.02kB  9.47%  fmt.Errorf
         0     0%   100%   513.56kB  9.50%  github.com/windmilleng/tilt/internal/cli.(*upCmd).run
         0     0%   100%  2804.01kB 51.85%  github.com/windmilleng/tilt/internal/cli.(*upCmd).run.func1
         0     0%   100%   513.56kB  9.50%  github.com/windmilleng/tilt/internal/cli.Execute
```

Fixes #1753