### PR TITLE
if we touched containers in LiveUpdate, return/record touched container IDs even if the BuildAndDeploy call fails [ch3105]

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -65,7 +65,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 		}
 
 		if !shouldFallBackForErr(err) {
-			return store.BuildResultSet{}, err
+			return br, err
 		}
 
 		if redirectErr, ok := err.(RedirectToNextBuilder); ok {

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -782,7 +782,7 @@ func TestLiveUpdateWithRunFailureReturnsContainerIDs(t *testing.T) {
 	result := resultSet[iTargID]
 	require.False(t, result.IsEmpty(), "expected build result for image target %s", iTargID)
 	require.Len(t, result.LiveUpdatedContainerIDs, 1)
-	require.Equal(t, result.LiveUpdatedContainerIDs[0], testContainerInfo)
+	require.Equal(t, result.LiveUpdatedContainerIDs[0].String(), k8s.MagicTestContainerID)
 
 	// LiveUpdate failed due to RunStepError, should NOT fall back to image build
 	assert.Equal(t, 0, f.docker.BuildCount, "expect no image build -> no docker build calls")

--- a/internal/engine/build_errors.go
+++ b/internal/engine/build_errors.go
@@ -46,6 +46,11 @@ func DontFallBackErrorf(msg string, a ...interface{}) DontFallBackError {
 	return DontFallBackError{fmt.Errorf(msg, a...)}
 }
 
+func IsDontFallBackError(err error) bool {
+	_, ok := err.(DontFallBackError)
+	return ok
+}
+
 var _ error = DontFallBackError{}
 
 // A permanent error indicates that the whole build pipeline needs to stop.
@@ -61,7 +66,7 @@ func shouldFallBackForErr(err error) bool {
 	}
 
 	cause := errors.Cause(err)
-	if _, ok := cause.(DontFallBackError); ok {
+	if IsDontFallBackError(cause) {
 		return false
 	}
 	return true

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -291,6 +291,40 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
+func TestRecordLiveUpdatedContainerIDsForFailedLiveUpdate(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
+	f.Start([]model.Manifest{manifest}, true)
+
+	call := f.nextCall()
+	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
+	f.waitForCompletedBuildCount(1)
+
+	expectedErr := fmt.Errorf("i can't let you do that dave")
+	f.b.nextBuildFailure = expectedErr
+	f.b.nextLiveUpdateContainerIDs = []container.ID{"c1", "c2"}
+
+	f.podEvent(podbuilder.New(t, manifest).
+		WithContainerIDAtIndex("c1", 0).
+		WithContainerIDAtIndex("c2", 1).
+		Build())
+	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+
+	call = f.nextCall()
+	f.waitForCompletedBuildCount(2)
+	f.withManifestState("sancho", func(ms store.ManifestState) {
+		// Manifest should have recorded last build as a failure, but
+		// ALSO have recorded the LiveUpdatedContainerIDs
+		require.Equal(t, expectedErr, ms.BuildHistory[0].Error)
+
+		assert.Equal(t, 2, len(ms.LiveUpdatedContainerIDs))
+	})
+}
 func TestBuildControllerManualTrigger(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -117,10 +117,13 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	}
 
 	err = lubad.buildAndDeploy(ctx, containerUpdater, iTarget, state, changedFiles, runs, hotReload)
-	if err != nil {
+	if err != nil && !IsDontFallBackError(err) {
 		return store.BuildResultSet{}, err
 	}
-	return liveUpdateState.createResultSet(), nil
+	// If no error, great!
+	// If we got a DontFallBack error, we still want to return a result set
+	// b/c we may have touched containers.
+	return liveUpdateState.createResultSet(), err
 }
 
 func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu containerupdate.ContainerUpdater, iTarget model.ImageTarget, state store.BuildState, changedFiles []build.PathMapping, runs []model.Run, hotReload bool) error {


### PR DESCRIPTION
if a user's Run step(s) fails, we don't fall back to an image build (b/c
        presumably the same thing will fail on the image build)
        however, any sync's have run successfully, which means
        that state on the running container has diverged, and we need
        to monitor it for crashes/do a crash rebuild if that container
        disappears. that means that we need to get that container's ID
        onto the manifest state, regardless of the fact that the
        BuildAndDeploy call as a whole has failed.