### PR TITLE
upper tests: print log on failure

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3012,6 +3012,11 @@ func (f *testFixture) LogLines() []string {
 }
 
 func (f *testFixture) TearDown() {
+	if f.T().Failed() {
+		f.withState(func(es store.EngineState) {
+			fmt.Println(es.Log.String())
+		})
+	}
 	f.TempDirFixture.TearDown()
 	f.kClient.TearDown()
 	close(f.fsWatcher.events)


### PR DESCRIPTION
### Problem

In upper tests, we get to see pretty much none of the tilt log when a test fails. The log is really helpful! For example, I had a syntax error in a Tiltfile, and the failure manifested as "timed out waiting for snack to build".

### Solution

In `TearDown`, if the test failed, print the full tilt log.

We could do it on success as well, but that might be spammy with `go test`