### PR TITLE
engine: Add a test for multi-line BuildLogAction

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2457,6 +2457,40 @@ func TestTeamNameStoredOnState(t *testing.T) {
 	})
 }
 
+func TestBuildLogAction(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	manifest := f.newManifest("alert-injester", nil)
+	f.Start([]model.Manifest{manifest}, true)
+
+	f.store.Dispatch(BuildStartedAction{
+		ManifestName: manifest.Name,
+		StartTime:    time.Now(),
+	})
+
+	f.store.Dispatch(BuildLogAction{
+		LogEvent: store.NewLogEvent(manifest.Name, []byte(`a
+bc
+def
+ghij`)),
+	})
+
+	f.WaitUntilManifestState("log appears", manifest.Name, func(ms store.ManifestState) bool {
+		return ms.CurrentBuild.Log.Len() > 0
+	})
+
+	f.withState(func(s store.EngineState) {
+		assert.Contains(t, s.Log.String(), `alert-injes…┊ a
+alert-injes…┊ bc
+alert-injes…┊ def
+alert-injes…┊ ghij`)
+	})
+
+	err := f.Stop()
+	assert.Nil(t, err)
+}
+
 type fakeTimerMaker struct {
 	restTimerLock *sync.Mutex
 	maxTimerLock  *sync.Mutex


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/prefix:

2e0743bb7c2c103634662788593b6b979e1646ea (2019-07-18 20:50:42 -0400)
engine: Add a test for multi-line BuildLogAction