### PR TITLE
watch: change the watcher interface to better match how we actually use it

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -55,14 +55,14 @@ type Upper struct {
 	store *store.Store
 }
 
-type FsWatcherMaker func(l logger.Logger) (watch.Notify, error)
+type FsWatcherMaker func(paths []string, ignore watch.PathMatcher, l logger.Logger) (watch.Notify, error)
 type ServiceWatcherMaker func(context.Context, *store.Store) error
 type PodWatcherMaker func(context.Context, *store.Store) error
 type timerMaker func(d time.Duration) <-chan time.Time
 
 func ProvideFsWatcherMaker() FsWatcherMaker {
-	return func(l logger.Logger) (watch.Notify, error) {
-		return watch.NewWatcher(l)
+	return func(paths []string, ignore watch.PathMatcher, l logger.Logger) (watch.Notify, error) {
+		return watch.NewWatcher(paths, ignore, l)
 	}
 }
 

--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -1,12 +1,49 @@
 package watch
 
+import "github.com/windmilleng/tilt/internal/logger"
+
 type FileEvent struct {
 	Path string
 }
 
 type Notify interface {
+	// Start watching the paths set at init time
+	Start() error
+
+	// Stop watching and close all channels
 	Close() error
-	Add(name string) error
+
+	// A channel to read off incoming file changes
 	Events() chan FileEvent
+
+	// A channel to read off show-stopping errors
 	Errors() chan error
+}
+
+// When we specify directories to watch, we often want to
+// ignore some subset of the files under those directories.
+//
+// For example:
+// - Watch /src/repo, but ignore /src/repo/.git
+// - Watch /src/repo, but ignore everything in /src/repo/bazel-bin except /src/repo/bazel-bin/app-binary
+//
+// The PathMatcher inteface helps us manage these ignores.
+// By design, fileutils.PatternMatcher (the interface that implements dockerignore)
+// satisfies this interface
+// https://godoc.org/github.com/docker/docker/pkg/fileutils#PatternMatcher
+type PathMatcher interface {
+	Matches(file string) (bool, error)
+	Exclusions() bool
+}
+
+type EmptyMatcher struct {
+}
+
+func (EmptyMatcher) Matches(f string) (bool, error) { return false, nil }
+func (EmptyMatcher) Exclusions() bool               { return false }
+
+var _ PathMatcher = EmptyMatcher{}
+
+func NewWatcher(paths []string, ignore PathMatcher, l logger.Logger) (Notify, error) {
+	return newWatcher(paths, ignore, l)
 }

--- a/internal/watch/watcher_darwin.go
+++ b/internal/watch/watcher_darwin.go
@@ -2,7 +2,6 @@ package watch
 
 import (
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/windmilleng/tilt/internal/logger"
@@ -19,14 +18,9 @@ type darwinNotify struct {
 	errors chan error
 	stop   chan struct{}
 
-	// TODO(nick): This mutex is needed for the case where we add paths after we
-	// start watching. But because fsevents supports recursive watches, we don't
-	// actually need this feature. We should change the api contract of wmNotify
-	// so that, for recursive watches, we can guarantee that the path list doesn't
-	// change.
-	sm *sync.Mutex
-
 	pathsWereWatching map[string]interface{}
+	ignore            PathMatcher
+	logger            logger.Logger
 	sawAnyHistoryDone bool
 }
 
@@ -44,9 +38,7 @@ func (d *darwinNotify) loop() {
 				e.Path = filepath.Join("/", e.Path)
 
 				if e.Flags&fsevents.HistoryDone == fsevents.HistoryDone {
-					d.sm.Lock()
 					d.sawAnyHistoryDone = true
-					d.sm.Unlock()
 					continue
 				}
 
@@ -63,6 +55,13 @@ func (d *darwinNotify) loop() {
 					continue
 				}
 
+				ignore, err := d.ignore.Matches(e.Path)
+				if err != nil {
+					d.logger.Infof("Error matching path %q: %v", e.Path, err)
+				} else if ignore {
+					continue
+				}
+
 				d.events <- FileEvent{
 					Path: e.Path,
 				}
@@ -71,41 +70,33 @@ func (d *darwinNotify) loop() {
 	}
 }
 
-func (d *darwinNotify) Add(name string) error {
-	d.sm.Lock()
-	defer d.sm.Unlock()
-
-	es := d.stream
-
+// Add a path to be watched. Should only be called during initialization.
+func (d *darwinNotify) initAdd(name string) {
 	// Check if this is a subdirectory of any of the paths
 	// we're already watching.
-	for _, parent := range es.Paths {
+	for _, parent := range d.stream.Paths {
 		if ospath.IsChild(parent, name) {
-			return nil
+			return
 		}
 	}
 
-	es.Paths = append(es.Paths, name)
+	d.stream.Paths = append(d.stream.Paths, name)
 
 	if d.pathsWereWatching == nil {
 		d.pathsWereWatching = make(map[string]interface{})
 	}
 	d.pathsWereWatching[name] = struct{}{}
+}
 
-	if len(es.Paths) == 1 {
-		es.Start()
-		go d.loop()
-	} else {
-		es.Restart()
-	}
+func (d *darwinNotify) Start() error {
+	d.stream.Start()
+
+	go d.loop()
 
 	return nil
 }
 
 func (d *darwinNotify) Close() error {
-	d.sm.Lock()
-	defer d.sm.Unlock()
-
 	d.stream.Stop()
 	close(d.errors)
 	close(d.stop)
@@ -121,8 +112,10 @@ func (d *darwinNotify) Errors() chan error {
 	return d.errors
 }
 
-func NewWatcher(l logger.Logger) (Notify, error) {
+func newWatcher(paths []string, ignore PathMatcher, l logger.Logger) (*darwinNotify, error) {
 	dw := &darwinNotify{
+		ignore: ignore,
+		logger: l,
 		stream: &fsevents.EventStream{
 			Latency: 1 * time.Millisecond,
 			Flags:   fsevents.FileEvents,
@@ -130,10 +123,13 @@ func NewWatcher(l logger.Logger) (Notify, error) {
 			// https://developer.apple.com/documentation/coreservices/1443980-fseventstreamcreate
 			EventID: fsevents.LatestEventID(),
 		},
-		sm:     &sync.Mutex{},
 		events: make(chan FileEvent),
 		errors: make(chan error),
 		stop:   make(chan struct{}),
+	}
+
+	for _, path := range paths {
+		dw.initAdd(path)
 	}
 
 	return dw, nil


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/watchapi:

5f5ac9d41d7258670ea7553b0f6d0bdf20609cc6 (2019-07-10 18:42:12 -0400)
watch: change the watcher interface to better match how we actually use it