### PR TITLE
tiltfile: test for multiple LiveUpdates on one manifest [ch2901]

### DIFF
--- a/internal/model/live_update.go
+++ b/internal/model/live_update.go
@@ -15,6 +15,10 @@ type LiveUpdate struct {
 }
 
 func NewLiveUpdate(steps []LiveUpdateStep, baseDir string) (LiveUpdate, error) {
+	if len(steps) == 0 {
+		return LiveUpdate{}, nil
+	}
+
 	// Check that all FallBackOn steps come at the beginning
 	// (Technically could do this in the loop below, but it's
 	// easier to reason about/modify this way.)
@@ -45,7 +49,7 @@ func NewLiveUpdate(steps []LiveUpdateStep, baseDir string) (LiveUpdate, error) {
 			}
 		}
 	}
-	return LiveUpdate{steps, baseDir}, nil
+	return LiveUpdate{Steps: steps, BaseDir: baseDir}, nil
 }
 
 func (lu LiveUpdate) Empty() bool { return len(lu.Steps) == 0 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3088,6 +3088,43 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', './sidecar',
 	f.loadAssertWarnings("Sorry, but Tilt only supports in-place updates for the first Tilt-built container on a pod, so we can't in-place update your image 'gcr.io/some-project-162817/sancho-sidecar'. If this is a feature you need, let us know!")
 }
 
+func TestMultipleLiveUpdatesOnManifestOKWithFeatureFlag(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.gitInit("")
+	f.file("sancho/Dockerfile", "FROM golang:1.10")
+	f.file("sidecar/Dockerfile", "FROM golang:1.10")
+	f.file("sancho.yaml", testyaml.SanchoSidecarYAML) // two containers
+	f.file("Tiltfile", `
+enable_feature('multiple_containers_per_pod') # psst! rename the test when you take out this flag.
+k8s_yaml('sancho.yaml')
+docker_build('gcr.io/some-project-162817/sancho', './sancho',
+  live_update=[sync('./foo', '/bar')]
+)
+docker_build('gcr.io/some-project-162817/sancho-sidecar', './sidecar',
+  live_update=[sync('./baz', '/quux')]
+)
+`)
+
+	sync1 := model.LiveUpdateSyncStep{Source: f.JoinPath("foo"), Dest: "/bar"}
+	expectedLU1, err := model.NewLiveUpdate([]model.LiveUpdateStep{sync1}, f.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sync2 := model.LiveUpdateSyncStep{Source: f.JoinPath("baz"), Dest: "/quux"}
+	expectedLU2, err := model.NewLiveUpdate([]model.LiveUpdateStep{sync2}, f.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.load()
+	f.assertNextManifest("sancho",
+		db(image("gcr.io/some-project-162817/sancho"), expectedLU1),
+		db(image("gcr.io/some-project-162817/sancho-sidecar"), expectedLU2),
+	)
+}
+
 func TestImpossibleLiveUpdatesOKNoLiveUpdate(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/test-multiple-live-update-on-manifest:

077b6ffa5378772edb74120eb0f6521d0c0122ff (2019-07-16 17:56:12 -0400)
tiltfile: test for multiple LiveUpdates on one manifest [ch2901]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics