### PR TITLE
model: remove the isDir arg from PathMatcher

### DIFF
--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -48,7 +48,7 @@ func (m PathMapping) Filter(matcher model.PathMatcher) ([]PathMapping, error) {
 			return err
 		}
 
-		match, err := matcher.Matches(path, info.IsDir())
+		match, err := matcher.Matches(path)
 		if err != nil {
 			return err
 		}

--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -163,7 +163,7 @@ func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string
 			return errors.Wrapf(err, "error walking to %s", path)
 		}
 
-		matches, err := a.filter.Matches(path, info.IsDir())
+		matches, err := a.filter.Matches(path)
 		if err != nil {
 			return err
 		}

--- a/internal/dockerignore/ignore.go
+++ b/internal/dockerignore/ignore.go
@@ -14,7 +14,7 @@ type dockerPathMatcher struct {
 	matcher  *fileutils.PatternMatcher
 }
 
-func (i dockerPathMatcher) Matches(f string, isDir bool) (bool, error) {
+func (i dockerPathMatcher) Matches(f string) (bool, error) {
 	rp, err := filepath.Rel(i.repoRoot, f)
 	if err != nil {
 		return false, err

--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -87,7 +87,7 @@ func (tf *testFixture) JoinPath(path ...string) string {
 }
 
 func (tf *testFixture) AssertResult(path string, expectedMatches bool) {
-	isIgnored, err := tf.tester.Matches(path, false)
+	isIgnored, err := tf.tester.Matches(path)
 	if err != nil {
 		tf.t.Fatal(err)
 	} else {

--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -271,7 +271,7 @@ func (w *WatchManager) dispatchFileChangesLoop(
 					st.Dispatch(NewErrorAction(err))
 					continue
 				}
-				isIgnored, err := filter.Matches(path, false)
+				isIgnored, err := filter.Matches(path)
 				if err != nil {
 					st.Dispatch(NewErrorAction(err))
 					continue

--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -12,7 +12,7 @@ type repoIgnoreTester struct {
 	repoRoot string
 }
 
-func (r repoIgnoreTester) Matches(f string, isDir bool) (bool, error) {
+func (r repoIgnoreTester) Matches(f string) (bool, error) {
 	// TODO(matt) what do we want to do with symlinks?
 	absPath, err := filepath.Abs(f)
 	if err != nil {

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -81,7 +81,7 @@ func (tf *testFixture) JoinPath(repoNum int, path ...string) string {
 
 func (tf *testFixture) AssertResult(description, path string, expectedMatches bool, expectError bool) {
 	tf.t.Run(description, func(t *testing.T) {
-		isIgnored, err := tf.tester.Matches(path, false)
+		isIgnored, err := tf.tester.Matches(path)
 		if expectError {
 			assert.Error(t, err)
 		} else {

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -109,11 +109,7 @@ func CreateRunMatcher(r model.Run) (model.PathMatcher, error) {
 // .#a.txt -> [some garbage]
 type tempBrokenSymlinkMatcher struct{}
 
-func (m tempBrokenSymlinkMatcher) Matches(path string, isDir bool) (bool, error) {
-	if isDir {
-		return false, nil
-	}
-
+func (m tempBrokenSymlinkMatcher) Matches(path string) (bool, error) {
 	if !strings.HasPrefix(filepath.Base(path), ".") {
 		return false, nil
 	}
@@ -135,6 +131,6 @@ func newDirectoryMatcher(dir string) (directoryMatcher, error) {
 	return directoryMatcher{dir}, nil
 }
 
-func (d directoryMatcher) Matches(p string, isDir bool) (bool, error) {
+func (d directoryMatcher) Matches(p string) (bool, error) {
 	return ospath.IsChild(d.dir, p), nil
 }

--- a/internal/model/matcher.go
+++ b/internal/model/matcher.go
@@ -9,13 +9,13 @@ import (
 )
 
 type PathMatcher interface {
-	Matches(f string, isDir bool) (bool, error)
+	Matches(f string) (bool, error)
 }
 
 // A Matcher that matches nothing.
 type emptyMatcher struct{}
 
-func (m emptyMatcher) Matches(f string, isDir bool) (bool, error) {
+func (m emptyMatcher) Matches(f string) (bool, error) {
 	return false, nil
 }
 
@@ -26,7 +26,7 @@ type fileMatcher struct {
 	paths map[string]bool
 }
 
-func (m fileMatcher) Matches(f string, isDir bool) (bool, error) {
+func (m fileMatcher) Matches(f string) (bool, error) {
 	return m.paths[f], nil
 }
 
@@ -56,7 +56,7 @@ type fileOrChildMatcher struct {
 	paths map[string]bool
 }
 
-func (m fileOrChildMatcher) Matches(f string, isDir bool) (bool, error) {
+func (m fileOrChildMatcher) Matches(f string) (bool, error) {
 	// (A) Exact match
 	if m.paths[f] {
 		return true, nil
@@ -112,7 +112,7 @@ func (ps PathSet) AnyMatch(paths []string) (bool, string, error) {
 	matcher := NewRelativeFileOrChildMatcher(ps.BaseDirectory, ps.Paths...)
 
 	for _, path := range paths {
-		match, err := matcher.Matches(path, false)
+		match, err := matcher.Matches(path)
 		if err != nil {
 			return false, "", err
 		}
@@ -134,9 +134,9 @@ func NewCompositeMatcher(matchers []PathMatcher) PathMatcher {
 	return CompositePathMatcher{Matchers: matchers}
 }
 
-func (c CompositePathMatcher) Matches(f string, isDir bool) (bool, error) {
+func (c CompositePathMatcher) Matches(f string) (bool, error) {
 	for _, t := range c.Matchers {
-		ret, err := t.Matches(f, isDir)
+		ret, err := t.Matches(f)
 		if err != nil {
 			return false, err
 		}

--- a/internal/model/matcher_test.go
+++ b/internal/model/matcher_test.go
@@ -49,7 +49,7 @@ func TestFileOrChildMatcher(t *testing.T) {
 	}
 
 	for f, expected := range expectedMatch {
-		match, err := matcher.Matches(f, false)
+		match, err := matcher.Matches(f)
 		if assert.NoError(t, err) {
 			assert.Equal(t, expected, match, "expected file '%s' match --> %t", f, expected)
 		}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4027,7 +4027,7 @@ func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Man
 				filterName = "FileChangeFilter"
 			}
 
-			actualFilter, err := filter.Matches(path, false)
+			actualFilter, err := filter.Matches(path)
 			if err != nil {
 				f.t.Fatalf("Error matching filter (%s): %v", path, err)
 			}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/matches:

62514ba62b8455b8fc37e66e5d88ccc1403428e2 (2019-07-11 11:44:51 -0400)
model: remove the isDir arg from PathMatcher