### PR TITLE
tiltfile: unknown feature flag checks are warnings

### DIFF
--- a/internal/tiltfile/features.go
+++ b/internal/tiltfile/features.go
@@ -1,6 +1,8 @@
 package tiltfile
 
 import (
+	"fmt"
+
 	"go.starlark.net/starlark"
 )
 
@@ -11,6 +13,10 @@ func (s *tiltfileState) enableFeature(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
+	if _, ok := s.f.GetAllFlags()[flag]; !ok {
+		s.warnings = append(s.warnings, fmt.Sprintf("Unknown feature flag used in check: %s", flag))
+		return starlark.None, nil
+	}
 	err = s.f.Enable(flag)
 	if err != nil {
 		return nil, err

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3581,8 +3581,9 @@ func TestEnableFeatureThatDoesntExist(t *testing.T) {
 	f.setupFoo()
 
 	f.file("Tiltfile", `enable_feature('testflag')`)
+	f.loadAllowWarnings()
 
-	f.loadErrString("Unknown feature flag: testflag")
+	f.assertWarnings("Unknown feature flag used in check: testflag")
 }
 
 func TestDisableFeatureThatDoesntExist(t *testing.T) {


### PR DESCRIPTION
I realized that this will be annoying now that we are deleting our first
feature flag. Once someone started tilt on a project that checks an old
feature flag it would crash. This changes unknown feature flags to be
warnings in the Tiltfile instead of errors.