### PR TITLE
engine: don't create container id arrays with empty elements

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -150,7 +150,9 @@ func (b *fakeBuildAndDeployer) nextBuildResult(iTarget model.ImageTarget, deploy
 		containerID = container.ID(fmt.Sprintf("dc-%s", path.Base(named.Name())))
 	}
 	result := store.NewImageBuildResult(iTarget.ID(), nt)
-	result.ContainerIDs = []container.ID{containerID}
+	if containerID != "" {
+		result.ContainerIDs = []container.ID{containerID}
+	}
 	return result
 }
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/slice:

fc3a7ca55bdb9dd7f535225dfc35a2d3f7efeb8a (2019-07-26 19:40:49 -0400)
engine: don't create container id arrays with empty elements