### PR TITLE
engine: make the ServiceWatcher responsible for mapping services to manifests

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -31,14 +31,19 @@ func NewPodChangeAction(pod *v1.Pod) PodChangeAction {
 }
 
 type ServiceChangeAction struct {
-	Service *v1.Service
-	URL     *url.URL
+	Service      *v1.Service
+	ManifestName model.ManifestName
+	URL          *url.URL
 }
 
 func (ServiceChangeAction) Action() {}
 
-func NewServiceChangeAction(service *v1.Service, url *url.URL) ServiceChangeAction {
-	return ServiceChangeAction{Service: service, URL: url}
+func NewServiceChangeAction(service *v1.Service, mn model.ManifestName, url *url.URL) ServiceChangeAction {
+	return ServiceChangeAction{
+		Service:      service,
+		ManifestName: mn,
+		URL:          url,
+	}
 }
 
 type BuildLogAction struct {
@@ -53,12 +58,6 @@ type PodLogAction struct {
 }
 
 func (PodLogAction) Action() {}
-
-// A little helper action so that we synchronize
-// Kubernetes events that happen while a `kubectl apply` is in-progress.
-type DeployStartedAction struct{}
-
-func (DeployStartedAction) Action() {}
 
 type DeployIDAction struct {
 	TargetID model.TargetID

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -205,7 +205,6 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 		return nil, err
 	}
 
-	st.Dispatch(DeployStartedAction{})
 	st.Dispatch(NewDeployIDAction(kTarget.ID(), deployID))
 
 	ctx, l := ibd.indentLogger(ctx)

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -18,11 +18,6 @@ import (
 )
 
 func handlePodChangeAction(ctx context.Context, state *store.EngineState, action PodChangeAction) {
-	if state.DeployInProgress {
-		state.DeployActionsDeferred = append(state.DeployActionsDeferred, action)
-		return
-	}
-
 	pod := action.Pod
 	mt, podInfo := ensureManifestTargetWithPod(state, pod)
 	if mt == nil || podInfo == nil {

--- a/internal/engine/service_watch.go
+++ b/internal/engine/service_watch.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
@@ -17,33 +19,70 @@ type ServiceWatcher struct {
 	ownerFetcher k8s.OwnerFetcher
 	watching     bool
 	nodeIP       k8s.NodeIP
+
+	mu                sync.RWMutex
+	knownDeployedUIDs map[types.UID]model.ManifestName
+	knownServices     map[types.UID]*v1.Service
 }
 
 func NewServiceWatcher(kCli k8s.Client, ownerFetcher k8s.OwnerFetcher, nodeIP k8s.NodeIP) *ServiceWatcher {
 	return &ServiceWatcher{
-		kCli:         kCli,
-		ownerFetcher: ownerFetcher,
-		nodeIP:       nodeIP,
+		kCli:              kCli,
+		ownerFetcher:      ownerFetcher,
+		nodeIP:            nodeIP,
+		knownDeployedUIDs: make(map[types.UID]model.ManifestName),
+		knownServices:     make(map[types.UID]*v1.Service),
 	}
 }
 
-func (w *ServiceWatcher) needsWatch(st store.RStore) bool {
+type serviceWatcherTaskList struct {
+	needsWatch bool
+	newUIDs    map[types.UID]model.ManifestName
+}
+
+func (w *ServiceWatcher) diff(st store.RStore) serviceWatcherTaskList {
 	state := st.RLockState()
 	defer st.RUnlockState()
 
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	newUIDs := make(map[types.UID]model.ManifestName)
 	atLeastOneK8s := false
-	for _, m := range state.Manifests() {
-		if m.IsK8s() {
-			atLeastOneK8s = true
+	for _, mt := range state.Targets() {
+		if !mt.Manifest.IsK8s() {
+			continue
+		}
+
+		name := mt.Manifest.Name
+		atLeastOneK8s = true
+		for id := range mt.State.K8sRuntimeState().DeployedUIDSet {
+			oldName := w.knownDeployedUIDs[id]
+			if name != oldName {
+				newUIDs[id] = name
+			}
 		}
 	}
-	return atLeastOneK8s && state.WatchFiles && !w.watching
+
+	needsWatch := atLeastOneK8s && state.WatchFiles && !w.watching
+	return serviceWatcherTaskList{
+		needsWatch: needsWatch,
+		newUIDs:    newUIDs,
+	}
 }
 
 func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore) {
-	if !w.needsWatch(st) {
-		return
+	taskList := w.diff(st)
+	if taskList.needsWatch {
+		w.setupWatch(ctx, st)
 	}
+
+	if len(taskList.newUIDs) > 0 {
+		w.setupNewUIDs(ctx, st, taskList.newUIDs)
+	}
+}
+
+func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore) {
 	w.watching = true
 
 	ch, err := w.kCli.WatchServices(ctx, []model.LabelPair{k8s.TiltRunLabel()})
@@ -56,6 +95,55 @@ func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore) {
 	go w.dispatchServiceChangesLoop(ctx, ch, st)
 }
 
+// When new UIDs are deployed, go through all our known services and dispatch
+// new events. This handles the case where we get the Service change event
+// before the deploy id shows up in the manifest, which is way more common than
+// you would think.
+func (w *ServiceWatcher) setupNewUIDs(ctx context.Context, st store.RStore, newUIDs map[types.UID]model.ManifestName) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for uid, mn := range newUIDs {
+		w.knownDeployedUIDs[uid] = mn
+
+		service, ok := w.knownServices[uid]
+		if !ok {
+			continue
+		}
+
+		err := dispatchServiceChange(st, service, mn, w.nodeIP)
+		if err != nil {
+			logger.Get(ctx).Infof("error resolving service url %s: %v", service.Name, err)
+		}
+	}
+}
+
+func (w *ServiceWatcher) maybeRecordServiceUpdate(service *v1.Service) (*v1.Service, model.ManifestName) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	uid := service.UID
+	oldService, ok := w.knownServices[uid]
+
+	// In "real" code, if we get two service updates with the same resource version,
+	// we can safely ignore the new one. But dispatching a spurious event
+	// in this case makes testing much easier, because the test harness doesn't need
+	// to keep track of ResourceVersions
+	olderThanKnown := ok && oldService.ResourceVersion > service.ResourceVersion
+	if olderThanKnown {
+		return nil, ""
+	}
+
+	w.knownServices[uid] = service
+
+	manifestName, ok := w.knownDeployedUIDs[uid]
+	if !ok {
+		return nil, ""
+	}
+
+	return service, manifestName
+}
+
 func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-chan *v1.Service, st store.RStore) {
 	for {
 		select {
@@ -64,7 +152,12 @@ func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-ch
 				return
 			}
 
-			err := dispatchServiceChange(st, service, w.nodeIP)
+			service, manifestName := w.maybeRecordServiceUpdate(service)
+			if service == nil {
+				continue
+			}
+
+			err := dispatchServiceChange(st, service, manifestName, w.nodeIP)
 			if err != nil {
 				logger.Get(ctx).Infof("error resolving service url %s: %v", service.Name, err)
 			}
@@ -74,14 +167,12 @@ func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-ch
 	}
 }
 
-func dispatchServiceChange(st store.RStore, service *v1.Service, ip k8s.NodeIP) error {
+func dispatchServiceChange(st store.RStore, service *v1.Service, mn model.ManifestName, ip k8s.NodeIP) error {
 	url, err := k8s.ServiceURL(service, ip)
 	if err != nil {
 		return err
 	}
 
-	// TODO(nick): Attach owner tree.
-
-	st.Dispatch(NewServiceChangeAction(service, url))
+	st.Dispatch(NewServiceChangeAction(service, mn, url))
 	return nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -208,7 +208,6 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 		b.nextDeployID = 0
 	}
 
-	st.Dispatch(DeployStartedAction{})
 	deployIDActions := NewDeployIDActionsForTargets(ids, dID)
 	for _, a := range deployIDActions {
 		st.Dispatch(a)
@@ -1837,7 +1836,7 @@ func TestUpper_ServiceEvent(t *testing.T) {
 
 	uid := f.b.resultsByID[manifest.K8sTarget().ID()].DeployedUIDs[0]
 	svc := servicebuilder.New(t, manifest).WithUID(uid).WithPort(8080).WithIP("1.2.3.4").Build()
-	dispatchServiceChange(f.store, svc, "")
+	dispatchServiceChange(f.store, svc, manifest.Name, "")
 
 	f.WaitUntilManifestState("lb updated", "foobar", func(ms store.ManifestState) bool {
 		return len(ms.K8sRuntimeState().LBs) > 0
@@ -1869,7 +1868,7 @@ func TestUpper_ServiceEventRemovesURL(t *testing.T) {
 	uid := f.b.resultsByID[manifest.K8sTarget().ID()].DeployedUIDs[0]
 	sb := servicebuilder.New(t, manifest).WithUID(uid).WithPort(8080).WithIP("1.2.3.4")
 	svc := sb.Build()
-	dispatchServiceChange(f.store, svc, "")
+	dispatchServiceChange(f.store, svc, manifest.Name, "")
 
 	f.WaitUntilManifestState("lb url added", "foobar", func(ms store.ManifestState) bool {
 		url := ms.K8sRuntimeState().LBs[k8s.ServiceName(svc.Name)]
@@ -1880,7 +1879,7 @@ func TestUpper_ServiceEventRemovesURL(t *testing.T) {
 	})
 
 	svc = sb.WithIP("").Build()
-	dispatchServiceChange(f.store, svc, "")
+	dispatchServiceChange(f.store, svc, manifest.Name, "")
 
 	f.WaitUntilManifestState("lb url removed", "foobar", func(ms store.ManifestState) bool {
 		url := ms.K8sRuntimeState().LBs[k8s.ServiceName(svc.Name)]

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
@@ -82,9 +81,6 @@ type EngineState struct {
 
 	TeamName string
 	Token    token.Token
-
-	DeployInProgress      bool
-	DeployActionsDeferred []Action
 }
 
 func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.ManifestName {
@@ -141,20 +137,6 @@ func (e EngineState) ManifestState(mn model.ManifestName) (*ManifestState, bool)
 		return nil, ok
 	}
 	return m.State, ok
-}
-
-func (e EngineState) ManifestStateForUID(uid types.UID) (*ManifestState, bool) {
-	for _, m := range e.ManifestTargets {
-		if !m.Manifest.IsK8s() {
-			continue
-		}
-
-		k8sState := m.State.K8sRuntimeState()
-		if k8sState.DeployedUIDSet.Contains(uid) {
-			return m.State, true
-		}
-	}
-	return nil, false
 }
 
 // Returns Manifests in a stable order

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -33,9 +33,10 @@ func NewK8sRuntimeState(deployID model.DeployID, pods ...Pod) K8sRuntimeState {
 		podMap[p.PodID] = &p
 	}
 	return K8sRuntimeState{
-		PodDeployID: deployID,
-		Pods:        podMap,
-		LBs:         make(map[k8s.ServiceName]*url.URL),
+		PodDeployID:    deployID,
+		Pods:           podMap,
+		LBs:            make(map[k8s.ServiceName]*url.URL),
+		DeployedUIDSet: NewUIDSet(),
 	}
 }
 

--- a/internal/testutils/servicebuilder/servicebuilder.go
+++ b/internal/testutils/servicebuilder/servicebuilder.go
@@ -15,9 +15,10 @@ type ServiceBuilder struct {
 	t        testing.TB
 	manifest model.Manifest
 
-	uid  types.UID
-	port int32
-	ip   string
+	uid      types.UID
+	port     int32
+	nodePort int32
+	ip       string
 }
 
 func New(t testing.TB, manifest model.Manifest) ServiceBuilder {
@@ -34,6 +35,11 @@ func (sb ServiceBuilder) WithUID(uid types.UID) ServiceBuilder {
 
 func (sb ServiceBuilder) WithPort(port int32) ServiceBuilder {
 	sb.port = port
+	return sb
+}
+
+func (sb ServiceBuilder) WithNodePort(port int32) ServiceBuilder {
+	sb.nodePort = port
 	return sb
 }
 
@@ -55,8 +61,8 @@ func (sb ServiceBuilder) getUid() types.UID {
 
 func (sb ServiceBuilder) Build() *v1.Service {
 	ports := []v1.ServicePort{}
-	if sb.port != 0 {
-		ports = append(ports, v1.ServicePort{Port: sb.port})
+	if sb.port != 0 || sb.nodePort != 0 {
+		ports = append(ports, v1.ServicePort{Port: sb.port, NodePort: sb.nodePort})
 	}
 	ingress := []v1.LoadBalancerIngress{}
 	if sb.ip != "" {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/uidexp:

3b43542b3dd4cf42c36ff9205d6da7b3e154cf40 (2019-08-22 13:13:54 -0400)
engine: make the ServiceWatcher responsible for mapping services to manifests