### PR TITLE
analytics_reporter: watch for context.Done when doing our initial report

### DIFF
--- a/internal/engine/analytics_reporter.go
+++ b/internal/engine/analytics_reporter.go
@@ -30,8 +30,13 @@ func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore) {
 	if !state.TiltStartTime.IsZero() && state.LastTiltfileError() == nil {
 		ar.started = true
 		go func() {
-			time.Sleep(time.Minute * 5)
-			ar.report() // report once pretty soon after startup...
+			select {
+			case <-time.After(time.Minute * 2):
+				ar.report() // report once pretty soon after startup...
+			case <-ctx.Done():
+				return
+			}
+
 			for {
 				select {
 				case <-time.After(analyticsReportingInterval):


### PR DESCRIPTION
I pressed "merge" on my last PR and realized the next second that
I wasn't paying attention to context cancellation while waiting to
report for the first time (which i set to do 2min after start to give
the user's state at least some time to get up and running). I think this
is better?