### PR TITLE
internal/feature: noop and obsolete flags let us deprecate flags

### DIFF
--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -19,7 +19,7 @@ func TestDown(t *testing.T) {
 	f := newDownFixture(t)
 	defer f.TearDown()
 
-	f.tfl.Manifests = append(f.tfl.Manifests, newK8sManifest())
+	f.tfl.Result = tiltfile.TiltfileLoadResult{Manifests: newK8sManifest()}
 	err := f.cmd.down(f.ctx, f.deps)
 	assert.NoError(t, err)
 	assert.Contains(t, f.kCli.DeletedYaml, "sancho")
@@ -29,7 +29,7 @@ func TestDownK8sFails(t *testing.T) {
 	f := newDownFixture(t)
 	defer f.TearDown()
 
-	f.tfl.Manifests = append(f.tfl.Manifests, newK8sManifest())
+	f.tfl.Result = tiltfile.TiltfileLoadResult{Manifests: newK8sManifest()}
 	f.kCli.DeleteError = fmt.Errorf("GARBLEGARBLE")
 	err := f.cmd.down(f.ctx, f.deps)
 	if assert.Error(t, err) {
@@ -41,7 +41,7 @@ func TestDownDCFails(t *testing.T) {
 	f := newDownFixture(t)
 	defer f.TearDown()
 
-	f.tfl.Manifests = append(f.tfl.Manifests, newDCManifest())
+	f.tfl.Result = tiltfile.TiltfileLoadResult{Manifests: newDCManifest()}
 	f.dcc.DownError = fmt.Errorf("GARBLEGARBLE")
 	err := f.cmd.down(f.ctx, f.deps)
 	if assert.Error(t, err) {
@@ -49,15 +49,15 @@ func TestDownDCFails(t *testing.T) {
 	}
 }
 
-func newK8sManifest() model.Manifest {
-	return model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{YAML: testyaml.SanchoYAML})
+func newK8sManifest() []model.Manifest {
+	return []model.Manifest{model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{YAML: testyaml.SanchoYAML})}
 }
 
-func newDCManifest() model.Manifest {
-	return model.Manifest{Name: "fe"}.WithDeployTarget(model.DockerComposeTarget{
+func newDCManifest() []model.Manifest {
+	return []model.Manifest{model.Manifest{Name: "fe"}.WithDeployTarget(model.DockerComposeTarget{
 		Name:        "fe",
 		ConfigPaths: []string{"dc.yaml"},
-	})
+	})}
 }
 
 type downFixture struct {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -108,7 +108,7 @@ var BaseWireSet = wire.NewSet(
 	provideThreads,
 	engine.NewKINDPusher,
 
-	feature.ProvideFeature,
+	wire.Value(feature.MainDefaults),
 )
 
 func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics *analytics.TiltAnalytics) (demo.Script, error) {

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -121,8 +121,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(switchCli)
 	imageController := engine.NewImageController(imageReaper)
-	featureFeature := feature.ProvideFeature()
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, k8sClient, dockerComposeClient, kubeContext, featureFeature)
+	defaults := _wireDefaultsValue
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, k8sClient, dockerComposeClient, kubeContext, defaults)
 	configsController := engine.NewConfigsController(tiltfileLoader, switchCli)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
@@ -157,7 +157,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	tiltVersionChecker := engine.NewTiltVersionChecker(githubClientFactory, timerMaker)
 	tiltAnalyticsSubscriber := engine.NewTiltAnalyticsSubscriber(analytics2)
 	clockworkClock := clockwork.NewRealClock()
-	eventWatchManager := engine.NewEventWatchManager(k8sClient, clockworkClock, featureFeature)
+	eventWatchManager := engine.NewEventWatchManager(k8sClient, clockworkClock)
 	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, imageController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, sailClient, tiltVersionChecker, tiltAnalyticsSubscriber, eventWatchManager)
 	upper := engine.NewUpper(ctx, storeStore, v2)
 	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, storeStore, branch, runtime, tiltfileLoader)
@@ -165,8 +165,9 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 }
 
 var (
-	_wireReducerValue = engine.UpperReducer
-	_wireLabelsValue  = dockerfile.Labels{}
+	_wireReducerValue  = engine.UpperReducer
+	_wireLabelsValue   = dockerfile.Labels{}
+	_wireDefaultsValue = feature.MainDefaults
 )
 
 func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Threads, error) {
@@ -254,8 +255,8 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	imageReaper := build.NewImageReaper(switchCli)
 	imageController := engine.NewImageController(imageReaper)
-	featureFeature := feature.ProvideFeature()
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, k8sClient, dockerComposeClient, kubeContext, featureFeature)
+	defaults := _wireDefaultsValue
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, k8sClient, dockerComposeClient, kubeContext, defaults)
 	configsController := engine.NewConfigsController(tiltfileLoader, switchCli)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
@@ -290,7 +291,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	tiltVersionChecker := engine.NewTiltVersionChecker(githubClientFactory, timerMaker)
 	tiltAnalyticsSubscriber := engine.NewTiltAnalyticsSubscriber(analytics2)
 	clockworkClock := clockwork.NewRealClock()
-	eventWatchManager := engine.NewEventWatchManager(k8sClient, clockworkClock, featureFeature)
+	eventWatchManager := engine.NewEventWatchManager(k8sClient, clockworkClock)
 	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, imageController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, sailClient, tiltVersionChecker, tiltAnalyticsSubscriber, eventWatchManager)
 	upper := engine.NewUpper(ctx, storeStore, v2)
 	threads := provideThreads(headsUpDisplay, upper, tiltBuild, sailMode)
@@ -430,8 +431,8 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 		return DownDeps{}, err
 	}
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
-	featureFeature := feature.ProvideFeature()
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, k8sClient, dockerComposeClient, kubeContext, featureFeature)
+	defaults := _wireDefaultsValue
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, k8sClient, dockerComposeClient, kubeContext, defaults)
 	downDeps := ProvideDownDeps(tiltfileLoader, dockerComposeClient, k8sClient)
 	return downDeps, nil
 }
@@ -448,7 +449,7 @@ var BaseWireSet = wire.NewSet(
 	provideWebPort,
 	provideWebDevPort,
 	provideNoBrowserFlag, server.ProvideHeadsUpServer, assets.ProvideAssetServer, server.ProvideHeadsUpServerController, provideSailMode,
-	provideSailURL, client.SailWireSet, provideThreads, engine.NewKINDPusher, feature.ProvideFeature,
+	provideSailURL, client.SailWireSet, provideThreads, engine.NewKINDPusher, wire.Value(feature.MainDefaults),
 )
 
 type Threads struct {

--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -85,7 +85,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 		FinishTime:         cc.clock(),
 		Err:                err,
 		Warnings:           tlr.Warnings,
-		Features:           tlr.NewFeatureFlags,
+		Features:           tlr.FeatureFlags,
 	})
 }
 

--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -59,8 +59,7 @@ func (f *ccFixture) run() ConfigsReloadedAction {
 		}
 	}()
 
-	f.tfl = tflResult([]model.Manifest{{Name: "bar"}})
-
+	f.tfl.Result = tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{{Name: "bar"}}}
 	f.st.NotifySubscribers(f.ctx)
 
 	a := store.WaitForAction(f.T(), reflect.TypeOf(ConfigsReloadedAction{}), f.getActions)
@@ -78,7 +77,7 @@ type ccFixture struct {
 	cc         *ConfigsController
 	st         *store.Store
 	getActions func() []store.Action
-	tfl        tiltfile.TiltfileLoader
+	tfl        *tiltfile.FakeTiltfileLoader
 	fc         *testutils.FakeClock
 }
 

--- a/internal/engine/configs_controller_test.go
+++ b/internal/engine/configs_controller_test.go
@@ -59,7 +59,7 @@ func (f *ccFixture) run() ConfigsReloadedAction {
 		}
 	}()
 
-	f.tfl.Manifests = []model.Manifest{{Name: "bar"}}
+	f.tfl = tflResult([]model.Manifest{{Name: "bar"}})
 
 	f.st.NotifySubscribers(f.ctx)
 
@@ -78,7 +78,7 @@ type ccFixture struct {
 	cc         *ConfigsController
 	st         *store.Store
 	getActions func() []store.Action
-	tfl        *tiltfile.FakeTiltfileLoader
+	tfl        tiltfile.TiltfileLoader
 	fc         *testutils.FakeClock
 }
 

--- a/internal/engine/event_watch_manager.go
+++ b/internal/engine/event_watch_manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/windmilleng/tilt/internal/feature"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
@@ -47,9 +46,6 @@ func NewEventWatchManager(kClient k8s.Client, clock clockwork.Clock) *EventWatch
 func (m *EventWatchManager) needsWatch(st store.RStore) bool {
 	state := st.RLockState()
 	defer st.RUnlockState()
-	if !state.Features[feature.Events] {
-		return false
-	}
 
 	atLeastOneK8s := false
 	for _, m := range state.Manifests() {

--- a/internal/engine/event_watch_manager_test.go
+++ b/internal/engine/event_watch_manager_test.go
@@ -216,8 +216,6 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 	ctx, cancel := context.WithCancel(ctx)
 
 	clock := clockwork.NewFakeClock()
-	// f := feature.ProvideFeature()
-	// f.Enable("events")
 
 	ret := &ewmFixture{
 		kClient: kClient,

--- a/internal/engine/event_watch_manager_test.go
+++ b/internal/engine/event_watch_manager_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/windmilleng/tilt/internal/feature"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
@@ -217,12 +216,12 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 	ctx, cancel := context.WithCancel(ctx)
 
 	clock := clockwork.NewFakeClock()
-	f := feature.ProvideFeature()
-	f.Enable("events")
+	// f := feature.ProvideFeature()
+	// f.Enable("events")
 
 	ret := &ewmFixture{
 		kClient: kClient,
-		ewm:     NewEventWatchManager(kClient, clock, f),
+		ewm:     NewEventWatchManager(kClient, clock),
 		ctx:     ctx,
 		cancel:  cancel,
 		t:       t,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1904,7 +1904,7 @@ func TestK8sEventDoNotLogNormalEvents(t *testing.T) {
 }
 
 func TestK8sEventLogTimestamp(t *testing.T) {
-	f := newTestFixture(t).EnableK8sEvents()
+	f := newTestFixture(t)
 	defer f.TearDown()
 
 	st := f.store.LockMutableStateForTesting()
@@ -2601,7 +2601,6 @@ func newTestFixture(t *testing.T) *testFixture {
 	hudsc := server.ProvideHeadsUpServerController(0, &server.HeadsUpServer{}, assets.NewFakeServer(), model.WebURL{}, false)
 	ghc := &github.FakeClient{}
 	sc := &client.FakeSailClient{}
-	// feature := feature.FromDefaults(feature.MainDefaults)
 	ewm := NewEventWatchManager(k8s, clockwork.NewRealClock())
 
 	ret := &testFixture{
@@ -2640,11 +2639,6 @@ func newTestFixture(t *testing.T) *testFixture {
 	}()
 
 	return ret
-}
-
-func (f *testFixture) EnableK8sEvents() *testFixture {
-	// f.feature.Enable(feature.Events)
-	return f
 }
 
 func (f *testFixture) Start(manifests []model.Manifest, watchFiles bool, initOptions ...initOption) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2538,7 +2538,6 @@ type testFixture struct {
 	ghc                   *github.FakeClient
 	opter                 *testOpter
 	tiltVersionCheckDelay time.Duration
-	// features              feature.FeatureSet
 
 	// old value of k8sEventsFeatureFlag env var, for teardown
 	// if nil, no reset needed.

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1787,7 +1787,7 @@ func TestUpper_PodLogs(t *testing.T) {
 }
 
 func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
-	f := newTestFixture(t).EnableK8sEvents()
+	f := newTestFixture(t)
 	defer f.TearDown()
 
 	entityUID := "someEntity"
@@ -1844,7 +1844,7 @@ func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
 }
 
 func TestK8sEventNotLoggedIfNoManifestForUID(t *testing.T) {
-	f := newTestFixture(t).EnableK8sEvents()
+	f := newTestFixture(t)
 	defer f.TearDown()
 
 	entityUID := "someEntity"
@@ -1871,7 +1871,7 @@ func TestK8sEventNotLoggedIfNoManifestForUID(t *testing.T) {
 }
 
 func TestK8sEventDoNotLogNormalEvents(t *testing.T) {
-	f := newTestFixture(t).EnableK8sEvents()
+	f := newTestFixture(t)
 	defer f.TearDown()
 
 	entityUID := "someEntity"
@@ -2601,7 +2601,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	hudsc := server.ProvideHeadsUpServerController(0, &server.HeadsUpServer{}, assets.NewFakeServer(), model.WebURL{}, false)
 	ghc := &github.FakeClient{}
 	sc := &client.FakeSailClient{}
-	feature := feature.FromDefaults(feature.MainDefaults)
+	// feature := feature.FromDefaults(feature.MainDefaults)
 	ewm := NewEventWatchManager(k8s, clockwork.NewRealClock())
 
 	ret := &testFixture{
@@ -2625,7 +2625,6 @@ func newTestFixture(t *testing.T) *testFixture {
 		ghc:                   ghc,
 		opter:                 to,
 		tiltVersionCheckDelay: versionCheckInterval,
-		feature:               feature,
 	}
 
 	tiltVersionCheckTimerMaker := func(d time.Duration) <-chan time.Time {
@@ -2645,7 +2644,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 func (f *testFixture) EnableK8sEvents() *testFixture {
 	// f.feature.Enable(feature.Events)
-	// return f
+	return f
 }
 
 func (f *testFixture) Start(manifests []model.Manifest, watchFiles bool, initOptions ...initOption) {
@@ -2654,6 +2653,7 @@ func (f *testFixture) Start(manifests []model.Manifest, watchFiles bool, initOpt
 
 // Empty `initManifests` will run start ALL manifests
 func (f *testFixture) startWithInitManifests(initManifests []model.ManifestName, manifests []model.Manifest, watchFiles bool, initOptions ...initOption) {
+	// f.tfl = tflResult(manifests)
 	ia := InitAction{
 		Manifests:       manifests,
 		WatchFiles:      watchFiles,
@@ -2664,6 +2664,14 @@ func (f *testFixture) startWithInitManifests(initManifests []model.ManifestName,
 		ia = o(ia)
 	}
 	f.Init(ia)
+}
+
+func tflResult(manifests []model.Manifest) tiltfile.TiltfileLoader {
+	r := tiltfile.NewFakeTiltfileLoader()
+	r.Result = tiltfile.TiltfileLoadResult{
+		Manifests: manifests,
+	}
+	return r
 }
 
 type initOption func(ia InitAction) InitAction

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2653,7 +2653,6 @@ func (f *testFixture) Start(manifests []model.Manifest, watchFiles bool, initOpt
 
 // Empty `initManifests` will run start ALL manifests
 func (f *testFixture) startWithInitManifests(initManifests []model.ManifestName, manifests []model.Manifest, watchFiles bool, initOptions ...initOption) {
-	// f.tfl = tflResult(manifests)
 	ia := InitAction{
 		Manifests:       manifests,
 		WatchFiles:      watchFiles,
@@ -2664,14 +2663,6 @@ func (f *testFixture) startWithInitManifests(initManifests []model.ManifestName,
 		ia = o(ia)
 	}
 	f.Init(ia)
-}
-
-func tflResult(manifests []model.Manifest) tiltfile.TiltfileLoader {
-	r := tiltfile.NewFakeTiltfileLoader()
-	r.Result = tiltfile.TiltfileLoadResult{
-		Manifests: manifests,
-	}
-	return r
 }
 
 type initOption func(ia InitAction) InitAction

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -83,7 +83,11 @@ func (s FeatureSet) Set(name string, enabled bool) error {
 
 // Get gets whether a feature is enabled.
 func (s FeatureSet) Get(name string) bool {
-	return s[name].Enabled
+	v, ok := s[name]
+	if !ok {
+		panic("get of unknown feature flag (code should use feature.Foo instead of \"foo\" to get a flag)")
+	}
+	return v.Enabled
 }
 
 // ToEnabled returns a copy of the enabled values of the FeatureSet

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -16,6 +16,12 @@ const (
 	// After Warn is Error, but it's not a value we can set
 )
 
+type ObsoleteError string
+
+func (s ObsoleteError) Error() string {
+	return string(s)
+}
+
 type Value struct {
 	Enabled bool
 	Status  Status
@@ -34,32 +40,25 @@ var MainDefaults = Defaults{
 	},
 }
 
-func (d Defaults) ToFeatureSet() FeatureSet {
+type FeatureSet map[string]Value
+
+func FromDefaults(d Defaults) FeatureSet {
 	r := make(FeatureSet)
 	for k, v := range d {
 		r[k] = v
 	}
-
 	return r
-}
-
-type FeatureSet map[string]Value
-
-type ObsoleteError string
-
-func (s ObsoleteError) Error() string {
-	return string(s)
 }
 
 func (s FeatureSet) Set(name string, enabled bool) error {
 	v, ok := s[name]
 	if !ok {
-		return fmt.Errorf("feature flag \"%s\" is removed; remove it from your Tiltfile", name)
+		return fmt.Errorf("Unknown feature flag: %s", name)
 	}
 
 	switch v.Status {
 	case Warn:
-		return ObsoleteError(fmt.Sprintf("feature flag \"%s\" is obsolete; remove mention of it from your Tiltfile", name))
+		return ObsoleteError(fmt.Sprintf("Obsolete feature flag: %s", name))
 	case Noop:
 		return nil
 	}
@@ -80,9 +79,3 @@ func (s FeatureSet) ToEnabled() map[string]bool {
 	}
 	return r
 }
-
-// // All feature flags need to be defined here with their default values
-// var flags = Defaults{
-// 	MultipleContainersPerPod: false,
-// 	Events:                   true,
-// }

--- a/internal/feature/flags_test.go
+++ b/internal/feature/flags_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetReturnsFalseIfKeyDoesntExist(t *testing.T) {
+func TestGetPanicsIfKeyDoesntExist(t *testing.T) {
 	m := FeatureSet{}
-	assert.False(t, m.Get("foo"))
+	assert.Panics(t, func() {
+		m.Get("foo")
+	})
 }
 
 func TestIsEnabled(t *testing.T) {
@@ -16,7 +18,7 @@ func TestIsEnabled(t *testing.T) {
 	assert.True(t, m.Get("foo"))
 }
 
-func TestSetReturnsErrorForUnknownKey(t *testing.T) {
+func TestSetReturnsErrorOnUnknownKey(t *testing.T) {
 	m := FeatureSet{}
 	err := m.Set("foo", false)
 	assert.EqualError(t, err, "Unknown feature flag: foo")

--- a/internal/feature/flags_test.go
+++ b/internal/feature/flags_test.go
@@ -36,8 +36,8 @@ func TestSetNoop(t *testing.T) {
 	assert.False(t, m.Get("foo"))
 }
 
-func TestSetWarn(t *testing.T) {
-	m := FeatureSet{"foo": Value{Status: Warn, Enabled: false}}
+func TestSetObsolete(t *testing.T) {
+	m := FeatureSet{"foo": Value{Status: Obsolete, Enabled: false}}
 	err := m.Set("foo", true)
 	assert.EqualError(t, err, "Obsolete feature flag: foo")
 }

--- a/internal/feature/flags_test.go
+++ b/internal/feature/flags_test.go
@@ -6,54 +6,45 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsEnabledReturnsAnErrorIfKeyDoesntExist(t *testing.T) {
-	m := newStaticMapFeature(map[string]bool{})
-	assert.Panics(t, func() {
-		m.IsEnabled("foo")
-	})
+func TestGetReturnsFalseIfKeyDoesntExist(t *testing.T) {
+	m := FeatureSet{}
+	assert.False(t, m.Get("foo"))
 }
 
 func TestIsEnabled(t *testing.T) {
-	m := newStaticMapFeature(map[string]bool{"foo": true})
-	enabled := m.IsEnabled("foo")
-
-	assert.True(t, enabled)
+	m := FeatureSet{"foo": {Enabled: true}}
+	assert.True(t, m.Get("foo"))
 }
 
-func TestEnableUnknownKey(t *testing.T) {
-	m := newStaticMapFeature(map[string]bool{})
-	err := m.Enable("foo")
+func TestSetReturnsErrorForUnknownKey(t *testing.T) {
+	m := FeatureSet{}
+	err := m.Set("foo", false)
 	assert.EqualError(t, err, "Unknown feature flag: foo")
 }
 
-func TestEnable(t *testing.T) {
-	m := newStaticMapFeature(map[string]bool{"foo": false})
-	err := m.Enable("foo")
+func TestSetSimple(t *testing.T) {
+	m := FeatureSet{"foo": Value{Enabled: false}}
+	err := m.Set("foo", true)
 	assert.NoError(t, err)
-	enabled := m.IsEnabled("foo")
-	assert.True(t, enabled)
+	assert.True(t, m.Get("foo"))
 }
 
-func TestDisableUnknownKey(t *testing.T) {
-	m := newStaticMapFeature(map[string]bool{})
-	err := m.Disable("foo")
-	assert.EqualError(t, err, "Unknown feature flag: foo")
-}
-
-func TestDisable(t *testing.T) {
-	m := newStaticMapFeature(map[string]bool{"foo": true})
-	err := m.Disable("foo")
+func TestSetNoop(t *testing.T) {
+	m := FeatureSet{"foo": Value{Status: Noop, Enabled: false}}
+	err := m.Set("foo", true)
 	assert.NoError(t, err)
-	enabled := m.IsEnabled("foo")
-	assert.False(t, enabled)
+	assert.False(t, m.Get("foo"))
 }
 
-func TestGetAllFlags(t *testing.T) {
-	defaults := map[string]bool{"foo": true}
-	f := newStaticMapFeature(defaults)
-	actual := f.GetAllFlags()
+func TestSetWarn(t *testing.T) {
+	m := FeatureSet{"foo": Value{Status: Warn, Enabled: false}}
+	err := m.Set("foo", true)
+	assert.EqualError(t, err, "Obsolete feature flag: foo")
+}
 
-	assert.Equal(t, defaults, actual)
-	// should be a new reference, so the pointers should not be equal.
-	assert.False(t, &defaults == &actual)
+func TestToEnabled(t *testing.T) {
+	m := FeatureSet{"foo": Value{Enabled: false}}
+	m.Set("foo", true)
+
+	assert.Equal(t, map[string]bool{"foo": true}, m.ToEnabled())
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -53,6 +53,7 @@ type TiltfileLoader interface {
 
 type FakeTiltfileLoader struct {
 	Result TiltfileLoadResult
+	Err    error
 	// Manifests   []model.Manifest
 	// ConfigFiles []string
 	// Warnings    []string
@@ -66,11 +67,7 @@ func NewFakeTiltfileLoader() *FakeTiltfileLoader {
 }
 
 func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, matching map[string]bool) (TiltfileLoadResult, error) {
-	return TiltfileLoadResult{
-		Manifests:   tfl.Manifests,
-		ConfigFiles: tfl.ConfigFiles,
-		Warnings:    tfl.Warnings,
-	}, tfl.Err
+	return tfl.Result, tfl.Err
 }
 
 func ProvideTiltfileLoader(

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -52,10 +52,11 @@ type TiltfileLoader interface {
 }
 
 type FakeTiltfileLoader struct {
-	Manifests   []model.Manifest
-	ConfigFiles []string
-	Warnings    []string
-	Err         error
+	Result TiltfileLoadResult
+	// Manifests   []model.Manifest
+	// ConfigFiles []string
+	// Warnings    []string
+	// Err         error
 }
 
 var _ TiltfileLoader = &FakeTiltfileLoader{}
@@ -115,7 +116,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	}
 
 	privateRegistry := tfl.kCli.PrivateRegistry(ctx)
-	s := newTiltfileState(ctx, tfl.dcCli, absFilename, tfl.kubeContext, privateRegistry, tfl.fDefaults.ToFeatureSet())
+	s := newTiltfileState(ctx, tfl.dcCli, absFilename, tfl.kubeContext, privateRegistry, feature.FromDefaults(tfl.fDefaults))
 	printedWarnings := false
 	defer func() {
 		tlr.ConfigFiles = s.configFiles

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -33,7 +33,7 @@ type TiltfileLoadResult struct {
 	ConfigFiles        []string
 	Warnings           []string
 	TiltIgnoreContents string
-	NewFeatureFlags    map[string]bool
+	FeatureFlags       map[string]bool
 }
 
 func (r TiltfileLoadResult) Orchestrator() model.Orchestrator {
@@ -54,10 +54,6 @@ type TiltfileLoader interface {
 type FakeTiltfileLoader struct {
 	Result TiltfileLoadResult
 	Err    error
-	// Manifests   []model.Manifest
-	// ConfigFiles []string
-	// Warnings    []string
-	// Err         error
 }
 
 var _ TiltfileLoader = &FakeTiltfileLoader{}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -35,7 +35,7 @@ type tiltfileState struct {
 	dcCli           dockercompose.DockerComposeClient
 	kubeContext     k8s.KubeContext
 	privateRegistry container.Registry
-	f               feature.Feature
+	features        feature.FeatureSet
 
 	// added to during execution
 	configFiles        []string
@@ -92,7 +92,7 @@ const (
 	k8sResourceAssemblyVersionReasonExplicit
 )
 
-func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClient, filename string, kubeContext k8s.KubeContext, privateRegistry container.Registry, f feature.Feature) *tiltfileState {
+func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClient, filename string, kubeContext k8s.KubeContext, privateRegistry container.Registry, features feature.FeatureSet) *tiltfileState {
 	lp := localPath{path: filename}
 	s := &tiltfileState{
 		ctx:                        ctx,
@@ -111,7 +111,7 @@ func newTiltfileState(ctx context.Context, dcCli dockercompose.DockerComposeClie
 		k8sResourceAssemblyVersion: 2,
 		k8sResourceOptions:         make(map[string]k8sResourceOptions),
 		triggerMode:                TriggerModeAuto,
-		f:                          f,
+		features:                   features,
 	}
 	s.filename = s.maybeAttachGitRepo(lp, filepath.Dir(lp.path))
 	return s
@@ -779,7 +779,7 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 
 		m = m.WithImageTargets(iTargets)
 
-		if !s.f.IsEnabled(feature.MultipleContainersPerPod) {
+		if !s.features.Get(feature.MultipleContainersPerPod) {
 			err = s.checkForImpossibleLiveUpdates(m)
 			if err != nil {
 				return nil, err

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4207,7 +4207,7 @@ func (f *fixture) entities(y string) []k8s.K8sEntity {
 }
 
 func (f *fixture) assertFeature(key string, enabled bool) {
-	assert.Equal(f.t, enabled, f.loadResult.NewFeatureFlags[key])
+	assert.Equal(f.t, enabled, f.loadResult.FeatureFlags[key])
 }
 
 type secretHelper struct {


### PR DESCRIPTION
We want to remove feature flags.

If Alice and Bob are on adjacent Tilt versions where the latter removes the flag, Bob will want to remove the flag, but then Alice will lose the feature.

Allow marking a flag "noop" (it's set to a fixed-value, but Bob doesn't see anything), then "obsolete" (Bob sees an error, removes it, and Alice isn't affected), and then removing it (where setting a value would be an error)