### PR TITLE
engine/test: rewrite live update build and deploy tests with manifestbuilder for easier refactoring

### DIFF
--- a/internal/testutils/manifestbuilder/assemble.go
+++ b/internal/testutils/manifestbuilder/assemble.go
@@ -4,10 +4,23 @@ import "github.com/windmilleng/tilt/internal/model"
 
 // Assemble these targets into a manifest, that deploys to k8s,
 // wiring up all the dependency ids so that the K8sTarget depends on all
-// the image targets
+// the deployed image targets
 func assembleK8s(m model.Manifest, k model.K8sTarget, iTargets ...model.ImageTarget) model.Manifest {
+	// images on which another image depends -- we assume they are base
+	// images, i.e. not deployed directly, and so the deploy target
+	// should not depend on them.
+	baseImages := make(map[model.TargetID]bool)
+	for _, iTarget := range iTargets {
+		for _, id := range iTarget.DependencyIDs() {
+			baseImages[id] = true
+		}
+	}
+
 	ids := make([]model.TargetID, 0, len(iTargets))
 	for _, iTarget := range iTargets {
+		if baseImages[iTarget.ID()] {
+			continue
+		}
 		ids = append(ids, iTarget.ID())
 	}
 	k = k.WithDependencyIDs(ids)
@@ -18,10 +31,23 @@ func assembleK8s(m model.Manifest, k model.K8sTarget, iTargets ...model.ImageTar
 
 // Assemble these targets into a manifest, that deploys to docker compose,
 // wiring up all the dependency ids so that the DockerComposeTarget depends on all
-// the image targets
+// the deployed image targets
 func assembleDC(m model.Manifest, dcTarg model.DockerComposeTarget, iTargets ...model.ImageTarget) model.Manifest {
+	// images on which another image depends -- we assume they are base
+	// images, i.e. not deployed directly, and so the deploy target
+	// should not depend on them.
+	baseImages := make(map[model.TargetID]bool)
+	for _, iTarget := range iTargets {
+		for _, id := range iTarget.DependencyIDs() {
+			baseImages[id] = true
+		}
+	}
+
 	ids := make([]model.TargetID, 0, len(iTargets))
 	for _, iTarget := range iTargets {
+		if baseImages[iTarget.ID()] {
+			continue
+		}
 		ids = append(ids, iTarget.ID())
 	}
 	dc := dcTarg.WithDependencyIDs(ids)

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -53,6 +53,29 @@ func (b ManifestBuilder) WithImageTargets(iTargs ...model.ImageTarget) ManifestB
 	return b
 }
 
+func (b ManifestBuilder) WithLiveUpdate(lu model.LiveUpdate) ManifestBuilder {
+	return b.WithLiveUpdateAtIndex(lu, 0)
+}
+
+func (b ManifestBuilder) WithLiveUpdateAtIndex(lu model.LiveUpdate, index int) ManifestBuilder {
+	if len(b.iTargets) <= index {
+		b.f.T().Fatal("WithLiveUpdateAtIndex: index %d out of range -- (manifestBuilder has %d image targets)", index, len(b.iTargets))
+	}
+
+	iTarg := b.iTargets[index]
+	switch bd := iTarg.BuildDetails.(type) {
+	case model.DockerBuild:
+		bd.LiveUpdate = lu
+		b.iTargets[index] = iTarg.WithBuildDetails(bd)
+	case model.CustomBuild:
+		bd.LiveUpdate = lu
+		b.iTargets[index] = iTarg.WithBuildDetails(bd)
+	default:
+		b.f.T().Fatal("unrecognized buildDetails type: %v", bd)
+	}
+	return b
+}
+
 func (b ManifestBuilder) Build() model.Manifest {
 	if b.k8sYAML != "" {
 		return assembleK8s(

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -59,7 +59,7 @@ func (b ManifestBuilder) WithLiveUpdate(lu model.LiveUpdate) ManifestBuilder {
 
 func (b ManifestBuilder) WithLiveUpdateAtIndex(lu model.LiveUpdate, index int) ManifestBuilder {
 	if len(b.iTargets) <= index {
-		b.f.T().Fatal("WithLiveUpdateAtIndex: index %d out of range -- (manifestBuilder has %d image targets)", index, len(b.iTargets))
+		b.f.T().Fatalf("WithLiveUpdateAtIndex: index %d out of range -- (manifestBuilder has %d image targets)", index, len(b.iTargets))
 	}
 
 	iTarg := b.iTargets[index]
@@ -71,7 +71,7 @@ func (b ManifestBuilder) WithLiveUpdateAtIndex(lu model.LiveUpdate, index int) M
 		bd.LiveUpdate = lu
 		b.iTargets[index] = iTarg.WithBuildDetails(bd)
 	default:
-		b.f.T().Fatal("unrecognized buildDetails type: %v", bd)
+		b.f.T().Fatalf("unrecognized buildDetails type: %v", bd)
 	}
 	return b
 }


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/live-upd-engine-tests-manifestbuilder:

63f80fa2dc6e41e46ddc3544593525cae3201aeb (2019-07-30 18:37:59 -0400)
engine/test: rewrite live update build and deploy tests with manifestbuilder for easier refactoring

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics