### PR TITLE
engine: fix flaky DC upper test

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2214,12 +2214,8 @@ func TestDockerComposeDetectsCrashes(t *testing.T) {
 	f.dcc.SendEvent(dcContainerEvtForManifest(m1, dockercompose.ActionStart))
 	f.dcc.SendEvent(dcContainerEvtForManifest(m1, dockercompose.ActionDie))
 
-	f.WaitUntilManifestState("has a status", m1.ManifestName(), func(st store.ManifestState) bool {
-		return st.DCResourceState().Status != ""
-	})
-
-	f.withManifestState(m1.ManifestName(), func(st store.ManifestState) {
-		assert.Equal(t, dockercompose.StatusCrash, st.DCResourceState().Status)
+	f.WaitUntilManifestState("is crashing", m1.ManifestName(), func(st store.ManifestState) bool {
+		return st.DCResourceState().Status == dockercompose.StatusCrash
 	})
 
 	f.withManifestState(m2.ManifestName(), func(st store.ManifestState) {
@@ -2235,11 +2231,7 @@ func TestDockerComposeDetectsCrashes(t *testing.T) {
 	f.dcc.SendEvent(dcContainerEvtForManifest(m1, dockercompose.ActionStart))
 
 	f.WaitUntilManifestState("is not crashing", m1.ManifestName(), func(st store.ManifestState) bool {
-		return st.DCResourceState().Status != dockercompose.StatusCrash
-	})
-
-	f.withManifestState(m1.ManifestName(), func(st store.ManifestState) {
-		assert.NotEqual(t, dockercompose.StatusCrash, st.DCResourceState().Status)
+		return st.DCResourceState().Status == dockercompose.StatusUp
 	})
 }
 


### PR DESCRIPTION
This test occasionally failed with:
```
        	Error:      	Not equal:
        	            	expected: "Crash"
        	            	actual  : "Down"
```

basically, [here](https://github.com/windmilleng/tilt/blob/8c9e1aacab535e1e7f790a8264948f443aff7ce8/internal/engine/upper_test.go#L2217), we send the container through a bunch of states and then assert that the first non-empty state that exists is "Crash". This passes if all the engine processes all state transitions before the test first notices the state is non-empty, but occasionally fails when the test manages to inspect the state in the middle of the state transitions.