### PR TITLE
engine: can LiveUpdate multiple images for same manifest [ch3005]

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -138,6 +138,24 @@ func TestNamespaceGKE(t *testing.T) {
 	assert.Equal(t, "sancho-ns", string(f.sCli.Namespace))
 }
 
+func TestYamlManifestDeploy(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
+	defer f.TearDown()
+
+	manifest := manifestbuilder.New(f, "some_yaml").
+		WithK8sYAML(testyaml.TracerYAML).Build()
+	targets := buildTargets(manifest)
+	_, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, store.BuildStateSet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 0, f.sCli.UpdateContainerCount)
+	assert.Equal(t, 0, f.docker.BuildCount)
+	assert.Equal(t, 0, f.docker.PushCount)
+	f.assertK8sUpsertCalled(true)
+}
+
 func TestContainerBuildLocal(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
 	defer f.TearDown()

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -807,7 +807,6 @@ func TestLiveUpdateMultipleImagesSamePod(t *testing.T) {
 
 	// one for each container update
 	assert.Equal(t, 2, f.sCli.UpdateContainerCount)
-
 }
 
 // The API boundaries between BuildAndDeployer and the ImageBuilder aren't obvious and

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -820,12 +820,19 @@ func TestOneLiveUpdateOneDockerBuildDoesImageBuild(t *testing.T) {
 	assert.Equal(t, 0, f.sCli.UpdateContainerCount)
 }
 
-// func TestLiveUpdateMultipleImagesOneRunErrorExecutesRestOfLiveUpdatesAndDoesntImageBuild(t *testing.T) {
-// 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-// 	defer f.TearDown()
-//
-// 	t.Fatal("not implemented")
-// }
+func TestLiveUpdateMultipleImagesOneRunErrorExecutesRestOfLiveUpdatesAndDoesntImageBuild(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
+	defer f.TearDown()
+
+	// First LiveUpdate will simulate a failed Run step
+	f.docker.ExecErrorsToThrow = []error{userFailureErr}
+
+	manifest, bs := multiImageLiveUpdateManifestAndBuildState(f)
+	_, err := f.bd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestLiveUpdateMultipleImagesOneUpdateErrorFallsBackToImageBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -291,6 +291,8 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
+// TODO(maia)	: test one live update fails --> fall back to image build
+
 func TestBuildControllerManualTrigger(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -291,7 +291,7 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
-// TODO(maia)	: test one live update fails --> fall back to image build
+// TODO(maia): test one live update fails --> fall back to image build
 
 func TestBuildControllerManualTrigger(t *testing.T) {
 	f := newTestFixture(t)

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -262,7 +262,56 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 
 	f.b.nextLiveUpdateContainerIDs = []container.ID{"c1", "c2"}
 	f.podEvent(podbuilder.New(t, manifest).
+		WithContainerIDAtIndex("c1", 0).
+		WithContainerIDAtIndex("c2", 1).
+		Build())
+	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+
+	call = f.nextCall()
+	f.waitForCompletedBuildCount(2)
+	f.withManifestState("sancho", func(ms store.ManifestState) {
+		assert.Equal(t, 2, len(ms.LiveUpdatedContainerIDs))
+	})
+
+	// Simulate pod event where one of the containers has been restarted with a new ID.
+	f.podEvent(podbuilder.New(t, manifest).
 		WithContainerID("c1").
+		WithContainerIDAtIndex("c3", 1).
+		Build())
+
+	call = f.nextCall()
+	f.waitForCompletedBuildCount(3)
+
+	f.withManifestState("sancho", func(ms store.ManifestState) {
+		assert.Equal(t, model.BuildReasonFlagCrash, ms.LastBuild().Reason)
+	})
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		WithImageTarget(NewSanchoSidecarLiveUpdateImageTarget(f)).
+		Build()
+	f.Start([]model.Manifest{manifest}, true)
+
+	call := f.nextCall()
+	iTargs := call.imageTargets()
+	require.Len(t, iTargs, 2)
+	assert.Equal(t, manifest.ImageTargetAt(0), iTargs[0])
+	assert.Equal(t, manifest.ImageTargetAt(1), iTargs[1])
+	f.waitForCompletedBuildCount(1)
+
+	f.b.nextLiveUpdateContainerIDs = []container.ID{"c1", "c2"}
+	f.podEvent(podbuilder.New(t, manifest).
+		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
 		Build())
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -61,6 +61,10 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	containerUpdater := lubad.containerUpdaterForSpecs(specs)
 	liveUpdInfos := make([]liveUpdInfo, len(liveUpdateStateSet))
 
+	if len(liveUpdateStateSet) == 0 {
+		return nil, RedirectToNextBuilderInfof("no targets for LiveUpdate found")
+	}
+
 	for i, liveUpdateState := range liveUpdateStateSet {
 		iTarget := liveUpdateState.iTarget
 		state := liveUpdateState.iTargetState

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -5,15 +5,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/pkg/errors"
 
-	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/containerupdate"
-
-	"github.com/opentracing/opentracing-go"
 
 	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/ignore"
@@ -47,80 +43,92 @@ func NewLiveUpdateBuildAndDeployer(dcu *containerupdate.DockerContainerUpdater,
 	}
 }
 
+// Info needed to perform a live update
+type liveUpdInfo struct {
+	iTarget      model.ImageTarget
+	state        store.BuildState
+	changedFiles []build.PathMapping
+	runs         []model.Run
+	hotReload    bool
+}
+
 func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
 	liveUpdateStateSet, err := extractImageTargetsForLiveUpdates(specs, stateSet)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
 
-	if len(liveUpdateStateSet) != 1 {
-		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("LiveUpdateBuildAndDeployer needs exactly one image target (got %d)", len(liveUpdateStateSet))
-	}
-
-	liveUpdateState := liveUpdateStateSet[0]
-	iTarget := liveUpdateState.iTarget
-	state := liveUpdateState.iTargetState
-	filesChanged := liveUpdateState.filesChanged
-
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LiveUpdateBuildAndDeployer-BuildAndDeploy")
-	span.SetTag("target", iTarget.ConfigurationRef.String())
-	defer span.Finish()
-
-	startTime := time.Now()
-	defer func() {
-		analytics.Get(ctx).Timer("build.container", time.Since(startTime), nil)
-	}()
-
-	// LiveUpdateBuildAndDeployer doesn't support initial build
-	// TODO(maia): put this check in extractImageTargetsForLiveUpdates()
-	if state.IsEmpty() {
-		return store.BuildResultSet{}, SilentRedirectToNextBuilderf("prev. build state is empty; LiveUpdate does not support initial deploy")
-	}
-
 	containerUpdater := lubad.containerUpdaterForSpecs(specs)
-	var changedFiles []build.PathMapping
-	var runs []model.Run
-	var hotReload bool
+	liveUpdInfos := make([]liveUpdInfo, len(liveUpdateStateSet))
 
-	if fbInfo := iTarget.AnyFastBuildInfo(); !fbInfo.Empty() {
-		changedFiles, err = build.FilesToPathMappings(filesChanged, fbInfo.Syncs)
-		if err != nil {
-			return store.BuildResultSet{}, err
-		}
-		runs = fbInfo.Runs
-		hotReload = fbInfo.HotReload
-	}
-	if luInfo := iTarget.AnyLiveUpdateInfo(); !luInfo.Empty() {
-		changedFiles, err = build.FilesToPathMappings(filesChanged, luInfo.SyncSteps())
-		if err != nil {
-			if pmErr, ok := err.(*build.PathMappingErr); ok {
-				// expected error for this builder. One of more files don't match sync's;
-				// i.e. they're within the docker context but not within a sync; do a full image build.
-				return nil, RedirectToNextBuilderInfof(
-					"at least one file (%s) doesn't match a LiveUpdate sync, so performing a full build", pmErr.File)
+	for i, liveUpdateState := range liveUpdateStateSet {
+		iTarget := liveUpdateState.iTarget
+		state := liveUpdateState.iTargetState
+		filesChanged := liveUpdateState.filesChanged
+
+		// span, ctx := opentracing.StartSpanFromContext(ctx, "LiveUpdateBuildAndDeployer-BuildAndDeploy")
+		// span.SetTag("target", iTarget.ConfigurationRef.String())
+		// defer span.Finish()
+		//
+		// startTime := time.Now()
+		// defer func() {
+		// 	analytics.Get(ctx).Timer("build.container", time.Since(startTime), nil)
+		// }()
+
+		var changedFiles []build.PathMapping
+		var runs []model.Run
+		var hotReload bool
+
+		if fbInfo := iTarget.AnyFastBuildInfo(); !fbInfo.Empty() {
+			changedFiles, err = build.FilesToPathMappings(filesChanged, fbInfo.Syncs)
+			if err != nil {
+				return store.BuildResultSet{}, err
 			}
+			runs = fbInfo.Runs
+			hotReload = fbInfo.HotReload
+		}
+		if luInfo := iTarget.AnyLiveUpdateInfo(); !luInfo.Empty() {
+			changedFiles, err = build.FilesToPathMappings(filesChanged, luInfo.SyncSteps())
+			if err != nil {
+				if pmErr, ok := err.(*build.PathMappingErr); ok {
+					// expected error for this builder. One of more files don't match sync's;
+					// i.e. they're within the docker context but not within a sync; do a full image build.
+					return nil, RedirectToNextBuilderInfof(
+						"at least one file (%s) doesn't match a LiveUpdate sync, so performing a full build", pmErr.File)
+				}
+				return store.BuildResultSet{}, err
+			}
+
+			// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
+			anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
+			if err != nil {
+				return nil, err
+			}
+			if anyMatch {
+				return store.BuildResultSet{}, RedirectToNextBuilderInfof(
+					"detected change to fall_back_on file '%s'", file)
+			}
+
+			runs = luInfo.RunSteps()
+			hotReload = !luInfo.ShouldRestart()
+		}
+
+		liveUpdInfos[i] = liveUpdInfo{
+			iTarget:      iTarget,
+			state:        state,
+			changedFiles: changedFiles,
+			runs:         runs,
+			hotReload:    hotReload,
+		}
+	}
+
+	for _, info := range liveUpdInfos {
+		err = lubad.buildAndDeploy(ctx, containerUpdater, info.iTarget, info.state, info.changedFiles, info.runs, info.hotReload)
+		if err != nil {
 			return store.BuildResultSet{}, err
 		}
-
-		// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
-		anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
-		if err != nil {
-			return nil, err
-		}
-		if anyMatch {
-			return store.BuildResultSet{}, RedirectToNextBuilderInfof(
-				"detected change to fall_back_on file '%s'", file)
-		}
-
-		runs = luInfo.RunSteps()
-		hotReload = !luInfo.ShouldRestart()
 	}
-
-	err = lubad.buildAndDeploy(ctx, containerUpdater, iTarget, state, changedFiles, runs, hotReload)
-	if err != nil {
-		return store.BuildResultSet{}, err
-	}
-	return liveUpdateState.createResultSet(), nil
+	return createResultSet(liveUpdateStateSet), nil
 }
 
 func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu containerupdate.ContainerUpdater, iTarget model.ImageTarget, state store.BuildState, changedFiles []build.PathMapping, runs []model.Run, hotReload bool) error {

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -178,7 +178,6 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 
 	var lastUserBuildFailure error
 	for _, cInfo := range state.RunningContainers {
-
 		// always pass a copy of the tar archive reader
 		// so multiple updates can access the same data
 		var archiveBuf bytes.Buffer

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -83,6 +83,17 @@ func (set BuildResultSet) LiveUpdatedContainerIDs() []container.ID {
 	return result
 }
 
+func MergeBuildResultsSet(a, b BuildResultSet) BuildResultSet {
+	res := make(BuildResultSet)
+	for k, v := range a {
+		res[k] = v
+	}
+	for k, v := range b {
+		res[k] = v
+	}
+	return res
+}
+
 // Returns a container ID iff it's the only container ID in the result set.
 // If there are multiple container IDs, we have to give up.
 func (set BuildResultSet) OneAndOnlyLiveUpdatedContainerID() container.ID {


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/live-update-multi-image:

04f913506b05d7ea143d32d3185905de89269620 (2019-08-02 11:08:45 -0400)
fix error handling & test

4fc089e00b408a8b2a5d8cbf26dd89dfed152f74 (2019-08-01 15:14:44 -0400)
wip

e11ff97109e1de79d72640f220e583a23940c49f (2019-08-01 14:37:59 -0400)
some tests

fbc8ac330bcfc9a1cd8044d74de435defb9d70e0 (2019-08-01 12:51:43 -0400)
another crash rebuild test

1a88d75dfc413bccdeab1f6284ce97e16d4b1ce8 (2019-08-01 12:30:35 -0400)
initial implementation of multi-image live update for same pod

5d4db2b9a8d0b9d9447b745b09ad9015158023b0 (2019-08-01 12:30:02 -0400)
Red test

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics