### PR TITLE
engine: Handle pod crashes when there are multiple containers

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -78,3 +78,11 @@ func MustNormalizeRef(ref string) string {
 	}
 	return normalized
 }
+
+func NewIDSet(ids ...ID) map[ID]bool {
+	result := make(map[ID]bool, len(ids))
+	for _, id := range ids {
+		result[id] = true
+	}
+	return result
+}

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/windmilleng/tilt/internal/hud/server"
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
 	"github.com/windmilleng/tilt/internal/testutils/podbuilder"
 
@@ -161,7 +162,7 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 	assert.Equal(t, "pod-id", c0.PodID.String(), "pod ID for cInfo at index 0")
 	assert.Equal(t, "pod-id", c1.PodID.String(), "pod ID for cInfo at index 1")
 
-	assert.Equal(t, podbuilder.FakeContainerID, c0.ContainerID, "container ID for cInfo at index 0")
+	assert.Equal(t, podbuilder.FakeContainerID(), c0.ContainerID, "container ID for cInfo at index 0")
 	assert.Equal(t, "cID-same-image", c1.ContainerID.String(), "container ID for cInfo at index 1")
 
 	assert.Equal(t, "sancho", c0.ContainerName.String(), "container name for cInfo at index 0")
@@ -218,7 +219,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	assert.Equal(t, []string{}, call.oneState().FilesChanged())
 	f.waitForCompletedBuildCount(1)
 
-	f.b.nextLiveUpdateContainerID = podbuilder.FakeContainerID
+	f.b.nextLiveUpdateContainerIDs = []container.ID{podbuilder.FakeContainerID()}
 	f.podEvent(f.testPod("pod-id", manifest, "Running", time.Now()))
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
@@ -227,7 +228,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.waitForCompletedBuildCount(2)
 	f.withManifestState("fe", func(ms store.ManifestState) {
 		assert.Equal(t, model.BuildReasonFlagChangedFiles, ms.LastBuild().Reason)
-		assert.Equal(t, podbuilder.FakeContainerID, ms.LiveUpdatedContainerID)
+		assert.Equal(t, podbuilder.FakeContainerIDSet(1), ms.LiveUpdatedContainerIDs)
 	})
 
 	// Restart the pod with a new container id, to simulate a container restart.
@@ -237,6 +238,51 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.waitForCompletedBuildCount(3)
 
 	f.withManifestState("fe", func(ms store.ManifestState) {
+		assert.Equal(t, model.BuildReasonFlagCrash, ms.LastBuild().Reason)
+	})
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
+	f.Start([]model.Manifest{manifest}, true)
+
+	call := f.nextCall()
+	assert.Equal(t, manifest.ImageTargetAt(0), call.image())
+	f.waitForCompletedBuildCount(1)
+
+	f.b.nextLiveUpdateContainerIDs = []container.ID{"c1", "c2"}
+	f.podEvent(podbuilder.New(t, manifest).
+		WithContainerID("c1").
+		WithContainerIDAtIndex("c2", 1).
+		Build())
+	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+
+	call = f.nextCall()
+	f.waitForCompletedBuildCount(2)
+	f.withManifestState("sancho", func(ms store.ManifestState) {
+		assert.Equal(t, 2, len(ms.LiveUpdatedContainerIDs))
+	})
+
+	// Simulate pod event where one of the containers has been restarted with a new ID.
+	f.podEvent(podbuilder.New(t, manifest).
+		WithContainerID("c1").
+		WithContainerIDAtIndex("c3", 1).
+		Build())
+
+	call = f.nextCall()
+	f.waitForCompletedBuildCount(3)
+
+	f.withManifestState("sancho", func(ms store.ManifestState) {
 		assert.Equal(t, model.BuildReasonFlagCrash, ms.LastBuild().Reason)
 	})
 

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -52,7 +52,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, pod *v
 			"WARNING: Resource %s is using port forwards, but no container ports on pod %s",
 			manifest.Name, podInfo.PodID)
 	}
-	checkForPodCrash(ctx, state, ms, *podInfo)
+	checkForContainerCrash(ctx, state, mt)
 
 	if int(podInfo.BlessedContainer().Restarts) > podInfo.ContainerRestarts {
 		ms.CrashLog = podInfo.CurrentLog
@@ -218,21 +218,34 @@ func getBlessedContainerID(iTargets []model.ImageTarget, pod *v1.Pod) (container
 	}
 	return "", nil
 }
-func checkForPodCrash(ctx context.Context, state *store.EngineState, ms *store.ManifestState, podInfo store.Pod) {
+
+func checkForContainerCrash(ctx context.Context, state *store.EngineState, mt *store.ManifestTarget) {
+	ms := mt.State
 	if ms.NeedsRebuildFromCrash {
 		// We're already aware the pod is crashing.
 		return
 	}
 
-	if ms.LiveUpdatedContainerID == "" || ms.LiveUpdatedContainerID == podInfo.ContainerID() {
+	runningContainers := store.AllRunningContainers(mt)
+	hitList := make(map[container.ID]bool, len(ms.LiveUpdatedContainerIDs))
+	for cID := range ms.LiveUpdatedContainerIDs {
+		hitList[cID] = true
+	}
+	for _, c := range runningContainers {
+		delete(hitList, c.ContainerID)
+	}
+
+	if len(hitList) == 0 {
 		// The pod is what we expect it to be.
 		return
 	}
 
 	// The pod isn't what we expect!
-	ms.CrashLog = podInfo.CurrentLog
+	// TODO(nick): We should store the logs by container ID, and
+	// only put the container that crashed in the CrashLog.
+	ms.CrashLog = ms.MostRecentPod().CurrentLog
 	ms.NeedsRebuildFromCrash = true
-	ms.LiveUpdatedContainerID = ""
+	ms.LiveUpdatedContainerIDs = container.NewIDSet()
 	msg := fmt.Sprintf("Detected a container change for %s. We could be running stale code. Rebuilding and deploying a new image.", ms.Name)
 	le := store.NewLogEvent(ms.Name, []byte(msg+"\n"))
 	if len(ms.BuildHistory) > 0 {

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -103,6 +103,31 @@ spec:
                 key: token
 `
 
+const SanchoTwoContainersOneImageYAML = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sancho-2c1i
+  namespace: sancho-ns
+  labels:
+    app: sancho-2c1i
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sancho-2c1i
+  template:
+    metadata:
+      labels:
+        app: sancho-2c1i
+    spec:
+      containers:
+      - name: sancho
+        image: gcr.io/some-project-162817/sancho
+      - name: sancho2
+        image: gcr.io/some-project-162817/sancho
+`
+
 const SanchoYAMLWithCommand = `
 apiVersion: apps/v1
 kind: Deployment

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -247,10 +247,10 @@ type ManifestState struct {
 	// The last `BuildHistoryLimit` builds. The most recent build is first in the slice.
 	BuildHistory []model.BuildRecord
 
-	// The container ID that we've run a LiveUpdate on, if any. Its contents have
-	// diverged from the image it's built on. If this container doesn't appear on
+	// The container IDs that we've run a LiveUpdate on, if any. Their contents have
+	// diverged from the image they are built on. If these container don't appear on
 	// the pod, we've lost that state and need to rebuild.
-	LiveUpdatedContainerID container.ID
+	LiveUpdatedContainerIDs map[container.ID]bool
 
 	// We detected stale code and are currently doing an image build
 	NeedsRebuildFromCrash bool
@@ -278,9 +278,10 @@ func NewState() *EngineState {
 
 func newManifestState(mn model.ManifestName) *ManifestState {
 	return &ManifestState{
-		Name:          mn,
-		BuildStatuses: make(map[model.TargetID]*BuildStatus),
-		LBs:           make(map[k8s.ServiceName]*url.URL),
+		Name:                    mn,
+		BuildStatuses:           make(map[model.TargetID]*BuildStatus),
+		LBs:                     make(map[k8s.ServiceName]*url.URL),
+		LiveUpdatedContainerIDs: container.NewIDSet(),
 	}
 }
 

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -16,7 +16,27 @@ import (
 )
 
 const FakeDeployID = model.DeployID(1234567890)
-const FakeContainerID = container.ID("myTestContainer")
+const fakeContainerID = container.ID("myTestContainer")
+
+func FakeContainerID() container.ID {
+	return FakeContainerIDAtIndex(0)
+}
+
+func FakeContainerIDAtIndex(index int) container.ID {
+	indexSuffix := ""
+	if index != 0 {
+		indexSuffix = fmt.Sprintf("-%d", index)
+	}
+	return container.ID(fmt.Sprintf("%s%s", fakeContainerID, indexSuffix))
+}
+
+func FakeContainerIDSet(size int) map[container.ID]bool {
+	result := container.NewIDSet()
+	for i := 0; i < size; i++ {
+		result[FakeContainerIDAtIndex(i)] = true
+	}
+	return result
+}
 
 // Builds Pod objects for testing
 //
@@ -77,11 +97,11 @@ func (b PodBuilder) WithImageAtIndex(image string, index int) PodBuilder {
 	return b
 }
 
-func (b PodBuilder) WithContainerID(cID string) PodBuilder {
+func (b PodBuilder) WithContainerID(cID container.ID) PodBuilder {
 	return b.WithContainerIDAtIndex(cID, 0)
 }
 
-func (b PodBuilder) WithContainerIDAtIndex(cID string, index int) PodBuilder {
+func (b PodBuilder) WithContainerIDAtIndex(cID container.ID, index int) PodBuilder {
 	if cID == "" {
 		b.cIDs[index] = ""
 	} else {
@@ -150,11 +170,7 @@ func (b PodBuilder) buildContainerID(index int) string {
 		return cID
 	}
 
-	indexSuffix := ""
-	if index != 0 {
-		indexSuffix = fmt.Sprintf("-%d", index)
-	}
-	return fmt.Sprintf("%s%s%s", k8s.ContainerIDPrefix, FakeContainerID, indexSuffix)
+	return fmt.Sprintf("%s%s", k8s.ContainerIDPrefix, FakeContainerIDAtIndex(index))
 }
 
 func (b PodBuilder) buildPhase() v1.PodPhase {


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch2905/crashes:

5b59a49d352acf630b5fe7c23f0e294c9c8be8e6 (2019-07-31 12:14:03 -0400)
engine: Handle pod crashes when there are multiple containers

6b9f39db6434f83ad7c32b59d5d383cc03f1242e (2019-07-30 18:49:10 -0400)
podbuilder: by default, use the image ref name from the YAML rather than making one up