### PR TITLE
tiltfile: fast build deprecation date

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -16,9 +16,9 @@ import (
 )
 
 const fastBuildDeprecationWarning = "FastBuild (`fast_build`; `add_fast_build`; " +
-	"`docker_build(...).add(...)`, etc.) will be deprecated soon; you can use Live " +
-	"Update instead! See https://docs.tilt.dev/live_update_tutorial.html for more " +
-	"information. If Live Update doesn't fit your use case, let us know."
+	"`docker_build(...).add(...)`, etc.) will be deprecated **ON THURS. 9/12/19**; " +
+	"you can use Live Update instead! See https://docs.tilt.dev/live_update_tutorial.html " +
+	"for more information. If Live Update doesn't fit your use case, let us know."
 
 type dockerImage struct {
 	tiltfilePath       string


### PR DESCRIPTION
Feel free to reject the date, or even the fact of setting a hard deadline,
but I would love for us to actually get fast_build out of our codebase.

This PR puts a deprecation deadline in the fast_build deprecation warning.
Come 9/12, we'd remove tiltfile support for `fast_build`, and remove FastBuild internally at our leisure.