### PR TITLE
log: fix appending multiple lines at once w/ prefix

### DIFF
--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -98,7 +98,7 @@ func TimestampPrefix(ts time.Time) []byte {
 // Returns a new instance of `Log` with content equal to `b` appended to the end of `l`
 // Performs truncation off the start of the log (at a newline) to ensure the resulting log is not
 // longer than `maxLogLengthInBytes`. (which maybe means a pedant would say this isn't strictly an `append`?)
-func AppendLog(l Log, le LogEvent, timestampsEnabled bool, prefix []byte) Log {
+func AppendLog(l Log, le LogEvent, timestampsEnabled bool, prefix string) Log {
 	isStartingNewLine := len(l.lines) == 0 || l.lines[len(l.lines)-1].IsComplete()
 	addedLines := linesFromBytes(le.Message())
 	if len(addedLines) == 0 {
@@ -117,7 +117,7 @@ func AppendLog(l Log, le LogEvent, timestampsEnabled bool, prefix []byte) Log {
 	if len(prefix) > 0 {
 		for i, line := range addedLines {
 			if i != 0 || isStartingNewLine {
-				addedLines[i] = append(prefix, line...)
+				addedLines[i] = append([]byte(prefix), line...)
 			}
 		}
 	}

--- a/internal/model/log_test.go
+++ b/internal/model/log_test.go
@@ -23,7 +23,7 @@ func (l logEvent) Time() time.Time {
 
 func TestLog_AppendUnderLimit(t *testing.T) {
 	l := NewLog("foo")
-	l = AppendLog(l, logEvent{time.Time{}, "bar"}, false, nil)
+	l = AppendLog(l, logEvent{time.Time{}, "bar"}, false, "")
 	assert.Equal(t, "foobar", l.String())
 }
 
@@ -39,7 +39,7 @@ func TestLog_AppendOverLimit(t *testing.T) {
 
 	s := sb.String()
 
-	l = AppendLog(l, logEvent{time.Time{}, s}, false, nil)
+	l = AppendLog(l, logEvent{time.Time{}, s}, false, "")
 
 	assert.Equal(t, s, l.String())
 }
@@ -55,7 +55,7 @@ func TestLog_Timestamps(t *testing.T) {
 
 	// appended text has a newline in the middle of the text (which should get a timestamp)
 	// and at the end of the text (which shouldn't)
-	l = AppendLog(l, logEvent{ts, "bar\nbaz\n"}, true, nil)
+	l = AppendLog(l, logEvent{ts, "bar\nbaz\n"}, true, "")
 
 	expected := "hello\n2019/03/06 12:34:56 bar\n2019/03/06 12:34:56 baz\n"
 	assert.Equal(t, expected, l.String())
@@ -63,7 +63,7 @@ func TestLog_Timestamps(t *testing.T) {
 
 func TestLogPrefix(t *testing.T) {
 	l := NewLog("hello\n")
-	l = AppendLog(l, logEvent{time.Now(), "bar\nbaz\n"}, false, []byte("prefix | "))
+	l = AppendLog(l, logEvent{time.Now(), "bar\nbaz\n"}, false, "prefix | ")
 	expected := "hello\nprefix | bar\nprefix | baz\n"
 	assert.Equal(t, expected, l.String())
 }


### PR DESCRIPTION
### Problem

The main log sometimes ends up with gobbledygook that does not appear in the resource log, e.g.:
```
alert-inges…┊   WORKDIR /usr/src/app
alert-inges…┊ 
 Ealert-inges…┊   COPY package.json ./
alert-inges…┊   COPY yarn.lock ./
alert-inges…┊ 
 Ealert-inges…┊ 
 EXPOSE 30alert-inges…┊ 
 Ealert-inges…┊ 
 EXPOSE 30alert-inges…┊ 
 EXPOSE 3000
alert-inges…┊   CMD ["yarn", "start"]
alert-inges…┊ 
```

The bug lies in [log.Append](https://github.com/windmilleng/tilt/blob/a6d13f0bb25655c6179629669ba991b26f6924e0/internal/model/log.go#L120). We're appending to `prefix` and sticking it in `logLines`, which means if we're given a `prefix` with enough cap, we could end up reusing the same backing array for multiple lines. From playing around with a unit test, this seems to only repro when 1) multiple lines are written in the same action and 2) the resource name is long enough to require truncating. I don't know about the internals of `append` or `fmt.Sprintf`, but, empirically, it looks like we don't get extra cap in the `prefix` `[]byte` when there's no truncation.

### Solution
pass `prefix` as a `string` to remove the possibility for `[]byte` shenanigans (also, just, like, a nicer API)