### PR TITLE
watch: fix behavior for unbuilt resources

### DIFF
--- a/internal/engine/watchmanager.go
+++ b/internal/engine/watchmanager.go
@@ -203,7 +203,12 @@ func (w *WatchManager) OnChange(ctx context.Context, st store.RStore) {
 			continue
 		}
 
-		watcher, err := w.fsWatcherMaker(target.Dependencies(), ignore, logger)
+		deps := target.Dependencies()
+		if len(deps) == 0 {
+			continue
+		}
+
+		watcher, err := w.fsWatcherMaker(deps, ignore, logger)
 		if err != nil {
 			st.Dispatch(NewErrorAction(err))
 			continue

--- a/internal/engine/watchmanager_test.go
+++ b/internal/engine/watchmanager_test.go
@@ -117,6 +117,21 @@ func TestWatchManager_PickUpTiltIgnoreChanges(t *testing.T) {
 	f.AssertActionsContain(actions, "bar/baz/foo")
 }
 
+// to protect against https://github.com/windmilleng/tilt/issues/1857
+func TestWatchManager_ZeroDependencies(t *testing.T) {
+	f := newWMFixture(t)
+	defer f.TearDown()
+
+	target := model.DockerComposeTarget{Name: "foo"}
+	f.SetManifestTarget(target)
+
+	for _, w := range f.fakeMultiWatcher.watchers {
+		if len(w.paths) == 0 {
+			assert.FailNow(t, "no watchers should be created with zero paths")
+		}
+	}
+}
+
 type wmFixture struct {
 	ctx              context.Context
 	cancel           func()


### PR DESCRIPTION
### Problem

#1857 

This was introduced by #1835 - the analytics repo has an unbuilt resource, which means it has 0 dependencies and we pass a list of empty paths to the fsevents API, which then writes errors directly to stdout.

### Solution

Don't add watchers for empty lists of paths, matching the pre-#1835 behavior.