### PR TITLE
Errors have button to get Alert URL

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -297,7 +297,6 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 	span, ctx := opentracing.StartSpanFromContext(ctx, "daemon-buildFromDf")
 	defer span.Finish()
 
-	// TODO(Han): Extend output to print without newline
 	ps.StartBuildStep(ctx, "Tarring context…")
 
 	// NOTE(maia): some people want to know what files we're adding (b/c `ADD . /` isn't descriptive)

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -27,6 +27,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/sail/client"
 	"github.com/windmilleng/tilt/internal/store"
+	tft "github.com/windmilleng/tilt/internal/tft/client"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 )
 
@@ -104,6 +105,7 @@ var BaseWireSet = wire.NewSet(
 	provideSailMode,
 	provideSailURL,
 	client.SailWireSet,
+	tft.ProvideClient,
 
 	provideThreads,
 	engine.NewKINDPusher,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -32,6 +32,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/sail/client"
 	"github.com/windmilleng/tilt/internal/store"
+	client2 "github.com/windmilleng/tilt/internal/tft/client"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 )
 
@@ -152,7 +153,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	sailRoomer := client.ProvideSailRoomer(sailURL)
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient)
+	clientClient := client2.ProvideClient()
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient, clientClient)
 	modelNoBrowser := provideNoBrowserFlag()
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL, modelNoBrowser)
 	githubClientFactory := engine.NewGithubClientFactory()
@@ -287,7 +289,8 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	sailRoomer := client.ProvideSailRoomer(sailURL)
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient)
+	clientClient := client2.ProvideClient()
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient, clientClient)
 	modelNoBrowser := provideNoBrowserFlag()
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL, modelNoBrowser)
 	githubClientFactory := engine.NewGithubClientFactory()
@@ -458,7 +461,7 @@ var BaseWireSet = wire.NewSet(
 	provideWebPort,
 	provideWebDevPort,
 	provideNoBrowserFlag, server.ProvideHeadsUpServer, assets.ProvideAssetServer, server.ProvideHeadsUpServerController, provideSailMode,
-	provideSailURL, client.SailWireSet, provideThreads, engine.NewKINDPusher, wire.Value(feature.MainDefaults),
+	provideSailURL, client.SailWireSet, client2.ProvideClient, provideThreads, engine.NewKINDPusher, wire.Value(feature.MainDefaults),
 )
 
 type Threads struct {

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -20,6 +20,7 @@ const (
 
 const MultipleContainersPerPod = "multiple_containers_per_pod"
 const Events = "events"
+const TeamAlerts = "team_alerts"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -39,6 +40,10 @@ var MainDefaults = Defaults{
 	},
 	Events: Value{
 		Enabled: true,
+		Status:  Active,
+	},
+	TeamAlerts: Value{
+		Enabled: false,
 		Status:  Active,
 	},
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -9,9 +10,6 @@ import (
 	"github.com/gorilla/mux"
 	_ "github.com/gorilla/websocket"
 	"github.com/windmilleng/wmclient/pkg/analytics"
-
-	"context"
-
 	tiltanalytics "github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/hud/webview"

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -265,18 +265,19 @@ func templateAlertURL(id tft.AlertID) string {
 }
 
 type tsAlert struct {
-	AlertType string `json:"alertType"`
-	Msg       string `json:"msg"`
-	Timestamp string `json:"timestamp"`
-	TitleMsg  string `json:"titleMsg"`
+	AlertType    string `json:"alertType"`
+	Header       string `json:"header"`
+	Msg          string `json:"msg"`
+	Timestamp    string `json:"timestamp"`
+	ResourceName string `json:"resourceName"`
 }
 
 func tsAlertToBackendAlert(alert tsAlert) tft.Alert {
 	return tft.Alert{
 		AlertType:    alert.AlertType,
+		Header:       alert.Header,
 		Msg:          alert.Msg,
 		RFC3339Time:  alert.Timestamp,
-		ResourceName: "", //TODO(Han)
-		Header:       alert.TitleMsg,
+		ResourceName: alert.ResourceName,
 	}
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -257,7 +257,7 @@ func (s *HeadsUpServer) HandleNewAlert(w http.ResponseWriter, req *http.Request)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	_, _ = w.Write(js)
 }
 
 func templateAlertURL(id tft.AlertID) string {

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	_ "github.com/gorilla/websocket"
 	"github.com/windmilleng/wmclient/pkg/analytics"
+
 	tiltanalytics "github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/assets"
 	"github.com/windmilleng/tilt/internal/hud/webview"

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -56,6 +56,7 @@ func ProvideHeadsUpServer(store *store.Store, assetServer assets.Server, analyti
 	//r.HandleFunc("/api/alerts_notification", s.HandleAlertsNotification)
 	r.HandleFunc("/api/sail", s.HandleSail)
 	r.HandleFunc("/api/trigger", s.HandleTrigger)
+	r.HandleFunc("/api/alerts/new", s.HandleNewAlert)
 	r.HandleFunc("/ws/view", s.ViewWebsocket)
 	r.PathPrefix("/").Handler(assetServer)
 
@@ -218,4 +219,26 @@ func MaybeSendToTriggerQueue(st store.RStore, name string) error {
 
 	st.Dispatch(AppendToTriggerQueueAction{Name: mName})
 	return nil
+}
+
+type NewAlertResponse struct {
+	Url string `json:"url"`
+}
+
+func (s *HeadsUpServer) HandleNewAlert(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "must be POST request", http.StatusBadRequest)
+		return
+	}
+
+	responsePayload := &NewAlertResponse{
+		Url: "http://www.something.com",
+	}
+	js, err := json.Marshal(responsePayload)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("unable to marshal JSON (%+v) response: %v", responsePayload, err), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -19,6 +19,8 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 )
 
+const TiltAlertsDomain = "alerts.tilt.dev"
+
 type analyticsPayload struct {
 	Verb string            `json:"verb"`
 	Name string            `json:"name"`
@@ -231,8 +233,11 @@ func (s *HeadsUpServer) HandleNewAlert(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	// TODO(dmiller): actually make request to alerts backend
+
+	id := ""
 	responsePayload := &NewAlertResponse{
-		Url: "http://www.something.com",
+		Url: templateAlertURL(id),
 	}
 	js, err := json.Marshal(responsePayload)
 	if err != nil {
@@ -241,4 +246,8 @@ func (s *HeadsUpServer) HandleNewAlert(w http.ResponseWriter, req *http.Request)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(js)
+}
+
+func templateAlertURL(id string) string {
+	return fmt.Sprintf("http://%s/%s", TiltAlertsDomain, id)
 }

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -368,6 +368,28 @@ func TestMaybeSendToTriggerQueue_notManualManifest(t *testing.T) {
 	store.AssertNoActionOfType(t, reflect.TypeOf(server.AppendToTriggerQueueAction{}), f.getActions)
 }
 
+func TestHandleNewAlert(t *testing.T) {
+	f := newTestFixture(t)
+
+	var jsonStr = []byte(`{"alertType": "build", "msg": "test", "timestamp": "2019-04-22T11:00:01-04:00", "tilteMsg": ""}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/alerts/new", bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(f.serv.HandleNewAlert)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+	assert.Contains(t, rr.Body.String(), "http://www.something.com")
+}
+
 type serverFixture struct {
 	t          *testing.T
 	serv       *server.HeadsUpServer

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -372,7 +372,7 @@ func TestMaybeSendToTriggerQueue_notManualManifest(t *testing.T) {
 func TestHandleNewAlert(t *testing.T) {
 	f := newTestFixture(t)
 
-	var jsonStr = []byte(`{"alertType": "build", "msg": "test", "timestamp": "2019-04-22T11:00:01-04:00", "tilteMsg": ""}`)
+	var jsonStr = []byte(`{"alertType": "build", "msg": "test", "timestamp": "2019-04-22T11:00:01-04:00", "header": "", "resourceName": "doggos"}`)
 	req, err := http.NewRequest(http.MethodPost, "/api/alerts/new", bytes.NewBuffer(jsonStr))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/sail/client"
 	"github.com/windmilleng/tilt/internal/store"
+	tft "github.com/windmilleng/tilt/internal/tft/client"
 )
 
 func TestHandleAnalyticsEmptyRequest(t *testing.T) {
@@ -387,7 +388,7 @@ func TestHandleNewAlert(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusBadRequest)
 	}
-	assert.Contains(t, rr.Body.String(), "http://www.something.com")
+	assert.Contains(t, rr.Body.String(), "aaaaaa")
 }
 
 type serverFixture struct {
@@ -406,7 +407,8 @@ func newTestFixture(t *testing.T) *serverFixture {
 	a := analytics.NewMemoryAnalytics()
 	a, ta := tiltanalytics.NewMemoryTiltAnalyticsForTest(tiltanalytics.NullOpter{})
 	sailCli := client.NewFakeSailClient()
-	serv := server.ProvideHeadsUpServer(st, assets.NewFakeServer(), ta, sailCli)
+	tftClient := tft.ProvideFakeClient()
+	serv := server.ProvideHeadsUpServer(st, assets.NewFakeServer(), ta, sailCli, tftClient)
 
 	return &serverFixture{
 		t:          t,

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -13,6 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 )
 
+// TODO(Han) add feature flags to here
 func StateToWebView(s store.EngineState) View {
 	ret := View{}
 

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -13,7 +13,6 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 )
 
-// TODO(Han) add feature flags to here
 func StateToWebView(s store.EngineState) View {
 	ret := View{}
 

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -102,6 +102,7 @@ func StateToWebView(s store.EngineState) View {
 	ret.NeedsAnalyticsNudge = NeedsNudge(s)
 	ret.RunningTiltBuild = s.TiltBuildInfo
 	ret.LatestTiltBuild = s.LatestTiltBuild
+	ret.FeatureFlags = s.Features
 
 	return ret
 }

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 )
 
-// TODO(Han) add feature flag test
-
 func TestStateToWebViewMultipleSyncs(t *testing.T) {
 	m := model.Manifest{
 		Name: "foo",
@@ -28,6 +26,7 @@ func TestStateToWebViewMultipleSyncs(t *testing.T) {
 			},
 		}),
 	)
+
 	state := newState([]model.Manifest{m})
 	ms := state.ManifestTargets[m.Name].State
 	ms.CurrentBuild.Edits = []string{"/a/b/d", "/a/b/c/d/e"}
@@ -130,6 +129,14 @@ func TestTriggerMode(t *testing.T) {
 
 	newM, _ := v.Resource(model.ManifestName("server"))
 	assert.Equal(t, model.TriggerModeManual, newM.TriggerMode)
+}
+
+func TestFeatureFlags(t *testing.T) {
+	state := newState(nil)
+	state.Features = map[string]bool{"foo_feature": true}
+
+	v := StateToWebView(*state)
+	assert.Equal(t, v.FeatureFlags, map[string]bool{"foo_feature": true})
 }
 
 func newState(manifests []model.Manifest) *store.EngineState {

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 )
 
+// TODO(Han) add feature flag test
+
 func TestStateToWebViewMultipleSyncs(t *testing.T) {
 	m := model.Manifest{
 		Name: "foo",

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -136,8 +136,9 @@ type View struct {
 	Resources     []Resource
 	LogTimestamps bool
 
-	SailEnabled bool
-	SailURL     string
+	FeatureFlags map[string]bool
+	SailEnabled  bool
+	SailURL      string
 
 	NeedsAnalyticsNudge bool
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -84,9 +84,6 @@ type EngineState struct {
 	AnalyticsOpt           analytics.Opt // changes to this field will propagate into the TiltAnalytics subscriber + we'll record them as user choice
 	AnalyticsNudgeSurfaced bool          // this flag is set the first time we show the analytics nudge to the user.
 
-	// Features should NOT be read. Use the feature package.
-	// This field is only here to trigger rebuilds when features are
-	// toggled in the Tiltfile.
 	Features map[string]bool
 
 	TeamName string

--- a/internal/tft/client/client.go
+++ b/internal/tft/client/client.go
@@ -1,0 +1,28 @@
+package client
+
+import "context"
+
+type Alert struct {
+	AlertType    string `json:"alertType"`
+	ResourceName string `json:"resourceName"`
+	Header       string `json:"header"`
+	Msg          string `json:"msg"`
+	RFC3339Time  string `json:"rfc3339Time"`
+}
+
+type AlertID string
+
+type Client interface {
+	SendAlert(ctx context.Context, alert Alert) (AlertID, error)
+}
+
+type tftClient struct{}
+
+func (t *tftClient) SendAlert(ctx context.Context, alert Alert) (AlertID, error) {
+	// TODO(dmiller): implement this
+	return "", nil
+}
+
+func ProvideClient() Client {
+	return &tftClient{}
+}

--- a/internal/tft/client/client.go
+++ b/internal/tft/client/client.go
@@ -36,7 +36,6 @@ func (t *tftClient) SendAlert(ctx context.Context, alert Alert) (AlertID, error)
 	if err != nil {
 		return "", err
 	}
-	fmt.Println(string(buf))
 	resp, err := http.Post(fmt.Sprintf("%s/api/alert", alertStorageBaseURL), "application/json", bytes.NewReader(buf))
 	if err != nil {
 		return "", err
@@ -50,7 +49,6 @@ func (t *tftClient) SendAlert(ctx context.Context, alert Alert) (AlertID, error)
 	if err != nil {
 		return "", err
 	}
-	fmt.Println(string(body))
 	var r newAlertResponse
 	err = json.Unmarshal(body, &r)
 	return AlertID(r.ID), nil

--- a/internal/tft/client/fake_client.go
+++ b/internal/tft/client/fake_client.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	"context"
+)
+
+type fakeClient struct{}
+
+func (f *fakeClient) SendAlert(ctx context.Context, alert Alert) (AlertID, error) {
+	return "aaaaaa", nil
+}
+
+func ProvideFakeClient() Client {
+	return &fakeClient{}
+}

--- a/web/src/AlertPane.test.tsx
+++ b/web/src/AlertPane.test.tsx
@@ -13,6 +13,8 @@ import {
   getResourceAlerts,
 } from "./alerts"
 
+// TODO(Han) fix all the type errors plz D:
+
 beforeEach(() => {
   Date.now = jest.fn(() => 1482363367071)
 })
@@ -217,6 +219,30 @@ it("renders one container unrecognized error", () => {
   let resources = [resource]
 
   const tree = renderer.create(<AlertPane resources={resources} />).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+// TODO(Han)
+it("renders the get alert link button when the feature is enabled", () => {
+  const ts = "1,555,970,585,039"
+  let resources: Array<Partial<Resource>> = [
+    {
+      Name: "foo",
+      Alerts: [
+        {
+          alertType: BuildFailedErrorType,
+          msg: "laa dee daa I'm an error\nfor real I am",
+          titleMsg: "",
+          timestamp: ts,
+        },
+      ],
+    },
+  ]
+
+  const tree = renderer
+    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .toJSON()
+
   expect(tree).toMatchSnapshot()
 })
 

--- a/web/src/AlertPane.test.tsx
+++ b/web/src/AlertPane.test.tsx
@@ -13,7 +13,7 @@ import {
   getResourceAlerts,
 } from "./alerts"
 
-// TODO(Han) fix all the type errors plz D:
+const fakeSendAlert = () => {}
 
 beforeEach(() => {
   Date.now = jest.fn(() => 1482363367071)
@@ -28,7 +28,13 @@ it("renders no errors", () => {
   ]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
 
   expect(tree).toMatchSnapshot()
@@ -51,7 +57,13 @@ it("renders one build error", () => {
   ]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
 
   expect(tree).toMatchSnapshot()
@@ -74,7 +86,13 @@ it("renders a build with an error", () => {
   ]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
 
   expect(tree).toMatchSnapshot()
@@ -100,7 +118,13 @@ it("renders one container start error", () => {
   let resources = [resource]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
   expect(tree).toMatchSnapshot()
 
@@ -109,7 +133,13 @@ it("renders one container start error", () => {
   resource.ResourceInfo.PodRestarts = 3
 
   const newTree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
   expect(newTree).toMatchSnapshot()
 })
@@ -132,7 +162,13 @@ it("shows that a container has restarted", () => {
   let resources = [resource]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -156,7 +192,13 @@ it("shows that a crash rebuild has occurred", () => {
   let resources = [resource]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -181,7 +223,13 @@ it("renders multiple lines of a crash log", () => {
   let resources = [resource]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -206,7 +254,13 @@ it("renders warnings", () => {
   let resources = [resource]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -218,11 +272,18 @@ it("renders one container unrecognized error", () => {
 
   let resources = [resource]
 
-  const tree = renderer.create(<AlertPane resources={resources} />).toJSON()
+  const tree = renderer
+    .create(
+      <AlertPane
+        resources={resources}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={false}
+      />
+    )
+    .toJSON()
   expect(tree).toMatchSnapshot()
 })
 
-// TODO(Han)
 it("renders the get alert link button when the feature is enabled", () => {
   const ts = "1,555,970,585,039"
   let resources: Array<Partial<Resource>> = [
@@ -240,7 +301,13 @@ it("renders the get alert link button when the feature is enabled", () => {
   ]
 
   const tree = renderer
-    .create(<AlertPane resources={resources as Array<Resource>} />)
+    .create(
+      <AlertPane
+        resources={resources as Array<Resource>}
+        handleSendAlert={fakeSendAlert}
+        teamAlertsIsEnabled={true}
+      />
+    )
     .toJSON()
 
   expect(tree).toMatchSnapshot()

--- a/web/src/AlertPane.test.tsx
+++ b/web/src/AlertPane.test.tsx
@@ -227,6 +227,18 @@ it("renders the get alert link button when the feature is enabled", () => {
   let resources: Array<Partial<Resource>> = [
     {
       Name: "foo",
+      ResourceInfo: {
+        PodName: "",
+        PodCreationTime: "",
+        PodUpdateStartTime: "",
+        PodStatus: "",
+        PodStatusMessage: "",
+        PodRestarts: 0,
+        PodLog: "",
+        YAML: "",
+        Endpoints: [],
+      },
+      BuildHistory: [],
       Alerts: [
         {
           alertType: BuildFailedErrorType,

--- a/web/src/AlertPane.test.tsx
+++ b/web/src/AlertPane.test.tsx
@@ -231,8 +231,9 @@ it("renders the get alert link button when the feature is enabled", () => {
         {
           alertType: BuildFailedErrorType,
           msg: "laa dee daa I'm an error\nfor real I am",
-          titleMsg: "",
+          header: "",
           timestamp: ts,
+          resourceName: "foo",
         },
       ],
     },

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -12,6 +12,7 @@ import { Alert } from "./alerts"
 type AlertsProps = {
   resources: Array<Resource>
   handleSendAlert: (alert: Alert) => void
+  featureFlags: { [featureFlag: string]: boolean }
 }
 
 function logToLines(s: string) {
@@ -20,10 +21,12 @@ function logToLines(s: string) {
 
 function alertElements(
   resources: Array<Resource>,
-  handleSendAlert: (alert: Alert) => void
+  handleSendAlert: (alert: Alert) => void,
+  featureFlags: { [featureFlag: string]: boolean }
 ) {
   let formatter = timeAgoFormatter
   let alertElements: Array<JSX.Element> = []
+
   resources.forEach(resource => {
     resource.Alerts.forEach(alert => {
       alertElements.push(
@@ -36,11 +39,14 @@ function alertElements(
             </p>
           </header>
           <section>{logToLines(alert.msg)}</section>
-          <footer>
-            <button onClick={() => handleSendAlert(alert)}>
-              Get Alert Link
-            </button>
-          </footer>
+          {!featureFlags ||
+            (featureFlags && featureFlags.team_alerts && (
+              <footer>
+                <button onClick={() => handleSendAlert(alert)}>
+                  Get Alert Link
+                </button>
+              </footer>
+            ))}
         </li>
       )
     })
@@ -57,7 +63,11 @@ class AlertPane extends PureComponent<AlertsProps> {
       </section>
     )
 
-    let alerts = alertElements(this.props.resources, this.props.handleSendAlert)
+    let alerts = alertElements(
+      this.props.resources,
+      this.props.handleSendAlert,
+      this.props.featureFlags
+    )
     if (alerts.length > 0) {
       el = <ul>{alerts}</ul>
     }

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -12,7 +12,7 @@ import { Alert } from "./alerts"
 type AlertsProps = {
   resources: Array<Resource>
   handleSendAlert: (alert: Alert) => void
-  featureFlags: { [featureFlag: string]: boolean }
+  teamAlertsIsEnabled: boolean
 }
 
 function logToLines(s: string) {
@@ -22,7 +22,7 @@ function logToLines(s: string) {
 function alertElements(
   resources: Array<Resource>,
   handleSendAlert: (alert: Alert) => void,
-  featureFlags: { [featureFlag: string]: boolean }
+  teamAlertsIsEnabled: boolean
 ) {
   let formatter = timeAgoFormatter
   let alertElements: Array<JSX.Element> = []
@@ -39,14 +39,13 @@ function alertElements(
             </p>
           </header>
           <section>{logToLines(alert.msg)}</section>
-          {!featureFlags ||
-            (featureFlags && featureFlags.team_alerts && (
-              <footer>
-                <button onClick={() => handleSendAlert(alert)}>
-                  Get Alert Link
-                </button>
-              </footer>
-            ))}
+          {teamAlertsIsEnabled && (
+            <footer>
+              <button onClick={() => handleSendAlert(alert)}>
+                Get Alert Link
+              </button>
+            </footer>
+          )}
         </li>
       )
     })
@@ -66,7 +65,7 @@ class AlertPane extends PureComponent<AlertsProps> {
     let alerts = alertElements(
       this.props.resources,
       this.props.handleSendAlert,
-      this.props.featureFlags
+      this.props.teamAlertsIsEnabled
     )
     if (alerts.length > 0) {
       el = <ul>{alerts}</ul>

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -35,9 +35,7 @@ function alertElements(
           <header>
             <p>{resource.Name}</p>
             {alert.header != "" && <p>{alert.header}</p>}
-            <time>
-              <TimeAgo date={alert.timestamp} formatter={formatter} />
-            </time>
+            <TimeAgo date={alert.timestamp} formatter={formatter} />
           </header>
           <section>{logToLines(alert.msg)}</section>
           {teamAlertsIsEnabled && (

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -33,10 +33,10 @@ function alertElements(
         <li key={alert.alertType + resource.Name} className="AlertPane-item">
           <header>
             <p>{resource.Name}</p>
-            {alert.titleMsg != "" && <p>{alert.titleMsg}</p>}
-            <p>
+            {alert.header != "" && <p>{alert.header}</p>}
+            <time>
               <TimeAgo date={alert.timestamp} formatter={formatter} />
-            </p>
+            </time>
           </header>
           <section>{logToLines(alert.msg)}</section>
           {teamAlertsIsEnabled && (

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -11,13 +11,17 @@ import { Alert } from "./alerts"
 
 type AlertsProps = {
   resources: Array<Resource>
+  handleSendAlert: (alert: Alert) => void
 }
 
 function logToLines(s: string) {
   return s.split("\n").map((l, i) => <AnsiLine key={"logLine" + i} line={l} />)
 }
 
-function alertElements(resources: Array<Resource>) {
+function alertElements(
+  resources: Array<Resource>,
+  handleSendAlert: (alert: Alert) => void
+) {
   let formatter = timeAgoFormatter
   let alertElements: Array<JSX.Element> = []
   resources.forEach(resource => {
@@ -32,6 +36,11 @@ function alertElements(resources: Array<Resource>) {
             </p>
           </header>
           <section>{logToLines(alert.msg)}</section>
+          <footer>
+            <button onClick={() => handleSendAlert(alert)}>
+              Get Alert Link
+            </button>
+          </footer>
         </li>
       )
     })
@@ -48,7 +57,7 @@ class AlertPane extends PureComponent<AlertsProps> {
       </section>
     )
 
-    let alerts = alertElements(this.props.resources)
+    let alerts = alertElements(this.props.resources, this.props.handleSendAlert)
     if (alerts.length > 0) {
       el = <ul>{alerts}</ul>
     }

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -8,7 +8,6 @@ class AppController {
   loadCount: number
   liveSocket: boolean
   tryConnectCount: number
-  // TOOD(dmiller): optional type?
   socket: WebSocket | null = null
   component: HUD
   disposed: boolean = false

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -19,7 +19,8 @@ import AlertPane from "./AlertPane"
 import PreviewList from "./PreviewList"
 import AnalyticsNudge from "./AnalyticsNudge"
 import NotFound from "./NotFound"
-import { getResourceAlerts, numberOfAlerts, Alert } from "./alerts"
+import { numberOfAlerts, Alert } from "./alerts"
+import Features from "./feature"
 
 type HudProps = {
   history: History
@@ -170,6 +171,12 @@ class HUD extends Component<HudProps, HudState> {
     let toggleSidebar = this.toggleSidebar
     let statusItems = resources.map(res => new StatusItem(res))
     let sidebarItems = resources.map(res => new SidebarItem(res))
+    var features: Features
+    if (this.state.View) {
+      features = new Features(this.state.View.FeatureFlags)
+    } else {
+      features = new Features({})
+    }
 
     let sidebarRoute = (t: ResourceView, props: RouteComponentProps<any>) => {
       let name = props.match.params.name
@@ -299,7 +306,7 @@ class HUD extends Component<HudProps, HudState> {
           <AlertPane
             resources={resources}
             handleSendAlert={this.sendAlert.bind(this)}
-            featureFlags={featureFlags}
+            teamAlertsIsEnabled={features.isEnabled("team_alerts")}
           />
         )
       }
@@ -307,7 +314,7 @@ class HUD extends Component<HudProps, HudState> {
         <AlertPane
           resources={[]}
           handleSendAlert={this.sendAlert.bind(this)}
-          featureFlags={featureFlags}
+          teamAlertsIsEnabled={features.isEnabled("team_alerts")}
         />
       )
     }
@@ -390,7 +397,7 @@ class HUD extends Component<HudProps, HudState> {
               <AlertPane
                 resources={resources}
                 handleSendAlert={this.sendAlert.bind(this)}
-                featureFlags={featureFlags}
+                teamAlertsIsEnabled={features.isEnabled("team_alerts")}
               />
             )}
           />

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -168,7 +168,6 @@ class HUD extends Component<HudProps, HudState> {
     let needsNudge = view ? view.NeedsAnalyticsNudge : false
     let message = this.state.Message
     let resources = (view && view.Resources) || []
-    let featureFlags = (view && view.FeatureFlags) || {}
     if (!resources.length) {
       return <LoadingScreen message={message} />
     }

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -142,6 +142,10 @@ class HUD extends Component<HudProps, HudState> {
     fetch(url, {
       method: "post",
       body: JSON.stringify(alert),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
     })
       .then(res => {
         res
@@ -150,7 +154,9 @@ class HUD extends Component<HudProps, HudState> {
             // TODO(dmiller): maybe set state here in the future
             window.open(value.url)
           })
-          .catch(err => console.error(err))
+          .catch(err => {
+            console.error(err)
+          })
       })
       .then(err => console.error(err))
   }

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -148,7 +148,6 @@ class HUD extends Component<HudProps, HudState> {
           .json()
           .then((value: NewAlertResponse) => {
             // TODO(dmiller): maybe set state here in the future
-            debugger
             window.open(value.url)
           })
           .catch(err => console.error(err))

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -36,6 +36,7 @@ type HudState = {
     NeedsAnalyticsNudge: boolean
     RunningTiltBuild: TiltBuild
     LatestTiltBuild: TiltBuild
+    FeatureFlags: { [featureFlag: string]: boolean }
   } | null
   IsSidebarClosed: boolean
 }
@@ -86,6 +87,7 @@ class HUD extends Component<HudProps, HudState> {
           Date: "",
           Dev: false,
         },
+        FeatureFlags: {},
       },
       IsSidebarClosed: false,
     }
@@ -160,6 +162,7 @@ class HUD extends Component<HudProps, HudState> {
     let needsNudge = view ? view.NeedsAnalyticsNudge : false
     let message = this.state.Message
     let resources = (view && view.Resources) || []
+    let featureFlags = (view && view.FeatureFlags) || {}
     if (!resources.length) {
       return <LoadingScreen message={message} />
     }
@@ -296,11 +299,16 @@ class HUD extends Component<HudProps, HudState> {
           <AlertPane
             resources={resources}
             handleSendAlert={this.sendAlert.bind(this)}
+            featureFlags={featureFlags}
           />
         )
       }
       return (
-        <AlertPane resources={[]} handleSendAlert={this.sendAlert.bind(this)} />
+        <AlertPane
+          resources={[]}
+          handleSendAlert={this.sendAlert.bind(this)}
+          featureFlags={featureFlags}
+        />
       )
     }
     let runningVersion = view && view.RunningTiltBuild
@@ -382,6 +390,7 @@ class HUD extends Component<HudProps, HudState> {
               <AlertPane
                 resources={resources}
                 handleSendAlert={this.sendAlert.bind(this)}
+                featureFlags={featureFlags}
               />
             )}
           />

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -260,6 +260,50 @@ exports[`renders one container unrecognized error 1`] = `
 </section>
 `;
 
+exports[`renders the get alert link button when the feature is enabled 1`] = `
+<section
+  className="AlertPane"
+>
+  <ul>
+    <li
+      className="AlertPane-item"
+    >
+      <header>
+        <p>
+          foo
+        </p>
+        <p>
+          <time
+            dateTime="1949-11-18T09:39:00.000Z"
+            title="1,555,970,585,039"
+          >
+            67yr
+          </time>
+        </p>
+      </header>
+      <section>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            laa dee daa I'm an error
+          </span>
+        </code>
+        <code>
+          <span
+            className={null}
+            style={null}
+          >
+            for real I am
+          </span>
+        </code>
+      </section>
+    </li>
+  </ul>
+</section>
+`;
+
 exports[`renders warnings 1`] = `
 <section
   className="AlertPane"

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -15,13 +15,11 @@ exports[`renders multiple lines of a crash log 1`] = `
         <p>
           Pod crashed
         </p>
-        <time>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
+        <time
+          dateTime="1949-11-18T09:39:00.000Z"
+          title="1,555,970,585,039"
+        >
+          67yr
         </time>
       </header>
       <section>
@@ -76,13 +74,11 @@ exports[`renders one container start error 1`] = `
         <p>
           foo
         </p>
-        <time>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
+        <time
+          dateTime="1949-11-18T09:39:00.000Z"
+          title="1,555,970,585,039"
+        >
+          67yr
         </time>
       </header>
       <section>
@@ -112,13 +108,11 @@ exports[`renders one container start error 2`] = `
         <p>
           foo
         </p>
-        <time>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
+        <time
+          dateTime="1949-11-18T09:39:00.000Z"
+          title="1,555,970,585,039"
+        >
+          67yr
         </time>
       </header>
       <section>
@@ -148,13 +142,11 @@ exports[`renders one container unrecognized error 1`] = `
         <p>
           vigoda
         </p>
-        <time>
-          <time
-            dateTime="2016-12-21T23:36:07.071Z"
-            title="2016-12-21 23:36"
-          >
-            &lt;5s
-          </time>
+        <time
+          dateTime="2016-12-21T23:36:07.071Z"
+          title="2016-12-21 23:36"
+        >
+          &lt;5s
         </time>
       </header>
       <section>
@@ -204,13 +196,11 @@ exports[`renders warnings 1`] = `
         <p>
           Pod crashed
         </p>
-        <time>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
+        <time
+          dateTime="1949-11-18T09:39:00.000Z"
+          title="1,555,970,585,039"
+        >
+          67yr
         </time>
       </header>
       <section>
@@ -234,13 +224,11 @@ exports[`renders warnings 1`] = `
         <p>
           foo
         </p>
-        <time>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
+        <time
+          dateTime="1949-11-18T09:39:00.000Z"
+          title="1,555,970,585,039"
+        >
+          67yr
         </time>
       </header>
       <section>
@@ -273,13 +261,11 @@ exports[`shows that a container has restarted 1`] = `
         <p>
           Restarts: 1
         </p>
-        <time>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
+        <time
+          dateTime="1949-11-18T09:39:00.000Z"
+          title="1,555,970,585,039"
+        >
+          67yr
         </time>
       </header>
       <section>
@@ -312,13 +298,11 @@ exports[`shows that a crash rebuild has occurred 1`] = `
         <p>
           Pod crashed
         </p>
-        <time>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
+        <time
+          dateTime="1949-11-18T09:39:00.000Z"
+          title="1,555,970,585,039"
+        >
+          67yr
         </time>
       </header>
       <section>

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -299,6 +299,13 @@ exports[`renders the get alert link button when the feature is enabled 1`] = `
           </span>
         </code>
       </section>
+      <footer>
+        <button
+          onClick={[Function]}
+        >
+          Get Alert Link
+        </button>
+      </footer>
     </li>
   </ul>
 </section>

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -15,14 +15,14 @@ exports[`renders multiple lines of a crash log 1`] = `
         <p>
           Pod crashed
         </p>
-        <p>
+        <time>
           <time
             dateTime="1949-11-18T09:39:00.000Z"
             title="1,555,970,585,039"
           >
             67yr
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>
@@ -76,14 +76,14 @@ exports[`renders one container start error 1`] = `
         <p>
           foo
         </p>
-        <p>
+        <time>
           <time
             dateTime="1949-11-18T09:39:00.000Z"
             title="1,555,970,585,039"
           >
             67yr
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>
@@ -112,14 +112,14 @@ exports[`renders one container start error 2`] = `
         <p>
           foo
         </p>
-        <p>
+        <time>
           <time
             dateTime="1949-11-18T09:39:00.000Z"
             title="1,555,970,585,039"
           >
             67yr
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>
@@ -148,14 +148,14 @@ exports[`renders one container unrecognized error 1`] = `
         <p>
           vigoda
         </p>
-        <p>
+        <time>
           <time
             dateTime="2016-12-21T23:36:07.071Z"
             title="2016-12-21 23:36"
           >
             &lt;5s
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>
@@ -238,14 +238,14 @@ exports[`renders warnings 1`] = `
         <p>
           Pod crashed
         </p>
-        <p>
+        <time>
           <time
             dateTime="1949-11-18T09:39:00.000Z"
             title="1,555,970,585,039"
           >
             67yr
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>
@@ -268,14 +268,14 @@ exports[`renders warnings 1`] = `
         <p>
           foo
         </p>
-        <p>
+        <time>
           <time
             dateTime="1949-11-18T09:39:00.000Z"
             title="1,555,970,585,039"
           >
             67yr
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>
@@ -307,14 +307,14 @@ exports[`shows that a container has restarted 1`] = `
         <p>
           Restarts: 1
         </p>
-        <p>
+        <time>
           <time
             dateTime="1949-11-18T09:39:00.000Z"
             title="1,555,970,585,039"
           >
             67yr
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>
@@ -346,14 +346,14 @@ exports[`shows that a crash rebuild has occurred 1`] = `
         <p>
           Pod crashed
         </p>
-        <p>
+        <time>
           <time
             dateTime="1949-11-18T09:39:00.000Z"
             title="1,555,970,585,039"
           >
             67yr
           </time>
-        </p>
+        </time>
       </header>
       <section>
         <code>

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -176,50 +176,16 @@ exports[`renders the get alert link button when the feature is enabled 1`] = `
 <section
   className="AlertPane"
 >
-  <ul>
-    <li
-      className="AlertPane-item"
-    >
-      <header>
-        <p>
-          foo
-        </p>
-        <p>
-          <time
-            dateTime="1949-11-18T09:39:00.000Z"
-            title="1,555,970,585,039"
-          >
-            67yr
-          </time>
-        </p>
-      </header>
-      <section>
-        <code>
-          <span
-            className={null}
-            style={null}
-          >
-            laa dee daa I'm an error
-          </span>
-        </code>
-        <code>
-          <span
-            className={null}
-            style={null}
-          >
-            for real I am
-          </span>
-        </code>
-      </section>
-      <footer>
-        <button
-          onClick={[Function]}
-        >
-          Get Alert Link
-        </button>
-      </footer>
-    </li>
-  </ul>
+  <section
+    className="Pane-empty-message"
+  >
+    <svg>
+      logo-wordmark-gray.svg
+    </svg>
+    <h2>
+      No Alerts Found
+    </h2>
+  </section>
 </section>
 `;
 

--- a/web/src/alerts.test.ts
+++ b/web/src/alerts.test.ts
@@ -23,7 +23,8 @@ describe("getResourceAlerts", () => {
         alertType: PodStatusErrorType,
         msg: "I'm a pod in Error",
         timestamp: "",
-        titleMsg: "",
+        header: "",
+        resourceName: "snack",
       },
     ]
     expect(actual).toEqual(expectedAlerts)
@@ -39,7 +40,8 @@ describe("getResourceAlerts", () => {
         alertType: PodRestartErrorType,
         msg: "",
         timestamp: "",
-        titleMsg: "Restarts: 1",
+        header: "Restarts: 1",
+        resourceName: "snack",
       },
     ]
     expect(actual).toEqual(expectedAlerts)
@@ -62,7 +64,8 @@ describe("getResourceAlerts", () => {
         alertType: BuildFailedErrorType,
         msg: "Build error log",
         timestamp: "10:00AM",
-        titleMsg: "Build error",
+        header: "Build error",
+        resourceName: "snack",
       },
     ]
     expect(actual).toEqual(expectedAlerts)
@@ -90,13 +93,14 @@ describe("getResourceAlerts", () => {
         alertType: CrashRebuildErrorType,
         msg: "Hello I am a crash log",
         timestamp: "10:00AM",
-        titleMsg: "Pod crashed",
+        header: "Pod crashed",
+        resourceName: "snack",
       },
     ]
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("should show a warning alert  using the first build history", () => {
+  it("should show a warning alert using the first build history", () => {
     let r: Resource = emptyResource()
     r.BuildHistory = [
       {
@@ -116,7 +120,8 @@ describe("getResourceAlerts", () => {
         alertType: WarningErrorType,
         msg: "Hi i'm a warning",
         timestamp: "10:00am",
-        titleMsg: "test",
+        header: "snack",
+        resourceName: "snack",
       },
     ]
     expect(actual).toEqual(expectedAlerts)
@@ -143,13 +148,15 @@ describe("getResourceAlerts", () => {
         alertType: PodRestartErrorType,
         msg: "I'm a pod that crashed",
         timestamp: "10:00AM",
-        titleMsg: "Restarts: 1",
+        header: "Restarts: 1",
+        resourceName: "snack",
       },
       {
         alertType: BuildFailedErrorType,
         msg: "Build error log",
         timestamp: "10:00AM",
-        titleMsg: "Build error",
+        header: "Build error",
+        resourceName: "snack",
       },
     ]
     expect(actual).toEqual(expectedAlerts)
@@ -172,19 +179,22 @@ describe("getResourceAlerts", () => {
         alertType: CrashRebuildErrorType,
         msg: "Hello I am a crash log",
         timestamp: "",
-        titleMsg: "Pod crashed",
+        header: "Pod crashed",
+        resourceName: "snack",
       },
       {
         alertType: BuildFailedErrorType,
         msg: "Build failed log",
         timestamp: "10:00am",
-        titleMsg: "Build error",
+        header: "Build error",
+        resourceName: "snack",
       },
       {
         alertType: WarningErrorType,
         msg: "Hi I am a warning",
         timestamp: "10:00am",
-        titleMsg: "test",
+        header: "snack",
+        resourceName: "snack",
       },
     ]
     expect(actual).toEqual(expectedAlerts)
@@ -203,7 +213,7 @@ describe("getResourceAlerts", () => {
 
 function emptyResource(): Resource {
   return {
-    Name: "test",
+    Name: "snack",
     CombinedLog: "",
     BuildHistory: [],
     CrashLog: "",

--- a/web/src/alerts.ts
+++ b/web/src/alerts.ts
@@ -1,12 +1,12 @@
 import { Resource } from "./types"
 import { podStatusIsError, podStatusIsCrash } from "./constants"
 
-// TODO(Han): add resource name here
 export type Alert = {
   alertType: string
+  header: string
   msg: string
   timestamp: string
-  titleMsg: string
+  resourceName: string
 }
 
 export const PodRestartErrorType = "PodRestartError"
@@ -84,9 +84,10 @@ function podStatusIsErrAlert(resource: Resource): Alert {
 
   return {
     alertType: PodStatusErrorType,
-    titleMsg: "",
+    header: "",
     msg: msg,
     timestamp: resource.ResourceInfo.PodCreationTime,
+    resourceName: resource.Name,
   }
 }
 
@@ -97,9 +98,10 @@ function podRestartAlert(resource: Resource): Alert {
 
   return {
     alertType: PodRestartErrorType,
-    titleMsg: titleMsg,
+    header: titleMsg,
     msg: msg,
     timestamp: resource.ResourceInfo.PodCreationTime,
+    resourceName: resource.Name,
   }
 }
 
@@ -107,9 +109,10 @@ function crashRebuildAlert(resource: Resource): Alert {
   let msg = resource.CrashLog || ""
   return {
     alertType: CrashRebuildErrorType,
-    titleMsg: "Pod crashed",
+    header: "Pod crashed",
     msg: msg,
     timestamp: resource.ResourceInfo.PodCreationTime,
+    resourceName: resource.Name,
   }
 }
 
@@ -117,9 +120,10 @@ function buildFailedAlert(resource: Resource): Alert {
   let msg = resource.BuildHistory[0].Log || ""
   return {
     alertType: BuildFailedErrorType,
-    titleMsg: "Build error",
+    header: "Build error",
     msg: msg,
     timestamp: resource.ResourceInfo.PodCreationTime,
+    resourceName: resource.Name,
   }
 }
 function warningsAlerts(resource: Resource): Array<Alert> {
@@ -133,9 +137,10 @@ function warningsAlerts(resource: Resource): Array<Alert> {
     warnings.forEach(w => {
       alertArray.push({
         alertType: WarningErrorType,
-        titleMsg: resource.Name,
+        header: resource.Name,
         msg: w,
         timestamp: resource.BuildHistory[0].FinishTime,
+        resourceName: resource.Name,
       })
     })
   }

--- a/web/src/alerts.ts
+++ b/web/src/alerts.ts
@@ -1,6 +1,7 @@
 import { Resource } from "./types"
 import { podStatusIsError, podStatusIsCrash } from "./constants"
 
+// TODO(Han): add resource name here
 export type Alert = {
   alertType: string
   msg: string

--- a/web/src/alerts.ts
+++ b/web/src/alerts.ts
@@ -93,12 +93,12 @@ function podStatusIsErrAlert(resource: Resource): Alert {
 
 function podRestartAlert(resource: Resource): Alert {
   let msg = resource.CrashLog || ""
-  let titleMsg = "Restarts: "
-  titleMsg = titleMsg.concat(resource.ResourceInfo.PodRestarts.toString())
+  let header = "Restarts: "
+  header = header.concat(resource.ResourceInfo.PodRestarts.toString())
 
   return {
     alertType: PodRestartErrorType,
-    header: titleMsg,
+    header: header,
     msg: msg,
     timestamp: resource.ResourceInfo.PodCreationTime,
     resourceName: resource.Name,

--- a/web/src/feature.test.ts
+++ b/web/src/feature.test.ts
@@ -1,0 +1,18 @@
+import Features from "./feature"
+
+describe("feature", () => {
+  it("returns false if the feature does not exist", () => {
+    let features = new Features({})
+    expect(features.isEnabled("foo")).toBe(false)
+  })
+
+  it("returns false if the feature does exist and is false", () => {
+    let features = new Features({ foo: false })
+    expect(features.isEnabled("foo")).toBe(false)
+  })
+
+  it("returns true if the feature does exist and is true", () => {
+    let features = new Features({ foo: true })
+    expect(features.isEnabled("foo")).toBe(true)
+  })
+})

--- a/web/src/feature.ts
+++ b/web/src/feature.ts
@@ -1,0 +1,19 @@
+// This Features wrapper behaves differently than the one in Go.
+// Checking for features that don't exist is *not* an error here.
+// This is important because when the React app starts,
+// it starts with an empty state and there won't be _any_ feature flags
+// until the first engine state comes in over the Websocket.
+export default class Features {
+  private flags: { [featureFlag: string]: boolean }
+
+  constructor(flags: { [featureFlag: string]: boolean }) {
+    this.flags = flags
+  }
+
+  public isEnabled(flag: string): boolean {
+    if (this.flags.hasOwnProperty(flag)) {
+      return this.flags[flag]
+    }
+    return false
+  }
+}


### PR DESCRIPTION
Hidden under a feature flag
(Add `enable_feature("team_alerts")` to your Tiltfile to see this WIP feature)

We were using `titleMsg` and `header` for the little bit of additional meta text we send along with errors. I standardized to the latter.

<img width="1355" alt="2019-07-26 - Alert button to get link" src="https://user-images.githubusercontent.com/20349/61980786-b87b0980-afc5-11e9-8d10-ba9e123c08f5.png">
