### PR TITLE
integration: fix namespace creation on macos

### DIFF
--- a/integration/analytics/Tiltfile
+++ b/integration/analytics/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 

--- a/integration/imagetags/Tiltfile
+++ b/integration/imagetags/Tiltfile
@@ -2,7 +2,7 @@
 k8s_resource_assembly_version(2)
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 

--- a/integration/live_update_base_image/Tiltfile
+++ b/integration/live_update_base_image/Tiltfile
@@ -1,6 +1,6 @@
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 

--- a/integration/oneup/Tiltfile
+++ b/integration/oneup/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 

--- a/integration/oneup_custom/Tiltfile
+++ b/integration/oneup_custom/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 

--- a/integration/onewatch/Tiltfile
+++ b/integration/onewatch/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 

--- a/integration/onewatch_exec/Tiltfile
+++ b/integration/onewatch_exec/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 

--- a/integration/shortlived_pods/Tiltfile
+++ b/integration/shortlived_pods/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 # HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo -n $SKIP_NAMESPACE'))
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
 if load_namespace:
   k8s_yaml('../namespace.yaml')
 


### PR DESCRIPTION
whatever sh-compatibility mode mac's `/bin/sh` uses doesn't support `-n` on its `echo` 🤷‍♂ 
```
$ sh -c 'echo -n hello'
-n hello
```
