### PR TITLE
tiltfile: record stats on arg usage

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -88,7 +88,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 	var dockerRef, entrypoint string
 	var contextVal, dockerfilePathVal, buildArgs, dockerfileContentsVal, cacheVal, liveUpdateVal, ignoreVal, onlyVal starlark.Value
 	var matchInEnvVars bool
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
 		"context", &contextVal,
 		"build_args?", &buildArgs,
@@ -250,7 +250,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 	var matchInEnvVars bool
 	var entrypoint string
 
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	err := s.unpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
 		"command", &command,
 		"deps", &deps,
@@ -395,7 +395,7 @@ func (s *tiltfileState) fastBuild(thread *starlark.Thread, fn *starlark.Builtin,
 	var dockerRef, entrypoint string
 	var baseDockerfile starlark.Value
 	var cacheVal starlark.Value
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	err := s.unpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
 		"base_dockerfile", &baseDockerfile,
 		"entrypoint?", &entrypoint,
@@ -512,7 +512,7 @@ func (b *fastBuild) AttrNames() []string {
 }
 
 func (b *fastBuild) hotReload(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs); err != nil {
+	if err := b.s.unpackArgs(fn.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 
@@ -529,7 +529,7 @@ func (b *fastBuild) add(thread *starlark.Thread, fn *starlark.Builtin, args star
 	var src starlark.Value
 	var mountPoint string
 
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "src", &src, "dest", &mountPoint); err != nil {
+	if err := b.s.unpackArgs(fn.Name(), args, kwargs, "src", &src, "dest", &mountPoint); err != nil {
 		return nil, err
 	}
 
@@ -549,7 +549,7 @@ func (b *fastBuild) add(thread *starlark.Thread, fn *starlark.Builtin, args star
 func (b *fastBuild) run(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var cmd string
 	var trigger starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "cmd", &cmd, "trigger?", &trigger); err != nil {
+	if err := b.s.unpackArgs(fn.Name(), args, kwargs, "cmd", &cmd, "trigger?", &trigger); err != nil {
 		return nil, err
 	}
 
@@ -635,7 +635,7 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 	}
 
 	var dr string
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "name", &dr); err != nil {
+	if err := s.unpackArgs(fn.Name(), args, kwargs, "name", &dr); err != nil {
 		return nil, err
 	}
 

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -33,7 +33,7 @@ func (dc dcResourceSet) Empty() bool { return reflect.DeepEqual(dc, dcResourceSe
 func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var configPathsValue starlark.Value
 
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "configPaths", &configPathsValue)
+	err := s.unpackArgs(fn.Name(), args, kwargs, "configPaths", &configPathsValue)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 	var imageVal starlark.Value
 	var triggerMode triggerMode
 
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
 		"image", &imageVal, // in future this will be optional
 		"trigger_mode?", &triggerMode,

--- a/internal/tiltfile/fail.go
+++ b/internal/tiltfile/fail.go
@@ -8,7 +8,7 @@ import (
 
 func (s *tiltfileState) fail(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var msg string
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "msg", &msg)
+	err := s.unpackArgs(fn.Name(), args, kwargs, "msg", &msg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/features.go
+++ b/internal/tiltfile/features.go
@@ -8,7 +8,7 @@ import (
 
 func (s *tiltfileState) enableFeature(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var flag string
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "msg", &flag)
+	err := s.unpackArgs(fn.Name(), args, kwargs, "msg", &flag)
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func (s *tiltfileState) enableFeature(thread *starlark.Thread, fn *starlark.Buil
 
 func (s *tiltfileState) disableFeature(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var flag string
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "msg", &flag)
+	err := s.unpackArgs(fn.Name(), args, kwargs, "msg", &flag)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/include.go
+++ b/internal/tiltfile/include.go
@@ -28,7 +28,7 @@ const (
 // scope (i.e., you can't load() a Tilfile for its side-effects).
 func (s *tiltfileState) include(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var p string
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "path", &p)
+	err := s.unpackArgs(fn.Name(), args, kwargs, "path", &p)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -100,7 +100,7 @@ func (r k8sResource) refSelectorList() []string {
 
 func (s *tiltfileState) k8sYaml(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var yamlValue starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"yaml", &yamlValue,
 	); err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (s *tiltfileState) k8sYaml(thread *starlark.Thread, fn *starlark.Builtin, a
 func (s *tiltfileState) filterYaml(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var yamlValue, labelsValue starlark.Value
 	var name, namespace, kind, apiVersion string
-	err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	err := s.unpackArgs(fn.Name(), args, kwargs,
 		"yaml", &yamlValue,
 		"labels?", &labelsValue,
 		"name?", &name,
@@ -202,7 +202,7 @@ func (s *tiltfileState) k8sResourceV1(thread *starlark.Thread, fn *starlark.Buil
 	var portForwardsVal starlark.Value
 	var extraPodSelectorsVal starlark.Value
 
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
 		"yaml?", &yamlValue,
 		"image?", &imageVal,
@@ -330,7 +330,7 @@ func (s *tiltfileState) k8sResourceV2(thread *starlark.Thread, fn *starlark.Buil
 	var extraPodSelectorsVal starlark.Value
 	var triggerMode triggerMode
 
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"workload", &workload,
 		"new_name?", &newName,
 		"port_forwards?", &portForwardsVal,
@@ -454,7 +454,7 @@ func starlarkValuesToJSONPaths(values []starlark.Value) ([]k8s.JSONPath, error) 
 func (s *tiltfileState) k8sImageJsonPath(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var apiVersion, kind, name, namespace string
 	var imageJSONPath starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"paths", &imageJSONPath,
 		"api_version?", &apiVersion,
 		"kind?", &kind,
@@ -493,7 +493,7 @@ func (s *tiltfileState) k8sKind(thread *starlark.Thread, fn *starlark.Builtin, a
 
 	var apiVersion, kind string
 	var imageJSONPath starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"kind", &kind,
 		"image_json_path?", &imageJSONPath,
 		"api_version?", &apiVersion,
@@ -523,7 +523,7 @@ func (s *tiltfileState) k8sKind(thread *starlark.Thread, fn *starlark.Builtin, a
 
 func (s *tiltfileState) workloadToResourceFunctionFn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var wtrf *starlark.Function
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"func", &wtrf); err != nil {
 		return nil, err
 	}
@@ -733,7 +733,7 @@ func (s *tiltfileState) portForward(thread *starlark.Thread, fn *starlark.Builti
 	var local int
 	var container int
 
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "local", &local, "container?", &container); err != nil {
+	if err := s.unpackArgs(fn.Name(), args, kwargs, "local", &local, "container?", &container); err != nil {
 		return nil, err
 	}
 
@@ -817,7 +817,7 @@ func (s *tiltfileState) imageJSONPaths(e k8s.K8sEntity) []k8s.JSONPath {
 
 func (s *tiltfileState) k8sResourceAssemblyVersionFn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var version int
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"version", &version,
 	); err != nil {
 		return nil, err
@@ -891,7 +891,7 @@ func (s *tiltfileState) k8sContext(thread *starlark.Thread, fn *starlark.Builtin
 
 func (s *tiltfileState) allowK8SContexts(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var contexts starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"contexts", &contexts,
 	); err != nil {
 		return nil, err

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -121,7 +121,7 @@ func (s *tiltfileState) recordLiveUpdateStep(step liveUpdateStep) {
 
 func (s *tiltfileState) liveUpdateFallBackOn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var files starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "paths", &files); err != nil {
+	if err := s.unpackArgs(fn.Name(), args, kwargs, "paths", &files); err != nil {
 		return nil, err
 	}
 	filesSlice := starlarkValueOrSequenceToSlice(files)
@@ -144,7 +144,7 @@ func (s *tiltfileState) liveUpdateFallBackOn(thread *starlark.Thread, fn *starla
 
 func (s *tiltfileState) liveUpdateSync(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var localPath, remotePath string
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "local_path", &localPath, "remote_path", &remotePath); err != nil {
+	if err := s.unpackArgs(fn.Name(), args, kwargs, "local_path", &localPath, "remote_path", &remotePath); err != nil {
 		return nil, err
 	}
 
@@ -160,7 +160,7 @@ func (s *tiltfileState) liveUpdateSync(thread *starlark.Thread, fn *starlark.Bui
 func (s *tiltfileState) liveUpdateRun(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var command string
 	var triggers starlark.Value
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "cmd", &command, "trigger?", &triggers); err != nil {
+	if err := s.unpackArgs(fn.Name(), args, kwargs, "cmd", &command, "trigger?", &triggers); err != nil {
 		return nil, err
 	}
 
@@ -185,7 +185,7 @@ func (s *tiltfileState) liveUpdateRun(thread *starlark.Thread, fn *starlark.Buil
 }
 
 func (s *tiltfileState) liveUpdateRestartContainer(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if err := starlark.UnpackArgs(fn.Name(), args, kwargs); err != nil {
+	if err := s.unpackArgs(fn.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -182,7 +182,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 
 	s.logger.Infof("Successfully loaded Tiltfile")
 
-	tfl.reportTiltfileLoaded(s.builtinCallCounts)
+	tfl.reportTiltfileLoaded(s.builtinCallCounts, s.builtinArgCounts)
 
 	tiltIgnoreContents, err := s.readFile(tiltIgnorePath(absFilename))
 	// missing tiltignore is fine
@@ -251,10 +251,15 @@ func starlarkValueOrSequenceToSlice(v starlark.Value) []starlark.Value {
 	}
 }
 
-func (tfl *tiltfileLoader) reportTiltfileLoaded(counts map[string]int) {
+func (tfl *tiltfileLoader) reportTiltfileLoaded(callCounts map[string]int, argCounts map[string]map[string]int) {
 	tags := make(map[string]string)
-	for builtinName, count := range counts {
+	for builtinName, count := range callCounts {
 		tags[fmt.Sprintf("tiltfile.invoked.%s", builtinName)] = strconv.Itoa(count)
+	}
+	for builtinName, counts := range argCounts {
+		for argName, count := range counts {
+			tags[fmt.Sprintf("tiltfile.invoked.%s.arg.%s", builtinName, argName)] = strconv.Itoa(count)
+		}
 	}
 	tfl.analytics.Incr("tiltfile.loaded", tags)
 }


### PR DESCRIPTION
### Problem

We already report stats on which tiltfile builtins are used, but sometimes individual args (e.g., `match_in_env_vars`, or `extra_pod_selectors`) can represent a decent amount of complexity to maintain and we can be unsure of their usage.

### Solution

When we report stats on which builtins get used, also report which args get used.
Unfortunately, this relies on being diligent about using `tiltfileState.unpackArgs` instead of `starlark.UnpackArgs`, but I don't see an easy way to avoid that.

e.g.:
`tiltfile.invoked.docker_build.args.context`, or `tiltfile.invoked.k8s_resource.args.extra_pod_selectors`