### PR TITLE
engine: Handle pod crashes when there are multiple containers

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -78,3 +78,11 @@ func MustNormalizeRef(ref string) string {
 	}
 	return normalized
 }
+
+func NewIDSet(ids ...ID) map[ID]bool {
+	result := make(map[ID]bool, len(ids))
+	for _, id := range ids {
+		result[id] = true
+	}
+	return result
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -221,7 +221,6 @@ func handleBuildStarted(ctx context.Context, state *store.EngineState, action Bu
 	}
 	ms.ConfigFilesThatCausedChange = []string{}
 	ms.CurrentBuild = bs
-	ms.LiveUpdatedContainerID = ""
 
 	for _, pod := range ms.PodSet.Pods {
 		pod.CurrentLog = model.Log{}
@@ -307,6 +306,22 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 			// # of pod restarts from old code (shouldn't be reflected in HUD)
 			pod.OldRestarts = pod.ContainerRestarts
 		}
+
+		liveUpdateContainerIDs := cb.Result.LiveUpdatedContainerIDs()
+		if len(liveUpdateContainerIDs) == 0 {
+			// Assume this was an image build, and reset all the container ids
+			ms.LiveUpdatedContainerIDs = container.NewIDSet()
+		} else {
+			for _, cID := range liveUpdateContainerIDs {
+				ms.LiveUpdatedContainerIDs[cID] = true
+			}
+
+			bestPod := ms.MostRecentPod()
+			if bestPod.StartedAt.After(bs.StartTime) ||
+				bestPod.UpdateStartTime.Equal(bs.StartTime) {
+				checkForPodCrash(ctx, engineState, mt)
+			}
+		}
 	}
 
 	if mt.Manifest.IsDC() {
@@ -332,17 +347,6 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 
 	if engineState.WatchFiles {
 		logger.Get(ctx).Debugf("[timing.py] finished build from file change") // hook for timing.py
-
-		cID := cb.Result.OneLiveUpdatedContainerIDForOldBehavior()
-		if cID != "" {
-			ms.LiveUpdatedContainerID = cID
-
-			bestPod := ms.MostRecentPod()
-			if bestPod.StartedAt.After(bs.StartTime) ||
-				bestPod.UpdateStartTime.Equal(bs.StartTime) {
-				checkForPodCrash(ctx, engineState, ms, bestPod)
-			}
-		}
 	}
 
 	return nil

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -103,6 +103,31 @@ spec:
                 key: token
 `
 
+const SanchoTwoContainersOneImageYAML = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sancho-2c1i
+  namespace: sancho-ns
+  labels:
+    app: sancho-2c1i
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sancho-2c1i
+  template:
+    metadata:
+      labels:
+        app: sancho-2c1i
+    spec:
+      containers:
+      - name: sancho
+        image: gcr.io/some-project-162817/sancho
+      - name: sancho2
+        image: gcr.io/some-project-162817/sancho
+`
+
 const SanchoYAMLWithCommand = `
 apiVersion: apps/v1
 kind: Deployment

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -247,10 +247,10 @@ type ManifestState struct {
 	// The last `BuildHistoryLimit` builds. The most recent build is first in the slice.
 	BuildHistory []model.BuildRecord
 
-	// The container ID that we've run a LiveUpdate on, if any. Its contents have
-	// diverged from the image it's built on. If this container doesn't appear on
+	// The container IDs that we've run a LiveUpdate on, if any. Their contents have
+	// diverged from the image they are built on. If these container don't appear on
 	// the pod, we've lost that state and need to rebuild.
-	LiveUpdatedContainerID container.ID
+	LiveUpdatedContainerIDs map[container.ID]bool
 
 	// We detected stale code and are currently doing an image build
 	NeedsRebuildFromCrash bool
@@ -278,9 +278,10 @@ func NewState() *EngineState {
 
 func newManifestState(mn model.ManifestName) *ManifestState {
 	return &ManifestState{
-		Name:          mn,
-		BuildStatuses: make(map[model.TargetID]*BuildStatus),
-		LBs:           make(map[k8s.ServiceName]*url.URL),
+		Name:                    mn,
+		BuildStatuses:           make(map[model.TargetID]*BuildStatus),
+		LBs:                     make(map[k8s.ServiceName]*url.URL),
+		LiveUpdatedContainerIDs: container.NewIDSet(),
 	}
 }
 

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -16,7 +16,27 @@ import (
 )
 
 const FakeDeployID = model.DeployID(1234567890)
-const FakeContainerID = container.ID("myTestContainer")
+const fakeContainerID = container.ID("myTestContainer")
+
+func FakeContainerID() container.ID {
+	return FakeContainerIDAtIndex(0)
+}
+
+func FakeContainerIDAtIndex(index int) container.ID {
+	indexSuffix := ""
+	if index != 0 {
+		indexSuffix = fmt.Sprintf("-%d", index)
+	}
+	return container.ID(fmt.Sprintf("%s%s", fakeContainerID, indexSuffix))
+}
+
+func FakeContainerIDSet(size int) map[container.ID]bool {
+	result := container.NewIDSet()
+	for i := 0; i < size; i++ {
+		result[FakeContainerIDAtIndex(i)] = true
+	}
+	return result
+}
 
 // Builds Pod objects for testing
 //
@@ -77,11 +97,11 @@ func (b PodBuilder) WithImageAtIndex(image string, index int) PodBuilder {
 	return b
 }
 
-func (b PodBuilder) WithContainerID(cID string) PodBuilder {
+func (b PodBuilder) WithContainerID(cID container.ID) PodBuilder {
 	return b.WithContainerIDAtIndex(cID, 0)
 }
 
-func (b PodBuilder) WithContainerIDAtIndex(cID string, index int) PodBuilder {
+func (b PodBuilder) WithContainerIDAtIndex(cID container.ID, index int) PodBuilder {
 	if cID == "" {
 		b.cIDs[index] = ""
 	} else {
@@ -153,11 +173,7 @@ func (b PodBuilder) buildContainerID(index int) string {
 		return cID
 	}
 
-	indexSuffix := ""
-	if index != 0 {
-		indexSuffix = fmt.Sprintf("-%d", index)
-	}
-	return fmt.Sprintf("%s%s%s", k8s.ContainerIDPrefix, FakeContainerID, indexSuffix)
+	return fmt.Sprintf("%s%s", k8s.ContainerIDPrefix, FakeContainerIDAtIndex(index))
 }
 
 func (b PodBuilder) buildPhase() v1.PodPhase {


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch2905/crashes:

174d659daf9e971b55f57d7bd5dac5d37e690348 (2019-07-30 18:12:37 -0400)
engine: Handle pod crashes when there are multiple containers

5731f72d6785c11c2ea4263ae34963127780383d (2019-07-30 18:00:52 -0400)
podbuilder: make sure index of image refs/cids matches number of containers