### PR TITLE
engine: don't return build results for images we didn't actually update

### DIFF
--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -110,7 +110,7 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 			dontFallBackErr = err
 		}
 	}
-	return createResultSet(liveUpdateStateSet), dontFallBackErr
+	return createResultSet(liveUpdateStateSet, liveUpdInfos), dontFallBackErr
 }
 
 func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu containerupdate.ContainerUpdater, iTarget model.ImageTarget, state store.BuildState, changedFiles []build.PathMapping, runs []model.Run, hotReload bool) error {

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -40,9 +40,18 @@ func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	return resultSet
 }
 
-func createResultSet(trees []liveUpdateStateTree) store.BuildResultSet {
+func createResultSet(trees []liveUpdateStateTree, luInfos []liveUpdInfo) store.BuildResultSet {
+	liveUpdatedTargetIDs := make(map[model.TargetID]bool)
+	for _, info := range luInfos {
+		liveUpdatedTargetIDs[info.iTarget.ID()] = true
+	}
+
 	resultSet := store.BuildResultSet{}
 	for _, t := range trees {
+		if !liveUpdatedTargetIDs[t.iTarget.ID()] {
+			// We didn't actually do a LiveUpdate for this tree
+			continue
+		}
 		resultSet = store.MergeBuildResultsSet(resultSet, t.createResultSet())
 	}
 	return resultSet

--- a/internal/model/target.go
+++ b/internal/model/target.go
@@ -53,6 +53,14 @@ func (id TargetID) String() string {
 	return fmt.Sprintf("%s:%s", id.Type, id.Name)
 }
 
+func TargetIDSet(tids []TargetID) map[TargetID]bool {
+	res := make(map[TargetID]bool)
+	for _, id := range tids {
+		res[id] = true
+	}
+	return res
+}
+
 type TargetSpec interface {
 	ID() TargetID
 


### PR DESCRIPTION
this was causing a bug in the integration test I'm writing where I would
live update service 1, but the LU would return container IDs 1 and 2 as
changed containers (even tho we only touched container 1); when I killed
container 2 (running service 2), we did a crash rebuild, which we should NOT
have done b/c c2 hadn't been live updated, so we didn't lose any state when
it went down.