### PR TITLE
store: remove FilesReplacedSet

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -471,21 +471,10 @@ func TestIncrementalBuildTwice(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := manifest.ImageTargetAt(0).ID()
-	rSet := firstResult[id].FilesReplacedSet
-	if len(rSet) != 1 || !rSet[aPath] {
-		t.Errorf("Expected replaced set with a.txt, actual: %v", rSet)
-	}
-
 	secondState := resultToStateSet(firstResult, []string{bPath}, f.deployInfo())
-	secondResult, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, secondState)
+	_, err = f.bd.BuildAndDeploy(f.ctx, f.st, targets, secondState)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	rSet = secondResult[id].FilesReplacedSet
-	if len(rSet) != 2 || !rSet[aPath] || !rSet[bPath] {
-		t.Errorf("Expected replaced set with a.txt, b.txt, actual: %v", rSet)
 	}
 
 	if f.docker.BuildCount != 0 {
@@ -520,24 +509,13 @@ func TestIncrementalBuildTwiceDeadPod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := manifest.ImageTargetAt(0).ID()
-	rSet := firstResult[id].FilesReplacedSet
-	if len(rSet) != 1 || !rSet[aPath] {
-		t.Errorf("Expected replaced set with a.txt, actual: %v", rSet)
-	}
-
 	// Kill the pod
 	f.docker.ExecErrorToThrow = fmt.Errorf("Dead pod")
 
 	secondState := resultToStateSet(firstResult, []string{bPath}, f.deployInfo())
-	secondResult, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, secondState)
+	_, err = f.bd.BuildAndDeploy(f.ctx, f.st, targets, secondState)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	rSet = secondResult[id].FilesReplacedSet
-	if len(rSet) != 0 {
-		t.Errorf("Expected empty replaced set, actual: %v", rSet)
 	}
 
 	if f.docker.BuildCount != 1 {

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -18,7 +18,7 @@ type liveUpdateStateTree struct {
 func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	iTargetID := t.iTarget.ID()
 	state := t.iTargetState
-	res := state.LastResult.ShallowCloneForContainerUpdate(state.FilesChangedSet)
+	res := state.LastResult
 	res.ContainerID = state.DeployInfo.ContainerID
 
 	resultSet := store.BuildResultSet{}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/files:

52d0e6a03e222bf15ed3fa09bc96f1ac61735a74 (2019-07-25 17:57:20 -0400)
store: remove FilesReplacedSet
This was only necessary in a world where we had two incremental build strategies
(incremental image builds and container updates). Now that we only have
container updates, we can remove the code needed to reconcile them when files diverged