### PR TITLE
store: Split LiveUpdate container ids from DockerCompose container ids

### DIFF
--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -79,7 +79,7 @@ func runTestCase(t *testing.T, f *bdFixture, tCase testCase) {
 		assert.Empty(t, f.k8s.Yaml, "expected no k8s deploy, but we deployed YAML: %s", f.k8s.Yaml)
 
 		// We did a container build, so we expect result to have the container ID we operated on
-		assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+		assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyLiveUpdatedContainerID().String())
 	} else {
 		expectedYaml := "image: gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
 		if !strings.Contains(f.k8s.Yaml, expectedYaml) {

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -164,7 +164,7 @@ func TestContainerBuildLocal(t *testing.T) {
 	id := manifest.ImageTargetAt(0).ID()
 	_, hasResult := result[id]
 	assert.True(t, hasResult)
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyLiveUpdatedContainerID().String())
 }
 
 func TestContainerBuildSynclet(t *testing.T) {
@@ -190,7 +190,7 @@ func TestContainerBuildSynclet(t *testing.T) {
 		t.Errorf("Expected 1 synclet containerUpdate, actual: %d", f.sCli.UpdateContainerCount)
 	}
 
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyLiveUpdatedContainerID().String())
 	assert.False(t, f.sCli.LastHotReload)
 }
 
@@ -235,7 +235,7 @@ func TestContainerBuildLocalTriggeredRuns(t *testing.T) {
 	id := manifest.ImageTargetAt(0).ID()
 	_, hasResult := result[id]
 	assert.True(t, hasResult)
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyLiveUpdatedContainerID().String())
 }
 
 func TestContainerBuildSyncletTriggeredRuns(t *testing.T) {
@@ -275,7 +275,7 @@ func TestContainerBuildSyncletTriggeredRuns(t *testing.T) {
 		t.Errorf("Expected 2 commands run by the synclet, actual: %d", f.sCli.CommandsRunCount)
 	}
 
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyLiveUpdatedContainerID().String())
 	assert.False(t, f.sCli.LastHotReload)
 }
 
@@ -358,7 +358,7 @@ func TestDockerBuildWithNestedFastBuildContainerUpdate(t *testing.T) {
 	id := manifest.ImageTargetAt(0).ID()
 	_, hasResult := result[id]
 	assert.True(t, hasResult)
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyLiveUpdatedContainerID().String())
 }
 
 func TestIncrementalBuildFailure(t *testing.T) {
@@ -696,7 +696,7 @@ func TestContainerBuildMultiStage(t *testing.T) {
 	assert.False(t, hasResult0)
 	_, hasResult1 := result[manifest.ImageTargetAt(1).ID()]
 	assert.True(t, hasResult1)
-	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyContainerID().String())
+	assert.Equal(t, k8s.MagicTestContainerID, result.OneAndOnlyLiveUpdatedContainerID().String())
 }
 
 func TestDockerComposeImageBuild(t *testing.T) {

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -217,7 +217,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	assert.Equal(t, []string{}, call.oneState().FilesChanged())
 	f.waitForCompletedBuildCount(1)
 
-	f.b.nextBuildContainer = podbuilder.FakeContainerID
+	f.b.nextLiveUpdateContainerID = podbuilder.FakeContainerID
 	f.podEvent(f.testPod("pod-id", manifest, "Running", podbuilder.FakeContainerID, time.Now()))
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
@@ -226,7 +226,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.waitForCompletedBuildCount(2)
 	f.withManifestState("fe", func(ms store.ManifestState) {
 		assert.Equal(t, model.BuildReasonFlagChangedFiles, ms.LastBuild().Reason)
-		assert.Equal(t, podbuilder.FakeContainerID, ms.ExpectedContainerID.String())
+		assert.Equal(t, podbuilder.FakeContainerID, ms.LiveUpdatedContainerID.String())
 	})
 
 	// Restart the pod with a new container id, to simulate a container restart.

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -126,14 +126,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	}
 
 	results := q.results
-	for _, iTarget := range iTargets {
-		if isImageDeployedToDC(iTarget, dcTarget) {
-			result := results[iTarget.ID()]
-			result.ContainerIDs = []container.ID{cid}
-			results[iTarget.ID()] = result
-		}
-	}
-	results[dcTarget.ID()] = store.NewContainerBuildResult(dcTarget.ID(), cid)
+	results[dcTarget.ID()] = store.NewDockerComposeDeployResult(dcTarget.ID(), cid)
 	return results, nil
 }
 

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -45,7 +45,7 @@ func TestDockerComposeTargetBuilt(t *testing.T) {
 		assert.Equal(t, dcName, call.ServiceName)
 		assert.True(t, call.ShouldBuild)
 	}
-	assert.Equal(t, expectedContainer, res.OneAndOnlyContainerID())
+	assert.Equal(t, expectedContainer, res[dcTarg.ID()].DockerComposeContainerID)
 }
 
 func TestTiltBuildsImage(t *testing.T) {

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -240,9 +240,9 @@ func TestImageIsDirtyAfterContainerBuild(t *testing.T) {
 	manifest := NewSanchoDockerBuildManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
 	result1 := store.BuildResult{
-		TargetID:     iTargetID1,
-		Image:        container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"),
-		ContainerIDs: []container.ID{container.ID("12345")},
+		TargetID:                iTargetID1,
+		Image:                   container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"),
+		LiveUpdatedContainerIDs: []container.ID{container.ID("12345")},
 	}
 
 	stateSet := store.BuildStateSet{

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -20,9 +20,9 @@ func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	state := t.iTargetState
 	res := state.LastResult
 
-	res.ContainerIDs = nil
+	res.LiveUpdatedContainerIDs = nil
 	for _, c := range state.RunningContainers {
-		res.ContainerIDs = append(res.ContainerIDs, c.ContainerID)
+		res.LiveUpdatedContainerIDs = append(res.LiveUpdatedContainerIDs, c.ContainerID)
 	}
 
 	resultSet := store.BuildResultSet{}

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -224,7 +224,7 @@ func checkForPodCrash(ctx context.Context, state *store.EngineState, ms *store.M
 		return
 	}
 
-	if ms.ExpectedContainerID == "" || ms.ExpectedContainerID == podInfo.ContainerID() {
+	if ms.LiveUpdatedContainerID == "" || ms.LiveUpdatedContainerID == podInfo.ContainerID() {
 		// The pod is what we expect it to be.
 		return
 	}
@@ -232,7 +232,7 @@ func checkForPodCrash(ctx context.Context, state *store.EngineState, ms *store.M
 	// The pod isn't what we expect!
 	ms.CrashLog = podInfo.CurrentLog
 	ms.NeedsRebuildFromCrash = true
-	ms.ExpectedContainerID = ""
+	ms.LiveUpdatedContainerID = ""
 	msg := fmt.Sprintf("Detected a container change for %s. We could be running stale code. Rebuilding and deploying a new image.", ms.Name)
 	le := store.NewLogEvent(ms.Name, []byte(msg+"\n"))
 	if len(ms.BuildHistory) > 0 {

--- a/internal/store/build_result_test.go
+++ b/internal/store/build_result_test.go
@@ -16,17 +16,17 @@ func imageID(s string) model.TargetID {
 	}
 }
 
-func TestOneAndOnlyContainerID(t *testing.T) {
+func TestOneAndOnlyLiveUpdatedContainerID(t *testing.T) {
 	set := BuildResultSet{
-		imageID("a"): BuildResult{ContainerIDs: []container.ID{"cA"}},
-		imageID("b"): BuildResult{ContainerIDs: []container.ID{"cB"}},
+		imageID("a"): BuildResult{LiveUpdatedContainerIDs: []container.ID{"cA"}},
+		imageID("b"): BuildResult{LiveUpdatedContainerIDs: []container.ID{"cB"}},
 	}
-	assert.Equal(t, "", string(set.OneAndOnlyContainerID()))
+	assert.Equal(t, "", string(set.OneAndOnlyLiveUpdatedContainerID()))
 
 	set = BuildResultSet{
-		imageID("a"): BuildResult{ContainerIDs: []container.ID{"cA"}},
-		imageID("b"): BuildResult{ContainerIDs: []container.ID{"cA"}},
-		imageID("c"): BuildResult{ContainerIDs: []container.ID{""}},
+		imageID("a"): BuildResult{LiveUpdatedContainerIDs: []container.ID{"cA"}},
+		imageID("b"): BuildResult{LiveUpdatedContainerIDs: []container.ID{"cA"}},
+		imageID("c"): BuildResult{LiveUpdatedContainerIDs: []container.ID{""}},
 	}
-	assert.Equal(t, "cA", string(set.OneAndOnlyContainerID()))
+	assert.Equal(t, "cA", string(set.OneAndOnlyLiveUpdatedContainerID()))
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -247,8 +247,11 @@ type ManifestState struct {
 	// The last `BuildHistoryLimit` builds. The most recent build is first in the slice.
 	BuildHistory []model.BuildRecord
 
-	// If the pod isn't running this container then it's possible we're running stale code
-	ExpectedContainerID container.ID
+	// The container ID that we've run a LiveUpdate on, if any. Its contents have
+	// diverged from the image it's built on. If this container doesn't appear on
+	// the pod, we've lost that state and need to rebuild.
+	LiveUpdatedContainerID container.ID
+
 	// We detected stale code and are currently doing an image build
 	NeedsRebuildFromCrash bool
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/liveupdated:

8317fa5bd419ed57e824b718e5e1cf9f4e63de49 (2019-07-29 16:35:02 -0400)
store: Split LiveUpdate container ids from DockerCompose container ids
These should have always been separate fields, since they trigger very different
behavior. Now that multiple containers can be updated with live_update, but
docker compose can only bring up one container per service, it seems like a good
excuse to fix this.