### PR TITLE
pod watch: delete dead pods

### DIFF
--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -102,6 +102,11 @@ func ensureManifestTargetWithPod(state *store.EngineState, pod *v1.Pod) (*store.
 	ns := k8s.NamespaceFromPod(pod)
 	hasSynclet := sidecar.PodSpecContainsSynclet(pod.Spec)
 
+	if pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero() && ms.PodSet.Pods != nil {
+		delete(ms.PodSet.Pods, podID)
+		return nil, nil
+	}
+
 	// CASE 1: We don't have a set of pods for this DeployID yet
 	if ms.PodSet.DeployID == 0 || ms.PodSet.DeployID != deployID {
 		ms.PodSet = store.PodSet{

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -32,12 +32,12 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, pod *v
 	}
 
 	// Update the status
-	podInfo.Deleting = pod.DeletionTimestamp != nil
+	podInfo.Deleting = pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero()
 	podInfo.Phase = pod.Status.Phase
 	podInfo.Status = podStatusToString(*pod)
 	podInfo.StatusMessages = podStatusErrorMessages(*pod)
 
-	defer prunePods(ms)
+	prunePods(ms)
 
 	oldRestartTotal := podInfo.AllContainerRestarts()
 	podInfo.Containers = podContainers(ctx, pod)
@@ -101,11 +101,6 @@ func ensureManifestTargetWithPod(state *store.EngineState, pod *v1.Pod) (*store.
 	status := podStatusToString(*pod)
 	ns := k8s.NamespaceFromPod(pod)
 	hasSynclet := sidecar.PodSpecContainsSynclet(pod.Spec)
-
-	if pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero() && ms.PodSet.Pods != nil {
-		delete(ms.PodSet.Pods, podID)
-		return nil, nil
-	}
 
 	// CASE 1: We don't have a set of pods for this DeployID yet
 	if ms.PodSet.DeployID == 0 || ms.PodSet.DeployID != deployID {
@@ -232,17 +227,17 @@ func checkForContainerCrash(ctx context.Context, state *store.EngineState, mt *s
 // If there's more than one pod, prune the deleting/dead ones so
 // that they don't clutter the output.
 func prunePods(ms *store.ManifestState) {
+	// Always remove pods that were manually deleted.
+	for key, pod := range ms.PodSet.Pods {
+		if pod.Deleting {
+			delete(ms.PodSet.Pods, key)
+		}
+	}
 	// Continue pruning until we have 1 pod.
 	for ms.PodSet.Len() > 1 {
 		bestPod := ms.MostRecentPod()
 
 		for key, pod := range ms.PodSet.Pods {
-			// Always remove pods that were manually deleted.
-			if pod.Deleting {
-				delete(ms.PodSet.Pods, key)
-				break
-			}
-
 			// Remove terminated pods if they aren't the most recent one.
 			isDead := pod.Phase == v1.PodSucceeded || pod.Phase == v1.PodFailed
 			if isDead && pod.PodID != bestPod.PodID {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1367,7 +1367,7 @@ func TestPodEventDeleted(t *testing.T) {
 		return state.PodSet.ContainsID("my-pod")
 	})
 
-	pod.DeletionTimestamp = &metav1.Time{pod.CreationTimestamp.Add(time.Minute)}
+	pod.DeletionTimestamp = &metav1.Time{Time: pod.CreationTimestamp.Add(time.Minute)}
 	f.podEvent(pod)
 
 	f.WaitUntilManifestState("podset is empty", mn, func(state store.ManifestState) bool {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1349,6 +1349,39 @@ func TestPodEventUpdateByTimestamp(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
+func TestPodEventDeleted(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+	mn := model.ManifestName("foobar")
+	manifest := f.newManifest(mn.String())
+	f.Start([]model.Manifest{manifest}, true)
+
+	call := f.nextCallComplete()
+	assert.True(t, call.oneState().IsEmpty())
+
+	creationTime := time.Now()
+	pod := f.testPod("my-pod", manifest, "Running", creationTime)
+	f.podEvent(pod)
+
+	f.WaitUntilManifestState("pod crashes", mn, func(state store.ManifestState) bool {
+		return state.PodSet.ContainsID("my-pod")
+	})
+
+	pod.DeletionTimestamp = &metav1.Time{pod.CreationTimestamp.Add(time.Minute)}
+	f.podEvent(pod)
+
+	f.WaitUntilManifestState("podset is empty", mn, func(state store.ManifestState) bool {
+		return state.PodSet.Len() == 0
+	})
+
+	err := f.Stop()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.assertAllBuildsConsumed()
+}
+
 func TestPodEventUpdateByPodName(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
fixes #1862 

### Problem

If a manifest loses its pod and doesn't get a new pod to replace it, we never remove that pod from its podset, so every time `PodLogController`'s `OnChange` gets called, it tries to watch the old pod and immediately fails and logs an error, resulting in spam.

Our normal mechanism for removing dead pods from a manifest's podset only kicks in when the podset has one more than one pod (which is normally the case because normally a pod gets deleted when a new pod gets created).

### Solution

Delete pods from podset as soon as we see they've been deleted.