### PR TITLE
web: can init from static HTTP response

### DIFF
--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -124,19 +124,12 @@ class AppController {
   setStateFromSnapshot(): void {
     let url = this.url
     fetch(url)
-      .then(resp =>
-        resp
-          .json()
-          .then(data => {
-            data.Resources = this.setDefaultResourceInfo(data.Resources)
-            // @ts-ignore
-            this.component.setAppState({ View: data })
-          })
-          .catch(err => {
-            // TODO(dmiller): set app state with an error message
-            console.error(err)
-          })
-      )
+      .then(resp => resp.json())
+      .then(data => {
+        data.Resources = this.setDefaultResourceInfo(data.Resources)
+        // @ts-ignore
+        this.component.setAppState({ View: data })
+      })
       .catch(err => {
         // TODO(dmiller): set app state with an error message
         console.error(err)

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -45,25 +45,29 @@ class AppController {
 
       let data = JSON.parse(event.data)
 
-      data.Resources = data.Resources.map((r: any) => {
-        if (r.ResourceInfo === null) {
-          r.ResourceInfo = {
-            PodName: "",
-            PodCreationTime: "",
-            PodUpdateStartTime: "",
-            PodStatus: "",
-            PodStatusMessage: "",
-            PodRestarts: 0,
-            PodLog: "",
-            YAML: "",
-            Endpoints: [],
-          }
-        }
-        r.Alerts = getResourceAlerts(r)
-        return r
-      })
+      data.Resources = this.setDefaultResourceInfo(data.Resources)
       // @ts-ignore
       this.component.setAppState({ View: data })
+    })
+  }
+
+  setDefaultResourceInfo(resources: Array<any>): Array<any> {
+    return resources.map(r => {
+      if (r.ResourceInfo === null) {
+        r.ResourceInfo = {
+          PodName: "",
+          PodCreationTime: "",
+          PodUpdateStartTime: "",
+          PodStatus: "",
+          PodStatusMessage: "",
+          PodRestarts: 0,
+          PodLog: "",
+          YAML: "",
+          Endpoints: [],
+        }
+      }
+      r.Alerts = getResourceAlerts(r)
+      return r
     })
   }
 
@@ -115,6 +119,28 @@ class AppController {
       })
       this.createNewSocket()
     }, timeout)
+  }
+
+  setStateFromSnapshot(): void {
+    let url = this.url
+    fetch(url)
+      .then(resp =>
+        resp
+          .json()
+          .then(data => {
+            data.Resources = this.setDefaultResourceInfo(data.Resources)
+            // @ts-ignore
+            this.component.setAppState({ View: data })
+          })
+          .catch(err => {
+            // TODO(dmiller): set app state with an error message
+            console.error(err)
+          })
+      )
+      .catch(err => {
+        // TODO(dmiller): set app state with an error message
+        console.error(err)
+      })
   }
 }
 

--- a/web/src/HUD.scss
+++ b/web/src/HUD.scss
@@ -29,3 +29,7 @@
   text-align: left;
   color: $color-gray-lightest;
 }
+
+.SnapshotMessage {
+  margin-top: $spacing-unit;
+}

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -112,9 +112,7 @@ class HUD extends Component<HudProps, HudState> {
   }
 
   componentWillUnmount() {
-    if (!this.pathBuilder.isSnapshot()) {
-      this.controller.dispose()
-    }
+    this.controller.dispose()
     this.unlisten()
   }
 

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -63,10 +63,7 @@ class HUD extends Component<HudProps, HudState> {
       window.location.host,
       window.location.pathname
     )
-    this.controller = new AppController(
-      this.pathBuilder.getWebsocketUrl(),
-      this
-    )
+    this.controller = new AppController(this.pathBuilder.getDataUrl(), this)
     this.history = props.history
     this.unlisten = () => {}
 
@@ -107,11 +104,17 @@ class HUD extends Component<HudProps, HudState> {
   }
 
   componentDidMount() {
-    this.controller.createNewSocket()
+    if (this.pathBuilder.isSnapshot()) {
+      this.controller.setStateFromSnapshot()
+    } else {
+      this.controller.createNewSocket()
+    }
   }
 
   componentWillUnmount() {
-    this.controller.dispose()
+    if (!this.pathBuilder.isSnapshot()) {
+      this.controller.dispose()
+    }
     this.unlisten()
   }
 
@@ -321,6 +324,23 @@ class HUD extends Component<HudProps, HudState> {
         )
       }
     }
+    let snapshotRoute = () => {
+      return (
+        <div className="SnapshotMessage">
+          <h1>Welcome to a Tilt snapshot!</h1>
+          <p>
+            In here you can look around and check out a "snapshot" of a Tilt
+            session.
+          </p>
+          <p>
+            Snapshots are static freeze frame points in time. Nothing will
+            change. Feel free to poke around and see what the person who sent
+            you this snapshot saw when they sent it to you.
+          </p>
+          <p>Have fun!</p>
+        </div>
+      )
+    }
     let runningVersion = view && view.RunningTiltBuild
     let latestVersion = view && view.LatestTiltBuild
 
@@ -407,6 +427,11 @@ class HUD extends Component<HudProps, HudState> {
           />
           <Route exact path={this.path("/preview")} render={previewRoute} />
           <Route exact path={this.path("/r/:name")} render={logsRoute} />
+          <Route
+            exact
+            path={this.path("/snapshot/:snap_id")}
+            render={snapshotRoute}
+          />
           <Route
             exact
             path={this.path("/r/:name/k8s")}

--- a/web/src/PathBuilder.test.tsx
+++ b/web/src/PathBuilder.test.tsx
@@ -3,30 +3,42 @@ import PathBuilder from "./PathBuilder"
 describe("PathBuilder", () => {
   it("handles tilt preview links", () => {
     let pb = new PathBuilder("localhost", "/r/fe/preview")
-    expect(pb.getWebsocketUrl()).toEqual("ws://localhost/ws/view")
+    expect(pb.getDataUrl()).toEqual("ws://localhost/ws/view")
     expect(pb.path("/")).toEqual("/")
   })
 
   it("handles ports", () => {
     let pb = new PathBuilder("localhost:10350", "/r/fe/preview")
-    expect(pb.getWebsocketUrl()).toEqual("ws://localhost:10350/ws/view")
+    expect(pb.getDataUrl()).toEqual("ws://localhost:10350/ws/view")
   })
 
   it("handles room root links", () => {
     let pb = new PathBuilder("localhost", "/view/dead-beef")
-    expect(pb.getWebsocketUrl()).toEqual("ws://localhost/join/dead-beef")
+    expect(pb.getDataUrl()).toEqual("ws://localhost/join/dead-beef")
     expect(pb.path("/")).toEqual("/view/dead-beef/")
   })
 
   it("handles room preview links", () => {
     let pb = new PathBuilder("localhost", "/view/deadbeef/r/fe/preview")
-    expect(pb.getWebsocketUrl()).toEqual("ws://localhost/join/deadbeef")
+    expect(pb.getDataUrl()).toEqual("ws://localhost/join/deadbeef")
     expect(pb.path("/")).toEqual("/view/deadbeef/")
   })
 
   it("handles https", () => {
     let pb = new PathBuilder("sail.tilt.dev", "/r/fe/preview")
-    expect(pb.getWebsocketUrl()).toEqual("wss://sail.tilt.dev/ws/view")
+    expect(pb.getDataUrl()).toEqual("wss://sail.tilt.dev/ws/view")
     expect(pb.path("/")).toEqual("/")
+  })
+
+  it("handles snapshots in prod", () => {
+    let pb = new PathBuilder("snapshots.tilt.dev", "/snapshot/aaaaaa")
+    expect(pb.getDataUrl()).toEqual(
+      "https://snapshots.tilt.dev/api/snapshots/aaaaaa"
+    )
+  })
+
+  it("handles snapshots in dev", () => {
+    let pb = new PathBuilder("localhost", "/snapshot/aaaaaa")
+    expect(pb.getDataUrl()).toEqual("http://localhost/api/snapshots/aaaaaa")
   })
 })

--- a/web/src/PathBuilder.test.tsx
+++ b/web/src/PathBuilder.test.tsx
@@ -33,12 +33,12 @@ describe("PathBuilder", () => {
   it("handles snapshots in prod", () => {
     let pb = new PathBuilder("snapshots.tilt.dev", "/snapshot/aaaaaa")
     expect(pb.getDataUrl()).toEqual(
-      "https://snapshots.tilt.dev/api/snapshots/aaaaaa"
+      "https://snapshots.tilt.dev/api/snapshot/aaaaaa"
     )
   })
 
   it("handles snapshots in dev", () => {
     let pb = new PathBuilder("localhost", "/snapshot/aaaaaa")
-    expect(pb.getDataUrl()).toEqual("http://localhost/api/snapshots/aaaaaa")
+    expect(pb.getDataUrl()).toEqual("http://localhost/api/snapshot/aaaaaa")
   })
 })

--- a/web/src/PathBuilder.tsx
+++ b/web/src/PathBuilder.tsx
@@ -2,23 +2,31 @@
 
 class PathBuilder {
   private host: string
-  private roomId: string
+  private roomId: string = ""
+  private snapId: string = ""
 
   constructor(host: string, pathname: string) {
     this.host = host
-    this.roomId = ""
 
-    let roomRe = new RegExp("^/view/([^/]+)")
+    const roomRe = new RegExp("^/view/([^/]+)")
     let roomMatch = roomRe.exec(pathname)
     if (roomMatch) {
       this.roomId = roomMatch[1]
     }
+    const snapshotRe = new RegExp("^/snapshot/([^/]+)")
+    let snapMatch = snapshotRe.exec(pathname)
+    if (snapMatch) {
+      this.snapId = snapMatch[1]
+    }
   }
 
-  getWebsocketUrl() {
+  getDataUrl() {
     let scheme = "wss"
     if (this.isLocal()) {
       scheme = "ws"
+    }
+    if (this.isSnapshot()) {
+      return this.snapshotUrl()
     }
     if (this.roomId) {
       return `${scheme}://${this.host}/join/${this.roomId}`
@@ -28,6 +36,18 @@ class PathBuilder {
 
   isLocal() {
     return this.host.indexOf("localhost") == 0
+  }
+
+  isSnapshot(): boolean {
+    return this.snapId !== ""
+  }
+
+  snapshotUrl(): string {
+    let scheme = "https"
+    if (this.isLocal()) {
+      scheme = "http"
+    }
+    return `${scheme}://${this.host}/api/snapshots/${this.snapId}`
   }
 
   rootPath() {

--- a/web/src/PathBuilder.tsx
+++ b/web/src/PathBuilder.tsx
@@ -47,7 +47,7 @@ class PathBuilder {
     if (this.isLocal()) {
       scheme = "http"
     }
-    return `${scheme}://${this.host}/api/snapshots/${this.snapId}`
+    return `${scheme}://${this.host}/api/snapshot/${this.snapId}`
   }
 
   rootPath() {


### PR DESCRIPTION
I couldn't really test this without some sort of working snapshot frontend server. I tested this by changing the URL that it loads from to `localhost:10350/api/view` manually.