### PR TITLE
engine: handle case where changed file matches sync for one image target but not another [ch3116]

### DIFF
--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -91,22 +91,20 @@ func FilterMappings(mappings []PathMapping, matcher model.PathMatcher) ([]PathMa
 // FilesToPathMappings converts a list of absolute local filepaths into pathMappings (i.e.
 // associates local filepaths with their syncs and destination paths), skipping those
 // that it cannot associate with a sync.
-func FilesToPathMappings(files []string, syncs []model.Sync) (pms []PathMapping,
-	couldntMap []string, err error) {
+func FilesToPathMappings(files []string, syncs []model.Sync) ([]PathMapping, error) {
+	pms := make([]PathMapping, 0, len(files))
 	for _, f := range files {
 		pm, couldMap, err := fileToPathMapping(f, syncs)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		if couldMap {
 			pms = append(pms, pm)
-		} else {
-			couldntMap = append(couldntMap, f)
 		}
 	}
 
-	return pms, couldntMap, nil
+	return pms, nil
 }
 
 func fileToPathMapping(file string, sync []model.Sync) (pm PathMapping, couldMap bool, err error) {

--- a/internal/build/path_mapping.go
+++ b/internal/build/path_mapping.go
@@ -89,22 +89,27 @@ func FilterMappings(mappings []PathMapping, matcher model.PathMatcher) ([]PathMa
 }
 
 // FilesToPathMappings converts a list of absolute local filepaths into pathMappings (i.e.
-// associates local filepaths with their syncs and destination paths).
-func FilesToPathMappings(files []string, syncs []model.Sync) ([]PathMapping, error) {
-	var pms []PathMapping
+// associates local filepaths with their syncs and destination paths), skipping those
+// that it cannot associate with a sync.
+func FilesToPathMappings(files []string, syncs []model.Sync) (pms []PathMapping,
+	couldntMap []string, err error) {
 	for _, f := range files {
-		pm, err := fileToPathMapping(f, syncs)
+		pm, couldMap, err := fileToPathMapping(f, syncs)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		pms = append(pms, pm)
+		if couldMap {
+			pms = append(pms, pm)
+		} else {
+			couldntMap = append(couldntMap, f)
+		}
 	}
 
-	return pms, nil
+	return pms, couldntMap, nil
 }
 
-func fileToPathMapping(file string, sync []model.Sync) (PathMapping, error) {
+func fileToPathMapping(file string, sync []model.Sync) (pm PathMapping, couldMap bool, err error) {
 	for _, s := range sync {
 		// Open Q: can you sync files inside of syncs?! o_0
 		// TODO(maia): are symlinks etc. gonna kick our asses here? If so, will
@@ -113,7 +118,7 @@ func fileToPathMapping(file string, sync []model.Sync) (PathMapping, error) {
 		if isChild {
 			localPathIsFile, err := isFile(s.LocalPath)
 			if err != nil {
-				return PathMapping{}, fmt.Errorf("error stat'ing: %v", err)
+				return PathMapping{}, false, fmt.Errorf("error stat'ing: %v", err)
 			}
 			var containerPath string
 			if endsWithSlash(s.ContainerPath) && localPathIsFile {
@@ -125,14 +130,14 @@ func fileToPathMapping(file string, sync []model.Sync) (PathMapping, error) {
 			return PathMapping{
 				LocalPath:     file,
 				ContainerPath: containerPath,
-			}, nil
+			}, true, nil
 		}
 	}
 	// (Potentially) expected case: the file doesn't match any sync src's. It's up
 	// to the caller to decide whether this is expected or not.
 	// E.g. for LiveUpdate, this is an expected case; for FastBuild, it means
 	// something is wrong (as we only WATCH files/dirs specified by the sync's).
-	return PathMapping{}, pathMappingErr(file, "File matches no syncs")
+	return PathMapping{}, false, nil
 }
 
 func endsWithSlash(path string) bool {
@@ -193,20 +198,4 @@ func PathMappingsToLocalPaths(mappings []PathMapping) []string {
 		res[i] = m.LocalPath
 	}
 	return res
-}
-
-type PathMappingErr struct {
-	s    string
-	File string
-}
-
-func (e *PathMappingErr) Error() string { return e.s }
-
-var _ error = &PathMappingErr{}
-
-func pathMappingErr(file string, msg string) *PathMappingErr {
-	return &PathMappingErr{
-		File: file,
-		s:    fmt.Sprintf("[File %s] %s", file, msg),
-	}
 }

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -102,7 +102,7 @@ func TestFileToDirectoryPathMapping(t *testing.T) {
 	assert.ElementsMatch(t, expected, actual)
 }
 
-func TestFileNotInSyncThrowsErr(t *testing.T) {
+func TestFileNotInSyncYieldsNoMapping(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
 	defer f.TearDown()
 
@@ -115,8 +115,9 @@ func TestFileNotInSyncThrowsErr(t *testing.T) {
 		},
 	}
 
-	_, err := FilesToPathMappings(files, syncs)
-	if assert.NotNil(t, err, "expected error for file not matching any syncs") {
-		assert.Contains(t, err.Error(), "matches no syncs")
+	actual, err := FilesToPathMappings(files, syncs)
+	if err != nil {
+		f.T().Fatal(err)
 	}
+	assert.Empty(t, actual, "expected no path mapping returned for a file not matching any syncs")
 }

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/exec"
 
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+
 	"github.com/windmilleng/tilt/internal/docker"
 
 	"github.com/windmilleng/tilt/internal/store"
@@ -250,7 +252,7 @@ func TestLiveUpdateDockerBuildLocalContainerDiffImgMultipleContainers(t *testing
 	sidecarTarg := NewSanchoSidecarLiveUpdateImageTarget(f)
 	tCase := testCase{
 		manifest: manifestbuilder.New(f, "sanchoWithSidecar").
-			WithK8sYAML(SanchoYAML).
+			WithK8sYAML(testyaml.SanchoSidecarYAML).
 			WithImageTargets(sanchoTarg, sidecarTarg).
 			Build(),
 		runningContainersByTarget: map[model.TargetID][]container.ID{
@@ -277,7 +279,7 @@ func TestLiveUpdateDockerBuildSyncletDiffImgMultipleContainers(t *testing.T) {
 	sidecarTarg := NewSanchoSidecarLiveUpdateImageTarget(f)
 	tCase := testCase{
 		manifest: manifestbuilder.New(f, "sanchoWithSidecar").
-			WithK8sYAML(SanchoYAML).
+			WithK8sYAML(testyaml.SanchoSidecarYAML).
 			WithImageTargets(sanchoTarg, sidecarTarg).
 			Build(),
 		runningContainersByTarget: map[model.TargetID][]container.ID{
@@ -308,7 +310,7 @@ func TestLiveUpdateDockerBuildExecDiffImgMultipleContainers(t *testing.T) {
 	sidecarTarg := NewSanchoSidecarDockerBuildImageTarget(f)
 	tCase := testCase{
 		manifest: manifestbuilder.New(f, "sanchoWithSidecar").
-			WithK8sYAML(SanchoYAML).
+			WithK8sYAML(testyaml.SanchoSidecarYAML).
 			WithImageTargets(sanchoTarg, sidecarTarg).
 			WithLiveUpdateAtIndex(sanchoLU, 0).
 			WithLiveUpdateAtIndex(sidecarLU, 1).
@@ -323,6 +325,43 @@ func TestLiveUpdateDockerBuildExecDiffImgMultipleContainers(t *testing.T) {
 
 		// two (tar archive + run step) per container
 		expectK8sExecCount: 4,
+	}
+	runTestCase(t, f, tCase)
+}
+
+func TestLiveUpdateDiffImgMultipleContainersOnlySomeSyncsMatch(t *testing.T) {
+	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeCrio)
+	defer f.TearDown()
+
+	sanchoSyncs := SanchoSyncSteps(f)
+	sanchoSyncs[0].Source = f.JoinPath("sancho")
+	sidecarSyncs := SyncStepsForApp("sidecar", f)
+	sidecarSyncs[0].Source = f.JoinPath("sidecar")
+
+	sanchoLU := assembleLiveUpdate(sanchoSyncs, SanchoRunSteps, false, nil, f)
+	sidecarLU := assembleLiveUpdate(sidecarSyncs, RunStepsForApp("sidecar"),
+		false, nil, f)
+	sanchoTarg := NewSanchoDockerBuildImageTarget(f)
+	sidecarTarg := NewSanchoSidecarDockerBuildImageTarget(f)
+
+	tCase := testCase{
+		manifest: manifestbuilder.New(f, "sanchoWithSidecar").
+			WithK8sYAML(testyaml.SanchoSidecarYAML).
+			WithImageTargets(sanchoTarg, sidecarTarg).
+			WithLiveUpdateAtIndex(sanchoLU, 0).
+			WithLiveUpdateAtIndex(sidecarLU, 1).
+			Build(),
+		runningContainersByTarget: map[model.TargetID][]container.ID{
+			sanchoTarg.ID():  []container.ID{"c1"},
+			sidecarTarg.ID(): []container.ID{"c2"},
+		},
+		changedFiles:           []string{"sidecar/a.txt"},
+		expectDockerBuildCount: 0,
+		expectDockerPushCount:  0,
+
+		// two (tar archive + run step) per container
+		// only the sidecar should be updated, so expect 2 calls
+		expectK8sExecCount: 2,
 	}
 	runTestCase(t, f, tCase)
 }

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -200,14 +200,14 @@ func liveUpdateInfoForStateTree(stateTree liveUpdateStateTree) (liveUpdInfo, err
 	var hotReload bool
 
 	if fbInfo := iTarget.AnyFastBuildInfo(); !fbInfo.Empty() {
-		fileMappings, _, err = build.FilesToPathMappings(filesChanged, fbInfo.Syncs)
+		fileMappings, err = build.FilesToPathMappings(filesChanged, fbInfo.Syncs)
 		if err != nil {
 			return liveUpdInfo{}, err
 		}
 		runs = fbInfo.Runs
 		hotReload = fbInfo.HotReload
 	} else if luInfo := iTarget.AnyLiveUpdateInfo(); !luInfo.Empty() {
-		fileMappings, _, err = build.FilesToPathMappings(filesChanged, luInfo.SyncSteps())
+		fileMappings, err = build.FilesToPathMappings(filesChanged, luInfo.SyncSteps())
 		if err != nil {
 			return liveUpdInfo{}, err
 		}

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -54,6 +55,8 @@ type liveUpdInfo struct {
 	hotReload    bool
 }
 
+func (lui liveUpdInfo) Empty() bool { return lui.iTarget.ID() == model.ImageTarget{}.ID() }
+
 func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
 	liveUpdateStateSet, err := extractImageTargetsForLiveUpdates(specs, stateSet)
 	if err != nil {
@@ -67,13 +70,29 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		return nil, RedirectToNextBuilderInfof("no targets for LiveUpdate found")
 	}
 
+	unclaimedFiles := allChangedFiles(liveUpdateStateSet)
 	for i, luStateTree := range liveUpdateStateSet {
 		luInfo, err := liveUpdateInfoForStateTree(luStateTree)
 		if err != nil {
 			return store.BuildResultSet{}, err
 		}
 
-		liveUpdInfos[i] = luInfo
+		for _, mapping := range luInfo.changedFiles {
+			delete(unclaimedFiles, mapping.LocalPath)
+		}
+
+		if !luInfo.Empty() {
+			liveUpdInfos[i] = luInfo
+		}
+	}
+
+	if len(unclaimedFiles) > 0 {
+		files := make([]string, 0, len(unclaimedFiles))
+		for f, _ := range unclaimedFiles {
+			files = append(files, f)
+		}
+		return nil, RedirectToNextBuilderInfof("found file(s) not matching a LiveUpdate sync, so "+
+			"performing a full build. (Files: %s)", strings.Join(files, ", "))
 	}
 
 	var dontFallBackErr error
@@ -176,31 +195,25 @@ func liveUpdateInfoForStateTree(stateTree liveUpdateStateTree) (liveUpdInfo, err
 	filesChanged := stateTree.filesChanged
 
 	var err error
-	var changedFiles []build.PathMapping
+	var fileMappings []build.PathMapping
 	var runs []model.Run
 	var hotReload bool
 
 	if fbInfo := iTarget.AnyFastBuildInfo(); !fbInfo.Empty() {
-		changedFiles, err = build.FilesToPathMappings(filesChanged, fbInfo.Syncs)
+		fileMappings, _, err = build.FilesToPathMappings(filesChanged, fbInfo.Syncs)
 		if err != nil {
 			return liveUpdInfo{}, err
 		}
 		runs = fbInfo.Runs
 		hotReload = fbInfo.HotReload
 	} else if luInfo := iTarget.AnyLiveUpdateInfo(); !luInfo.Empty() {
-		changedFiles, err = build.FilesToPathMappings(filesChanged, luInfo.SyncSteps())
+		fileMappings, _, err = build.FilesToPathMappings(filesChanged, luInfo.SyncSteps())
 		if err != nil {
-			if pmErr, ok := err.(*build.PathMappingErr); ok {
-				// expected error for this builder. One of more files don't match sync's;
-				// i.e. they're within the docker context but not within a sync; do a full image build.
-				return liveUpdInfo{}, RedirectToNextBuilderInfof(
-					"at least one file (%s) doesn't match a LiveUpdate sync, so performing a full build", pmErr.File)
-			}
 			return liveUpdInfo{}, err
 		}
 
 		// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
-		anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(changedFiles))
+		anyMatch, file, err := luInfo.FallBackOnFiles().AnyMatch(build.PathMappingsToLocalPaths(fileMappings))
 		if err != nil {
 			return liveUpdInfo{}, err
 		}
@@ -217,10 +230,15 @@ func liveUpdateInfoForStateTree(stateTree liveUpdateStateTree) (liveUpdInfo, err
 			"which should have already been validated", iTarget.ID()))
 	}
 
+	if len(fileMappings) == 0 {
+		// No files matched a sync for this image, no LiveUpdate to run
+		return liveUpdInfo{}, nil
+	}
+
 	return liveUpdInfo{
 		iTarget:      iTarget,
 		state:        state,
-		changedFiles: changedFiles,
+		changedFiles: fileMappings,
 		runs:         runs,
 		hotReload:    hotReload,
 	}, nil

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -47,3 +47,13 @@ func createResultSet(trees []liveUpdateStateTree) store.BuildResultSet {
 	}
 	return resultSet
 }
+
+func allChangedFiles(trees []liveUpdateStateTree) map[string]bool {
+	res := make(map[string]bool)
+	for _, t := range trees {
+		for _, f := range t.filesChanged {
+			res[f] = true
+		}
+	}
+	return res
+}

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"log"
 	"sort"
 
 	"github.com/docker/distribution/reference"
@@ -270,7 +269,6 @@ func RunningContainersForTarget(iTarget model.ImageTarget, deployID model.Deploy
 	for _, c := range pod.Containers {
 		// Only return containers matching our image
 		if c.ImageRef == nil || iTarget.DeploymentRef.Name() != c.ImageRef.Name() {
-			log.Println("SKIPPING", iTarget.DeploymentRef, c.ImageRef)
 			continue
 		}
 		if c.ID == "" || c.Name == "" || !c.Ready {


### PR DESCRIPTION
If `a.txt` is in the docker ctx for both `appimg` and `sidecarimg`, and the docker_build for `appimg` syncs `a.txt` and sidecar does not, we’ll get a “file matches no syncs” error when making path mappings for sidecar and fall back to an image build.

after this PR, we do NOT fall back to image build: instead, we can see that only the app has changed files, and do a LiveUpdate for the app but not the sidecar