### PR TITLE
web: update ts ResourceInfo to match go ResourceInfo

### DIFF
--- a/web/src/testdata.test.tsx
+++ b/web/src/testdata.test.tsx
@@ -78,6 +78,7 @@ function oneResource(): Resource {
       PodName: "vigoda-pod",
       PodCreationTime: ts,
       PodStatus: "Running",
+      PodStatusMessage: "",
       PodRestarts: 0,
       Endpoints: ["1.2.3.4:8080"],
       PodLog: "1\n2\n3\n4\nabe vigoda is now dead\n5\n6\n7\n8\n",
@@ -253,6 +254,7 @@ function twoResourceView(): view {
     PendingBuildReason: 0,
     ResourceInfo: {
       PodStatus: "Running",
+      PodStatusMessage: "",
       PodRestarts: 0,
       PodCreationTime: "",
       PodLog: "",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -59,13 +59,14 @@ export type Resource = {
   PendingBuildReason: number
   PendingBuildSince: string
   ResourceInfo: {
-    PodCreationTime: string
-    PodLog: string
     PodName: string
-    PodRestarts: number
+    PodCreationTime: string
     PodUpdateStartTime: string
-    YAML: string
     PodStatus: string
+    PodStatusMessage: string
+    PodRestarts: number
+    PodLog: string
+    YAML: string
     Endpoints: Array<string>
   }
   RuntimeStatus: string


### PR DESCRIPTION
1. We have code using `ResourceInfo.PodStatusMessage`, but that wasn't a field on that type (I'm not really sure why this wasn't an error).
2. Reorder the fields to match how they're defined in go, to make it easier to keep them the same.

This PR led me to wonder about #1869, but that's a problem for later.