### PR TITLE
store/engine: BuildResult can have multiple container IDs

### DIFF
--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -129,7 +129,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	for _, iTarget := range iTargets {
 		if isImageDeployedToDC(iTarget, dcTarget) {
 			result := results[iTarget.ID()]
-			result.ContainerID = cid
+			result.ContainerIDs = []container.ID{cid}
 			results[iTarget.ID()] = result
 		}
 	}

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -240,9 +240,9 @@ func TestImageIsDirtyAfterContainerBuild(t *testing.T) {
 	manifest := NewSanchoDockerBuildManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
 	result1 := store.BuildResult{
-		TargetID:    iTargetID1,
-		Image:       container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"),
-		ContainerID: container.ID("12345"),
+		TargetID:     iTargetID1,
+		Image:        container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"),
+		ContainerIDs: []container.ID{container.ID("12345")},
 	}
 
 	stateSet := store.BuildStateSet{

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -20,8 +20,10 @@ func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	state := t.iTargetState
 	res := state.LastResult
 
-	// TODO(maia): result should have a LIST of expected container IDs
-	res.ContainerID = state.OneContainerInfo().ContainerID
+	res.ContainerIDs = nil
+	for _, c := range state.RunningContainers {
+		res.ContainerIDs = append(res.ContainerIDs, c.ContainerID)
+	}
 
 	resultSet := store.BuildResultSet{}
 	resultSet[iTargetID] = res

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -331,7 +331,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	if engineState.WatchFiles {
 		logger.Get(ctx).Debugf("[timing.py] finished build from file change") // hook for timing.py
 
-		cID := cb.Result.OneAndOnlyContainerID()
+		cID := cb.Result.OneContainerIDForOldBehavior()
 		if cID != "" {
 			ms.ExpectedContainerID = cID
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -150,7 +150,7 @@ func (b *fakeBuildAndDeployer) nextBuildResult(iTarget model.ImageTarget, deploy
 		containerID = container.ID(fmt.Sprintf("dc-%s", path.Base(named.Name())))
 	}
 	result := store.NewImageBuildResult(iTarget.ID(), nt)
-	result.ContainerID = containerID
+	result.ContainerIDs = []container.ID{containerID}
 	return result
 }
 
@@ -3211,7 +3211,7 @@ func containerResultSet(manifest model.Manifest, id container.ID) store.BuildRes
 	for _, iTarget := range manifest.ImageTargets {
 		ref, _ := reference.WithTag(iTarget.DeploymentRef, "deadbeef")
 		result := store.NewImageBuildResult(iTarget.ID(), ref)
-		result.ContainerID = id
+		result.ContainerIDs = []container.ID{id}
 		resultSet[iTarget.ID()] = result
 	}
 	return resultSet

--- a/internal/store/build_result_test.go
+++ b/internal/store/build_result_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/model"
 )
 
@@ -17,15 +18,15 @@ func imageID(s string) model.TargetID {
 
 func TestOneAndOnlyContainerID(t *testing.T) {
 	set := BuildResultSet{
-		imageID("a"): BuildResult{ContainerID: "cA"},
-		imageID("b"): BuildResult{ContainerID: "cB"},
+		imageID("a"): BuildResult{ContainerIDs: []container.ID{"cA"}},
+		imageID("b"): BuildResult{ContainerIDs: []container.ID{"cB"}},
 	}
 	assert.Equal(t, "", string(set.OneAndOnlyContainerID()))
 
 	set = BuildResultSet{
-		imageID("a"): BuildResult{ContainerID: "cA"},
-		imageID("b"): BuildResult{ContainerID: "cA"},
-		imageID("c"): BuildResult{ContainerID: ""},
+		imageID("a"): BuildResult{ContainerIDs: []container.ID{"cA"}},
+		imageID("b"): BuildResult{ContainerIDs: []container.ID{"cA"}},
+		imageID("c"): BuildResult{ContainerIDs: []container.ID{""}},
 	}
 	assert.Equal(t, "cA", string(set.OneAndOnlyContainerID()))
 }


### PR DESCRIPTION
Hello @dbentley, @nicks,

Please review the following commits I made in branch maiamcc/build-result-multi-container:

a86e80e3a1bb62a42644c8378e8836e6d11b7b17 (2019-07-26 15:26:13 -0400)
store/engine: BuildResult can have multiple container IDs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics