### PR TITLE
k8s: change client.Get to use an ObjectReference

### DIFF
--- a/internal/engine/event_watch_manager_test.go
+++ b/internal/engine/event_watch_manager_test.go
@@ -148,29 +148,6 @@ func TestEventWatchManager_janitor(t *testing.T) {
 	f.assertUIDMapKeys([]types.UID{obj2.GetUID()})
 }
 
-func TestGetGroup(t *testing.T) {
-	for _, test := range []struct {
-		name          string
-		apiVersion    string
-		expectedGroup string
-	}{
-		{"normal", "apps/v1", "apps"},
-		// core types have an empty group
-		{"core", "/v1", ""},
-		// on some versions of k8s, deployment is buggy and doesn't have a version in its apiVersion
-		{"no version", "extensions", "extensions"},
-		{"alpha version", "apps/v1alpha1", "apps"},
-		{"beta version", "apps/v1beta1", "apps"},
-		// I've never seen this in the wild, but the docs say it's legal
-		{"alpha version, no second number", "apps/v1alpha", "apps"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			obj := v1.ObjectReference{APIVersion: test.apiVersion}
-			assert.Equal(t, test.expectedGroup, getGroup(obj))
-		})
-	}
-}
-
 func (f *ewmFixture) makeEvent(obj unstructured.Unstructured) *v1.Event {
 	return &v1.Event{
 		ObjectMeta:     metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: f.clock.Now()}},

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -119,6 +119,29 @@ func TestUpsertToTerminatingNamespaceForbidden(t *testing.T) {
 
 }
 
+func TestGetGroup(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		apiVersion    string
+		expectedGroup string
+	}{
+		{"normal", "apps/v1", "apps"},
+		// core types have an empty group
+		{"core", "/v1", ""},
+		// on some versions of k8s, deployment is buggy and doesn't have a version in its apiVersion
+		{"no version", "extensions", "extensions"},
+		{"alpha version", "apps/v1alpha1", "apps"},
+		{"beta version", "apps/v1beta1", "apps"},
+		// I've never seen this in the wild, but the docs say it's legal
+		{"alpha version, no second number", "apps/v1alpha", "apps"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			obj := v1.ObjectReference{APIVersion: test.apiVersion}
+			assert.Equal(t, test.expectedGroup, getGroup(obj))
+		})
+	}
+}
+
 type call struct {
 	argv  []string
 	stdin string

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -30,7 +30,7 @@ func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity) err
 	return errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) Get(group, version, kind, namespace, name, resourceVersion string) (*unstructured.Unstructured, error) {
+func (ec *explodingClient) GetByReference(ref v1.ObjectReference) (*unstructured.Unstructured, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -78,7 +78,6 @@ type ExecCall struct {
 
 type GetKey struct {
 	Group           string
-	Version         string
 	Kind            string
 	Namespace       string
 	Name            string
@@ -240,8 +239,13 @@ func (c *FakeK8sClient) Delete(ctx context.Context, entities []K8sEntity) error 
 	return nil
 }
 
-func (c *FakeK8sClient) Get(group, version, kind, namespace, name, resourceVersion string) (*unstructured.Unstructured, error) {
-	key := GetKey{group, version, kind, namespace, name, resourceVersion}
+func (c *FakeK8sClient) GetByReference(ref v1.ObjectReference) (*unstructured.Unstructured, error) {
+	group := getGroup(ref)
+	kind := ref.Kind
+	namespace := ref.Namespace
+	name := ref.Name
+	resourceVersion := ref.ResourceVersion
+	key := GetKey{group, kind, namespace, name, resourceVersion}
 	resp, ok := c.GetResources[key]
 	if !ok {
 		return nil, fmt.Errorf("No response found for %v", key)


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/k8sget:

1d0b0d30a7d207cc04517bb37f2de7855e45aa02 (2019-08-13 13:45:52 -0400)
k8s: change client.Get to use an ObjectReference