### PR TITLE
engine: WatchManager should pass ignore filters to watch.Notify instead of doing filtering itself

### DIFF
--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -111,6 +111,8 @@ func (m tempBrokenSymlinkMatcher) Matches(path string) (bool, error) {
 	return ospath.IsBrokenSymlink(path)
 }
 
+func (tempBrokenSymlinkMatcher) Exclusions() bool { return true }
+
 type directoryMatcher struct {
 	dir string
 }
@@ -127,4 +129,8 @@ func newDirectoryMatcher(dir string) (directoryMatcher, error) {
 
 func (d directoryMatcher) Matches(p string) (bool, error) {
 	return ospath.IsChild(d.dir, p), nil
+}
+
+func (directoryMatcher) Exclusions() bool {
+	return false
 }


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/exclusions2:

76ca868fb10da22135a768eab465f6446b19584f (2019-07-11 20:12:00 -0400)
engine: WatchManager should pass ignore filters to watch.Notify instead of doing filtering itself

5ed8139440f7b8b6cc1bd2eeee82ab20d61ae1f2 (2019-07-11 20:05:40 -0400)
watch: FileEvents must always be absolute
there were a lot of confused tests that were using relative paths, then trying to workaround this