### PR TITLE
tiltfile: emit an error when 'only' contains a file glob. Fixes issue 1982

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -173,14 +173,14 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, errors.Wrap(err, "live_update")
 	}
 
-	ignores, error := parseValuesToStrings(ignoreVal, "ignore")
-	if error != nil {
-		return nil, error
+	ignores, err := parseValuesToStrings(ignoreVal, "ignore")
+	if err != nil {
+		return nil, err
 	}
 
-	onlys, error2 := parseValuesToStrings(onlyVal, "only")
-	if error2 != nil {
-		return nil, error2
+	onlys, err := s.parseOnly(onlyVal)
+	if err != nil {
+		return nil, err
 	}
 
 	var entrypointCmd model.Cmd
@@ -212,6 +212,23 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 	// (but use DockerBuild info for image builds)
 	fb := &fastBuild{s: s, img: r}
 	return fb, nil
+}
+
+func (s *tiltfileState) parseOnly(val starlark.Value) ([]string, error) {
+	paths, err := parseValuesToStrings(val, "only")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range paths {
+		// We want to forbid file globs due to these issues:
+		// https://github.com/windmilleng/tilt/issues/1982
+		// https://github.com/moby/moby/issues/30018
+		if strings.Contains(p, "*") {
+			return nil, fmt.Errorf("'only' does not support '*' file globs. Must be a real path: %s", p)
+		}
+	}
+	return paths, nil
 }
 
 func (s *tiltfileState) fastBuildForImage(image *dockerImage) model.FastBuild {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3421,7 +3421,7 @@ func TestDockerbuildOnly(t *testing.T) {
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
 	f.file("Tiltfile", `
-docker_build('gcr.io/foo', '.', only="myservice/**")
+docker_build('gcr.io/foo', '.', only="myservice")
 k8s_yaml('foo.yaml')
 `)
 
@@ -3441,7 +3441,7 @@ func TestDockerbuildOnlyAsArray(t *testing.T) {
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
 	f.file("Tiltfile", `
-docker_build('gcr.io/foo', '.', only=["common/**", "myservice/**"])
+docker_build('gcr.io/foo', '.', only=["common", "myservice"])
 k8s_yaml('foo.yaml')
 `)
 
@@ -3472,6 +3472,22 @@ k8s_yaml('foo.yaml')
 	f.loadErrString("only must be a string or a sequence of strings; found a starlark.Int")
 }
 
+func TestDockerbuildInvalidOnlyGlob(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile("foo/Dockerfile")
+	f.yaml("foo.yaml", deployment("foo", image("fooimage")))
+
+	f.file("Tiltfile", `
+k8s_resource_assembly_version(2)
+docker_build('fooimage', 'foo', only=["**/common"])
+k8s_yaml('foo.yaml')
+`)
+
+	f.loadErrString("'only' does not support '*' file globs")
+}
+
 func TestDockerbuildOnlyAndIgnore(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -3479,7 +3495,7 @@ func TestDockerbuildOnlyAndIgnore(t *testing.T) {
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
 	f.file("Tiltfile", `
-docker_build('gcr.io/foo', '.', ignore="**/*.md", only=["common/**", "myservice/**"])
+docker_build('gcr.io/foo', '.', ignore="**/*.md", only=["common", "myservice"])
 k8s_yaml('foo.yaml')
 `)
 
@@ -3524,7 +3540,7 @@ func TestDockerbuildOnlyHasException(t *testing.T) {
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
 	f.file("Tiltfile", `
-docker_build('gcr.io/foo', '.', only="!myservice/**")
+docker_build('gcr.io/foo', '.', only="!myservice")
 k8s_yaml('foo.yaml')
 `)
 


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/issue1982:

3556c4a73fd71d5057f4a9912d2e102d3cc9d359 (2019-08-08 12:41:42 -0400)
tiltfile: emit an error when 'only' contains a file glob. Fixes issue 1982