### PR TITLE
fix nil pointer in synclet when we send a FailedRunStep

### DIFF
--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -176,7 +176,7 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 			if lastUserBuildFailure != nil {
 				// This build succeeded, but previously at least one failed due to user error.
 				// We may have inconsistent state--bail, and fall back to full build.
-				return fmt.Errorf("INCONSISTENT STATE: container %s successfully updated,"+
+				return fmt.Errorf("INCONSISTENT STATE: container %s successfully updated, "+
 					"but last update failed with '%v'", cInfo.ContainerID, lastUserBuildFailure)
 			}
 		}

--- a/internal/synclet/client_adapter.go
+++ b/internal/synclet/client_adapter.go
@@ -77,6 +77,7 @@ func (s *SyncletCli) UpdateContainer(
 				Cmd:      model.Cmd{Argv: []string{frs.Cmd}},
 				ExitCode: int(frs.ExitCode),
 			}
+			continue
 		}
 
 		if err == io.EOF {


### PR DESCRIPTION
#1985 introduced a bug:
- synclet server sends a message on run step failure (includes FailedRunStep field and nothing else)
- client receives that reply, processes the FailedRunStep, and _keeps going_, resulting in a nil pointer error when we try to read `LogMessage` info from the reply