### PR TITLE
 web: move share snapshot in to modal, show register token URL 

### DIFF
--- a/internal/cloud/url.go
+++ b/internal/cloud/url.go
@@ -1,4 +1,4 @@
-package tft
+package cloud
 
 import (
 	"fmt"

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -13,10 +13,10 @@ import (
 	"github.com/windmilleng/wmclient/pkg/analytics"
 
 	tiltanalytics "github.com/windmilleng/tilt/internal/analytics"
+	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/sail/client"
 	"github.com/windmilleng/tilt/internal/store"
-	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/pkg/assets"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/sail/client"
 	"github.com/windmilleng/tilt/internal/store"
-	"github.com/windmilleng/tilt/internal/tft"
+	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/pkg/assets"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -237,11 +237,11 @@ type snapshotIDResponse struct {
 }
 
 func templateSnapshotURL(id SnapshotID) string {
-	return fmt.Sprintf("https://%s/snapshot/%s", tft.Domain, id)
+	return fmt.Sprintf("https://%s/snapshot/%s", cloud.Domain, id)
 }
 
 func newSnapshotURL() string {
-	return fmt.Sprintf("https://%s/api/snapshot/new", tft.Domain)
+	return fmt.Sprintf("https://%s/api/snapshot/new", cloud.Domain)
 }
 
 func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Request) {

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -16,13 +16,12 @@ import (
 	"github.com/windmilleng/tilt/internal/hud/webview"
 	"github.com/windmilleng/tilt/internal/sail/client"
 	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/tft"
 	"github.com/windmilleng/tilt/pkg/assets"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
-//TODO TFT: change snapshot url to be snapshot.tilt.dev
-const tiltSnapshotDomain = "alerts.tilt.dev"
 const httpTimeOut = 5 * time.Second
 
 type analyticsPayload struct {
@@ -238,11 +237,11 @@ type snapshotIDResponse struct {
 }
 
 func templateSnapshotURL(id SnapshotID) string {
-	return fmt.Sprintf("https://%s/snapshot/%s", tiltSnapshotDomain, id)
+	return fmt.Sprintf("https://%s/snapshot/%s", tft.Domain, id)
 }
 
 func newSnapshotURL() string {
-	return fmt.Sprintf("https://%s/api/snapshot/new", tiltSnapshotDomain)
+	return fmt.Sprintf("https://%s/api/snapshot/new", tft.Domain)
 }
 
 func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Request) {

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -10,6 +10,7 @@ import (
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/tft"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -102,6 +103,7 @@ func StateToWebView(s store.EngineState) View {
 	ret.RunningTiltBuild = s.TiltBuildInfo
 	ret.LatestTiltBuild = s.LatestTiltBuild
 	ret.FeatureFlags = s.Features
+	ret.RegisterTokenURL = tft.RegisterTokenURL(s.Token)
 
 	return ret
 }

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -10,7 +10,7 @@ import (
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
-	"github.com/windmilleng/tilt/internal/tft"
+	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -103,7 +103,7 @@ func StateToWebView(s store.EngineState) View {
 	ret.RunningTiltBuild = s.TiltBuildInfo
 	ret.LatestTiltBuild = s.LatestTiltBuild
 	ret.FeatureFlags = s.Features
-	ret.RegisterTokenURL = tft.RegisterTokenURL(s.Token)
+	ret.RegisterTokenURL = cloud.RegisterTokenURL(s.Token)
 
 	return ret
 }

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -6,11 +6,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
-	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/token"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -151,6 +152,14 @@ func TestFeatureFlags(t *testing.T) {
 
 	v := StateToWebView(*state)
 	assert.Equal(t, v.FeatureFlags, map[string]bool{"foo_feature": true})
+}
+
+func TestRegisterTokenURL(t *testing.T) {
+	state := newState(nil)
+	state.Token = token.Token("aaaaaaa")
+
+	v := StateToWebView(*state)
+	require.Equal(t, v.RegisterTokenURL, "https://alerts.tilt.dev/register_token?token=aaaaaaa")
 }
 
 func newState(manifests []model.Manifest) *store.EngineState {

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -144,6 +144,7 @@ type View struct {
 
 	RunningTiltBuild model.TiltBuild
 	LatestTiltBuild  model.TiltBuild
+	RegisterTokenURL string
 }
 
 func (v View) Resource(n model.ManifestName) (Resource, bool) {

--- a/internal/tft/url.go
+++ b/internal/tft/url.go
@@ -1,0 +1,14 @@
+package tft
+
+import(
+	"fmt"
+
+	"github.com/windmilleng/tilt/internal/token"
+)
+
+//TODO TFT: change snapshot url to be cloud.tilt.dev
+const Domain = "alerts.tilt.dev"
+
+func RegisterTokenURL(t token.Token) string {
+	return fmt.Sprintf("https://%s/register_token?token=%s", Domain, t)
+}

--- a/internal/tft/url.go
+++ b/internal/tft/url.go
@@ -1,6 +1,6 @@
 package tft
 
-import(
+import (
 	"fmt"
 
 	"github.com/windmilleng/tilt/internal/token"

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -92,7 +92,7 @@ class AppController {
         Message: "Disconnected…",
         IsSidebarClosed: false,
         SnapshotLink: "",
-        ShowSnapshotModal: false,
+        showSnapshotModal: false,
       })
       this.createNewSocket()
       return
@@ -118,7 +118,7 @@ class AppController {
         Message: message,
         IsSidebarClosed: false,
         SnapshotLink: "",
-        ShowSnapshotModal: false,
+        showSnapshotModal: false,
       })
       this.createNewSocket()
     }, timeout)

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -92,6 +92,7 @@ class AppController {
         Message: "Disconnected…",
         IsSidebarClosed: false,
         SnapshotLink: "",
+        ShowSnapshotModal: false,
       })
       this.createNewSocket()
       return
@@ -117,6 +118,7 @@ class AppController {
         Message: message,
         IsSidebarClosed: false,
         SnapshotLink: "",
+        ShowSnapshotModal: false,
       })
       this.createNewSocket()
     }, timeout)

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -43,7 +43,7 @@ type HudState = {
   } | null
   IsSidebarClosed: boolean
   SnapshotLink: string
-  ShowSnapshotModal: boolean
+  showSnapshotModal: boolean
 }
 
 type NewSnapshotResponse = {
@@ -95,7 +95,7 @@ class HUD extends Component<HudProps, HudState> {
       },
       IsSidebarClosed: false,
       SnapshotLink: "",
-      ShowSnapshotModal: false,
+      showSnapshotModal: false,
     }
 
     this.toggleSidebar = this.toggleSidebar.bind(this)
@@ -206,7 +206,7 @@ class HUD extends Component<HudProps, HudState> {
       )
     }
 
-    let handleOpenModal = () => this.setState({ ShowSnapshotModal: true })
+    let handleOpenModal = () => this.setState({ showSnapshotModal: true })
 
     let topBarRoute = (t: ResourceView, props: RouteComponentProps<any>) => {
       let name =
@@ -353,8 +353,8 @@ class HUD extends Component<HudProps, HudState> {
         <AnalyticsNudge needsNudge={needsNudge} />
         <ShareSnapshotModal
           handleSendSnapshot={this.sendSnapshot.bind(this, this.state)}
-          handleClose={() => this.setState({ ShowSnapshotModal: false })}
-          show={this.state.ShowSnapshotModal}
+          handleClose={() => this.setState({ showSnapshotModal: false })}
+          show={this.state.showSnapshotModal}
           snapshotUrl={this.state.SnapshotLink}
           registerTokenUrl={registerTokenUrl}
         />

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -19,8 +19,9 @@ import AlertPane from "./AlertPane"
 import PreviewList from "./PreviewList"
 import AnalyticsNudge from "./AnalyticsNudge"
 import NotFound from "./NotFound"
-import { numberOfAlerts, Alert, isK8sResourceInfo } from "./alerts"
+import { numberOfAlerts, isK8sResourceInfo } from "./alerts"
 import Features from "./feature"
+import ShareSnapshotModal from "./ShareSnapshotModal"
 
 type HudProps = {
   history: History
@@ -38,9 +39,11 @@ type HudState = {
     RunningTiltBuild: TiltBuild
     LatestTiltBuild: TiltBuild
     FeatureFlags: { [featureFlag: string]: boolean }
+    RegisterTokenURL: string
   } | null
   IsSidebarClosed: boolean
   SnapshotLink: string
+  ShowSnapshotModal: boolean
 }
 
 type NewSnapshotResponse = {
@@ -48,14 +51,6 @@ type NewSnapshotResponse = {
   url: string
 }
 
-function hudStatetoSnapshot(h: HUD): Snapshot {
-  //used this because hudState has extra fields we don't care about
-  return {
-    Message: h.state.Message,
-    View: h.state.View,
-    IsSidebarClosed: h.state.IsSidebarClosed,
-  }
-}
 // The Main HUD view, as specified in
 // https://docs.google.com/document/d/1VNIGfpC4fMfkscboW0bjYYFJl07um_1tsFrbN-Fu3FI/edit#heading=h.l8mmnclsuxl1
 class HUD extends Component<HudProps, HudState> {
@@ -96,9 +91,11 @@ class HUD extends Component<HudProps, HudState> {
           Dev: false,
         },
         FeatureFlags: {},
+        RegisterTokenURL: "",
       },
       IsSidebarClosed: false,
       SnapshotLink: "",
+      ShowSnapshotModal: false,
     }
 
     this.toggleSidebar = this.toggleSidebar.bind(this)
@@ -209,6 +206,8 @@ class HUD extends Component<HudProps, HudState> {
       )
     }
 
+    let handleOpenModal = () => this.setState({ ShowSnapshotModal: true })
+
     let topBarRoute = (t: ResourceView, props: RouteComponentProps<any>) => {
       let name =
         props.match.params && props.match.params.name
@@ -227,10 +226,8 @@ class HUD extends Component<HudProps, HudState> {
               sailEnabled={sailEnabled}
               sailUrl={sailUrl}
               numberOfAlerts={numAlerts}
-              state={this.state}
-              handleSendSnapshot={this.sendSnapshot.bind(this)}
-              snapshotURL={this.state.SnapshotLink}
               showSnapshotButton={showSnapshot}
+              handleOpenModal={handleOpenModal}
             />
           )
         }
@@ -251,10 +248,8 @@ class HUD extends Component<HudProps, HudState> {
           sailEnabled={sailEnabled}
           sailUrl={sailUrl}
           numberOfAlerts={numAlerts}
-          state={this.state}
-          handleSendSnapshot={this.sendSnapshot.bind(this)}
-          snapshotURL={this.state.SnapshotLink}
           showSnapshotButton={showSnapshot}
+          handleOpenModal={handleOpenModal}
         />
       )
     }
@@ -351,10 +346,19 @@ class HUD extends Component<HudProps, HudState> {
     }
     let runningVersion = view && view.RunningTiltBuild
     let latestVersion = view && view.LatestTiltBuild
+    let registerTokenUrl = (view && view.RegisterTokenURL) || ""
 
     return (
       <div className="HUD">
         <AnalyticsNudge needsNudge={needsNudge} />
+        <ShareSnapshotModal
+          handleSendSnapshot={this.sendSnapshot.bind(this)}
+          handleClose={() => this.setState({ ShowSnapshotModal: false })}
+          show={this.state.ShowSnapshotModal}
+          state={this.state}
+          snapshotUrl={this.state.SnapshotLink}
+          registerTokenUrl={registerTokenUrl}
+        />
         <Switch>
           <Route
             path={this.path("/r/:name/alerts")}

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -352,10 +352,9 @@ class HUD extends Component<HudProps, HudState> {
       <div className="HUD">
         <AnalyticsNudge needsNudge={needsNudge} />
         <ShareSnapshotModal
-          handleSendSnapshot={this.sendSnapshot.bind(this)}
+          handleSendSnapshot={this.sendSnapshot.bind(this, this.state)}
           handleClose={() => this.setState({ ShowSnapshotModal: false })}
           show={this.state.ShowSnapshotModal}
-          state={this.state}
           snapshotUrl={this.state.SnapshotLink}
           registerTokenUrl={registerTokenUrl}
         />

--- a/web/src/ShareSnapshotModal.scss
+++ b/web/src/ShareSnapshotModal.scss
@@ -1,0 +1,60 @@
+@import "constants";
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width:100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.modal-main {
+  position:fixed;
+  background: $color-white;
+  color: $color-gray-darkest;
+  width: 80%;
+  height: auto;
+  top:50%;
+  left:50%;
+  transform: translate(-50%,-50%);
+}
+
+.display-block {
+  display: block;
+}
+
+.display-none {
+  display: none;
+}
+
+.TopBar-snapshotUrlWrap {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+
+.TopBar-snapshotUrlWrap button {
+  background-color: transparent;
+  border: 1px solid rgba($color-white, $translucent-ish);
+  color: $color-white;
+  text-transform: uppercase;
+  padding-top: $spacing-unit / 3;
+  padding-bottom: $spacing-unit / 3;
+  padding-left: $spacing-unit / 2;
+  padding-right: $spacing-unit / 2;
+}
+
+.TopBar-snapshotUrlWrap button:hover {
+  cursor: pointer;
+  background-color: $color-gray-dark;
+}
+
+.TopBar-snapshotUrl {
+  background-color: $color-gray-dark;
+  border: 1px solid $color-gray-darkest;
+  padding-left: $spacing-unit / 2;
+  padding-right: $spacing-unit / 2;
+  user-select: all;
+}

--- a/web/src/ShareSnapshotModal.test.tsx
+++ b/web/src/ShareSnapshotModal.test.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import renderer from "react-test-renderer"
+import ShareSnapshotModal from "./ShareSnapshotModal"
+import { Snapshot } from "./types"
+
+const testState: Snapshot = {
+  Message: "",
+  View: null,
+  IsSidebarClosed: false,
+}
+const fakeSendsnapshot = (snapshot: Snapshot) => void {}
+const fakeHandleCloseModal = () => {}
+
+describe("ShareSnapshotModal", () => {
+  it("renders with modal open", () => {
+    const tree = renderer
+      .create(
+        <ShareSnapshotModal
+          handleSendSnapshot={fakeSendsnapshot}
+          handleClose={fakeHandleCloseModal}
+          show={true}
+          state={testState}
+          snapshotUrl="http://test.com"
+          registerTokenUrl="http://registertoken.com"
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("renders with modal closed", () => {
+    const tree = renderer
+      .create(
+        <ShareSnapshotModal
+          handleSendSnapshot={fakeSendsnapshot}
+          handleClose={fakeHandleCloseModal}
+          show={false}
+          state={testState}
+          snapshotUrl="http://test.com"
+          registerTokenUrl="http://registertoken.com"
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/web/src/ShareSnapshotModal.test.tsx
+++ b/web/src/ShareSnapshotModal.test.tsx
@@ -1,14 +1,8 @@
 import React from "react"
 import renderer from "react-test-renderer"
 import ShareSnapshotModal from "./ShareSnapshotModal"
-import { Snapshot } from "./types"
 
-const testState: Snapshot = {
-  Message: "",
-  View: null,
-  IsSidebarClosed: false,
-}
-const fakeSendsnapshot = (snapshot: Snapshot) => void {}
+const fakeSendsnapshot = () => {}
 const fakeHandleCloseModal = () => {}
 
 describe("ShareSnapshotModal", () => {
@@ -19,7 +13,6 @@ describe("ShareSnapshotModal", () => {
           handleSendSnapshot={fakeSendsnapshot}
           handleClose={fakeHandleCloseModal}
           show={true}
-          state={testState}
           snapshotUrl="http://test.com"
           registerTokenUrl="http://registertoken.com"
         />
@@ -36,7 +29,6 @@ describe("ShareSnapshotModal", () => {
           handleSendSnapshot={fakeSendsnapshot}
           handleClose={fakeHandleCloseModal}
           show={false}
-          state={testState}
           snapshotUrl="http://test.com"
           registerTokenUrl="http://registertoken.com"
         />

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -39,9 +39,9 @@ export default class ShareSnapshotModal extends PureComponent<props> {
         <div className="modal-main">
           <section className="modal-snapshotUrlWrap">
             <button onClick={this.props.handleClose}>close</button>
-            <button onClick={() => window.open(this.props.snapshotUrl)}>
+            <a href={this.props.snapshotUrl} target="_blank">
               Open link in new tab
-            </button>
+            </a>
           </section>
           <hr />
           {this.loggedOutTiltCloudCopy()}

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -3,10 +3,9 @@ import { Snapshot } from "./types"
 import "./ShareSnapshotModal.scss"
 
 type props = {
-  handleSendSnapshot: (snapshot: Snapshot) => void
+  handleSendSnapshot: () => void
   handleClose: () => void
   show: boolean
-  state: Snapshot
   snapshotUrl: string
   registerTokenUrl: string
 }
@@ -21,7 +20,7 @@ export default function ShareSnapshotModal(props: props) {
         <section className="modal-main">
           <section className="modal-snapshotUrlWrap">
             <button onClick={props.handleClose}>close</button>
-            <button onClick={() => props.handleSendSnapshot(props.state)}>
+            <button onClick={() => props.handleSendSnapshot()}>
               Share Snapshot
             </button>
           </section>

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { Snapshot } from "./types"
+import "./ShareSnapshotModal.scss"
+
+type props = {
+  handleSendSnapshot: (snapshot: Snapshot) => void
+  handleClose: () => void
+  show: boolean
+  state: Snapshot
+  snapshotUrl: string
+  registerTokenUrl: string
+}
+export default function ShareSnapshotModal(props: props) {
+  const showHideClassName = props.show
+    ? "modal display-block"
+    : "modal display-none"
+  const hasLink = props.snapshotUrl !== ""
+  if (!hasLink) {
+    return (
+      <div className={showHideClassName}>
+        <section className="modal-main">
+          <section className="modal-snapshotUrlWrap">
+            <button onClick={props.handleClose}>close</button>
+            <button onClick={() => props.handleSendSnapshot(props.state)}>
+              Share Snapshot
+            </button>
+          </section>
+          <hr />
+          {loggedOutTiltCloudCopy(props.registerTokenUrl)}
+        </section>
+      </div>
+    )
+  }
+
+  return (
+    <div className={showHideClassName}>
+      <section className="modal-main">
+        <section className="modal-snapshotUrlWrap">
+          <button onClick={props.handleClose}>close</button>
+          <button onClick={() => window.open(props.snapshotUrl)}>
+            Open link in new tab
+          </button>
+        </section>
+        <hr />
+        {loggedOutTiltCloudCopy("")}
+      </section>
+    </div>
+  )
+}
+
+const loggedOutTiltCloudCopy = (registerTokenURL: string) => (
+  <section className="modal-cloud">
+    <p>
+      Go to <a href={registerTokenURL}>TiltCloud</a> to manage your snapshots.
+      <br />
+      (You'll just need to link your GitHub Account)
+    </p>
+  </section>
+)

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { PureComponent } from "react"
 import { Snapshot } from "./types"
 import "./ShareSnapshotModal.scss"
 
@@ -9,50 +9,57 @@ type props = {
   snapshotUrl: string
   registerTokenUrl: string
 }
-export default function ShareSnapshotModal(props: props) {
-  const showHideClassName = props.show
-    ? "modal display-block"
-    : "modal display-none"
-  const hasLink = props.snapshotUrl !== ""
-  if (!hasLink) {
+
+// TODO(dmiller): in the future this should also show if you are logged in and who you are
+export default class ShareSnapshotModal extends PureComponent<props> {
+  render() {
+    const showHideClassName = this.props.show
+      ? "modal display-block"
+      : "modal display-none"
+    const hasLink = this.props.snapshotUrl !== ""
+    if (!hasLink) {
+      return (
+        <div className={showHideClassName}>
+          <div className="modal-main">
+            <section className="modal-snapshotUrlWrap">
+              <button onClick={this.props.handleClose}>close</button>
+              <button onClick={() => this.props.handleSendSnapshot()}>
+                Share Snapshot
+              </button>
+            </section>
+            <hr />
+            {this.loggedOutTiltCloudCopy()}
+          </div>
+        </div>
+      )
+    }
+
     return (
       <div className={showHideClassName}>
         <div className="modal-main">
           <section className="modal-snapshotUrlWrap">
-            <button onClick={props.handleClose}>close</button>
-            <button onClick={() => props.handleSendSnapshot()}>
-              Share Snapshot
+            <button onClick={this.props.handleClose}>close</button>
+            <button onClick={() => window.open(this.props.snapshotUrl)}>
+              Open link in new tab
             </button>
           </section>
           <hr />
-          {loggedOutTiltCloudCopy(props.registerTokenUrl)}
+          {this.loggedOutTiltCloudCopy()}
         </div>
       </div>
     )
   }
 
-  return (
-    <div className={showHideClassName}>
-      <div className="modal-main">
-        <section className="modal-snapshotUrlWrap">
-          <button onClick={props.handleClose}>close</button>
-          <button onClick={() => window.open(props.snapshotUrl)}>
-            Open link in new tab
-          </button>
-        </section>
-        <hr />
-        {loggedOutTiltCloudCopy("")}
-      </div>
-    </div>
-  )
+  loggedOutTiltCloudCopy() {
+    return (
+      <section className="modal-cloud">
+        <p>
+          Go to <a href={this.props.registerTokenUrl}>TiltCloud</a> to manage
+          your snapshots.
+          <br />
+          (You'll just need to link your GitHub Account)
+        </p>
+      </section>
+    )
+  }
 }
-
-const loggedOutTiltCloudCopy = (registerTokenURL: string) => (
-  <section className="modal-cloud">
-    <p>
-      Go to <a href={registerTokenURL}>TiltCloud</a> to manage your snapshots.
-      <br />
-      (You'll just need to link your GitHub Account)
-    </p>
-  </section>
-)

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -17,7 +17,7 @@ export default function ShareSnapshotModal(props: props) {
   if (!hasLink) {
     return (
       <div className={showHideClassName}>
-        <section className="modal-main">
+        <div className="modal-main">
           <section className="modal-snapshotUrlWrap">
             <button onClick={props.handleClose}>close</button>
             <button onClick={() => props.handleSendSnapshot()}>
@@ -26,14 +26,14 @@ export default function ShareSnapshotModal(props: props) {
           </section>
           <hr />
           {loggedOutTiltCloudCopy(props.registerTokenUrl)}
-        </section>
+        </div>
       </div>
     )
   }
 
   return (
     <div className={showHideClassName}>
-      <section className="modal-main">
+      <div className="modal-main">
         <section className="modal-snapshotUrlWrap">
           <button onClick={props.handleClose}>close</button>
           <button onClick={() => window.open(props.snapshotUrl)}>
@@ -42,7 +42,7 @@ export default function ShareSnapshotModal(props: props) {
         </section>
         <hr />
         {loggedOutTiltCloudCopy("")}
-      </section>
+      </div>
     </div>
   )
 }

--- a/web/src/TopBar.test.tsx
+++ b/web/src/TopBar.test.tsx
@@ -1,16 +1,10 @@
 import React from "react"
 import renderer from "react-test-renderer"
 import { MemoryRouter } from "react-router"
-import { Resource, ResourceView, Snapshot, TiltBuild } from "./types"
+import { ResourceView, Snapshot } from "./types"
 import TopBar from "./TopBar"
 
-const testState: Snapshot = {
-  Message: "",
-  View: null,
-  IsSidebarClosed: false,
-}
-
-const fakeSendSnapshot = (snapshot: Snapshot) => void {}
+const fakeHandleOpenModal = () => {}
 
 it("shows sail share button", () => {
   const tree = renderer
@@ -24,10 +18,8 @@ it("shows sail share button", () => {
           sailEnabled={true}
           sailUrl=""
           numberOfAlerts={0}
-          state={testState}
-          handleSendSnapshot={fakeSendSnapshot}
-          snapshotURL=""
           showSnapshotButton={false}
+          handleOpenModal={fakeHandleOpenModal}
         />
       </MemoryRouter>
     )
@@ -48,10 +40,8 @@ it("shows sail url", () => {
           sailEnabled={true}
           sailUrl="www.sail.dev/xyz"
           numberOfAlerts={1}
-          state={testState}
-          handleSendSnapshot={fakeSendSnapshot}
-          snapshotURL=""
           showSnapshotButton={false}
+          handleOpenModal={fakeHandleOpenModal}
         />
       </MemoryRouter>
     )
@@ -72,10 +62,8 @@ it("shows snapshot url", () => {
           sailEnabled={false}
           sailUrl="www.sail.dev/xyz"
           numberOfAlerts={1}
-          state={testState}
-          handleSendSnapshot={fakeSendSnapshot}
-          snapshotURL=""
           showSnapshotButton={true}
+          handleOpenModal={fakeHandleOpenModal}
         />
       </MemoryRouter>
     )

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -28,8 +28,7 @@ class TopBar extends PureComponent<TopBarProps> {
           numberOfAlerts={this.props.numberOfAlerts}
         />
         <section className="TopBar-tools">
-          {this.props.showSnapshotButton &&
-            renderSnapshotModal(this.props.handleOpenModal)}
+          {this.props.showSnapshotButton && this.renderSnapshotModal()}
           <SailInfo
             sailEnabled={this.props.sailEnabled}
             sailUrl={this.props.sailUrl}
@@ -38,14 +37,14 @@ class TopBar extends PureComponent<TopBarProps> {
       </div>
     )
   }
-}
 
-const renderSnapshotModal = (handleOpenModal: () => void) => {
-  return (
-    <section className="TopBar-snapshotUrlWrap">
-      <button onClick={handleOpenModal}>Share Snapshot</button>
-    </section>
-  )
+  renderSnapshotModal() {
+    return (
+      <section className="TopBar-snapshotUrlWrap">
+        <button onClick={this.props.handleOpenModal}>Share Snapshot</button>
+      </section>
+    )
+  }
 }
 
 export default TopBar

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -12,10 +12,8 @@ type TopBarProps = {
   sailEnabled: boolean
   sailUrl: string
   numberOfAlerts: number
-  state: Snapshot
-  handleSendSnapshot: (snapshot: Snapshot) => void
-  snapshotURL: string
   showSnapshotButton: boolean
+  handleOpenModal: () => void
 }
 
 class TopBar extends PureComponent<TopBarProps> {
@@ -31,11 +29,7 @@ class TopBar extends PureComponent<TopBarProps> {
         />
         <section className="TopBar-tools">
           {this.props.showSnapshotButton &&
-            renderSnapshotLinkButton(
-              this.props.state,
-              this.props.handleSendSnapshot,
-              this.props.snapshotURL
-            )}
+            renderSnapshotModal(this.props.handleOpenModal)}
           <SailInfo
             sailEnabled={this.props.sailEnabled}
             sailUrl={this.props.sailUrl}
@@ -46,33 +40,12 @@ class TopBar extends PureComponent<TopBarProps> {
   }
 }
 
-function renderSnapshotLinkButton(
-  snapshot: Snapshot,
-  handleSendSnapshot: (snapshot: Snapshot) => void,
-  snapshotURL: string
-) {
-  let hasLink = snapshotURL !== ""
-  if (!hasLink) {
-    return (
-      <section className="TopBar-snapshotUrlWrap">
-        <button onClick={() => handleSendSnapshot(snapshot)}>
-          Share Snapshot
-        </button>
-      </section>
-    )
-  } else {
-    return (
-      <section className="TopBar-snapshotUrlWrap">
-        <p className="TopBar-snapshotUrl">{snapshotURL}</p>
-        <button
-          title="Open link in new tab"
-          onClick={() => window.open(snapshotURL)}
-        >
-          Open
-        </button>
-      </section>
-    )
-  }
+const renderSnapshotModal = (handleOpenModal: () => void) => {
+  return (
+    <section className="TopBar-snapshotUrlWrap">
+      <button onClick={handleOpenModal}>Share Snapshot</button>
+    </section>
+  )
 }
 
 export default TopBar

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -15,11 +15,12 @@ exports[`ShareSnapshotModal renders with modal closed 1`] = `
       >
         close
       </button>
-      <button
-        onClick={[Function]}
+      <a
+        href="http://test.com"
+        target="_blank"
       >
         Open link in new tab
-      </button>
+      </a>
     </section>
     <hr />
     <section
@@ -56,11 +57,12 @@ exports[`ShareSnapshotModal renders with modal open 1`] = `
       >
         close
       </button>
-      <button
-        onClick={[Function]}
+      <a
+        href="http://test.com"
+        target="_blank"
       >
         Open link in new tab
-      </button>
+      </a>
     </section>
     <hr />
     <section

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`ShareSnapshotModal renders with modal closed 1`] = `
       <p>
         Go to 
         <a
-          href=""
+          href="http://registertoken.com"
         >
           TiltCloud
         </a>
@@ -69,7 +69,7 @@ exports[`ShareSnapshotModal renders with modal open 1`] = `
       <p>
         Go to 
         <a
-          href=""
+          href="http://registertoken.com"
         >
           TiltCloud
         </a>

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ShareSnapshotModal renders with modal closed 1`] = `
 <div
   className="modal display-none"
 >
-  <section
+  <div
     className="modal-main"
   >
     <section
@@ -37,7 +37,7 @@ exports[`ShareSnapshotModal renders with modal closed 1`] = `
         (You'll just need to link your GitHub Account)
       </p>
     </section>
-  </section>
+  </div>
 </div>
 `;
 
@@ -45,7 +45,7 @@ exports[`ShareSnapshotModal renders with modal open 1`] = `
 <div
   className="modal display-block"
 >
-  <section
+  <div
     className="modal-main"
   >
     <section
@@ -78,6 +78,6 @@ exports[`ShareSnapshotModal renders with modal open 1`] = `
         (You'll just need to link your GitHub Account)
       </p>
     </section>
-  </section>
+  </div>
 </div>
 `;

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ShareSnapshotModal renders with modal closed 1`] = `
+<div
+  className="modal display-none"
+>
+  <section
+    className="modal-main"
+  >
+    <section
+      className="modal-snapshotUrlWrap"
+    >
+      <button
+        onClick={[Function]}
+      >
+        close
+      </button>
+      <button
+        onClick={[Function]}
+      >
+        Open link in new tab
+      </button>
+    </section>
+    <hr />
+    <section
+      className="modal-cloud"
+    >
+      <p>
+        Go to 
+        <a
+          href=""
+        >
+          TiltCloud
+        </a>
+         to manage your snapshots.
+        <br />
+        (You'll just need to link your GitHub Account)
+      </p>
+    </section>
+  </section>
+</div>
+`;
+
+exports[`ShareSnapshotModal renders with modal open 1`] = `
+<div
+  className="modal display-block"
+>
+  <section
+    className="modal-main"
+  >
+    <section
+      className="modal-snapshotUrlWrap"
+    >
+      <button
+        onClick={[Function]}
+      >
+        close
+      </button>
+      <button
+        onClick={[Function]}
+      >
+        Open link in new tab
+      </button>
+    </section>
+    <hr />
+    <section
+      className="modal-cloud"
+    >
+      <p>
+        Go to 
+        <a
+          href=""
+        >
+          TiltCloud
+        </a>
+         to manage your snapshots.
+        <br />
+        (You'll just need to link your GitHub Account)
+      </p>
+    </section>
+  </section>
+</div>
+`;


### PR DESCRIPTION
It's pretty ugly, but:

![Screen Shot 2019-08-21 at 5 49 00 PM](https://user-images.githubusercontent.com/452453/63470976-01df3d00-c43c-11e9-9dfe-b24ba855f31e.png)

After clicking "Share Snapshot":

![Screen Shot 2019-08-21 at 5 49 10 PM](https://user-images.githubusercontent.com/452453/63470990-0b68a500-c43c-11e9-9edb-0c8a8be08c45.png)

Will probably need to rope @nicks in for some styling help 😅 