### PR TITLE
dockerignore: improve MatchesEntireDir

### DIFF
--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -15,7 +15,9 @@ func TestMatches(t *testing.T) {
 	tf := newTestFixture(t, "node_modules")
 	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("node_modules", "foo"), true)
+	tf.AssertResultEntireDir(tf.JoinPath("node_modules"), true)
 	tf.AssertResult(tf.JoinPath("foo", "bar"), false)
+	tf.AssertResultEntireDir(tf.JoinPath("foo"), false)
 }
 
 func TestComment(t *testing.T) {
@@ -45,6 +47,22 @@ func TestException(t *testing.T) {
 	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("docs", "stuff.md"), true)
 	tf.AssertResult(tf.JoinPath("docs", "README.md"), false)
+	tf.AssertResultEntireDir(tf.JoinPath("docs"), false)
+}
+
+func TestNestedException(t *testing.T) {
+	tf := newTestFixture(t, "a", "!a/b", "a/b/c")
+	defer tf.TearDown()
+	tf.AssertResultEntireDir(tf.JoinPath("a"), false)
+	tf.AssertResultEntireDir(tf.JoinPath("a", "b"), false)
+	tf.AssertResultEntireDir(tf.JoinPath("a", "b", "c"), true)
+}
+
+func TestOrthogonalException(t *testing.T) {
+	tf := newTestFixture(t, "a", "b", "!b/README.md")
+	defer tf.TearDown()
+	tf.AssertResultEntireDir(tf.JoinPath("a"), true)
+	tf.AssertResultEntireDir(tf.JoinPath("b"), false)
 }
 
 func TestNoDockerignoreFile(t *testing.T) {
@@ -52,6 +70,7 @@ func TestNoDockerignoreFile(t *testing.T) {
 	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("hi"), false)
 	tf.AssertResult(tf.JoinPath("hi", "hello"), false)
+	tf.AssertResultEntireDir(tf.JoinPath("hi"), false)
 }
 
 type testFixture struct {
@@ -88,6 +107,17 @@ func (tf *testFixture) JoinPath(path ...string) string {
 
 func (tf *testFixture) AssertResult(path string, expectedMatches bool) {
 	isIgnored, err := tf.tester.Matches(path)
+	if err != nil {
+		tf.t.Fatal(err)
+	} else {
+		if assert.NoError(tf.t, err) {
+			assert.Equalf(tf.t, expectedMatches, isIgnored, "Expected isIgnored to be %t for file %s, got %t", expectedMatches, path, isIgnored)
+		}
+	}
+}
+
+func (tf *testFixture) AssertResultEntireDir(path string, expectedMatches bool) {
+	isIgnored, err := tf.tester.MatchesEntireDir(path)
 	if err != nil {
 		tf.t.Fatal(err)
 	} else {

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -509,6 +509,32 @@ func TestIgnoreCreatedDir(t *testing.T) {
 	assert.Equal(t, expectedWatches, int(numberOfWatches.Value()))
 }
 
+func TestIgnoreCreatedDirWithExclusions(t *testing.T) {
+	f := newNotifyFixture(t)
+	defer f.tearDown()
+
+	root := f.paths[0]
+	ignore, _ := dockerignore.NewDockerPatternMatcher(root,
+		[]string{
+			"a/b",
+			"c",
+			"!c/d",
+		})
+	f.setIgnore(ignore)
+
+	a := f.JoinPath(root, "a")
+	b := f.JoinPath(a, "b")
+	file := f.JoinPath(b, "bigFile")
+	f.WriteFile(file, "hello")
+	f.assertEvents(a)
+
+	expectedWatches := 2
+	if runtime.GOOS == "darwin" {
+		expectedWatches = 1
+	}
+	assert.Equal(t, expectedWatches, int(numberOfWatches.Value()))
+}
+
 func TestIgnoreInitialDir(t *testing.T) {
 	f := newNotifyFixture(t)
 	defer f.tearDown()


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/exclusions3:

59bcf2b409861707988db8407524b17ddfb6a491 (2019-07-16 16:24:29 -0400)
dockerignore: improve MatchesEntireDir