### PR TITLE
git: remove another pathmatcher implementation

### DIFF
--- a/internal/git/gitignore.go
+++ b/internal/git/gitignore.go
@@ -2,37 +2,10 @@ package git
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
-	"strings"
+
+	"github.com/windmilleng/tilt/internal/model"
 )
 
-// ignores files specified in $ROOT/.git/
-type repoIgnoreTester struct {
-	repoRoot string
-}
-
-func (r repoIgnoreTester) Matches(f string) (bool, error) {
-	// TODO(matt) what do we want to do with symlinks?
-	absPath, err := filepath.Abs(f)
-	if err != nil {
-		return false, err
-	}
-
-	// match everything inside the .git/ directory
-	gitPath := fmt.Sprintf("%s/", filepath.Join(r.repoRoot, ".git"))
-	if strings.HasPrefix(absPath, gitPath) {
-		return true, nil
-	}
-
-	// match the .git directory itself
-	if filepath.Base(absPath) == ".git" {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func NewRepoIgnoreTester(ctx context.Context, repoRoot string) (*repoIgnoreTester, error) {
-	return &repoIgnoreTester{repoRoot}, nil
+func NewRepoIgnoreTester(ctx context.Context, repoRoot string) model.PathMatcher {
+	return model.NewRelativeFileOrChildMatcher(repoRoot, ".git")
 }

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -68,11 +68,7 @@ func (tf *testFixture) UseSingleRepoTester() {
 }
 
 func (tf *testFixture) UseSingleRepoTesterWithPath(path string) {
-	tester, err := git.NewRepoIgnoreTester(tf.ctx, path)
-	if err != nil {
-		tf.t.Fatal(err)
-	}
-	tf.tester = tester
+	tf.tester = git.NewRepoIgnoreTester(tf.ctx, path)
 }
 
 func (tf *testFixture) JoinPath(repoNum int, path ...string) string {

--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -29,10 +29,7 @@ func CreateBuildContextFilter(m repoTarget) model.PathMatcher {
 		}
 	}
 	for _, r := range m.LocalRepos() {
-		gim, err := git.NewRepoIgnoreTester(context.Background(), r.LocalPath)
-		if err == nil {
-			matchers = append(matchers, gim)
-		}
+		matchers = append(matchers, git.NewRepoIgnoreTester(context.Background(), r.LocalPath))
 	}
 	for _, r := range m.Dockerignores() {
 		dim, err := dockerignore.DockerIgnoreTesterFromContents(r.LocalPath, r.Contents)
@@ -56,10 +53,7 @@ type IgnorableTarget interface {
 func CreateFileChangeFilter(m IgnorableTarget) (model.PathMatcher, error) {
 	matchers := []model.PathMatcher{}
 	for _, r := range m.LocalRepos() {
-		gim, err := git.NewRepoIgnoreTester(context.Background(), r.LocalPath)
-		if err == nil {
-			matchers = append(matchers, gim)
-		}
+		matchers = append(matchers, git.NewRepoIgnoreTester(context.Background(), r.LocalPath))
 	}
 	for _, di := range m.Dockerignores() {
 		dim, err := dockerignore.DockerIgnoreTesterFromContents(di.LocalPath, di.Contents)


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/gitignore:

654066c8d25b969cb473ca8481413715d887a9e6 (2019-07-11 18:35:25 -0400)
git: remove another pathmatcher implementation