### PR TITLE
tiltfile: include entity and image name when failing to parse image names in k8s objects

### DIFF
--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -251,7 +251,7 @@ func (e K8sEntity) FindImages(imageJSONPaths []JSONPath, envVarImages []containe
 	for _, c := range containers {
 		ref, err := container.ParseNamed(c.Image)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "parsing %s", c.Image)
 		}
 
 		result = append(result, ref)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -543,7 +543,7 @@ func (s *tiltfileState) isWorkload(e k8s.K8sEntity) (bool, error) {
 
 	images, err := e.FindImages(s.imageJSONPaths(e), s.envVarImages())
 	if err != nil {
-		return false, err
+		return false, errors.Wrapf(err, "finding images in %s", e.Name())``
 	} else {
 		return len(images) > 0, nil
 	}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -543,7 +543,7 @@ func (s *tiltfileState) isWorkload(e k8s.K8sEntity) (bool, error) {
 
 	images, err := e.FindImages(s.imageJSONPaths(e), s.envVarImages())
 	if err != nil {
-		return false, errors.Wrapf(err, "finding images in %s", e.Name())``
+		return false, errors.Wrapf(err, "finding images in %s", e.Name())
 	} else {
 		return len(images) > 0, nil
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -522,7 +522,7 @@ docker_build('gcr.io/a', 'a')
 	f.loadErrString("Image for ref \"gcr.io/a\" has already been defined")
 }
 
-func TestInvalidImageName(t *testing.T) {
+func TestInvalidImageNameInDockerBuild(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -532,7 +532,27 @@ k8s_yaml('all.yaml')
 docker_build("ceci n'est pas une valid image ref", 'a')
 `)
 
-	f.loadErrString("invalid reference format")
+	f.loadErrString("invalid reference format", "asdf", "asdf")
+}
+
+func TestInvalidImageNameInK8SYAML(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+yaml_str = """
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - image: IMAGE_URL
+"""
+
+k8s_yaml([blob(yaml_str)])`)
+
+	f.loadErrString("invalid reference format", "test-pod", "IMAGE_URL")
 }
 
 func TestFastBuildAddString(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -532,7 +532,7 @@ k8s_yaml('all.yaml')
 docker_build("ceci n'est pas une valid image ref", 'a')
 `)
 
-	f.loadErrString("invalid reference format", "asdf", "asdf")
+	f.loadErrString("invalid reference format")
 }
 
 func TestInvalidImageNameInK8SYAML(t *testing.T) {


### PR DESCRIPTION
fixes #1918 

old output:
```
Starting Tilt (v0.9.3-dev, built 2019-07-24)…
Installing Tilt NodeJS dependencies…
Beginning Tiltfile execution
invalid reference format: repository name must be lowercase
Starting Tilt webpack server…
```

new output:
```
Starting Tilt (v0.9.3-dev, built 2019-07-26)…
Beginning Tiltfile execution
Installing Tilt NodeJS dependencies…
finding images in test-pod: parsing IMAGE_URL: invalid reference format:
repository name must be lowercase
Starting Tilt webpack server…
```