### PR TITLE
tiltfile: log changed files, take two

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -247,17 +246,9 @@ func (c *BuildController) logBuildEntry(ctx context.Context, entry buildEntry, c
 		s := logger.Blue(l).Sprintf(" ├──────────────────────────────────────────────")
 		l.Infof("\n%s%s%s", p, name, s)
 	} else {
-		var changedPathsToPrint []string
-		if len(changedFiles) > maxChangedFilesToPrint {
-			changedPathsToPrint = append(changedPathsToPrint, changedFiles[:maxChangedFilesToPrint]...)
-			changedPathsToPrint = append(changedPathsToPrint, "...")
-		} else {
-			changedPathsToPrint = changedFiles
-		}
-
 		if len(changedFiles) > 0 {
 			p := logger.Green(l).Sprintf("%d changed: ", len(changedFiles))
-			l.Infof("\n%s%v\n", p, ospath.TryAsCwdChildren(changedPathsToPrint))
+			l.Infof("\n%s%v\n", p, formatFileChangeList(changedFiles))
 		}
 
 		rp := logger.Blue(l).Sprintf("──┤ Rebuilding: ")

--- a/internal/engine/changed_file_list.go
+++ b/internal/engine/changed_file_list.go
@@ -1,0 +1,22 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/windmilleng/tilt/internal/ospath"
+)
+
+// When we kick off a build because some files changed, only print the first `maxChangedFilesToPrint`
+const maxChangedFilesToPrint = 5
+
+func formatFileChangeList(changedFiles []string) string {
+	var changedPathsToPrint []string
+	if len(changedFiles) > maxChangedFilesToPrint {
+		changedPathsToPrint = append(changedPathsToPrint, changedFiles[:maxChangedFilesToPrint]...)
+		changedPathsToPrint = append(changedPathsToPrint, "...")
+	} else {
+		changedPathsToPrint = changedFiles
+	}
+
+	return fmt.Sprintf("%v", ospath.TryAsCwdChildren(changedFiles))
+}

--- a/internal/engine/changed_file_list_test.go
+++ b/internal/engine/changed_file_list_test.go
@@ -1,0 +1,23 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatChangedFileListTruncates(t *testing.T) {
+	actual := formatFileChangeList([]string{"a", "b", "c", "d", "e", "f"})
+	expected := "[a b c d e f]"
+	require.Equal(t, expected, actual)
+}
+
+func TestFormatChangedFileListMakesRelative(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	actual := formatFileChangeList([]string{filepath.Join(wd, "foo"), "/bar/baz"})
+	expected := "[foo /bar/baz]"
+	require.Equal(t, expected, actual)
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -42,9 +42,6 @@ const watchBufferMaxTimeInMs = 10000
 var watchBufferMinRestDuration = watchBufferMinRestInMs * time.Millisecond
 var watchBufferMaxDuration = watchBufferMaxTimeInMs * time.Millisecond
 
-// When we kick off a build because some files changed, only print the first `maxChangedFilesToPrint`
-const maxChangedFilesToPrint = 5
-
 // TODO(nick): maybe this should be called 'BuildEngine' or something?
 // Upper seems like a poor and undescriptive name.
 type Upper struct {


### PR DESCRIPTION
#1969 was reverted because it logged "1 changed file: [Tiltfile]" on startup.

This is pretty much the same, but with that log message wrapped by the same `if !firstBuild` check we use in BuildController, and a unit test for what actually gets logged.