### PR TITLE
portforwardcontroller: add tests for auto-discovery

### DIFF
--- a/internal/engine/portforwardcontroller_test.go
+++ b/internal/engine/portforwardcontroller_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,7 +81,6 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 
 	f.plc.OnChange(f.ctx, f.st)
 	assert.Equal(t, 0, len(f.plc.activeForwards))
-
 	state = f.st.LockMutableStateForTesting()
 	state.ManifestTargets["fe"].State.K8sRuntimeState().Pods["pod-id"].Containers = []store.Container{
 		store.Container{Ports: []int32{8000}},
@@ -90,6 +90,86 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 	f.plc.OnChange(f.ctx, f.st)
 	assert.Equal(t, 1, len(f.plc.activeForwards))
 	assert.Equal(t, 8000, f.kCli.LastForwardPortRemotePort)
+}
+
+func TestPortForwardAutoDiscovery2(t *testing.T) {
+	f := newPLCFixture(t)
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{
+		Name: "fe",
+	}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort: 8080,
+			},
+		},
+	})
+	state.UpsertManifestTarget(store.NewManifestTarget(m))
+	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState(0, store.Pod{
+		PodID: "pod-id",
+		Phase: v1.PodRunning,
+		Containers: []store.Container{
+			store.Container{Ports: []int32{8000, 8080}},
+		},
+	})
+	f.st.UnlockMutableState()
+
+	f.plc.OnChange(f.ctx, f.st)
+	assert.Equal(t, 1, len(f.plc.activeForwards))
+	assert.Equal(t, 8080, f.kCli.LastForwardPortRemotePort)
+}
+
+type portForwardTestCase struct {
+	spec           []model.PortForward
+	containerPorts []int32
+	expected       []model.PortForward
+}
+
+func TestPopulatePortForward(t *testing.T) {
+	cases := []portForwardTestCase{
+		{
+			spec:           []model.PortForward{{LocalPort: 8080}},
+			containerPorts: []int32{8080},
+			expected:       []model.PortForward{{ContainerPort: 8080, LocalPort: 8080}},
+		},
+		{
+			spec:           []model.PortForward{{LocalPort: 8080}},
+			containerPorts: []int32{8000, 8080, 8001},
+			expected:       []model.PortForward{{ContainerPort: 8080, LocalPort: 8080}},
+		},
+		{
+			spec:           []model.PortForward{{LocalPort: 8080}, {LocalPort: 8000}},
+			containerPorts: []int32{8000, 8080, 8001},
+			expected: []model.PortForward{
+				{ContainerPort: 8080, LocalPort: 8080},
+				{ContainerPort: 8000, LocalPort: 8000},
+			},
+		},
+		{
+			spec:           []model.PortForward{{ContainerPort: 8000, LocalPort: 8080}},
+			containerPorts: []int32{8000, 8080, 8001},
+			expected:       []model.PortForward{{ContainerPort: 8000, LocalPort: 8080}},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
+			m := model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{
+				PortForwards: c.spec,
+			})
+			pod := store.Pod{
+				Containers: []store.Container{
+					store.Container{Ports: c.containerPorts},
+				},
+			}
+
+			actual := populatePortForwards(m, pod)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
 }
 
 type plcFixture struct {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/portforward:

95aeffd0d028cf749c82d6626483bb66194a1901 (2019-08-20 14:12:48 -0400)
portforwardcontroller: add tests for auto-discovery