### PR TITLE
snapshots: log http errors

### DIFF
--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -234,6 +234,7 @@ func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Reque
 	request, err := http.NewRequest(http.MethodPost, newSnapshotURL(), req.Body)
 	response, err := s.httpCli.Do(request)
 	if err != nil {
+		log.Printf("Error creating snapshot: %v\n", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		_, err := w.Write([]byte(err.Error()))
 		if err != nil {
@@ -244,6 +245,7 @@ func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Reque
 
 	responseWithID, err := ioutil.ReadAll(response.Body)
 	if err != nil {
+		log.Printf("Error reading response when creating snapshot: %v\n", err)
 		log.Printf("Error reading responseWithID: %v\n", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return


### PR DESCRIPTION
creating snapshots was failing for me and the reason did not appear anywhere in the tilt log or js console