### PR TITLE
tilt: disable version check on dev builds

### DIFF
--- a/internal/engine/version_checker.go
+++ b/internal/engine/version_checker.go
@@ -36,6 +36,12 @@ func (tvc *TiltVersionChecker) OnChange(ctx context.Context, st store.RStore) {
 		return
 	}
 
+	s := st.RLockState()
+	defer st.RUnlockState()
+	if s.TiltBuildInfo.Dev {
+		return
+	}
+
 	tvc.client = tvc.clientFactory()
 	tvc.started = true
 


### PR DESCRIPTION
I got github API rate limited while trying to repro a flaky integration test.

We don't show the version notification in the UI for dev builds anyway, so we might as well not call the API in the first place.