### PR TITLE
k8s: Allow GetByReference to return structured objects as well as unstructured ones

### DIFF
--- a/internal/engine/event_watch_manager.go
+++ b/internal/engine/event_watch_manager.go
@@ -80,7 +80,7 @@ func (m *EventWatchManager) createEntry(ctx context.Context, involvedObject v1.O
 		expiresAt:         m.clock.Now().Add(uidMapEntryTTL),
 	}
 
-	o, err := m.kClient.GetByReference(involvedObject)
+	e, err := m.kClient.GetByReference(involvedObject)
 	if err != nil {
 		// if the lookup was an error, wipe out resourceVersion so that we don't cache a potentially
 		// ephemeral negative result
@@ -89,14 +89,14 @@ func (m *EventWatchManager) createEntry(ctx context.Context, involvedObject v1.O
 		return ret
 	}
 
-	mn := model.ManifestName(o.GetLabels()[k8s.ManifestNameLabel])
+	mn := model.ManifestName(e.Labels()[k8s.ManifestNameLabel])
 	if mn == "" {
 		return ret
 	}
 
-	ret.obj = k8s.K8sEntity{Obj: o}
+	ret.obj = e
 	ret.manifest = mn
-	ret.belongsToThisTilt = o.GetLabels()[k8s.TiltRunIDLabel] == k8s.TiltRunID
+	ret.belongsToThisTilt = e.Labels()[k8s.TiltRunIDLabel] == k8s.TiltRunID
 	return ret
 }
 

--- a/internal/engine/pod_watch.go
+++ b/internal/engine/pod_watch.go
@@ -85,7 +85,7 @@ func (w *PodWatcher) OnChange(ctx context.Context, st store.RStore) {
 			st.Dispatch(NewErrorAction(err))
 			return
 		}
-		go dispatchPodChangesLoop(ctx, ch, st)
+		go w.dispatchPodChangesLoop(ctx, ch, st)
 	}
 
 	for _, pw := range teardown {
@@ -104,7 +104,7 @@ func (w *PodWatcher) removeWatch(toRemove PodWatch) {
 	}
 }
 
-func dispatchPodChangesLoop(ctx context.Context, ch <-chan *v1.Pod, st store.RStore) {
+func (w *PodWatcher) dispatchPodChangesLoop(ctx context.Context, ch <-chan *v1.Pod, st store.RStore) {
 	for {
 		select {
 		case pod, ok := <-ch:

--- a/internal/engine/pod_watch_test.go
+++ b/internal/engine/pod_watch_test.go
@@ -198,9 +198,10 @@ func newPWFixture(t *testing.T) *pwFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 
+	pw := NewPodWatcher(kClient)
 	ret := &pwFixture{
 		kClient: kClient,
-		pw:      NewPodWatcher(kClient),
+		pw:      pw,
 		ctx:     ctx,
 		cancel:  cancel,
 		t:       t,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1909,8 +1909,8 @@ func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
 	obj := unstructured.Unstructured{}
 	obj.SetLabels(map[string]string{k8s.TiltRunIDLabel: k8s.TiltRunID, k8s.ManifestNameLabel: name.String()})
 	obj.SetName(objRef.Name)
-	f.kClient.GetResources = map[k8s.GetKey]*unstructured.Unstructured{
-		k8s.GetKey{Name: e.Name()}: &obj,
+	f.kClient.GetResources = map[k8s.GetKey]k8s.K8sEntity{
+		k8s.GetKey{Name: e.Name()}: k8s.NewK8sEntity(&obj),
 	}
 
 	f.Start([]model.Manifest{manifest}, true)
@@ -2024,8 +2024,8 @@ func TestK8sEventLogTimestamp(t *testing.T) {
 
 	obj := unstructured.Unstructured{}
 	obj.SetLabels(map[string]string{k8s.TiltRunIDLabel: k8s.TiltRunID, k8s.ManifestNameLabel: name.String()})
-	f.kClient.GetResources = map[k8s.GetKey]*unstructured.Unstructured{
-		k8s.GetKey{}: &obj,
+	f.kClient.GetResources = map[k8s.GetKey]k8s.K8sEntity{
+		k8s.GetKey{}: k8s.NewK8sEntity(&obj),
 	}
 
 	f.Start([]model.Manifest{manifest}, true)

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -24,19 +24,25 @@ type K8sEntity struct {
 	Obj runtime.Object
 }
 
+func NewK8sEntity(obj runtime.Object) K8sEntity {
+	return K8sEntity{Obj: obj}
+}
+
 type k8sMeta interface {
 	GetName() string
 	GetNamespace() string
 	GetUID() types.UID
 	GetLabels() map[string]string
+	GetOwnerReferences() []metav1.OwnerReference
 }
 
 type emptyMeta struct{}
 
-func (emptyMeta) GetName() string              { return "" }
-func (emptyMeta) GetNamespace() string         { return "" }
-func (emptyMeta) GetUID() types.UID            { return "" }
-func (emptyMeta) GetLabels() map[string]string { return make(map[string]string) }
+func (emptyMeta) GetName() string                             { return "" }
+func (emptyMeta) GetNamespace() string                        { return "" }
+func (emptyMeta) GetUID() types.UID                           { return "" }
+func (emptyMeta) GetLabels() map[string]string                { return make(map[string]string) }
+func (emptyMeta) GetOwnerReferences() []metav1.OwnerReference { return nil }
 
 var _ k8sMeta = emptyMeta{}
 var _ k8sMeta = &metav1.ObjectMeta{}
@@ -169,9 +175,7 @@ func (e K8sEntity) ImmutableOnceCreated() bool {
 }
 
 func (e K8sEntity) DeepCopy() K8sEntity {
-	return K8sEntity{
-		Obj: e.Obj.DeepCopyObject(),
-	}
+	return NewK8sEntity(e.Obj.DeepCopyObject())
 }
 
 // EntitiesWithDependentsAndRest returns two lists of k8s entities: those that may have dependencies,

--- a/internal/k8s/entity_test.go
+++ b/internal/k8s/entity_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestTypedPodGVK(t *testing.T) {
-	entity := K8sEntity{Obj: &v1.Pod{}}
+	entity := NewK8sEntity(&v1.Pod{})
 	assert.Equal(t, "", entity.GVK().Group)
 	assert.Equal(t, "v1", entity.GVK().Version)
 	assert.Equal(t, "Pod", entity.GVK().Kind)
 }
 
 func TestTypedDeploymentGVK(t *testing.T) {
-	entity := K8sEntity{Obj: &appsv1.Deployment{}}
+	entity := NewK8sEntity(&appsv1.Deployment{})
 	assert.Equal(t, "apps", entity.GVK().Group)
 	assert.Equal(t, "v1", entity.GVK().Version)
 	assert.Equal(t, "Deployment", entity.GVK().Kind)

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -30,8 +29,8 @@ func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity) err
 	return errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) GetByReference(ref v1.ObjectReference) (*unstructured.Unstructured, error) {
-	return nil, errors.Wrap(ec.err, "could not set up k8s client")
+func (ec *explodingClient) GetByReference(ref v1.ObjectReference) (K8sEntity, error) {
+	return K8sEntity{}, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) PodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, lp []model.LabelPair) ([]v1.Pod, error) {

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -62,7 +61,7 @@ type FakeK8sClient struct {
 	Runtime     container.Runtime
 	Registry    container.Registry
 
-	GetResources map[GetKey]*unstructured.Unstructured
+	GetResources map[GetKey]K8sEntity
 
 	ExecCalls  []ExecCall
 	ExecErrors []error
@@ -239,7 +238,7 @@ func (c *FakeK8sClient) Delete(ctx context.Context, entities []K8sEntity) error 
 	return nil
 }
 
-func (c *FakeK8sClient) GetByReference(ref v1.ObjectReference) (*unstructured.Unstructured, error) {
+func (c *FakeK8sClient) GetByReference(ref v1.ObjectReference) (K8sEntity, error) {
 	group := getGroup(ref)
 	kind := ref.Kind
 	namespace := ref.Namespace
@@ -248,7 +247,7 @@ func (c *FakeK8sClient) GetByReference(ref v1.ObjectReference) (*unstructured.Un
 	key := GetKey{group, kind, namespace, name, resourceVersion}
 	resp, ok := c.GetResources[key]
 	if !ok {
-		return nil, fmt.Errorf("No response found for %v", key)
+		return K8sEntity{}, fmt.Errorf("No response found for %v", key)
 	}
 
 	return resp, nil

--- a/internal/k8s/names_test.go
+++ b/internal/k8s/names_test.go
@@ -61,7 +61,7 @@ func TestUniqueResourceNames(t *testing.T) {
 				obj.SetNamespace(w.namespace)
 				obj.SetKind(w.kind)
 				obj.SetAPIVersion(fmt.Sprintf("%s/1.0", w.group))
-				entities = append(entities, K8sEntity{Obj: &obj})
+				entities = append(entities, NewK8sEntity(&obj))
 
 				expectedNames = append(expectedNames, w.expectedResourceName)
 			}


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/entity:

1959f82b8f6ad23e67df8388ae5c034aba8235e6 (2019-08-14 10:57:20 -0400)
k8s: Allow GetByReference to return structured objects as well as unstructured ones