### PR TITLE
tiltfile: log changed files before tiltfile rebuild

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
-	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
 )
 
@@ -247,17 +246,9 @@ func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry, c
 		s := logger.Blue(l).Sprintf(" ├──────────────────────────────────────────────")
 		l.Infof("\n%s%s%s", p, name, s)
 	} else {
-		var changedPathsToPrint []string
-		if len(changedFiles) > maxChangedFilesToPrint {
-			changedPathsToPrint = append(changedPathsToPrint, changedFiles[:maxChangedFilesToPrint]...)
-			changedPathsToPrint = append(changedPathsToPrint, "...")
-		} else {
-			changedPathsToPrint = changedFiles
-		}
-
 		if len(changedFiles) > 0 {
 			p := logger.Green(l).Sprintf("%d changed: ", len(changedFiles))
-			l.Infof("\n%s%v\n", p, ospath.TryAsCwdChildren(changedPathsToPrint))
+			l.Infof("\n%s%v\n", p, formatFileChangeList(changedFiles))
 		}
 
 		rp := logger.Blue(l).Sprintf("──┤ Rebuilding: ")

--- a/internal/engine/changed_file_list.go
+++ b/internal/engine/changed_file_list.go
@@ -1,0 +1,22 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/windmilleng/tilt/internal/ospath"
+)
+
+// When we kick off a build because some files changed, only print the first `maxChangedFilesToPrint`
+const maxChangedFilesToPrint = 5
+
+func formatFileChangeList(changedFiles []string) string {
+	var changedPathsToPrint []string
+	if len(changedFiles) > maxChangedFilesToPrint {
+		changedPathsToPrint = append(changedPathsToPrint, changedFiles[:maxChangedFilesToPrint]...)
+		changedPathsToPrint = append(changedPathsToPrint, "...")
+	} else {
+		changedPathsToPrint = changedFiles
+	}
+
+	return fmt.Sprintf("%v", ospath.TryAsCwdChildren(changedFiles))
+}

--- a/internal/engine/changed_file_list_test.go
+++ b/internal/engine/changed_file_list_test.go
@@ -1,0 +1,23 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatChangedFileListTruncates(t *testing.T) {
+	actual := formatFileChangeList([]string{"a", "b", "c", "d", "e", "f"})
+	expected := "[a b c d e f]"
+	require.Equal(t, expected, actual)
+}
+
+func TestFormatChangedFileListMakesRelative(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	actual := formatFileChangeList([]string{filepath.Join(wd, "foo"), "/bar/baz"})
+	expected := "[foo /bar/baz]"
+	require.Equal(t, expected, actual)
+}

--- a/internal/engine/configs_controller.go
+++ b/internal/engine/configs_controller.go
@@ -62,8 +62,20 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 		matching[string(m)] = true
 	}
 
+	var changedFiles []string
+	for k := range filesChanged {
+		changedFiles = append(changedFiles, k)
+	}
+
+	l := logger.Get(ctx)
+
+	if len(changedFiles) > 0 {
+		p := logger.Green(l).Sprintf("%d changed: ", len(changedFiles))
+		l.Infof("\n%s%v\n", p, formatFileChangeList(changedFiles))
+	}
+
 	actionWriter := NewTiltfileLogWriter(st)
-	loadCtx := logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), actionWriter))
+	loadCtx := logger.WithLogger(ctx, logger.NewLogger(l.Level(), actionWriter))
 
 	tlr, err := cc.tfl.Load(loadCtx, tiltfilePath, matching)
 	if err == nil && len(tlr.Manifests) == 0 {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -42,9 +42,6 @@ const watchBufferMaxTimeInMs = 10000
 var watchBufferMinRestDuration = watchBufferMinRestInMs * time.Millisecond
 var watchBufferMaxDuration = watchBufferMaxTimeInMs * time.Millisecond
 
-// When we kick off a build because some files changed, only print the first `maxChangedFilesToPrint`
-const maxChangedFilesToPrint = 5
-
 // TODO(nick): maybe this should be called 'BuildEngine' or something?
 // Upper seems like a poor and undescriptive name.
 type Upper struct {


### PR DESCRIPTION
### Problem

If you change a file that causes the Tiltfile to reexecute, it doesn't appear anywhere in the log, so it can be pretty frustrating to figure out why the Tiltfile rebuilt

### Solution

Make ConfigsController log changed files the same way that BuildController does.
(Maybe at some point in the future we want to merge these controllers? I haven't given it much thought.)