### PR TITLE
tiltfile: add 'entrypoint' opt arg to docker_build and custom_build, translate into image target [ch2886]

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -29,7 +29,7 @@ type dockerImage struct {
 	matchInEnvVars     bool
 	ignores            []string
 	onlys              []string
-	entrypoint         model.Cmd // optional: override container entrypoint/command with this
+	entrypoint         model.Cmd // optional: if specified, we override the image entrypoint/k8s command with this
 
 	// fast-build properties -- will be deprecated
 	syncs        []pathSync

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -490,6 +490,20 @@ dc_resource('no-svc-with-this-name-eek', 'gcr.io/foo')
 	f.loadErrString("no Docker Compose service found with name")
 }
 
+func TestDockerComposeDoesntSupportEntrypointOverride(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile("foo/Dockerfile")
+	f.file("docker-compose.yml", simpleConfig)
+	f.file("Tiltfile", `docker_build('gcr.io/foo', './foo', entrypoint='./foo')
+docker_compose('docker-compose.yml')
+dc_resource('foo', 'gcr.io/foo')
+`)
+
+	f.loadErrString("docker_build/custom_build.entrypoint not supported for Docker Compose resources")
+}
+
 func (f *fixture) assertDcManifest(name string, opts ...interface{}) model.Manifest {
 	m := f.assertNextManifest(name)
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -916,8 +916,8 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 			MatchInEnvVars:   image.matchInEnvVars,
 		}.WithCachePaths(image.cachePaths)
 
-		if !image.entrypointOverride.Empty() {
-			iTarget = iTarget.WithOverrideCommand(image.entrypointOverride)
+		if !image.entrypoint.Empty() {
+			iTarget = iTarget.WithOverrideCommand(image.entrypoint)
 		}
 
 		lu := image.liveUpdate

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/windmilleng/tilt/internal/sliceutils"
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -3592,6 +3593,42 @@ func TestDisableFeatureThatDoesntExist(t *testing.T) {
 	f.loadErrString("Unknown feature flag: testflag")
 }
 
+func TestDockerBuildEntrypoint(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile("Dockerfile")
+	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
+	f.file("Tiltfile", `
+docker_build('gcr.io/foo', '.', entrypoint="/bin/the_app")
+k8s_yaml('foo.yaml')
+`)
+
+	f.load()
+	f.assertNextManifest("foo", db(image("gcr.io/foo"), entrypoint("/bin/the_app")))
+}
+
+func TestCustomBuildEntrypoint(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile("Dockerfile")
+	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
+	f.file("Tiltfile", `
+custom_build('gcr.io/foo', 'docker build -t $EXPECTED_REF foo',
+ ['foo'], entrypoint="/bin/the_app")
+k8s_yaml('foo.yaml')
+`)
+
+	f.load()
+	f.assertNextManifest("foo", cb(
+		image("gcr.io/foo"),
+		deps(f.JoinPath("foo")),
+		cmd("docker build -t $EXPECTED_REF foo"),
+		entrypoint("/bin/the_app")),
+	)
+}
+
 type fixture struct {
 	ctx context.Context
 	out *bytes.Buffer
@@ -3874,6 +3911,11 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 
 			for _, matcher := range opt.matchers {
 				switch matcher := matcher.(type) {
+				case entrypointHelper:
+					if !sliceutils.StringSliceEquals(matcher.cmd.Argv, image.OverrideCmd.Argv) {
+						f.t.Fatalf("expected OverrideCommand (aka entrypoint) %v, got %v",
+							matcher.cmd.Argv, image.OverrideCmd.Argv)
+					}
 				case nestedFBHelper:
 					dbInfo := image.DockerBuildInfo()
 					if matcher.fb == nil {
@@ -3936,6 +3978,11 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 					assert.Equal(f.t, matcher.tag, cbInfo.Tag)
 				case disablePushHelper:
 					assert.Equal(f.t, matcher.disabled, cbInfo.DisablePush)
+				case entrypointHelper:
+					if !sliceutils.StringSliceEquals(matcher.cmd.Argv, image.OverrideCmd.Argv) {
+						f.t.Fatalf("expected OverrideCommand (aka entrypoint) %v, got %v",
+							matcher.cmd.Argv, image.OverrideCmd.Argv)
+					}
 				case fbHelper:
 					if cbInfo.Fast.Empty() {
 						f.t.Fatalf("Expected manifest %v to have fast build, but it didn't", m.Name)
@@ -4373,6 +4420,14 @@ type cbHelper struct {
 
 func cb(img imageHelper, opts ...interface{}) cbHelper {
 	return cbHelper{img, opts}
+}
+
+type entrypointHelper struct {
+	cmd model.Cmd
+}
+
+func entrypoint(command string) entrypointHelper {
+	return entrypointHelper{model.ToShellCmd(command)}
 }
 
 type nestedFBHelper struct {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/windmilleng/tilt/internal/sliceutils"
 	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/windmilleng/tilt/internal/sliceutils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/windmilleng/wmclient/pkg/analytics"


### PR DESCRIPTION
Hello @landism, @nicks, @mariabelenvivanco,

Please review the following commits I made in branch maiamcc/tiltfile-override-entrypoint:

7f8a4527c3f97b522e35b7566f0c6d71babfab2d (2019-07-10 17:18:09 -0400)
rename a fastBuild-related field to free up better names

29bc4349a2f670a6635d702e36828307caa0d80e (2019-07-10 17:16:15 -0400)
tests

79181b35f8e53117620beaa4aa1f5239a69d1b44 (2019-07-10 17:16:01 -0400)
tiltfile: add 'entrypoint' opt arg to docker_build and custom_build, translate into image target

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics