### PR TITLE
hud/server: create snapshot HTTP bootstrap simulacrum

### DIFF
--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -64,6 +64,7 @@ func ProvideHeadsUpServer(store *store.Store, assetServer assets.Server, analyti
 	r.HandleFunc("/api/sail", s.HandleSail)
 	r.HandleFunc("/api/trigger", s.HandleTrigger)
 	r.HandleFunc("/api/snapshot/new", s.HandleNewSnapshot)
+	// this endpoint is only used for testing snapshots in development
 	r.HandleFunc("/api/snapshot/{snapshot_id}", s.SnapshotJSON)
 	r.HandleFunc("/ws/view", s.ViewWebsocket)
 


### PR DESCRIPTION
With this change someone working on Tilt locally can navigate to
http://localhost:10350/snapshot/aaaaaa and Tilt will make a request to
localhost:10350/api/snapshot/aaaaaa which will serialize the current
Tilt engine state in to the snapshot format that the frontend understands
and return it.

Tilt will bootstrap off of this HTTP request thus simulating snapshots.

This addresses only part of ch3234