### PR TITLE
docker/test: better error spoofing for fake docker client

### DIFF
--- a/internal/containerupdate/docker_container_updater_test.go
+++ b/internal/containerupdate/docker_container_updater_test.go
@@ -90,7 +90,7 @@ func TestUpdateContainerHotReloadDoesNotRestartContainer(t *testing.T) {
 func TestUpdateContainerKillTask(t *testing.T) {
 	f := newDCUFixture(t)
 
-	f.dCli.ExecErrorToThrow = docker.ExitError{ExitCode: build.TaskKillExitCode}
+	f.dCli.SetExecError(docker.ExitError{ExitCode: build.TaskKillExitCode})
 
 	cmdA := model.Cmd{Argv: []string{"cat"}}
 	err := f.dcu.UpdateContainer(f.ctx, TestContainerInfo, nil, nil, []model.Cmd{cmdA}, false)

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -367,7 +367,7 @@ func TestIncrementalBuildFailure(t *testing.T) {
 
 	changed := f.WriteFile("a.txt", "a")
 	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, testContainerInfo)
-	f.docker.ExecErrorToThrow = docker.ExitError{ExitCode: 1}
+	f.docker.SetExecError(docker.ExitError{ExitCode: 1})
 
 	manifest := NewSanchoFastBuildManifest(f)
 	targets := buildTargets(manifest)
@@ -400,7 +400,7 @@ func TestIncrementalBuildKilled(t *testing.T) {
 	changed := f.WriteFile("a.txt", "a")
 
 	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, testContainerInfo)
-	f.docker.ExecErrorToThrow = docker.ExitError{ExitCode: build.TaskKillExitCode}
+	f.docker.SetExecError(docker.ExitError{ExitCode: build.TaskKillExitCode})
 
 	manifest := NewSanchoFastBuildManifest(f)
 	targets := buildTargets(manifest)
@@ -420,7 +420,7 @@ func TestFallBackToImageDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
 	defer f.TearDown()
 
-	f.docker.ExecErrorToThrow = errors.New("some random error")
+	f.docker.SetExecError(errors.New("some random error"))
 
 	changed := f.WriteFile("a.txt", "a")
 	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, testContainerInfo)
@@ -441,7 +441,7 @@ func TestFallBackToImageDeploy(t *testing.T) {
 func TestNoFallbackForDontFallBackError(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
 	defer f.TearDown()
-	f.docker.ExecErrorToThrow = DontFallBackErrorf("i'm melllting")
+	f.docker.SetExecError(DontFallBackErrorf("i'm melllting"))
 
 	changed := f.WriteFile("a.txt", "a")
 	bs := resultToStateSet(alreadyBuiltSet, []string{changed}, testContainerInfo)
@@ -516,7 +516,7 @@ func TestIncrementalBuildTwiceDeadPod(t *testing.T) {
 	}
 
 	// Kill the pod
-	f.docker.ExecErrorToThrow = fmt.Errorf("Dead pod")
+	f.docker.SetExecError(fmt.Errorf("Dead pod"))
 
 	secondState := resultToStateSet(firstResult, []string{bPath}, testContainerInfo)
 	_, err = f.bd.BuildAndDeploy(f.ctx, f.st, targets, secondState)


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/fake-docker-cli-errors:

4f745428be5656f492eb719bb607bc69ab521d61 (2019-07-30 16:16:42 -0400)
docker/test: better error spoofing for fake docker client

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics