### PR TITLE
model: remove a bunch of dead PathMatcher code

### DIFF
--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -18,14 +18,6 @@ func TestMatches(t *testing.T) {
 	tf.AssertResult(tf.JoinPath("foo", "bar"), false)
 }
 
-func TestPatterns(t *testing.T) {
-	tf := newTestFixture(t, "node_modules")
-	defer tf.TearDown()
-
-	patterns := tf.tester.(model.PatternMatcher).AsMatchPatterns()
-	assert.Equal(t, []string{"node_modules"}, patterns)
-}
-
 func TestComment(t *testing.T) {
 	tf := newTestFixture(t, "# generated code")
 	defer tf.TearDown()

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -3,7 +3,6 @@ package model
 import (
 	"path/filepath"
 
-	"github.com/gobwas/glob"
 	"github.com/pkg/errors"
 
 	"github.com/windmilleng/tilt/internal/ospath"
@@ -124,39 +123,6 @@ func (ps PathSet) AnyMatch(paths []string) (bool, string, error) {
 	return false, "", nil
 }
 
-type globMatcher struct {
-	globs []glob.Glob
-}
-
-func (gm globMatcher) Matches(f string, isDir bool) (bool, error) {
-	for _, g := range gm.globs {
-		if g.Match(f) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func NewGlobMatcher(globs ...string) PathMatcher {
-	ret := globMatcher{}
-	for _, g := range globs {
-		ret.globs = append(ret.globs, glob.MustCompile(g))
-	}
-
-	return ret
-}
-
-type PatternMatcher interface {
-	PathMatcher
-
-	// Express this PathMatcher as a sequence of filepath.Match
-	// patterns. These patterns are widely useful in Docker-land because
-	// they're suitable in .dockerignore or Dockerfile ADD statements
-	// https://docs.docker.com/engine/reference/builder/#add
-	AsMatchPatterns() []string
-}
-
 type CompositePathMatcher struct {
 	Matchers []PathMatcher
 }
@@ -165,19 +131,7 @@ func NewCompositeMatcher(matchers []PathMatcher) PathMatcher {
 	if len(matchers) == 0 {
 		return EmptyMatcher
 	}
-	cMatcher := CompositePathMatcher{Matchers: matchers}
-	pMatchers := make([]PatternMatcher, len(matchers))
-	for i, m := range matchers {
-		pm, ok := m.(CompositePatternMatcher)
-		if !ok {
-			return cMatcher
-		}
-		pMatchers[i] = pm
-	}
-	return CompositePatternMatcher{
-		CompositePathMatcher: cMatcher,
-		Matchers:             pMatchers,
-	}
+	return CompositePathMatcher{Matchers: matchers}
 }
 
 func (c CompositePathMatcher) Matches(f string, isDir bool) (bool, error) {
@@ -193,18 +147,4 @@ func (c CompositePathMatcher) Matches(f string, isDir bool) (bool, error) {
 	return false, nil
 }
 
-type CompositePatternMatcher struct {
-	CompositePathMatcher
-	Matchers []PatternMatcher
-}
-
-func (c CompositePatternMatcher) AsMatchPatterns() []string {
-	result := []string{}
-	for _, m := range c.Matchers {
-		result = append(result, m.AsMatchPatterns()...)
-	}
-	return result
-}
-
 var _ PathMatcher = CompositePathMatcher{}
-var _ PatternMatcher = CompositePatternMatcher{}


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/matcher:

e37e5500ec9dfef64a17ed00718aa8a7cc294738 (2019-07-10 17:30:36 -0400)
model: remove a bunch of dead PathMatcher code