### PR TITLE
k8s: override PodManagementPolicy to Parallel on deploy. Fixes issue 1962

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -238,6 +238,10 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 				return err
 			}
 
+			// StatefulSet pods should be managed in parallel. See:
+			// https://github.com/windmilleng/tilt/issues/1962
+			e = k8s.InjectParallelPodManagementPolicy(e)
+
 			// When working with a local k8s cluster, we set the pull policy to Never,
 			// to ensure that k8s fails hard if the image is missing from docker.
 			policy := v1.PullIfNotPresent

--- a/internal/k8s/statefulset.go
+++ b/internal/k8s/statefulset.go
@@ -1,0 +1,33 @@
+package k8s
+
+import (
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1beta2"
+)
+
+// By default, StatefulSets use OrderedPodManagement.
+//
+// This is a bad policy for development. If the pod goes into a crash loop,
+// the StatefulSet operator will get wedged and require manual invervention.
+// See:
+// https://github.com/windmilleng/tilt/issues/1962
+//
+// Tilt should change all statefulsets to use a parallel policy.
+func InjectParallelPodManagementPolicy(entity K8sEntity) K8sEntity {
+	switch entity.Obj.(type) {
+	case *v1.StatefulSet:
+		entity = entity.DeepCopy()
+		entity.Obj.(*v1.StatefulSet).Spec.PodManagementPolicy = v1.ParallelPodManagement
+		return entity
+	case *v1beta1.StatefulSet:
+		entity = entity.DeepCopy()
+		entity.Obj.(*v1beta1.StatefulSet).Spec.PodManagementPolicy = v1beta1.ParallelPodManagement
+		return entity
+	case *v1beta2.StatefulSet:
+		entity = entity.DeepCopy()
+		entity.Obj.(*v1beta2.StatefulSet).Spec.PodManagementPolicy = v1beta2.ParallelPodManagement
+		return entity
+	}
+	return entity
+}

--- a/internal/k8s/statefulset_test.go
+++ b/internal/k8s/statefulset_test.go
@@ -1,0 +1,21 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+)
+
+func TestStatefulsetPodManagementPolicy(t *testing.T) {
+	ss, err := ParseYAMLFromString(testyaml.RedisStatefulSetYAML)
+	assert.Nil(t, err)
+
+	newEntity := InjectParallelPodManagementPolicy(ss[0])
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, result, "podManagementPolicy: Parallel")
+}


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/issue1962:

b61cb42a3f41f8fcbd8b992b2cf4f9ed8ae042a1 (2019-08-06 18:29:11 -0400)
k8s: override PodManagementPolicy to Parallel on deploy. Fixes issue 1962