### PR TITLE
engine: fix flaky EventWatchManagerTest

### DIFF
--- a/internal/engine/event_watch_manager_test.go
+++ b/internal/engine/event_watch_manager_test.go
@@ -137,11 +137,13 @@ func TestEventWatchManager_janitor(t *testing.T) {
 
 	f.assertUIDMapKeys([]types.UID{obj1.GetUID()})
 
+	f.clock.BlockUntil(1)
 	f.clock.Advance(uidMapEntryTTL / 2)
 
 	f.kClient.EmitEvent(f.ctx, f.makeEvent(obj2))
 	f.assertUIDMapKeys([]types.UID{obj1.GetUID(), obj2.GetUID()})
 
+	f.clock.BlockUntil(1)
 	f.clock.Advance(uidMapEntryTTL/2 + 1)
 	f.assertUIDMapKeys([]types.UID{obj2.GetUID()})
 }


### PR DESCRIPTION
There was a race condition here - basically sometimes we'd perform the last `clock.Advance` before the janitor's loop got back to its next `<-clock.After`, so then the janitor would just block forever and the test would fail. This is the result of using a fake clock and not a real problem.

[`FakeClock.BlockUntil`](https://github.com/windmilleng/tilt/blob/52bc7aaf97d59c6ba74e11f7bb0834567b1c9ce2/vendor/github.com/jonboulle/clockwork/clockwork.go#L25) seems like an easy solution to this. I'd seen this method but wasn't really sure why it existed. Maybe this is why!