### PR TITLE
tiltfile/engine: metrics for multi-container usage

### DIFF
--- a/internal/analytics/utils.go
+++ b/internal/analytics/utils.go
@@ -1,0 +1,11 @@
+package analytics
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+)
+
+func HashMD5(s string) string {
+	h := md5.Sum([]byte(s))
+	return base64.StdEncoding.EncodeToString(h[:])
+}

--- a/internal/cli/analytics.go
+++ b/internal/cli/analytics.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"crypto/md5"
-	"encoding/base64"
 	"os"
 	"os/exec"
 	"runtime"
@@ -77,8 +75,7 @@ func globalTags() map[string]string {
 	// store a hash of the git remote to help us guess how many users are running it on the same repository
 	origin := normalizeGitRemote(gitOrigin("."))
 	if origin != "" {
-		h := md5.Sum([]byte(origin))
-		ret["git.origin"] = base64.StdEncoding.EncodeToString(h[:])
+		ret["git.origin"] = tiltanalytics.HashMD5(origin)
 	}
 
 	return ret

--- a/internal/engine/analytics_reporter.go
+++ b/internal/engine/analytics_reporter.go
@@ -85,6 +85,9 @@ func (ar *AnalyticsReporter) report() {
 	if st.LastTiltfileError() != nil {
 		tiltfileIsInError = "true"
 	} else {
+		// ~~ report image targets per resource?
+		// ~~ report # resources with 2+ live updates
+
 		// only report when there's no tiltfile error, to avoid polluting aggregations
 		stats["resource.count"] = strconv.Itoa(len(st.ManifestDefinitionOrder))
 		stats["resource.dockercompose.count"] = strconv.Itoa(dcCount)

--- a/internal/engine/analytics_reporter.go
+++ b/internal/engine/analytics_reporter.go
@@ -58,7 +58,6 @@ func (ar *AnalyticsReporter) report() {
 			if len(m.ImageTargets) == 0 {
 				unbuiltCount++
 			}
-			// Open Q: stat for number of resources with multiple image targets? (# targets per resource?)
 		}
 		if m.IsDC() {
 			dcCount++
@@ -74,9 +73,6 @@ func (ar *AnalyticsReporter) report() {
 			}
 			if !it.AnyLiveUpdateInfo().Empty() {
 				if !seenLU {
-					// OPEN Q: do we want to report the number of LiveUpd _targets_ or
-					// LiveUpd _resources_ (and separately report whether there are resources
-					// with more than one LiveUpd on them)? <- this does the latter
 					seenLU = true
 					liveUpdateCount++
 				} else if !multiLU {

--- a/internal/engine/analytics_reporter_test.go
+++ b/internal/engine/analytics_reporter_test.go
@@ -68,17 +68,18 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 	tf.run()
 
 	expectedTags := map[string]string{
-		"builds.completed_count":                 "3",
-		"resource.count":                         "11",
-		"resource.dockercompose.count":           "3",
-		"resource.unbuiltresources.count":        "3",
-		"resource.fastbuild.count":               "1",
-		"resource.anyfastbuild.count":            "2",
-		"resource.liveupdate.count":              "3",
-		"resource.k8s.count":                     "4",
-		"resource.multipleimageliveupdate.count": "1",
-		"tiltfile.error":                         "false",
-		"up.starttime":                           state.TiltStartTime.Format(time.RFC3339),
+		"builds.completed_count":                              "3",
+		"resource.count":                                      "11",
+		"resource.dockercompose.count":                        "3",
+		"resource.unbuiltresources.count":                     "3",
+		"resource.fastbuild.count":                            "1",
+		"resource.anyfastbuild.count":                         "2",
+		"resource.liveupdate.count":                           "3",
+		"resource.k8s.count":                                  "4",
+		"resource.sameimagemultiplecontainerliveupdate.count": "0", // tests for this below
+		"resource.multipleimageliveupdate.count":              "1",
+		"tiltfile.error":                                      "false",
+		"up.starttime":                                        state.TiltStartTime.Format(time.RFC3339),
 	}
 
 	tf.assertStats(t, expectedTags)

--- a/internal/engine/analytics_reporter_test.go
+++ b/internal/engine/analytics_reporter_test.go
@@ -42,6 +42,8 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 	tf.addManifest(tf.nextManifest().WithDeployTarget(dTarg))                                  // dc
 	tf.addManifest(tf.nextManifest().WithDeployTarget(dTarg))                                  // dc
 	tf.addManifest(tf.nextManifest().WithImageTarget(imgTargDBWithLU).WithDeployTarget(dTarg)) // dc, liveupdate
+	tf.addManifest(tf.nextManifest().WithImageTargets(
+		[]model.ImageTarget{imgTargDBWithLU, imgTargDBWithLU})) // liveupdate, multipleimageliveupdate
 
 	state := tf.ar.store.LockMutableStateForTesting()
 	state.TiltStartTime = time.Now()
@@ -53,16 +55,17 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 	tf.run()
 
 	expectedTags := map[string]string{
-		"builds.completed_count":          "3",
-		"resource.count":                  "10",
-		"resource.dockercompose.count":    "3",
-		"resource.unbuiltresources.count": "3",
-		"resource.fastbuild.count":        "1",
-		"resource.anyfastbuild.count":     "2",
-		"resource.liveupdate.count":       "2",
-		"resource.k8s.count":              "4",
-		"tiltfile.error":                  "false",
-		"up.starttime":                    state.TiltStartTime.Format(time.RFC3339),
+		"builds.completed_count":                 "3",
+		"resource.count":                         "11",
+		"resource.dockercompose.count":           "3",
+		"resource.unbuiltresources.count":        "3",
+		"resource.fastbuild.count":               "1",
+		"resource.anyfastbuild.count":            "2",
+		"resource.liveupdate.count":              "3",
+		"resource.k8s.count":                     "4",
+		"resource.multipleimageliveupdate.count": "1",
+		"tiltfile.error":                         "false",
+		"up.starttime":                           state.TiltStartTime.Format(time.RFC3339),
 	}
 
 	tf.assertStats(t, expectedTags)

--- a/internal/engine/pod_watch_test.go
+++ b/internal/engine/pod_watch_test.go
@@ -220,7 +220,7 @@ func (f *pwFixture) TearDown() {
 }
 
 func newManifestTargetWithSelectors(m model.Manifest, selectors []labels.Selector) (*store.ManifestTarget, error) {
-	dt, err := k8s.NewTarget(model.TargetName(m.Name), nil, nil, selectors, nil)
+	dt, err := k8s.NewTarget(model.TargetName(m.Name), nil, nil, selectors, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -13,7 +13,8 @@ func NewTarget(
 	entities []K8sEntity,
 	portForwards []model.PortForward,
 	extraPodSelectors []labels.Selector,
-	dependencyIDs []model.TargetID) (model.K8sTarget, error) {
+	dependencyIDs []model.TargetID,
+	refInjectCounts map[string]int) (model.K8sTarget, error) {
 	yaml, err := SerializeSpecYAML(entities)
 	if err != nil {
 		return model.K8sTarget{}, err
@@ -29,11 +30,11 @@ func NewTarget(
 		PortForwards:      portForwards,
 		ExtraPodSelectors: extraPodSelectors,
 		DisplayNames:      displayNames,
-	}.WithDependencyIDs(dependencyIDs), nil
+	}.WithDependencyIDs(dependencyIDs).WithRefInjectCounts(refInjectCounts), nil
 }
 
 func NewK8sOnlyManifest(name model.ManifestName, entities []K8sEntity) (model.Manifest, error) {
-	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil)
+	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil)
 	if err != nil {
 		return model.Manifest{}, err
 	}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -67,7 +67,8 @@ func (r *k8sResource) addRefSelector(selector container.RefSelector) {
 	r.refSelectors = append(r.refSelectors, selector)
 }
 
-func (r *k8sResource) addEntities(entities []k8s.K8sEntity, imageJSONPaths func(e k8s.K8sEntity) []k8s.JSONPath, envVarImages []container.RefSelector) error {
+func (r *k8sResource) addEntities(entities []k8s.K8sEntity,
+	imageJSONPaths func(e k8s.K8sEntity) []k8s.JSONPath, envVarImages []container.RefSelector) error {
 	r.entities = append(r.entities, entities...)
 
 	for _, entity := range entities {
@@ -76,6 +77,7 @@ func (r *k8sResource) addEntities(entities []k8s.K8sEntity, imageJSONPaths func(
 			return err
 		}
 		for _, image := range images {
+			// ~ if image already in here, wanna record a stat about same-img-multi-c
 			if !r.imageRefMap[image.String()] {
 				r.imageRefMap[image.String()] = true
 				r.imageRefs = append(r.imageRefs, image)

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -140,7 +140,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	var manifests []model.Manifest
 
 	if len(resources.k8s) > 0 {
-		manifests, err = s.translateK8s(ctx, resources.k8s)
+		manifests, err = s.translateK8s(resources.k8s)
 		if err != nil {
 			return TiltfileLoadResult{}, err
 		}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -140,7 +140,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	var manifests []model.Manifest
 
 	if len(resources.k8s) > 0 {
-		manifests, err = s.translateK8s(resources.k8s)
+		manifests, err = s.translateK8s(ctx, resources.k8s)
 		if err != nil {
 			return TiltfileLoadResult{}, err
 		}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -635,6 +635,8 @@ func (s *tiltfileState) assembleK8sUnresourced() error {
 }
 
 func (s *tiltfileState) validateK8s(r *k8sResource) error {
+	// a. r.imageRefMap should be image -> count
+	// ~~ look at r.imageRefMap, log stat for any count > 1 if liveupd
 	if len(r.entities) == 0 {
 		if len(r.refSelectors) > 0 {
 			return fmt.Errorf("resource %q: could not find k8s entities matching "+

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -9,8 +9,6 @@ import (
 
 	"go.starlark.net/syntax"
 
-	"github.com/windmilleng/tilt/internal/analytics"
-
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
@@ -782,9 +780,7 @@ Is this a typo? Existing resources in Tiltfile: %s`,
 	return result, nil
 }
 
-func (s *tiltfileState) translateK8s(ctx context.Context, resources []*k8sResource) ([]model.Manifest, error) {
-	a := analytics.Get(ctx)
-
+func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest, error) {
 	var result []model.Manifest
 	for _, r := range resources {
 		mn := model.ManifestName(r.name)
@@ -819,15 +815,6 @@ func (s *tiltfileState) translateK8s(ctx context.Context, resources []*k8sResour
 		}
 
 		result = append(result, m)
-		for _, iTarg := range iTargets {
-			ref := iTarg.ConfigurationRef.String()
-			hasLiveUpd := fmt.Sprintf("%t", !iTarg.AnyLiveUpdateInfo().Empty())
-			count := r.imageRefMap[ref]
-
-			a.Count("containersForRef", map[string]string{
-				"ref": analytics.HashMD5(ref), "live_update": hasLiveUpd,
-			}, count)
-		}
 	}
 
 	return result, nil

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -793,7 +793,7 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 			TriggerMode: tm,
 		}
 
-		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities, s.portForwardsToDomain(r), r.extraPodSelectors, r.dependencyIDs)
+		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities, s.portForwardsToDomain(r), r.extraPodSelectors, r.dependencyIDs, r.imageRefMap)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -7,7 +7,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"go.starlark.net/syntax"
+
+	"github.com/windmilleng/tilt/internal/analytics"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -782,7 +785,9 @@ Is this a typo? Existing resources in Tiltfile: %s`,
 	return result, nil
 }
 
-func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest, error) {
+func (s *tiltfileState) translateK8s(ctx context.Context, resources []*k8sResource) ([]model.Manifest, error) {
+	a := analytics.Get(ctx)
+
 	var result []model.Manifest
 	for _, r := range resources {
 		mn := model.ManifestName(r.name)
@@ -817,6 +822,13 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 		}
 
 		result = append(result, m)
+		spew.Dump(r.imageRefMap)
+		for _, iTarg := range iTargets {
+			ref := iTarg.ConfigurationRef.String()
+			hasLiveUpd := fmt.Sprintf("%t", !iTarg.AnyLiveUpdateInfo().Empty())
+			count := r.imageRefMap[ref]
+			a.Count("containersForRef", map[string]string{"ref": ref, "live_update": hasLiveUpd}, count)
+		}
 	}
 
 	return result, nil

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1850,21 +1850,21 @@ k8s_yaml(['sancho.yaml', 'blorg.yaml', 'doggos.yaml'])
 	expected := []analytics.CountEvent{{
 		Name: "containersForRef",
 		Tags: map[string]string{
-			"ref":         testyaml.SanchoImage,
+			"ref":         tiltanalytics.HashMD5(testyaml.SanchoImage),
 			"live_update": "true",
 		},
 		N: 2,
 	}, {
 		Name: "containersForRef",
 		Tags: map[string]string{
-			"ref":         "gcr.io/blorg-dev/blorg-backend:devel-nick",
+			"ref":         tiltanalytics.HashMD5("gcr.io/blorg-dev/blorg-backend:devel-nick"),
 			"live_update": "true",
 		},
 		N: 1,
 	}, {
 		Name: "containersForRef",
 		Tags: map[string]string{
-			"ref":         "gcr.io/windmill-public-containers/servantes/doggos",
+			"ref":         tiltanalytics.HashMD5("gcr.io/windmill-public-containers/servantes/doggos"),
 			"live_update": "false",
 		},
 		N: 1,

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -21,12 +21,23 @@ type K8sTarget struct {
 	DisplayNames []string
 
 	dependencyIDs []TargetID
+
+	// Map configRef -> number of times we (expect to) inject it.
+	// NOTE(maia): currently this map is only for use in metrics, though someday
+	// we want a better way of mapping configRefs -> their injection point(s)
+	// (right now, Tiltfile and Engine have two different ways of finding a
+	// given image in a k8s entity.
+	refInjectCounts map[string]int
 }
 
 func (k8s K8sTarget) Empty() bool { return reflect.DeepEqual(k8s, K8sTarget{}) }
 
 func (k8s K8sTarget) DependencyIDs() []TargetID {
 	return k8s.dependencyIDs
+}
+
+func (k8s K8sTarget) RefInjectCounts() map[string]int {
+	return k8s.refInjectCounts
 }
 
 func (k8s K8sTarget) Validate() error {
@@ -50,6 +61,11 @@ func (k8s K8sTarget) ID() TargetID {
 
 func (k8s K8sTarget) WithDependencyIDs(ids []TargetID) K8sTarget {
 	k8s.dependencyIDs = DedupeTargetIDs(ids)
+	return k8s
+}
+
+func (k8s K8sTarget) WithRefInjectCounts(ric map[string]int) K8sTarget {
+	k8s.refInjectCounts = ric
 	return k8s
 }
 


### PR DESCRIPTION
Would love feedback on how to report these stats for best slice-ability.

This PR records info on:
- number of containers running each ref
- number of resources with mutli-container live update