### PR TITLE
engine: use fake DC client in upper tests

### DIFF
--- a/internal/engine/testdata/fixture_docker-config.yml
+++ b/internal/engine/testdata/fixture_docker-config.yml
@@ -5,8 +5,6 @@ services:
     image: redis:alpine
     network_mode: bridge
   server:
-    build:
-      context: REPLACE_ME
     environment:
       NAME: TheServer
     expose:

--- a/internal/engine/testdata/fixture_docker-config.yml
+++ b/internal/engine/testdata/fixture_docker-config.yml
@@ -1,13 +1,17 @@
-server:
-  build: .
-  links:
-    - redis
-  expose:
-    - "3000"
-  environment:
-    - NAME=TheServer
-
-redis:
-  image: redis:alpine
-  expose:
-    - "6379"
+services:
+  redis:
+    expose:
+      - '6379'
+    image: redis:alpine
+    network_mode: bridge
+  server:
+    build:
+      context: REPLACE_ME
+    environment:
+      NAME: TheServer
+    expose:
+      - '3000'
+    links:
+      - redis
+    network_mode: bridge
+version: '2.1'

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3032,11 +3032,7 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 	}
 	f.dcc.ConfigOutput = string(y)
 
-	servicesOutput := strings.Builder{}
-	for s := range dcConfig.Services {
-		_, _ = servicesOutput.WriteString(fmt.Sprintf("%s\n", s))
-	}
-	f.dcc.ServicesOutput = servicesOutput.String()
+	f.dcc.ServicesOutput = "redis\nserver\n"
 
 	tlr, err := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), nil)
 	if err != nil {

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -132,7 +132,7 @@ func (s *tiltfileState) getDCService(name string) (*dcService, error) {
 
 // Go representations of docker-compose.yml
 // (Add fields as we need to support more things)
-type dcConfig struct {
+type DcConfig struct {
 	Services map[string]dcServiceConfig
 }
 
@@ -227,7 +227,7 @@ func (p *Ports) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // We use a custom Unmarshal method here so that we can store the RawYAML in addition
 // to unmarshaling the fields we care about into structs.
-func (c *dcConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *DcConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	aux := struct {
 		Services map[string]interface{} `yaml:"services"`
 	}{}
@@ -287,7 +287,7 @@ type dcService struct {
 	TriggerMode triggerMode
 }
 
-func (c dcConfig) GetService(name string) (dcService, error) {
+func (c DcConfig) GetService(name string) (dcService, error) {
 	svcConfig, ok := c.Services[name]
 	if !ok {
 		return dcService{}, fmt.Errorf("no service %s found in config", name)
@@ -386,7 +386,7 @@ func parseDCConfig(ctx context.Context, dcc dockercompose.DockerComposeClient, c
 }
 
 func getConfigAndServiceNames(ctx context.Context, dcc dockercompose.DockerComposeClient,
-	configPaths []string) (conf dcConfig, svcNames []string, err error) {
+	configPaths []string) (conf DcConfig, svcNames []string, err error) {
 	// calls to `docker-compose config` take a bit, and we need two,
 	// so do them in parallel to make things faster
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
(because reproing a flaky DC upper test is really annoying when it takes 2 seconds)