### PR TITLE
engine: fix regression from #1908 that caused spam about 'no container ports' when trying to port fwd (tho port forwarding still worked)

### DIFF
--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -70,7 +70,7 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	}()
 
 	// LiveUpdateBuildAndDeployer doesn't support initial build
-	// ~~ put this check in extractImageTargetsForLiveUpdates()
+	// TODO(maia): put this check in extractImageTargetsForLiveUpdates()
 	if state.IsEmpty() {
 		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("prev. build state is empty; LiveUpdate does not support initial deploy")
 	}

--- a/internal/engine/portforwardcontroller.go
+++ b/internal/engine/portforwardcontroller.go
@@ -47,7 +47,7 @@ func (m *PortForwardController) diff(ctx context.Context, st store.RStore) (toSt
 			continue
 		}
 
-		forwards := PopulatePortForwards(manifest, pod)
+		forwards := populatePortForwards(manifest, pod)
 		if len(forwards) == 0 {
 			continue
 		}
@@ -127,9 +127,9 @@ type portForwardEntry struct {
 }
 
 // Extract the port-forward specs from the manifest. If any of them
-// have ContainerPort = 0, populate them with the default port in the pod spec.
+// have ContainerPort = 0, populate them with the default port for the pod.
 // Quietly drop forwards that we can't populate.
-func PopulatePortForwards(m model.Manifest, pod store.Pod) []model.PortForward {
+func populatePortForwards(m model.Manifest, pod store.Pod) []model.PortForward {
 	cPorts := pod.ContainerPorts()
 	fwds := m.K8sTarget().PortForwards
 	forwards := make([]model.PortForward, 0, len(fwds))
@@ -144,4 +144,10 @@ func PopulatePortForwards(m model.Manifest, pod store.Pod) []model.PortForward {
 		forwards = append(forwards, forward)
 	}
 	return forwards
+}
+
+func portForwardsAreValid(m model.Manifest, pod store.Pod) bool {
+	expectedFwds := m.K8sTarget().PortForwards
+	actualFwds := populatePortForwards(m, pod)
+	return len(actualFwds) == len(expectedFwds)
 }


### PR DESCRIPTION
Hello @nicks, @dbentley,

Please review the following commits I made in branch maiamcc/fix-no-container-ports-spam:

bbe6e5397090628f20900071fafe59a26a3266a3 (2019-07-26 17:17:38 -0400)
engine: fix regression from #1908 that caused spam about 'no container ports' when trying to port fwd (tho port forwarding still worked)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics