### PR TITLE
podbuilder: by default, use the image ref name from the YAML rather than making one up

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -58,7 +58,7 @@ func MustParseNamedTagged(s string) reference.NamedTagged {
 func MustParseNamed(s string) reference.Named {
 	n, err := reference.ParseNormalizedNamed(s)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("MustParseNamed(%q): %v", s, err))
 	}
 	return n
 }

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -288,10 +288,14 @@ func TestBuildQueueOrdering(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
-	m1 := f.newManifest("manifest1").WithTriggerMode(model.TriggerModeManual)
-	m2 := f.newManifest("manifest2").WithTriggerMode(model.TriggerModeManual)
-	m3 := f.newManifest("manifest3").WithTriggerMode(model.TriggerModeManual)
-	m4 := f.newManifest("manifest4").WithTriggerMode(model.TriggerModeManual)
+	m1 := f.newManifestWithRef("manifest1", container.MustParseNamed("manifest1")).
+		WithTriggerMode(model.TriggerModeManual)
+	m2 := f.newManifestWithRef("manifest2", container.MustParseNamed("manifest2")).
+		WithTriggerMode(model.TriggerModeManual)
+	m3 := f.newManifestWithRef("manifest3", container.MustParseNamed("manifest3")).
+		WithTriggerMode(model.TriggerModeManual)
+	m4 := f.newManifestWithRef("manifest4", container.MustParseNamed("manifest4")).
+		WithTriggerMode(model.TriggerModeManual)
 
 	// attach to state in different order than we plan to trigger them
 	manifests := []model.Manifest{m4, m2, m3, m1}


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/podbuilder6:

6b9f39db6434f83ad7c32b59d5d383cc03f1242e (2019-07-30 18:49:10 -0400)
podbuilder: by default, use the image ref name from the YAML rather than making one up