### PR TITLE
k8s: add an owner visitor that can traverse owner trees

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -44,7 +44,8 @@ var K8sWireSet = wire.NewSet(
 	k8s.ProvideKubectlRunner,
 	k8s.ProvideContainerRuntime,
 	k8s.ProvideServerVersion,
-	k8s.ProvideK8sClient)
+	k8s.ProvideK8sClient,
+	k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -68,12 +68,13 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
-	podWatcher := engine.NewPodWatcher(k8sClient)
+	ownerFetcher := k8s.ProvideOwnerFetcher(k8sClient)
+	podWatcher := engine.NewPodWatcher(k8sClient, ownerFetcher)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
 		return demo.Script{}, err
 	}
-	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
+	serviceWatcher := engine.NewServiceWatcher(k8sClient, ownerFetcher, nodeIP)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -205,12 +206,13 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, portForwarder, namespace, kubectlRunner, clientConfig)
-	podWatcher := engine.NewPodWatcher(k8sClient)
+	ownerFetcher := k8s.ProvideOwnerFetcher(k8sClient)
+	podWatcher := engine.NewPodWatcher(k8sClient, ownerFetcher)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
 	if err != nil {
 		return Threads{}, err
 	}
-	serviceWatcher := engine.NewServiceWatcher(k8sClient, nodeIP)
+	serviceWatcher := engine.NewServiceWatcher(k8sClient, ownerFetcher, nodeIP)
 	podLogManager := engine.NewPodLogManager(k8sClient)
 	portForwardController := engine.NewPortForwardController(k8sClient)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -486,7 +488,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientSet, k8s.ProvideRESTConfig, k8s.ProvidePortForwarder, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient)
+var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientSet, k8s.ProvideRESTConfig, k8s.ProvidePortForwarder, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,

--- a/internal/engine/pod_watch.go
+++ b/internal/engine/pod_watch.go
@@ -15,13 +15,15 @@ import (
 )
 
 type PodWatcher struct {
-	kCli    k8s.Client
-	watches []PodWatch
+	kCli         k8s.Client
+	ownerFetcher k8s.OwnerFetcher
+	watches      []PodWatch
 }
 
-func NewPodWatcher(kCli k8s.Client) *PodWatcher {
+func NewPodWatcher(kCli k8s.Client, ownerFetcher k8s.OwnerFetcher) *PodWatcher {
 	return &PodWatcher{
-		kCli: kCli,
+		kCli:         kCli,
+		ownerFetcher: ownerFetcher,
 	}
 }
 
@@ -111,6 +113,9 @@ func (w *PodWatcher) dispatchPodChangesLoop(ctx context.Context, ch <-chan *v1.P
 			if !ok {
 				return
 			}
+
+			// TODO(nick): Attach OwnerTree
+
 			st.Dispatch(NewPodChangeAction(pod))
 		case <-ctx.Done():
 			return

--- a/internal/engine/pod_watch_test.go
+++ b/internal/engine/pod_watch_test.go
@@ -198,7 +198,8 @@ func newPWFixture(t *testing.T) *pwFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 
-	pw := NewPodWatcher(kClient)
+	of := k8s.ProvideOwnerFetcher(kClient)
+	pw := NewPodWatcher(kClient, of)
 	ret := &pwFixture{
 		kClient: kClient,
 		pw:      pw,

--- a/internal/engine/service_watch.go
+++ b/internal/engine/service_watch.go
@@ -13,15 +13,17 @@ import (
 )
 
 type ServiceWatcher struct {
-	kCli     k8s.Client
-	watching bool
-	nodeIP   k8s.NodeIP
+	kCli         k8s.Client
+	ownerFetcher k8s.OwnerFetcher
+	watching     bool
+	nodeIP       k8s.NodeIP
 }
 
-func NewServiceWatcher(kCli k8s.Client, nodeIP k8s.NodeIP) *ServiceWatcher {
+func NewServiceWatcher(kCli k8s.Client, ownerFetcher k8s.OwnerFetcher, nodeIP k8s.NodeIP) *ServiceWatcher {
 	return &ServiceWatcher{
-		kCli:   kCli,
-		nodeIP: nodeIP,
+		kCli:         kCli,
+		ownerFetcher: ownerFetcher,
+		nodeIP:       nodeIP,
 	}
 }
 
@@ -77,6 +79,8 @@ func dispatchServiceChange(st store.RStore, service *v1.Service, ip k8s.NodeIP) 
 	if err != nil {
 		return err
 	}
+
+	// TODO(nick): Attach owner tree.
 
 	st.Dispatch(NewServiceChangeAction(service, url))
 	return nil

--- a/internal/engine/service_watch_test.go
+++ b/internal/engine/service_watch_test.go
@@ -88,10 +88,12 @@ func newSWFixture(t *testing.T) *swFixture {
 	ctx, cancel := context.WithCancel(ctx)
 
 	nip := k8s.NodeIP("fakeip")
+	of := k8s.ProvideOwnerFetcher(kClient)
+	sw := NewServiceWatcher(kClient, of, nip)
 
 	ret := &swFixture{
 		kClient: kClient,
-		sw:      NewServiceWatcher(kClient, nip),
+		sw:      sw,
 		nip:     nip,
 		ctx:     ctx,
 		cancel:  cancel,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2728,8 +2728,9 @@ func newTestFixture(t *testing.T) *testFixture {
 	reaper := build.NewImageReaper(dockerClient)
 
 	kCli := k8s.NewFakeK8sClient()
-	pw := NewPodWatcher(kCli)
-	sw := NewServiceWatcher(kCli, "")
+	of := k8s.ProvideOwnerFetcher(kCli)
+	pw := NewPodWatcher(kCli, of)
+	sw := NewServiceWatcher(kCli, of, "")
 
 	fakeHud := hud.NewFakeHud()
 

--- a/internal/k8s/owner_fetcher.go
+++ b/internal/k8s/owner_fetcher.go
@@ -1,0 +1,123 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// The ObjectRefTree only contains immutable properties
+// of a Kubernetes object: the name, namespace, and UID
+type ObjectRefTree struct {
+	Ref    v1.ObjectReference
+	Owners []ObjectRefTree
+}
+
+func (t ObjectRefTree) stringLines() []string {
+	result := []string{fmt.Sprintf("%s:%s", t.Ref.Kind, t.Ref.Name)}
+	for _, owner := range t.Owners {
+		// indent each of the owners by two spaces
+		branchLines := owner.stringLines()
+		for _, branchLine := range branchLines {
+			result = append(result, fmt.Sprintf("  %s", branchLine))
+		}
+	}
+	return result
+}
+
+func (t ObjectRefTree) String() string {
+	return strings.Join(t.stringLines(), "\n")
+}
+
+type OwnerFetcher struct {
+	kCli  Client
+	cache map[types.UID]ObjectRefTree
+	mu    *sync.RWMutex
+}
+
+func ProvideOwnerFetcher(kCli Client) OwnerFetcher {
+	return OwnerFetcher{
+		kCli:  kCli,
+		cache: make(map[types.UID]ObjectRefTree),
+		mu:    &sync.RWMutex{},
+	}
+}
+
+func (v OwnerFetcher) getCachedTree(id types.UID) (ObjectRefTree, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	tree, ok := v.cache[id]
+	return tree, ok
+}
+
+func (v OwnerFetcher) setCachedTree(id types.UID, tree ObjectRefTree) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.cache[id] = tree
+}
+
+func (v OwnerFetcher) OwnerTreeOf(entity K8sEntity) (ObjectRefTree, error) {
+	meta := entity.meta()
+	uid := meta.GetUID()
+	if uid == "" {
+		return ObjectRefTree{}, fmt.Errorf("Can only get owners of deployed entities")
+	}
+
+	tree, ok := v.getCachedTree(uid)
+	if ok {
+		return tree, nil
+	}
+
+	apiVersion, kind := entity.GVK().ToAPIVersionAndKind()
+	ref := v1.ObjectReference{
+		Kind:       kind,
+		APIVersion: apiVersion,
+		Name:       meta.GetName(),
+		Namespace:  meta.GetNamespace(),
+		UID:        meta.GetUID(),
+	}
+	tree = ObjectRefTree{Ref: ref}
+
+	owners, err := v.ownersOfMeta(meta)
+	if err != nil {
+		return ObjectRefTree{}, err
+	}
+	for _, owner := range owners {
+		ownerTree, err := v.OwnerTreeOf(owner)
+		if err != nil {
+			return ObjectRefTree{}, err
+		}
+		tree.Owners = append(tree.Owners, ownerTree)
+	}
+	v.setCachedTree(uid, tree)
+	return tree, nil
+}
+
+func (v OwnerFetcher) ownersOfMeta(meta k8sMeta) ([]K8sEntity, error) {
+	owners := meta.GetOwnerReferences()
+	result := make([]K8sEntity, 0, len(owners))
+	for _, owner := range owners {
+		ref := v1.ObjectReference{
+			APIVersion: owner.APIVersion,
+			Kind:       owner.Kind,
+			Namespace:  meta.GetNamespace(),
+			Name:       owner.Name,
+			UID:        owner.UID,
+		}
+
+		owner, err := v.kCli.GetByReference(ref)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		result = append(result, owner)
+	}
+
+	return result, nil
+}

--- a/internal/k8s/owner_fetcher_test.go
+++ b/internal/k8s/owner_fetcher_test.go
@@ -1,0 +1,92 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVisitOneParent(t *testing.T) {
+	kCli := &FakeK8sClient{}
+	ov := ProvideOwnerFetcher(kCli)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-a",
+			UID:  "pod-a-uid",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "rs-a",
+					UID:        "rs-a-uid",
+				},
+			},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rs-a",
+			UID:  "rs-a-uid",
+		},
+	}
+	kCli.GetResources = make(map[GetKey]K8sEntity)
+	kCli.GetResources[GetKey{"apps", "ReplicaSet", "", "rs-a", ""}] = K8sEntity{Obj: rs}
+
+	tree, err := ov.OwnerTreeOf(K8sEntity{Obj: pod})
+	assert.NoError(t, err)
+	assert.Equal(t, `Pod:pod-a
+  ReplicaSet:rs-a`, tree.String())
+}
+
+func TestVisitTwoParents(t *testing.T) {
+	kCli := &FakeK8sClient{}
+	ov := ProvideOwnerFetcher(kCli)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-a",
+			UID:  "pod-a-uid",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "rs-a",
+					UID:        "rs-a-uid",
+				},
+			},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rs-a",
+			UID:  "rs-a-uid",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "dep-a",
+					UID:        "dep-a-uid",
+				},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dep-a",
+			UID:  "dep-a-uid",
+		},
+	}
+	kCli.GetResources = make(map[GetKey]K8sEntity)
+	kCli.GetResources[GetKey{"apps", "ReplicaSet", "", "rs-a", ""}] = K8sEntity{Obj: rs}
+	kCli.GetResources[GetKey{"apps", "Deployment", "", "dep-a", ""}] = K8sEntity{Obj: dep}
+
+	tree, err := ov.OwnerTreeOf(K8sEntity{Obj: pod})
+	assert.NoError(t, err)
+	assert.Equal(t, `Pod:pod-a
+  ReplicaSet:rs-a
+    Deployment:dep-a`, tree.String())
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch3086/owners:

ff9035dba2a725227e7753afa15863400b397b5c (2019-08-14 11:48:11 -0400)
k8s: add an owner visitor that can traverse owner trees