### PR TITLE
integration: misc fixes

### DIFF
--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -161,6 +161,7 @@ func (f *k8sFixture) ClearResource(name string) {
 }
 
 func (f *k8sFixture) ClearNamespace() {
+	f.ClearResource("jobs")
 	f.ClearResource("deployments")
 	f.ClearResource("services")
 }

--- a/integration/shortlived_pods/shortlived_pods.yaml
+++ b/integration/shortlived_pods/shortlived_pods.yaml
@@ -16,7 +16,7 @@ spec:
           image: alpine
           command: ["sh", "-c", "echo this is a successful job"]
       restartPolicy: Never
-  backoffLimit: 4
+  backoffLimit: 0
 ---
 apiVersion: batch/v1
 kind: Job
@@ -36,5 +36,5 @@ spec:
           image: alpine
           command: ["sh", "-c", "echo this job will fail && false"]
       restartPolicy: Never
-  backoffLimit: 4
+  backoffLimit: 0
 


### PR DESCRIPTION
I was trying to fix the TestShortLivedPods flakiness failure `does not contain "this job will fail"`, but failed. I did find a few other minor issues while trying to debug that, but AFAIK none of them have actually been problems for anyone.

1. Our integration tests delete the `tilt-integration` namespace on startup. `kubectl` doesn't wait for namespace deletion to complete before returning, so this gave us a race condition where we could try to create objects in that namespace, and it'd fail with an error like "namespace is still deleting". So, we now block until deletion completes.
2. If a background tilt command fails, log it instead of silently ignoring.
3. Delete jobs when we're deleting deployments and services.
4. `backoffLimit: 4` on our failure job meant that we'd end up with 4 pods when it failed. TThe test checks for all pods with that label to have failed, so it'd only continue when either it had restarted and failed that many times, or if it happened to check between one pod failing and the next pod starting, which just seems like too much room for weirdness.