### PR TITLE
engine: don't run empty LiveUpdateInfos thru buildAndDeploy (eliminates log spam when LU-ing only one of multiple images)

### DIFF
--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -64,14 +64,14 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	}
 
 	containerUpdater := lubad.containerUpdaterForSpecs(specs)
-	liveUpdInfos := make([]liveUpdInfo, len(liveUpdateStateSet))
+	liveUpdInfos := make([]liveUpdInfo, 0, len(liveUpdateStateSet))
 
 	if len(liveUpdateStateSet) == 0 {
 		return nil, RedirectToNextBuilderInfof("no targets for LiveUpdate found")
 	}
 
 	unclaimedFiles := allChangedFiles(liveUpdateStateSet)
-	for i, luStateTree := range liveUpdateStateSet {
+	for _, luStateTree := range liveUpdateStateSet {
 		luInfo, err := liveUpdateInfoForStateTree(luStateTree)
 		if err != nil {
 			return store.BuildResultSet{}, err
@@ -82,7 +82,7 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		}
 
 		if !luInfo.Empty() {
-			liveUpdInfos[i] = luInfo
+			liveUpdInfos = append(liveUpdInfos, luInfo)
 		}
 	}
 


### PR DESCRIPTION
Previously, LiveUpdating a manifest with two images, changing a file that synced to only one of the images, would get:
```
-> Updating container(s): abc123
-> Updating container(s):
```
(the second empty log line being from an empty LiveUpdInfo that we ran thru `buildAndDeploy`)

this PR fixes the typo in []liveUpdInfos initialization that caused us to run empties thru the deploy process