### PR TITLE
k8s: remove custom uid type. We don't need two uid types

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/windmilleng/tilt/internal/dockercompose"
@@ -180,7 +181,7 @@ type LatestVersionAction struct {
 func (LatestVersionAction) Action() {}
 
 type UIDUpdateAction struct {
-	UID          k8s.UID
+	UID          types.UID
 	EventType    watch.EventType
 	ManifestName model.ManifestName
 	Entity       k8s.K8sEntity

--- a/internal/engine/event_watch_manager.go
+++ b/internal/engine/event_watch_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
@@ -29,7 +30,7 @@ type uidMapEntry struct {
 type EventWatchManager struct {
 	kClient  k8s.Client
 	watching bool
-	uidMap   map[k8s.UID]uidMapEntry
+	uidMap   map[types.UID]uidMapEntry
 	uidMapMu sync.RWMutex
 	clock    clockwork.Clock
 }
@@ -37,7 +38,7 @@ type EventWatchManager struct {
 func NewEventWatchManager(kClient k8s.Client, clock clockwork.Clock) *EventWatchManager {
 	return &EventWatchManager{
 		kClient: kClient,
-		uidMap:  make(map[k8s.UID]uidMapEntry),
+		uidMap:  make(map[types.UID]uidMapEntry),
 		clock:   clock,
 	}
 }
@@ -104,7 +105,7 @@ func (m *EventWatchManager) createEntry(ctx context.Context, involvedObject v1.O
 // object at the same time, they can each result in their own API request.
 // We're currently assuming this matters sufficiently rarely that it's not worth the code complexity to fix.
 func (m *EventWatchManager) getEntry(ctx context.Context, obj v1.ObjectReference) uidMapEntry {
-	uid := k8s.UID(obj.UID)
+	uid := obj.UID
 
 	m.uidMapMu.RLock()
 	entry, ok := m.uidMap[uid]

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -43,7 +43,6 @@ type PodID string
 type NodeID string
 type ServiceName string
 type KubeContext string
-type UID string
 
 const DefaultNamespace = Namespace("default")
 

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -141,8 +141,8 @@ func (e K8sEntity) Namespace() Namespace {
 	return Namespace(n)
 }
 
-func (e K8sEntity) UID() UID {
-	return UID(e.meta().GetUID())
+func (e K8sEntity) UID() types.UID {
+	return e.meta().GetUID()
 }
 
 func (e K8sEntity) Labels() map[string]string {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/uid:

c7a8854d30c11e9eb96f9caaf1b2ff241668f457 (2019-08-13 15:52:18 -0400)
k8s: remove custom uid type. We don't need two uid types