### PR TITLE
tiltfile: only calculate absolute paths on a starlark thread

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -111,7 +111,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 	if contextVal == nil {
 		return nil, fmt.Errorf("Argument 2 (context): empty but is required")
 	}
-	context, err := s.localPathFromSkylarkValue(contextVal)
+	context, err := s.absPathFromStarlarkValue(thread, contextVal)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 			return nil, fmt.Errorf("Argument (dockerfile_contents): must be string or blob.")
 		}
 	} else if dockerfilePathVal != nil {
-		dockerfilePath, err = s.localPathFromSkylarkValue(dockerfilePathVal)
+		dockerfilePath, err = s.absPathFromStarlarkValue(thread, dockerfilePathVal)
 		if err != nil {
 			return nil, err
 		}
@@ -264,7 +264,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 	defer iter.Done()
 	var v starlark.Value
 	for iter.Next(&v) {
-		p, err := s.localPathFromSkylarkValue(v)
+		p, err := s.absPathFromStarlarkValue(thread, v)
 		if err != nil {
 			return nil, fmt.Errorf("Argument 3 (deps): %v", err)
 		}
@@ -386,7 +386,7 @@ func (s *tiltfileState) fastBuild(thread *starlark.Thread, fn *starlark.Builtin,
 		return nil, err
 	}
 
-	baseDockerfilePath, err := s.localPathFromSkylarkValue(baseDockerfile)
+	baseDockerfilePath, err := s.absPathFromStarlarkValue(thread, baseDockerfile)
 	if err != nil {
 		return nil, fmt.Errorf("Argument 2 (base_dockerfile): %v", err)
 	}
@@ -515,7 +515,7 @@ func (b *fastBuild) add(thread *starlark.Thread, fn *starlark.Builtin, args star
 	}
 
 	s := pathSync{}
-	lp, err := b.s.localPathFromSkylarkValue(src)
+	lp, err := b.s.absPathFromStarlarkValue(thread, src)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s.%s(): invalid type for src (arg 1)", b.String(), fn.Name())
 	}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -106,7 +106,7 @@ func (s *tiltfileState) k8sYaml(thread *starlark.Thread, fn *starlark.Builtin, a
 		return nil, err
 	}
 
-	entities, err := s.yamlEntitiesFromSkylarkValueOrList(yamlValue)
+	entities, err := s.yamlEntitiesFromSkylarkValueOrList(thread, yamlValue)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin
 		}
 	}
 
-	entities, err := s.yamlEntitiesFromSkylarkValueOrList(yamlValue)
+	entities, err := s.yamlEntitiesFromSkylarkValueOrList(thread, yamlValue)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (s *tiltfileState) k8sResourceV1(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
-	entities, err := s.yamlEntitiesFromSkylarkValueOrList(yamlValue)
+	entities, err := s.yamlEntitiesFromSkylarkValueOrList(thread, yamlValue)
 	if err != nil {
 		return nil, err
 	}
@@ -626,11 +626,11 @@ func (s *tiltfileState) makeK8sResource(name string) (*k8sResource, error) {
 	return r, nil
 }
 
-func (s *tiltfileState) yamlEntitiesFromSkylarkValueOrList(v starlark.Value) ([]k8s.K8sEntity, error) {
+func (s *tiltfileState) yamlEntitiesFromSkylarkValueOrList(thread *starlark.Thread, v starlark.Value) ([]k8s.K8sEntity, error) {
 	values := starlarkValueOrSequenceToSlice(v)
 	var ret []k8s.K8sEntity
 	for _, value := range values {
-		entities, err := s.yamlEntitiesFromSkylarkValue(value)
+		entities, err := s.yamlEntitiesFromSkylarkValue(thread, value)
 		if err != nil {
 			return nil, err
 		}
@@ -648,14 +648,14 @@ func parseYAMLFromBlob(blob blob) ([]k8s.K8sEntity, error) {
 	return ret, nil
 }
 
-func (s *tiltfileState) yamlEntitiesFromSkylarkValue(v starlark.Value) ([]k8s.K8sEntity, error) {
+func (s *tiltfileState) yamlEntitiesFromSkylarkValue(thread *starlark.Thread, v starlark.Value) ([]k8s.K8sEntity, error) {
 	switch v := v.(type) {
 	case nil:
 		return nil, nil
 	case *blob:
 		return parseYAMLFromBlob(*v)
 	default:
-		yamlPath, err := s.localPathFromSkylarkValue(v)
+		yamlPath, err := s.absPathFromStarlarkValue(thread, v)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -305,7 +305,9 @@ func newLiveUpdateFixture(t *testing.T) *liveUpdateFixture {
 	var steps []model.LiveUpdateStep
 
 	steps = append(steps,
-		model.LiveUpdateFallBackOnStep{Files: []string{"foo/i", "foo/j"}},
+		model.LiveUpdateFallBackOnStep{
+			Files: []string{f.JoinPath("foo/i"), f.JoinPath("foo/j")},
+		},
 		model.LiveUpdateSyncStep{Source: f.JoinPath("foo", "b"), Dest: "/c"},
 		model.LiveUpdateRunStep{
 			Command:  model.ToShellCmd("f"),

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -879,10 +879,12 @@ func (s *tiltfileState) validateLiveUpdate(iTarget model.ImageTarget, g model.Ta
 	}
 
 	for _, path := range lu.FallBackOnFiles().Paths {
-		absPath := s.absPath(path)
-		if !ospath.IsChildOfOne(watchedPaths, absPath) {
+		if !filepath.IsAbs(path) {
+			return fmt.Errorf("internal error: path not resolved correctly! Please report to https://github.com/windmilleng/tilt/issues : %s", path)
+		}
+		if !ospath.IsChildOfOne(watchedPaths, path) {
 			return fmt.Errorf("fall_back_on paths '%s' is not a child of any watched filepaths (%v)",
-				absPath, watchedPaths)
+				path, watchedPaths)
 		}
 
 	}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/starlark:

4d77b774900c2a224fd637e81fdf96f1dd389780 (2019-08-05 18:34:15 -0400)
tiltfile: only calculate absolute paths on a starlark thread
in preparation for multiple tiltfiles, where the current Tiltfile will change over time