### PR TITLE
goreleaser: add windows but mark it as alpha

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
   goos:
   - linux
   - darwin
+  - windows
   # Cross-compiling darwin is a pain due to fsevents,
   # and we don't expect darwin/386 users anyway.
   ignore:
@@ -16,6 +17,7 @@ builds:
 archive:
   name_template: "{{ .ProjectName }}.{{ .Version }}.{{ .Os }}.{{ .Arch }}"
   replacements:
+    windows: windows_ALPHA
     darwin: mac
     linux: linux
     386: i386


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/windows2:

e86e0a1dceaf51480b9f7c203bffec53997a727b (2019-08-02 11:57:16 -0400)
goreleaser: add windows but mark it as alpha