### PR TITLE
docker: even if DOCKER_BUILDKIT=1, don't use buildkit on platforms that don't support it

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -170,7 +170,7 @@ func getDockerBuilderVersion(v types.Version, env k8s.Env) (types.BuilderVersion
 			// This error message is copied from Docker, for consistency.
 			return "", errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")
 		}
-		if buildkitEnabled {
+		if buildkitEnabled && SupportsBuildkit(v, env) {
 			return types.BuilderBuildKit, nil
 
 		}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -51,7 +51,7 @@ func TestProvideBuilderVersion(t *testing.T) {
 	cases := []builderVersionTestCase{
 		{"1.37", "", types.BuilderV1},
 		{"1.37", "0", types.BuilderV1},
-		{"1.37", "1", types.BuilderBuildKit},
+		{"1.37", "1", types.BuilderV1},
 		{"1.40", "", types.BuilderBuildKit},
 		{"1.40", "0", types.BuilderV1},
 		{"1.40", "1", types.BuilderBuildKit},


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/issue1892:

2d153b85b5344a19cceae4efeadc34e43a026917 (2019-07-23 11:39:09 -0400)
docker: even if DOCKER_BUILDKIT=1, don't use buildkit on platforms that don't support it