### PR TITLE
goreleaser: don't bother with i386 architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,13 +9,8 @@ builds:
   - linux
   - darwin
   - windows
-  # Cross-compiling darwin is a pain due to fsevents,
-  # and we don't expect darwin/386 users anyway.
-  ignore:
-  - goos: darwin
-    goarch: 386
-  - goos: windows
-    goarch: 386
+  goarch:
+  - amd64
 archive:
   name_template: "{{ .ProjectName }}.{{ .Version }}.{{ .Os }}.{{ .Arch }}"
   replacements:


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/arch:

b4449387e127667671522badbf8cc592abc70529 (2019-08-13 11:35:11 -0400)
goreleaser: don't bother with i386 architectures