### PR TITLE
engine: tee archive correctly even when run step fails

### DIFF
--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -278,6 +278,21 @@ func TarPath(ctx context.Context, writer io.Writer, path string) error {
 	return ab.Close()
 }
 
+func TarArchiveForPaths(ctx context.Context, toArchive []PathMapping, filter model.PathMatcher) (io.Reader, error) {
+	pr, pw := io.Pipe()
+	ab := NewArchiveBuilder(pw, filter)
+	err := ab.ArchivePathsIfExist(ctx, toArchive)
+	if err != nil {
+		_ = pw.CloseWithError(errors.Wrap(err, "archivePathsIfExists"))
+		return nil, err
+	} else {
+		_ = ab.Close()
+		_ = pw.Close()
+
+	}
+	return pr, nil
+}
+
 // Dedupe the entries with last-entry-wins semantics.
 func dedupeEntries(entries []archiveEntry) []archiveEntry {
 	seenIndex := make(map[string]int, len(entries))

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -136,11 +136,7 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 
 	var lastUserBuildFailure error
 	for _, cInfo := range state.RunningContainers {
-		archive, err := build.TarArchiveForPaths(ctx, toArchive, filter)
-		if err != nil {
-			return errors.Wrap(err, "TarArchiveForPaths")
-		}
-
+		archive := build.TarArchiveForPaths(ctx, toArchive, filter)
 		err = cu.UpdateContainer(ctx, cInfo, archive,
 			build.PathMappingsToContainerPaths(toRemove), boiledSteps, hotReload)
 		if err != nil {

--- a/internal/engine/live_update_build_and_deployer_test.go
+++ b/internal/engine/live_update_build_and_deployer_test.go
@@ -217,7 +217,7 @@ func TestErrorStopsSubsequentContainerUpdates(t *testing.T) {
 	require.Len(t, f.cu.Calls, 1, "should only call UpdateContainer once (error should stop subsequent calls)")
 }
 
-func TestUpdateMultipleContainersTeesArchive(t *testing.T) {
+func TestUpdateMultipleContainersWithSameTarArchive(t *testing.T) {
 	f := newFixture(t)
 	defer f.teardown()
 
@@ -267,7 +267,7 @@ func TestUpdateMultipleContainersTeesArchive(t *testing.T) {
 	}
 }
 
-func TestUpdateMultipleContainersTeesArchiveOnRunStepFailure(t *testing.T) {
+func TestUpdateMultipleContainersWithSameTarArchiveOnRunStepFailure(t *testing.T) {
 	f := newFixture(t)
 	defer f.teardown()
 

--- a/internal/engine/live_update_build_and_deployer_test.go
+++ b/internal/engine/live_update_build_and_deployer_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
+var rsf = build.RunStepFailure{
+	Cmd:      model.ToShellCmd("omgwtfbbq"),
+	ExitCode: 123,
+}
+
 var TestContainerInfo = store.ContainerInfo{
 	PodID:         "somepod",
 	ContainerID:   docker.TestContainer,
@@ -102,7 +107,7 @@ func TestDontFallBackOnUserError(t *testing.T) {
 	f := newFixture(t)
 	defer f.teardown()
 
-	f.cu.UpdateErr = build.RunStepFailure{ExitCode: 12345}
+	f.cu.SetUpdateErr(build.RunStepFailure{ExitCode: 12345})
 
 	err := f.lubad.buildAndDeploy(f.ctx, f.cu, model.ImageTarget{}, TestBuildState, nil, nil, false)
 	if assert.NotNil(t, err) {
@@ -205,7 +210,7 @@ func TestErrorStopsSubsequentContainerUpdates(t *testing.T) {
 		RunningContainers: cInfos,
 	}
 
-	f.cu.UpdateErr = fmt.Errorf("👀")
+	f.cu.SetUpdateErr(fmt.Errorf("👀"))
 	err := f.lubad.buildAndDeploy(f.ctx, f.cu, model.ImageTarget{}, state, nil, nil, false)
 	require.NotNil(t, err)
 	assert.Contains(t, "👀", err.Error())
@@ -259,6 +264,56 @@ func TestUpdateMultipleContainersTeesArchive(t *testing.T) {
 	for i, call := range f.cu.Calls {
 		assert.Equal(t, cInfos[i], call.ContainerInfo)
 		testutils.AssertFilesInTar(f.t, tar.NewReader(call.Archive), expected)
+	}
+}
+
+func TestUpdateMultipleContainersTeesArchiveOnRunStepFailure(t *testing.T) {
+	f := newFixture(t)
+	defer f.teardown()
+
+	cInfo1 := store.ContainerInfo{
+		PodID:         "mypod",
+		ContainerID:   "cid1",
+		ContainerName: "container1",
+		Namespace:     "ns-foo",
+	}
+	cInfo2 := store.ContainerInfo{
+		PodID:         "mypod",
+		ContainerID:   "cid2",
+		ContainerName: "container2",
+		Namespace:     "ns-foo",
+	}
+
+	cInfos := []store.ContainerInfo{cInfo1, cInfo2}
+	state := store.BuildState{
+		LastResult:        alreadyBuilt,
+		FilesChangedSet:   map[string]bool{"foo.py": true},
+		RunningContainers: cInfos,
+	}
+
+	// Write files so we know whether to cp to or rm from container
+	f.WriteFile("hi", "hello")
+	f.WriteFile("planets/earth", "world")
+
+	paths := []build.PathMapping{
+		build.PathMapping{LocalPath: f.JoinPath("hi"), ContainerPath: "/src/hi"},
+		build.PathMapping{LocalPath: f.JoinPath("planets/earth"), ContainerPath: "/src/planets/earth"},
+	}
+	expected := []expectedFile{
+		expectFile("src/hi", "hello"),
+		expectFile("src/planets/earth", "world"),
+	}
+
+	f.cu.UpdateErrs = []error{rsf, rsf}
+	err := f.lubad.buildAndDeploy(f.ctx, f.cu, model.ImageTarget{}, state, paths, nil, true)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Run step \"omgwtfbbq\" failed with exit code: 123")
+
+	require.Len(t, f.cu.Calls, 2)
+
+	for i, call := range f.cu.Calls {
+		assert.Equal(t, cInfos[i], call.ContainerInfo, "ContainerUpdater call[%d]", i)
+		testutils.AssertFilesInTar(f.t, tar.NewReader(call.Archive), expected, "ContainerUpdater call[%d]", i)
 	}
 }
 


### PR DESCRIPTION
Fixes observed bug:
- introduce syntax error to same_img
- first container fails to update with go build error (expected)
- second container updates successfully (i.e. runs `go build` w/o error),
and we fall back to image build b/c of "inconsistent state: one update
succeeded, one failed"

The second `go build` succeeded b/c we weren't correctly syncing the change with the
syntax error to the second container -- early return from `buildAndDeploy` meant that
we didn't appropriately tee the tar reader.