### PR TITLE
integration: bump timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,10 @@ shorttest:
 
 integration:
 ifneq ($(CIRCLECI),true)
-		go test -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 500s ./integration
+		go test -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
 else
 		mkdir -p test-results
-		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./integration -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 600s
+		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./integration -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
 endif
 
 dev-js:


### PR DESCRIPTION
I think #2014 made it so we're now hitting the integration test timeout, causing us to occasionally fail in master. At some point we might want to speed this up, but for now let's not waste our time investigating fake failures.