### PR TITLE
docker: fix minikube detection when DOCKER_HOST is already set to the minikube docker host. Fixes https://github.com/windmilleng/tilt/issues/1892

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -56,7 +56,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 		t.Fatal(err)
 	}
 
-	dCli, err := docker.NewDockerClient(ctx, docker.Env(dEnv), env)
+	dCli, err := docker.NewDockerClient(ctx, docker.Env(dEnv))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/clients.go
+++ b/internal/docker/clients.go
@@ -2,24 +2,22 @@ package docker
 
 import (
 	"context"
-
-	"github.com/windmilleng/tilt/internal/k8s"
 )
 
 type LocalClient Client
 type ClusterClient Client
 
-func ProvideClusterCli(ctx context.Context, lEnv LocalEnv, cEnv ClusterEnv, kEnv k8s.Env, lClient LocalClient) (ClusterClient, error) {
+func ProvideClusterCli(ctx context.Context, lEnv LocalEnv, cEnv ClusterEnv, lClient LocalClient) (ClusterClient, error) {
 	// If the Cluster Env and the LocalEnv are the same, we can re-use the cluster
 	// client as a local client.
 	if Env(lEnv) == Env(cEnv) {
 		return ClusterClient(lClient), nil
 	}
-	result, err := NewDockerClient(ctx, Env(cEnv), kEnv)
+	result, err := NewDockerClient(ctx, Env(cEnv))
 	return ClusterClient(result), err
 }
 
 func ProvideLocalCli(ctx context.Context, lEnv LocalEnv) (LocalClient, error) {
-	result, err := NewDockerClient(ctx, Env(lEnv), k8s.EnvNone)
+	result, err := NewDockerClient(ctx, Env(lEnv))
 	return LocalClient(result), err
 }

--- a/internal/docker/wire.go
+++ b/internal/docker/wire.go
@@ -31,4 +31,9 @@ var ClusterWireSet = wire.NewSet(
 var LocalWireSet = wire.NewSet(
 	ProvideLocalCli,
 	ProvideLocalEnv,
+	ProvideEmptyClusterEnv,
 	ProvideLocalAsDefault)
+
+func ProvideEmptyClusterEnv() ClusterEnv {
+	return ClusterEnv{}
+}

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -15,7 +15,8 @@ import (
 // Injectors from wire.go:
 
 func WireSynclet(ctx context.Context, runtime container.Runtime) (*Synclet, error) {
-	localEnv, err := docker.ProvideLocalEnv(ctx)
+	clusterEnv := docker.ProvideEmptyClusterEnv()
+	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/issue1892:

1895acfc8eb21783d71b6a41cb4dca35d2966c3f (2019-07-24 12:23:55 -0400)
docker: fix minikube detection when DOCKER_HOST is already set to the minikube docker host. Fixes https://github.com/windmilleng/tilt/issues/1892