### PR TITLE
tilt: add feature flag for snapshots

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -21,6 +21,7 @@ const (
 const MultipleContainersPerPod = "multiple_containers_per_pod"
 const Events = "events"
 const TeamAlerts = "team_alerts"
+const Snapshots = "snapshots"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -43,6 +44,10 @@ var MainDefaults = Defaults{
 		Status:  Active,
 	},
 	TeamAlerts: Value{
+		Enabled: false,
+		Status:  Active,
+	},
+	Snapshots: Value{
 		Enabled: false,
 		Status:  Active,
 	},


### PR DESCRIPTION
I hope you're sitting down for this one.

I've verified that dropping a `console.log(features.isEnabled("snapshots"))` in HUD.tsx reflects whether I've enabled the feature in my Tiltfile.