### PR TITLE
Use include() to reduce duplication in integration tests

### DIFF
--- a/integration/Tiltfile
+++ b/integration/Tiltfile
@@ -1,0 +1,6 @@
+# -*- mode: Python -*-
+
+# HACK: load namespaces on `tilt up` but not on `tilt down`
+load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
+if load_namespace:
+  k8s_yaml('namespace.yaml')

--- a/integration/analytics/Tiltfile
+++ b/integration/analytics/Tiltfile
@@ -1,9 +1,6 @@
 # -*- mode: Python -*-
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 # If you get push errors, you can change the default_registry.
 # Create tilt_option.json with contents: {"default_registry": "gcr.io/my-personal-project"}

--- a/integration/imagetags/Tiltfile
+++ b/integration/imagetags/Tiltfile
@@ -1,10 +1,7 @@
 
 k8s_resource_assembly_version(2)
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 repo = 'gcr.io/windmill-test-containers'
 docker_build(repo + '/imagetags-common', 'common')

--- a/integration/live_update_base_image/Tiltfile
+++ b/integration/live_update_base_image/Tiltfile
@@ -1,8 +1,5 @@
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 repo = 'gcr.io/windmill-test-containers'
 docker_build(repo + '/live-update-base-image-common', 'common')

--- a/integration/oneup/Tiltfile
+++ b/integration/oneup/Tiltfile
@@ -1,9 +1,6 @@
 # -*- mode: Python -*-
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 # If you get push errors, you can change the default_registry.
 # Create tilt_option.json with contents: {"default_registry": "gcr.io/my-personal-project"}

--- a/integration/oneup_custom/Tiltfile
+++ b/integration/oneup_custom/Tiltfile
@@ -1,9 +1,6 @@
 # -*- mode: Python -*-
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 custom_build(
   'gcr.io/windmill-test-containers/integration/oneup-custom',

--- a/integration/onewatch/Tiltfile
+++ b/integration/onewatch/Tiltfile
@@ -1,9 +1,6 @@
 # -*- mode: Python -*-
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 k8s_yaml('deployment.yaml')
 repo = local_git_repo('../../')

--- a/integration/onewatch_exec/Tiltfile
+++ b/integration/onewatch_exec/Tiltfile
@@ -1,9 +1,6 @@
 # -*- mode: Python -*-
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 k8s_yaml('deployment.yaml')
 repo = local_git_repo('../../')

--- a/integration/same_img_multi_container/Tiltfile
+++ b/integration/same_img_multi_container/Tiltfile
@@ -1,9 +1,6 @@
 # -*- mode: Python -*-
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 # If you get push errors, you can change the default_registry.
 # Create tilt_option.json with contents: {"default_registry": "gcr.io/my-personal-project"}

--- a/integration/shortlived_pods/Tiltfile
+++ b/integration/shortlived_pods/Tiltfile
@@ -1,9 +1,6 @@
 # -*- mode: Python -*-
 
-# HACK: load namespaces on `tilt up` but not on `tilt down`
-load_namespace = not str(local('echo $SKIP_NAMESPACE')).strip()
-if load_namespace:
-  k8s_yaml('../namespace.yaml')
+include('../Tiltfile')
 
 default_registry(read_json('tilt_option.json', {})
                  .get('default_registry', 'gcr.io/windmill-test-containers/servantes'))


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/load2:

5724fb870b78216e84f9fffcdda6e8b99932f5c2 (2019-08-08 17:41:10 -0400)
Use include() to reduce duplication in integration tests