### PR TITLE
containerupdater: fix kubectl exec updater to handle RunStepFailure

### DIFF
--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -229,6 +229,9 @@ func (f *k8sFixture) SetRestrictedCredentials() {
 	// docker-for-desktop has a default binding that gives service accounts access to everything.
 	// See: https://github.com/docker/for-mac/issues/3694
 	f.runCommandSilently("kubectl", "delete", "clusterrolebinding", "docker-for-desktop-binding", "--ignore-not-found")
+
+	// The service account needs the namespace to exist.
+	f.runCommandSilently("kubectl", "apply", "-f", "namespace.yaml")
 	f.runCommandSilently("kubectl", "apply", "-f", "service-account.yaml")
 	f.runCommandSilently("kubectl", "apply", "-f", "access.yaml")
 	f.getSecrets()

--- a/integration/onewatch_test.go
+++ b/integration/onewatch_test.go
@@ -33,7 +33,14 @@ func TestOneWatch(t *testing.T) {
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "🍄 One-Up! 🍄")
 
-	f.ReplaceContents("main.go", "One-Up", "Two-Up")
+	// Introduce a syntax error
+	f.ReplaceContents("main.go", "One-Up", "One-Up\"")
+
+	f.WaitUntil(ctx, "live_update syntax error", func() (string, error) {
+		return f.logs.String(), nil
+	}, "FAILED TO UPDATE CONTAINER")
+
+	f.ReplaceContents("main.go", "One-Up\"", "Two-Up")
 
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/internal/containerupdate/exec_updater.go
+++ b/internal/containerupdate/exec_updater.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/k8s"
-
 	"github.com/windmilleng/tilt/internal/logger"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
@@ -59,7 +59,7 @@ func (cu *ExecUpdater) UpdateContainer(ctx context.Context, cInfo store.Containe
 		err := cu.kCli.Exec(ctx, cInfo.PodID, cInfo.ContainerName, cInfo.Namespace,
 			c.Argv, nil, w, w)
 		if err != nil {
-			return err
+			return build.WrapCodeExitError(err, cInfo.ContainerID, c)
 		}
 
 	}

--- a/internal/containerupdate/synclet_updater.go
+++ b/internal/containerupdate/synclet_updater.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/tilt/internal/model"
 	"github.com/windmilleng/tilt/internal/store"
 )
@@ -37,9 +36,5 @@ func (cu *SyncletUpdater) UpdateContainer(ctx context.Context, cInfo store.Conta
 		return err
 	}
 
-	err = sCli.UpdateContainer(ctx, cInfo.ContainerID, archiveBytes, filesToDelete, cmds, hotReload)
-	if err != nil && build.IsRunStepFailure(err) {
-		return err
-	}
-	return nil
+	return sCli.UpdateContainer(ctx, cInfo.ContainerID, archiveBytes, filesToDelete, cmds, hotReload)
 }

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -63,7 +63,8 @@ type FakeK8sClient struct {
 
 	GetResources map[GetKey]*unstructured.Unstructured
 
-	ExecCalls []ExecCall
+	ExecCalls  []ExecCall
+	ExecErrors []error
 }
 
 type ExecCall struct {
@@ -340,6 +341,12 @@ func (c *FakeK8sClient) Exec(ctx context.Context, podID PodID, cName container.N
 		Cmd:   cmd,
 		Stdin: stdinBytes,
 	})
+
+	if len(c.ExecErrors) > 0 {
+		err = c.ExecErrors[0]
+		c.ExecErrors = c.ExecErrors[1:]
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/liveupdate:

9e16268684663664fdf5c3302a2bd6a415520873 (2019-08-02 13:14:18 -0400)
containerupdater: fix kubectl exec updater to handle RunStepFailure