### PR TITLE
tiltfile: enable multiple live updates per manifest by default [ch3185]

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -35,7 +35,7 @@ type Defaults map[string]Value
 // MainDefaults is the defaults we use in Main
 var MainDefaults = Defaults{
 	MultipleContainersPerPod: Value{
-		Enabled: false,
+		Enabled: true,
 		Status:  Active,
 	},
 	Events: Value{

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -828,8 +828,6 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 // We won't collect container info on any subsequent containers (i.e. subsequent image
 // targets), so will never be able to LiveUpdate them.
 func (s *tiltfileState) checkForImpossibleLiveUpdates(m model.Manifest) error {
-	seenDeployedImage := false
-
 	g, err := model.NewTargetGraph(m.TargetSpecs())
 	if err != nil {
 		return err
@@ -837,11 +835,6 @@ func (s *tiltfileState) checkForImpossibleLiveUpdates(m model.Manifest) error {
 
 	for _, iTarg := range m.ImageTargets {
 		isDeployed := m.IsImageDeployed(iTarg)
-		isFirstDeployedImage := false
-		if isDeployed && !seenDeployedImage {
-			isFirstDeployedImage = true
-			seenDeployedImage = true
-		}
 
 		// This check only applies to images with live updates.
 		isInPlaceUpdate := !iTarg.AnyFastBuildInfo().Empty() || !iTarg.AnyLiveUpdateInfo().Empty()
@@ -853,16 +846,6 @@ func (s *tiltfileState) checkForImpossibleLiveUpdates(m model.Manifest) error {
 		// should probably emit a different kind of warning.
 		if !isDeployed {
 			continue
-		}
-
-		if !isFirstDeployedImage {
-			// TODO(maia): s/in-place updates/live updates after we fully deprecate FastBuild
-			s.warnings = append(s.warnings, fmt.Sprintf("Sorry, but Tilt only supports in-place updates "+
-				"for the first Tilt-built container on a pod, so we can't in-place update your image '%s'. If this "+
-				"is a feature you need, let us know!", iTarg.DeploymentRef.String()))
-
-			// Only emit the warning once
-			return nil
 		}
 
 		err = s.validateLiveUpdate(iTarg, g)


### PR DESCRIPTION
Hello @jazzdan, @nicks,

Please review the following commits I made in branch maiamcc/rm-multic-feature-flag:

a8b6458c0ff5369034474eef868e21c1a922237f (2019-08-12 15:37:56 -0400)
tiltfile: enable multiple live updates per manifest by default

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics