### PR TITLE
tiltfile: handle duplicate resources without erroring

### DIFF
--- a/internal/k8s/names.go
+++ b/internal/k8s/names.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Calculates names for workloads by using the shortest uniquely matching identifiers
-func UniqueNames(es []K8sEntity, minComponents int) ([]string, error) {
+func UniqueNames(es []K8sEntity, minComponents int) []string {
 	ret := make([]string, len(es))
 	// how many resources potentially map to a given name
 	counts := make(map[string]int)
@@ -27,12 +27,23 @@ func UniqueNames(es []K8sEntity, minComponents int) ([]string, error) {
 				break
 			}
 		}
+
 		if ret[i] == "" {
-			return nil, fmt.Errorf("unable to find a unique resource name for '%s'", names[len(names)-1])
+			// If we hit this case, this means we have two resources with the same
+			// name/kind/namespace/group This usually means the user is trying to
+			// deploy the same resource twice. Kubernetes will not treat these as
+			// unique.
+			//
+			// We should surface a warning or error about this somewhere else that has
+			// more context on how to fix it.
+			// https://github.com/windmilleng/tilt/issues/1852
+			//
+			// But for now, append the index to the name to make it unique
+			ret[i] = fmt.Sprintf("%s:%d", names[len(names)-1], i)
 		}
 	}
 
-	return ret, nil
+	return ret
 }
 
 // returns a list of potential names, in order of preference

--- a/internal/k8s/names_test.go
+++ b/internal/k8s/names_test.go
@@ -24,6 +24,10 @@ func TestUniqueResourceNames(t *testing.T) {
 		{"one workload, just name", []workload{
 			{"foo", "Deployment", "default", "", "foo"},
 		}},
+		{"one workload, same name", []workload{
+			{"foo", "Deployment", "default", "", "foo:deployment:default::0"},
+			{"foo", "Deployment", "default", "", "foo:deployment:default::1"},
+		}},
 		{"one workload, by name", []workload{
 			{"foo", "Deployment", "default", "", "foo"},
 			{"bar", "Deployment", "default", "", "bar"},
@@ -63,10 +67,7 @@ func TestUniqueResourceNames(t *testing.T) {
 				expectedNames = append(expectedNames, w.expectedResourceName)
 			}
 
-			actualNames, err := UniqueNames(entities, 1)
-			if err != nil {
-				assert.NoError(t, err)
-			}
+			actualNames := UniqueNames(entities, 1)
 			assert.Equal(t, expectedNames, actualNames)
 		})
 	}

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -21,10 +21,7 @@ func NewTarget(
 
 	// Use a min component count of 2 for computing names,
 	// so that the resource type appears
-	displayNames, err := UniqueNames(entities, 2)
-	if err != nil {
-		return model.K8sTarget{}, errors.Wrap(err, "k8s.NewTarget")
-	}
+	displayNames := UniqueNames(entities, 2)
 
 	return model.K8sTarget{
 		Name:              name,

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -849,7 +849,7 @@ func (s *tiltfileState) calculateResourceNames(workloads []k8s.K8sEntity) ([]str
 		}
 		return names, nil
 	} else {
-		return k8s.UniqueNames(workloads, 1)
+		return k8s.UniqueNames(workloads, 1), nil
 	}
 }
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/duplicate:

33d4bb143e0e7db76dd8e3ce6143afe563ecd4b5 (2019-07-15 10:21:19 -0400)
tiltfile: handle duplicate resources without erroring
fixes https://github.com/windmilleng/tilt/issues/1853
helps with https://github.com/windmilleng/tilt/issues/1852, until we find a better way to address this