### PR TITLE
engine/store: s/deployInfo/containerInfo, can attach multiple containerInfos to a  BuildState if that target is deployed to multiple containers [ch3004]

### DIFF
--- a/internal/containerupdate/container_updater.go
+++ b/internal/containerupdate/container_updater.go
@@ -9,6 +9,6 @@ import (
 )
 
 type ContainerUpdater interface {
-	UpdateContainer(ctx context.Context, deployInfo store.DeployInfo,
+	UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
 		archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error
 }

--- a/internal/containerupdate/docker_container_updater_test.go
+++ b/internal/containerupdate/docker_container_updater_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 )
 
-var TestDeployInfo = store.DeployInfo{
+var TestContainerInfo = store.ContainerInfo{
 	PodID:         "somepod",
 	ContainerID:   docker.TestContainer,
 	ContainerName: "my-container",
@@ -29,7 +29,7 @@ func TestUpdateInContainerCopiesAndRmsFiles(t *testing.T) {
 
 	archive := bytes.NewBuffer([]byte("hello world"))
 	toDelete := []string{"/src/does-not-exist"}
-	err := f.dcu.UpdateContainer(f.ctx, TestDeployInfo, archive, toDelete, nil, false)
+	err := f.dcu.UpdateContainer(f.ctx, TestContainerInfo, archive, toDelete, nil, false)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestUpdateContainerExecsRuns(t *testing.T) {
 	cmdA := model.Cmd{Argv: []string{"a"}}
 	cmdB := model.Cmd{Argv: []string{"cu", "and cu", "another cu"}}
 
-	err := f.dcu.UpdateContainer(f.ctx, TestDeployInfo, nil, nil, []model.Cmd{cmdA, cmdB}, false)
+	err := f.dcu.UpdateContainer(f.ctx, TestContainerInfo, nil, nil, []model.Cmd{cmdA, cmdB}, false)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestUpdateContainerExecsRuns(t *testing.T) {
 func TestUpdateContainerRestartsContainer(t *testing.T) {
 	f := newDCUFixture(t)
 
-	err := f.dcu.UpdateContainer(f.ctx, TestDeployInfo, nil, nil, nil, false)
+	err := f.dcu.UpdateContainer(f.ctx, TestContainerInfo, nil, nil, nil, false)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestUpdateContainerRestartsContainer(t *testing.T) {
 func TestUpdateContainerHotReloadDoesNotRestartContainer(t *testing.T) {
 	f := newDCUFixture(t)
 
-	err := f.dcu.UpdateContainer(f.ctx, TestDeployInfo, nil, nil, nil, true)
+	err := f.dcu.UpdateContainer(f.ctx, TestContainerInfo, nil, nil, nil, true)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestUpdateContainerKillTask(t *testing.T) {
 	f.dCli.ExecErrorToThrow = docker.ExitError{ExitCode: build.TaskKillExitCode}
 
 	cmdA := model.Cmd{Argv: []string{"cat"}}
-	err := f.dcu.UpdateContainer(f.ctx, TestDeployInfo, nil, nil, []model.Cmd{cmdA}, false)
+	err := f.dcu.UpdateContainer(f.ctx, TestContainerInfo, nil, nil, []model.Cmd{cmdA}, false)
 	msg := "killed by container engine"
 	if err == nil || !strings.Contains(err.Error(), msg) {
 		f.t.Errorf("Expected error %q, actual: %v", msg, err)

--- a/internal/containerupdate/exec_updater_test.go
+++ b/internal/containerupdate/exec_updater_test.go
@@ -25,7 +25,7 @@ var cmds = []model.Cmd{cmdA, cmdB}
 func TestUpdateContainerDoesntSupportRestart(t *testing.T) {
 	f := newExecFixture(t)
 
-	err := f.ecu.UpdateContainer(f.ctx, TestDeployInfo, newReader("boop"), toDelete, cmds, false)
+	err := f.ecu.UpdateContainer(f.ctx, TestContainerInfo, newReader("boop"), toDelete, cmds, false)
 	if assert.NotNil(t, err, "expect Exec UpdateContainer to fail if !hotReload") {
 		assert.Contains(t, err.Error(), "ExecUpdater does not support `restart_container()` step")
 	}
@@ -35,7 +35,7 @@ func TestUpdateContainerDeletesFiles(t *testing.T) {
 	f := newExecFixture(t)
 
 	// No files to delete
-	err := f.ecu.UpdateContainer(f.ctx, TestDeployInfo, newReader("boop"), nil, cmds, true)
+	err := f.ecu.UpdateContainer(f.ctx, TestContainerInfo, newReader("boop"), nil, cmds, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestUpdateContainerDeletesFiles(t *testing.T) {
 	}
 
 	// Two files to delete
-	err = f.ecu.UpdateContainer(f.ctx, TestDeployInfo, newReader("boop"), toDelete, cmds, true)
+	err = f.ecu.UpdateContainer(f.ctx, TestContainerInfo, newReader("boop"), toDelete, cmds, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ cmd 2: %v`, rmCmd, call.Cmd)
 func TestUpdateContainerTarsArchive(t *testing.T) {
 	f := newExecFixture(t)
 
-	err := f.ecu.UpdateContainer(f.ctx, TestDeployInfo, newReader("hello world"), nil, nil, true)
+	err := f.ecu.UpdateContainer(f.ctx, TestContainerInfo, newReader("hello world"), nil, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestUpdateContainerTarsArchive(t *testing.T) {
 func TestUpdateContainerRunsCommands(t *testing.T) {
 	f := newExecFixture(t)
 
-	err := f.ecu.UpdateContainer(f.ctx, TestDeployInfo, newReader("hello world"), nil, cmds, true)
+	err := f.ecu.UpdateContainer(f.ctx, TestContainerInfo, newReader("hello world"), nil, cmds, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/containerupdate/fake_container_updater.go
+++ b/internal/containerupdate/fake_container_updater.go
@@ -15,21 +15,21 @@ type FakeContainerUpdater struct {
 }
 
 type UpdateContainerCall struct {
-	DeployInfo store.DeployInfo
-	Archive    io.Reader
-	ToDelete   []string
-	Cmds       []model.Cmd
-	HotReload  bool
+	ContainerInfo store.ContainerInfo
+	Archive       io.Reader
+	ToDelete      []string
+	Cmds          []model.Cmd
+	HotReload     bool
 }
 
-func (cu *FakeContainerUpdater) UpdateContainer(ctx context.Context, deployInfo store.DeployInfo,
+func (cu *FakeContainerUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
 	archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error {
 	cu.Calls = append(cu.Calls, UpdateContainerCall{
-		DeployInfo: deployInfo,
-		Archive:    archiveToCopy,
-		ToDelete:   filesToDelete,
-		Cmds:       cmds,
-		HotReload:  hotReload,
+		ContainerInfo: cInfo,
+		Archive:       archiveToCopy,
+		ToDelete:      filesToDelete,
+		Cmds:          cmds,
+		HotReload:     hotReload,
 	})
 
 	err := cu.UpdateErr

--- a/internal/containerupdate/synclet_updater.go
+++ b/internal/containerupdate/synclet_updater.go
@@ -22,12 +22,12 @@ func NewSyncletUpdater(sm SyncletManager) *SyncletUpdater {
 	return &SyncletUpdater{sm: sm}
 }
 
-func (cu *SyncletUpdater) UpdateContainer(ctx context.Context, deployInfo store.DeployInfo,
+func (cu *SyncletUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
 	archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncletUpdater-UpdateContainer")
 	defer span.Finish()
 
-	sCli, err := cu.sm.ClientForPod(ctx, deployInfo.PodID, deployInfo.Namespace)
+	sCli, err := cu.sm.ClientForPod(ctx, cInfo.PodID, cInfo.Namespace)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (cu *SyncletUpdater) UpdateContainer(ctx context.Context, deployInfo store.
 		return err
 	}
 
-	err = sCli.UpdateContainer(ctx, deployInfo.ContainerID, archiveBytes, filesToDelete, cmds, hotReload)
+	err = sCli.UpdateContainer(ctx, cInfo.ContainerID, archiveBytes, filesToDelete, cmds, hotReload)
 	if err != nil && build.IsUserBuildFailure(err) {
 		return err
 	}

--- a/internal/containerupdate/synclet_updater_test.go
+++ b/internal/containerupdate/synclet_updater_test.go
@@ -15,7 +15,7 @@ import (
 func TestUpdateContainer(t *testing.T) {
 	f := newSyncletFixture(t)
 
-	err := f.scu.UpdateContainer(f.ctx, TestDeployInfo, newReader("hello world"), toDelete, cmds, false)
+	err := f.scu.UpdateContainer(f.ctx, TestContainerInfo, newReader("hello world"), toDelete, cmds, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -870,7 +870,7 @@ func (f *bdFixture) createBuildStateSet(manifest model.Manifest, changedFiles []
 
 		state := store.NewBuildState(alreadyBuilt, filesChangingImage)
 		if manifest.IsImageDeployed(iTarget) {
-			state = state.WithRunningContainer(testContainerInfo)
+			state = state.WithRunningContainers([]store.ContainerInfo{testContainerInfo})
 		}
 		bs[iTarget.ID()] = state
 	}
@@ -883,10 +883,10 @@ func (f *bdFixture) createBuildStateSet(manifest model.Manifest, changedFiles []
 	return bs
 }
 
-func resultToStateSet(resultSet store.BuildResultSet, files []string, deploy store.ContainerInfo) store.BuildStateSet {
+func resultToStateSet(resultSet store.BuildResultSet, files []string, cInfo store.ContainerInfo) store.BuildStateSet {
 	stateSet := store.BuildStateSet{}
 	for id, result := range resultSet {
-		state := store.NewBuildState(result, files).WithRunningContainer(deploy)
+		state := store.NewBuildState(result, files).WithRunningContainers([]store.ContainerInfo{cInfo})
 		stateSet[id] = state
 	}
 	return stateSet

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -327,11 +327,11 @@ func buildStateSet(manifest model.Manifest, specs []model.TargetSpec, ms *store.
 			iTarget, ok := spec.(model.ImageTarget)
 			if ok {
 				if manifest.IsK8s() {
-					buildState = buildState.WithDeployTarget(store.NewDeployInfo(iTarget, ms.DeployID, ms.PodSet))
+					buildState = buildState.WithRunningContainer(store.RunningContainersForTarget(iTarget, ms.DeployID, ms.PodSet))
 				}
 
 				if manifest.IsDC() {
-					buildState = buildState.WithDeployTarget(store.NewDeployInfoFromDC(ms.DCResourceState()))
+					buildState = buildState.WithRunningContainer(store.RunningContainersForDC(ms.DCResourceState()))
 				}
 			}
 		}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -327,11 +327,11 @@ func buildStateSet(manifest model.Manifest, specs []model.TargetSpec, ms *store.
 			iTarget, ok := spec.(model.ImageTarget)
 			if ok {
 				if manifest.IsK8s() {
-					buildState = buildState.WithRunningContainer(store.RunningContainersForTarget(iTarget, ms.DeployID, ms.PodSet))
+					buildState = buildState.WithRunningContainers(store.RunningContainersForTarget(iTarget, ms.DeployID, ms.PodSet))
 				}
 
 				if manifest.IsDC() {
-					buildState = buildState.WithRunningContainer(store.RunningContainersForDC(ms.DCResourceState()))
+					buildState = buildState.WithRunningContainers(store.RunningContainersForDC(ms.DCResourceState()))
 				}
 			}
 		}

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/windmilleng/tilt/internal/hud/server"
 
@@ -112,6 +114,93 @@ func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	// we're doing an image build)
 	call = f.nextCall()
 	assert.Equal(t, "", call.oneState().OneContainerInfo().PodID.String())
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestBuildControllerTwoContainers(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	sync := model.Sync{LocalPath: f.Path(), ContainerPath: "/go"}
+	manifest := f.newManifest("fe", []model.Sync{sync})
+	f.Start([]model.Manifest{manifest}, true)
+
+	call := f.nextCall()
+	assert.Equal(t, manifest.ImageTargetAt(0), call.image())
+	assert.Equal(t, []string{}, call.oneState().FilesChanged())
+
+	// container already on this pod matches the image built by this manifest
+	f.pod = f.testPod("pod-id", "fe", "Running", testContainer, time.Now())
+	imgName := f.pod.Status.ContainerStatuses[0].Image
+	f.pod.Status.ContainerStatuses = append(f.pod.Status.ContainerStatuses, v1.ContainerStatus{
+		Name:        "same image",
+		Image:       imgName, // matches image built by this manifest
+		Ready:       true,
+		ContainerID: "docker://cID-same-image",
+	}, v1.ContainerStatus{
+		Name:        "different image",
+		Image:       "different-image", // does NOT match image built by this manifest
+		Ready:       false,
+		ContainerID: "docker://cID-different-image",
+	})
+	f.podEvent(f.pod)
+	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+
+	call = f.nextCall()
+	runningContainers := call.oneState().RunningContainers
+
+	require.Len(t, runningContainers, 2, "expect info for two containers (those "+
+		"matching the image built by this manifest")
+
+	c0 := runningContainers[0]
+	c1 := runningContainers[1]
+
+	assert.Equal(t, "pod-id", c0.PodID.String(), "pod ID for cInfo at index 0")
+	assert.Equal(t, "pod-id", c1.PodID.String(), "pod ID for cInfo at index 1")
+
+	assert.Equal(t, testContainer, c0.ContainerID.String(), "container ID for cInfo at index 0")
+	assert.Equal(t, "cID-same-image", c1.ContainerID.String(), "container ID for cInfo at index 1")
+
+	assert.Equal(t, "test container!", c0.ContainerName.String(), "container name for cInfo at index 0")
+	assert.Equal(t, "same image", c1.ContainerName.String(), "container name for cInfo at index 1")
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	sync := model.Sync{LocalPath: f.Path(), ContainerPath: "/go"}
+	manifest := f.newManifest("fe", []model.Sync{sync})
+	f.Start([]model.Manifest{manifest}, true)
+
+	call := f.nextCall()
+	assert.Equal(t, manifest.ImageTargetAt(0), call.image())
+	assert.Equal(t, []string{}, call.oneState().FilesChanged())
+
+	// container already on this pod matches the image built by this manifest
+	f.pod = f.testPod("pod-id", "fe", "Running", testContainer, time.Now())
+	imgName := f.pod.Status.ContainerStatuses[0].Image
+	f.pod.Status.ContainerStatuses = append(f.pod.Status.ContainerStatuses, v1.ContainerStatus{
+		Name:        "same image",
+		Image:       imgName, // matches image built by this manifest
+		Ready:       false,
+		ContainerID: "docker://cID-same-image",
+	})
+	f.podEvent(f.pod)
+	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+
+	// If even one of the containers matching this image is !ready, we have to do a
+	// full rebuild, so don't return ANY RunningContainers.
+	call = f.nextCall()
+	runningContainers := call.oneState().RunningContainers
+	assert.Empty(t, runningContainers)
 
 	err := f.Stop()
 	assert.NoError(t, err)

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -32,7 +32,7 @@ func TestBuildControllerOnePod(t *testing.T) {
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
-	assert.Equal(t, "pod-id", call.oneState().RunningContainer.PodID.String())
+	assert.Equal(t, "pod-id", call.oneState().OneContainerInfo().PodID.String())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -58,7 +58,7 @@ func TestBuildControllerIgnoresImageTags(t *testing.T) {
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
-	assert.Equal(t, "pod-id", call.oneState().RunningContainer.PodID.String())
+	assert.Equal(t, "pod-id", call.oneState().OneContainerInfo().PodID.String())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -80,7 +80,7 @@ func TestBuildControllerDockerCompose(t *testing.T) {
 
 	call = f.nextCall()
 	imageState := call.state[imageTarget.ID()]
-	assert.Equal(t, "dc-sancho", imageState.RunningContainer.ContainerID.String())
+	assert.Equal(t, "dc-sancho", imageState.OneContainerInfo().ContainerID.String())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -111,7 +111,7 @@ func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	// if there are multiple pods, so make sure we're not sending deploy info (i.e. that
 	// we're doing an image build)
 	call = f.nextCall()
-	assert.Equal(t, "", call.oneState().RunningContainer.PodID.String())
+	assert.Equal(t, "", call.oneState().OneContainerInfo().PodID.String())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -136,7 +136,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
-	assert.Equal(t, "pod-id", call.oneState().RunningContainer.PodID.String())
+	assert.Equal(t, "pod-id", call.oneState().OneContainerInfo().PodID.String())
 	f.waitForCompletedBuildCount(2)
 	f.withManifestState("fe", func(ms store.ManifestState) {
 		assert.Equal(t, model.BuildReasonFlagChangedFiles, ms.LastBuild().Reason)
@@ -146,7 +146,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	// Restart the pod with a new container id, to simulate a container restart.
 	f.podEvent(f.testPod("pod-id", "fe", "Running", "funnyContainerID", time.Now()))
 	call = f.nextCall()
-	assert.True(t, call.oneState().RunningContainer.Empty())
+	assert.True(t, call.oneState().OneContainerInfo().Empty())
 	f.waitForCompletedBuildCount(3)
 
 	f.withManifestState("fe", func(ms store.ManifestState) {

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -66,9 +66,9 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		// Now that we have fast build information, we know this CAN be updated in
 		// a container. Check to see if we have enough information about the container
 		// that would need to be updated.
-		deployInfo := state.DeployInfo
-		if deployInfo.Empty() {
-			return nil, RedirectToNextBuilderInfof("don't have info for deployed container of image %q (often a result of the deployment not yet being ready)", iTarget.DeploymentRef.String())
+		cInfo := state.RunningContainer
+		if cInfo.Empty() {
+			return nil, RedirectToNextBuilderInfof("don't have info for running container of image %q (often a result of the deployment not yet being ready)", iTarget.DeploymentRef.String())
 		}
 
 		filesChanged, err := filesChangedTree(g, iTarget, stateSet)

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -64,10 +64,9 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		}
 
 		// Now that we have fast build information, we know this CAN be updated in
-		// a container. Check to see if we have enough information about the container
-		// that would need to be updated.
-		cInfo := state.RunningContainer
-		if cInfo.Empty() {
+		// a container(s). Check to see if we have enough information about the
+		// container(s) that would need to be updated.
+		if len(state.RunningContainers) == 0 {
 			return nil, RedirectToNextBuilderInfof("don't have info for running container of image %q (often a result of the deployment not yet being ready)", iTarget.DeploymentRef.String())
 		}
 

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -70,6 +70,7 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	}()
 
 	// LiveUpdateBuildAndDeployer doesn't support initial build
+	// ~~ put this check in extractImageTargetsForLiveUpdates()
 	if state.IsEmpty() {
 		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("prev. build state is empty; LiveUpdate does not support initial deploy")
 	}
@@ -124,7 +125,7 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 	l := logger.Get(ctx)
 	l.Infof("  → Updating container…")
 
-	deployInfo := state.DeployInfo
+	cInfo := state.RunningContainer
 	filter := ignore.CreateBuildContextFilter(iTarget)
 	boiledSteps, err := build.BoilRuns(runs, changedFiles)
 	if err != nil {
@@ -138,7 +139,7 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 	}
 
 	if len(toRemove) > 0 {
-		l.Infof("Will delete %d file(s) from container: %s", len(toRemove), deployInfo.ContainerID.ShortStr())
+		l.Infof("Will delete %d file(s) from container: %s", len(toRemove), cInfo.ContainerID.ShortStr())
 		for _, pm := range toRemove {
 			l.Infof("- '%s' (matched local path: '%s')", pm.ContainerPath, pm.LocalPath)
 		}
@@ -158,13 +159,13 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 	}()
 
 	if len(toArchive) > 0 {
-		l.Infof("Will copy %d file(s) to container: %s", len(toArchive), deployInfo.ContainerID.ShortStr())
+		l.Infof("Will copy %d file(s) to container: %s", len(toArchive), cInfo.ContainerID.ShortStr())
 		for _, pm := range toArchive {
 			l.Infof("- %s", pm.PrettyStr())
 		}
 	}
 
-	err = cu.UpdateContainer(ctx, deployInfo, pr, build.PathMappingsToContainerPaths(toRemove), boiledSteps, hotReload)
+	err = cu.UpdateContainer(ctx, cInfo, pr, build.PathMappingsToContainerPaths(toRemove), boiledSteps, hotReload)
 	if err != nil {
 		if build.IsUserBuildFailure(err) {
 			return WrapDontFallBackError(err)

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -125,7 +125,7 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 	l := logger.Get(ctx)
 	l.Infof("  → Updating container…")
 
-	cInfo := state.RunningContainer
+	cInfo := state.OneContainerInfo()
 	filter := ignore.CreateBuildContextFilter(iTarget)
 	boiledSteps, err := build.BoilRuns(runs, changedFiles)
 	if err != nil {

--- a/internal/engine/live_update_build_and_deployer_test.go
+++ b/internal/engine/live_update_build_and_deployer_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
-var TestDeployInfo = store.DeployInfo{
+var TestContainerInfo = store.ContainerInfo{
 	PodID:         "somepod",
 	ContainerID:   docker.TestContainer,
 	ContainerName: "my-container",
@@ -27,9 +27,9 @@ var TestDeployInfo = store.DeployInfo{
 }
 
 var TestBuildState = store.BuildState{
-	LastResult:      alreadyBuilt,
-	FilesChangedSet: map[string]bool{"foo.py": true},
-	DeployInfo:      TestDeployInfo,
+	LastResult:       alreadyBuilt,
+	FilesChangedSet:  map[string]bool{"foo.py": true},
+	RunningContainer: TestContainerInfo,
 }
 
 func TestBuildAndDeployBoilsSteps(t *testing.T) {

--- a/internal/engine/live_update_build_and_deployer_test.go
+++ b/internal/engine/live_update_build_and_deployer_test.go
@@ -27,9 +27,9 @@ var TestContainerInfo = store.ContainerInfo{
 }
 
 var TestBuildState = store.BuildState{
-	LastResult:       alreadyBuilt,
-	FilesChangedSet:  map[string]bool{"foo.py": true},
-	RunningContainer: TestContainerInfo,
+	LastResult:        alreadyBuilt,
+	FilesChangedSet:   map[string]bool{"foo.py": true},
+	RunningContainers: []store.ContainerInfo{TestContainerInfo},
 }
 
 func TestBuildAndDeployBoilsSteps(t *testing.T) {

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -19,7 +19,9 @@ func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	iTargetID := t.iTarget.ID()
 	state := t.iTargetState
 	res := state.LastResult
-	res.ContainerID = state.DeployInfo.ContainerID
+
+	// ~~ res.containerIDs = [di.cid for di in state.deployInfos]
+	res.ContainerID = state.RunningContainer.ContainerID
 
 	resultSet := store.BuildResultSet{}
 	resultSet[iTargetID] = res

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -20,8 +20,8 @@ func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	state := t.iTargetState
 	res := state.LastResult
 
-	// ~~ res.containerIDs = [di.cid for di in state.deployInfos]
-	res.ContainerID = state.RunningContainer.ContainerID
+	// TODO(maia): result should have a LIST of expected container IDs
+	res.ContainerID = state.OneContainerInfo().ContainerID
 
 	resultSet := store.BuildResultSet{}
 	resultSet[iTargetID] = res

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1650,7 +1650,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
-	assert.Equal(t, "pod-id", call.oneState().RunningContainer.PodID.String())
+	assert.Equal(t, "pod-id", call.oneState().OneContainerInfo().PodID.String())
 	f.waitForCompletedBuildCount(2)
 	f.withManifestState("fe", func(ms store.ManifestState) {
 		assert.Equal(t, model.BuildReasonFlagChangedFiles, ms.LastBuild().Reason)
@@ -1661,7 +1661,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	// Restart the pod with a new container id, to simulate a container restart.
 	f.podEvent(f.testPod("pod-id", "fe", "Running", "funnyContainerID", time.Now()))
 	call = f.nextCall()
-	assert.True(t, call.oneState().RunningContainer.Empty())
+	assert.True(t, call.oneState().OneContainerInfo().Empty())
 	f.waitForCompletedBuildCount(3)
 
 	f.withManifestState("fe", func(ms store.ManifestState) {
@@ -1674,7 +1674,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	// at this point we have not received a pod event for pod that was started by the crash-rebuild,
 	// so any known pod info would have to be invalid to use for a build and this BuildState should
 	// not have any ContainerInfo
-	assert.True(t, call.oneState().RunningContainer.Empty())
+	assert.True(t, call.oneState().OneContainerInfo().Empty())
 
 	err := f.Stop()
 	assert.NoError(t, err)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1650,7 +1650,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
-	assert.Equal(t, "pod-id", call.oneState().DeployInfo.PodID.String())
+	assert.Equal(t, "pod-id", call.oneState().RunningContainer.PodID.String())
 	f.waitForCompletedBuildCount(2)
 	f.withManifestState("fe", func(ms store.ManifestState) {
 		assert.Equal(t, model.BuildReasonFlagChangedFiles, ms.LastBuild().Reason)
@@ -1661,7 +1661,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	// Restart the pod with a new container id, to simulate a container restart.
 	f.podEvent(f.testPod("pod-id", "fe", "Running", "funnyContainerID", time.Now()))
 	call = f.nextCall()
-	assert.True(t, call.oneState().DeployInfo.Empty())
+	assert.True(t, call.oneState().RunningContainer.Empty())
 	f.waitForCompletedBuildCount(3)
 
 	f.withManifestState("fe", func(ms store.ManifestState) {
@@ -1672,8 +1672,9 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main2.go"))
 	call = f.nextCall()
 	// at this point we have not received a pod event for pod that was started by the crash-rebuild,
-	// so any known pod info would have to be invalid to use for a build and this buildstate should not have any deployinfo
-	assert.True(t, call.oneState().DeployInfo.Empty())
+	// so any known pod info would have to be invalid to use for a build and this BuildState should
+	// not have any ContainerInfo
+	assert.True(t, call.oneState().RunningContainer.Empty())
 
 	err := f.Stop()
 	assert.NoError(t, err)

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -182,7 +182,7 @@ func (c ContainerInfo) Empty() bool {
 	return c == ContainerInfo{}
 }
 
-// IF all containers running the given image are ready, returns info for them.
+// If all containers running the given image are ready, returns info for them.
 // (Currently only supports containers running on a single pod.)
 func RunningContainersForTarget(iTarget model.ImageTarget, deployID model.DeployID, podSet PodSet) []ContainerInfo {
 	if podSet.Len() != 1 {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -802,8 +802,8 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 //
 // Currently, we only collect container information for the first Tilt-built container
 // on the pod (b/c of how we assemble resources, this corresponds to the first image target).
-// We won't collect container info (including DeployInfo) on any subsequent containers
-// (i.e. subsequent image targets), so will never be able to LiveUpdate them.
+// We won't collect container info on any subsequent containers (i.e. subsequent image
+// targets), so will never be able to LiveUpdate them.
 func (s *tiltfileState) checkForImpossibleLiveUpdates(m model.Manifest) error {
 	seenDeployedImage := false
 


### PR DESCRIPTION
Hello @landism, @dbentley,

Please review the following commits I made in branch maiamcc/build-state-container-info:

2cba776cba2696e7d8f169865a896b75ccd9e345 (2019-07-26 14:42:13 -0400)
tests

0d8c430dadb73c00111f230c81bc727c2e5f526a (2019-07-26 14:39:29 -0400)
make containerInfo for all containers on pod

ca0d8448596b0a2e6ac8ec022c9ccab24ec2ebc1 (2019-07-26 12:42:36 -0400)
store multiple container infos (theoretically)

b6a00b125d47617c45e40571be16ab6d52303282 (2019-07-26 11:48:18 -0400)
s/deployInfo/containerInfo

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics