### PR TITLE
hud: allow enter on yaml resource

### DIFF
--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -206,10 +206,6 @@ func (h *Hud) handleScreenEvent(ctx context.Context, dispatch func(action store.
 				break
 			}
 			_, r := h.selectedResource()
-			if r.IsYAML() {
-				h.currentViewState.AlertMessage = fmt.Sprintf("YAML Resources don't have logs")
-				break
-			}
 
 			if h.webURL.Empty() {
 				break


### PR DESCRIPTION
there was no unit test for this, but I did run tilt and confirm that hitting enter on the yaml resource gets me the log in the web ui