### PR TITLE
k8s: use 'tilt kubectl apply' instead of 'kubectl apply'

### DIFF
--- a/internal/k8s/logging_kubectl_runner.go
+++ b/internal/k8s/logging_kubectl_runner.go
@@ -20,7 +20,7 @@ func (k loggingKubectlRunner) logExecStart(ctx context.Context, args []string, s
 		return
 	}
 
-	logger.Get(ctx).Infof("Running: %q\n", append([]string{"kubectl"}, args...))
+	logger.Get(ctx).Infof("Running: %q\n", append([]string{"tilt", "kubectl"}, args...))
 
 	if stdin != "" {
 		logger.Get(ctx).Infof("stdin: '%s'\n", stdin)

--- a/internal/k8s/logging_kubectl_runner_test.go
+++ b/internal/k8s/logging_kubectl_runner_test.go
@@ -27,7 +27,7 @@ func TestLoggingKubectlRunnerNoStdin(t *testing.T) {
 	assert.Equal(t, "bar", stderr)
 
 	l := f.log()
-	assert.Contains(t, l, `Running: ["kubectl" "-v" "6" "hello" "goodbye"]`)
+	assert.Contains(t, l, `Running: ["tilt" "kubectl" "-v" "6" "hello" "goodbye"]`)
 	assert.Contains(t, l, `stdout: 'foo'`)
 	assert.Contains(t, l, `stderr: 'bar'`)
 }
@@ -53,7 +53,7 @@ func TestLoggingKubectlRunnerStdin(t *testing.T) {
 	assert.Equal(t, "bar", stderr)
 
 	l := f.log()
-	assert.Contains(t, l, `Running: ["kubectl" "-v" "6" "hello" "goodbye"]`)
+	assert.Contains(t, l, `Running: ["tilt" "kubectl" "-v" "6" "hello" "goodbye"]`)
 	assert.Contains(t, l, `stdout: 'foo'`)
 	assert.Contains(t, l, `stderr: 'bar'`)
 	assert.Contains(t, l, `stdin: 'some yaml'`)


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/fork3:

638258f99dd4041f3ae39b17d2b34ed4643c9f8d (2019-08-09 12:48:55 -0400)
k8s: use 'tilt kubectl apply' instead of 'kubectl apply'