### PR TITLE
enable verbose mode for tilt up integ tests (previously only printed output if test failed)

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -152,12 +151,8 @@ func (f *fixture) tiltCmd(tiltArgs []string, outWriter io.Writer) *exec.Cmd {
 }
 
 func (f *fixture) TiltUp(name string) {
-	out := bytes.NewBuffer(nil)
-	cmd := f.tiltCmd([]string{"up", name, "--watch=false", "--debug", "--hud=false", "--port=0", "--image-tag-prefix=" + imageTagPrefix}, out)
-	err := cmd.Run()
-	if err != nil {
-		f.t.Fatalf("Failed to up service: %v. Logs:\n%s", err, out.String())
-	}
+	cmd := f.tiltCmd([]string{"up", name, "--watch=false", "--debug", "--hud=false", "--port=0", "--image-tag-prefix=" + imageTagPrefix}, os.Stdout)
+	f.runInBackground(cmd)
 }
 
 func (f *fixture) runInBackground(cmd *exec.Cmd) {


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/integ-verbose:

98c06fded29d9e3df07430d01353a0aaf611ab63 (2019-08-13 15:01:51 -0400)
enable verbose mode for tilt up integ tests (previously only printed output if test failed)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics