### PR TITLE
engine: categorize pods by manifest in pod_watch instead of in the reducer

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -21,13 +21,17 @@ func NewErrorAction(err error) store.ErrorAction {
 }
 
 type PodChangeAction struct {
-	Pod *v1.Pod
+	Pod          *v1.Pod
+	ManifestName model.ManifestName
 }
 
 func (PodChangeAction) Action() {}
 
-func NewPodChangeAction(pod *v1.Pod) PodChangeAction {
-	return PodChangeAction{Pod: pod}
+func NewPodChangeAction(pod *v1.Pod, mn model.ManifestName) PodChangeAction {
+	return PodChangeAction{
+		Pod:          pod,
+		ManifestName: mn,
+	}
 }
 
 type ServiceChangeAction struct {

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
@@ -19,7 +18,7 @@ import (
 
 func handlePodChangeAction(ctx context.Context, state *store.EngineState, action PodChangeAction) {
 	pod := action.Pod
-	mt, podInfo := ensureManifestTargetWithPod(state, pod)
+	mt, podInfo := ensureManifestTargetWithPod(state, pod, action.ManifestName)
 	if mt == nil || podInfo == nil {
 		return
 	}
@@ -66,22 +65,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 // ensuring that some Pod exists on the state.
 //
 // Intended as a helper for pod-mutating events.
-func ensureManifestTargetWithPod(state *store.EngineState, pod *v1.Pod) (*store.ManifestTarget, *store.Pod) {
-	manifestName := model.ManifestName(pod.ObjectMeta.Labels[k8s.ManifestNameLabel])
-	if manifestName == "" {
-		// if there's no ManifestNameLabel, then maybe it matches some manifest's ExtraPodSelectors
-		for _, m := range state.Manifests() {
-			if m.IsK8s() {
-				for _, lps := range m.K8sTarget().ExtraPodSelectors {
-					if lps.Matches(labels.Set(pod.ObjectMeta.GetLabels())) {
-						manifestName = m.Name
-						break
-					}
-				}
-			}
-		}
-	}
-
+func ensureManifestTargetWithPod(state *store.EngineState, pod *v1.Pod, manifestName model.ManifestName) (*store.ManifestTarget, *store.Pod) {
 	mt, ok := state.ManifestTargets[manifestName]
 	if !ok {
 		// This is OK. The user could have edited the manifest recently.

--- a/internal/engine/pod_watch_test.go
+++ b/internal/engine/pod_watch_test.go
@@ -9,13 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
+	"github.com/windmilleng/tilt/internal/testutils/podbuilder"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -23,12 +25,12 @@ func TestPodWatch(t *testing.T) {
 	f := newPWFixture(t)
 	defer f.TearDown()
 
-	f.addManifestWithSelectors("server")
+	manifest := f.addManifestWithSelectors("server")
 
 	f.pw.OnChange(f.ctx, f.store)
 
 	ls := k8s.TiltRunSelector()
-	p := podNamed("hello")
+	p := podbuilder.New(t, manifest).Build()
 	f.kClient.EmitPod(ls, p)
 
 	f.assertWatchedSelectors(ls)
@@ -43,16 +45,20 @@ func TestPodWatchExtraSelectors(t *testing.T) {
 	ls := k8s.TiltRunSelector()
 	ls1 := labels.Set{"foo": "bar"}.AsSelector()
 	ls2 := labels.Set{"baz": "quu"}.AsSelector()
-	f.addManifestWithSelectors("server", ls1, ls2)
+	manifest := f.addManifestWithSelectors("server", ls1, ls2)
 
 	f.pw.OnChange(f.ctx, f.store)
 
 	f.assertWatchedSelectors(ls, ls1, ls2)
 
-	p := podNamed("pod1")
+	p := podbuilder.New(t, manifest).
+		WithoutManifestLabel().
+		WithPodLabel("foo", "bar").
+		Build()
 	f.kClient.EmitPod(ls1, p)
 
 	f.assertObservedPods(p)
+	assert.Equal(t, []model.ManifestName{manifest.Name}, f.manifestNames)
 }
 
 func TestPodWatchHandleSelectorChange(t *testing.T) {
@@ -61,39 +67,51 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 
 	ls := k8s.TiltRunSelector()
 	ls1 := labels.Set{"foo": "bar"}.AsSelector()
-	f.addManifestWithSelectors("server1", ls1)
+	manifest := f.addManifestWithSelectors("server1", ls1)
 
 	f.pw.OnChange(f.ctx, f.store)
 
 	f.assertWatchedSelectors(ls, ls1)
 
-	p := podNamed("pod1")
+	p := podbuilder.New(t, manifest).
+		WithoutManifestLabel().
+		WithPodLabel("foo", "bar").
+		Build()
 	f.kClient.EmitPod(ls1, p)
 
 	f.assertObservedPods(p)
 	f.clearPods()
 
 	ls2 := labels.Set{"baz": "quu"}.AsSelector()
-	f.addManifestWithSelectors("server2", ls2)
+	manifest2 := f.addManifestWithSelectors("server2", ls2)
 	f.removeManifest("server1")
 
 	f.pw.OnChange(f.ctx, f.store)
 
 	f.assertWatchedSelectors(ls, ls2)
 
-	p2 := podNamed("pod2")
+	p2 := podbuilder.New(t, manifest2).Build()
 	f.kClient.EmitPod(ls, p2)
 	f.assertObservedPods(p2)
 	f.clearPods()
 
-	f.kClient.EmitPod(ls1, podNamed("pod3"))
-	p4 := podNamed("pod4")
+	p3 := podbuilder.New(t, manifest2).
+		WithoutManifestLabel().
+		WithPodLabel("foo", "bar").
+		Build()
+	f.kClient.EmitPod(ls1, p3)
+
+	p4 := podbuilder.New(t, manifest2).
+		WithoutManifestLabel().
+		WithPodLabel("baz", "quu").
+		Build()
 	f.kClient.EmitPod(ls2, p4)
-	p5 := podNamed("pod5")
+
+	p5 := podbuilder.New(t, manifest2).Build()
 	f.kClient.EmitPod(ls, p5)
 
 	f.assertObservedPods(p4, p5)
-
+	assert.Equal(t, []model.ManifestName{manifest2.Name, manifest2.Name}, f.manifestNames)
 }
 
 type podStatusTestCase struct {
@@ -145,19 +163,17 @@ func TestPodStatus(t *testing.T) {
 	}
 }
 
-func podNamed(name string) *corev1.Pod {
-	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}}
-}
-
-func (f *pwFixture) addManifestWithSelectors(manifestName string, ls ...labels.Selector) {
+func (f *pwFixture) addManifestWithSelectors(manifestName string, ls ...labels.Selector) model.Manifest {
 	state := f.store.LockMutableStateForTesting()
 	state.WatchFiles = true
-	mt, err := newManifestTargetWithSelectors(model.Manifest{Name: model.ManifestName(manifestName)}, ls)
-	if err != nil {
-		f.t.Fatalf("error creating manifest target with selectors: %+v", err)
-	}
+	m := manifestbuilder.New(f, model.ManifestName(manifestName)).
+		WithK8sYAML(SanchoYAML).
+		WithK8sPodSelectors(ls).
+		Build()
+	mt := store.NewManifestTarget(m)
 	state.UpsertManifestTarget(mt)
 	f.store.UnlockMutableState()
+	return mt.Manifest
 }
 
 func (f *pwFixture) removeManifest(manifestName string) {
@@ -175,13 +191,15 @@ func (f *pwFixture) removeManifest(manifestName string) {
 }
 
 type pwFixture struct {
-	t       *testing.T
-	kClient *k8s.FakeK8sClient
-	pw      *PodWatcher
-	ctx     context.Context
-	cancel  func()
-	store   *store.Store
-	pods    []*corev1.Pod
+	*tempdir.TempDirFixture
+	t             *testing.T
+	kClient       *k8s.FakeK8sClient
+	pw            *PodWatcher
+	ctx           context.Context
+	cancel        func()
+	store         *store.Store
+	pods          []*corev1.Pod
+	manifestNames []model.ManifestName
 }
 
 func (pw *pwFixture) reducer(ctx context.Context, state *store.EngineState, action store.Action) {
@@ -190,6 +208,7 @@ func (pw *pwFixture) reducer(ctx context.Context, state *store.EngineState, acti
 		pw.t.Errorf("Expected action type PodLogAction. Actual: %T", action)
 	}
 	pw.pods = append(pw.pods, a.Pod)
+	pw.manifestNames = append(pw.manifestNames, a.ManifestName)
 }
 
 func newPWFixture(t *testing.T) *pwFixture {
@@ -201,11 +220,12 @@ func newPWFixture(t *testing.T) *pwFixture {
 	of := k8s.ProvideOwnerFetcher(kClient)
 	pw := NewPodWatcher(kClient, of)
 	ret := &pwFixture{
-		kClient: kClient,
-		pw:      pw,
-		ctx:     ctx,
-		cancel:  cancel,
-		t:       t,
+		TempDirFixture: tempdir.NewTempDirFixture(t),
+		kClient:        kClient,
+		pw:             pw,
+		ctx:            ctx,
+		cancel:         cancel,
+		t:              t,
 	}
 
 	st := store.NewStore(store.Reducer(ret.reducer), store.LogActionsFlag(false))
@@ -217,17 +237,9 @@ func newPWFixture(t *testing.T) *pwFixture {
 }
 
 func (f *pwFixture) TearDown() {
+	f.TempDirFixture.TearDown()
 	f.kClient.TearDown()
 	f.cancel()
-}
-
-func newManifestTargetWithSelectors(m model.Manifest, selectors []labels.Selector) (*store.ManifestTarget, error) {
-	dt, err := k8s.NewTarget(model.TargetName(m.Name), nil, nil, selectors, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	m = m.WithDeployTarget(dt)
-	return store.NewManifestTarget(m), nil
 }
 
 func (f *pwFixture) assertObservedPods(pods ...*corev1.Pod) {
@@ -258,4 +270,5 @@ func (f *pwFixture) assertWatchedSelectors(ls ...labels.Selector) {
 
 func (f *pwFixture) clearPods() {
 	f.pods = nil
+	f.manifestNames = nil
 }

--- a/internal/k8s/owner_fetcher.go
+++ b/internal/k8s/owner_fetcher.go
@@ -17,6 +17,14 @@ type ObjectRefTree struct {
 	Owners []ObjectRefTree
 }
 
+func (t ObjectRefTree) UIDs() []types.UID {
+	result := []types.UID{t.Ref.UID}
+	for _, owner := range t.Owners {
+		result = append(result, owner.UIDs()...)
+	}
+	return result
+}
+
 func (t ObjectRefTree) stringLines() []string {
 	result := []string{fmt.Sprintf("%s:%s", t.Ref.Kind, t.Ref.Name)}
 	for _, owner := range t.Owners {

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -3,6 +3,8 @@ package manifestbuilder
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -20,8 +22,9 @@ type ManifestBuilder struct {
 	f    Fixture
 	name model.ManifestName
 
-	k8sYAML       string
-	dcConfigPaths []string
+	k8sYAML         string
+	k8sPodSelectors []labels.Selector
+	dcConfigPaths   []string
 
 	iTargets []model.ImageTarget
 }
@@ -35,6 +38,11 @@ func New(f Fixture, name model.ManifestName) ManifestBuilder {
 
 func (b ManifestBuilder) WithK8sYAML(yaml string) ManifestBuilder {
 	b.k8sYAML = yaml
+	return b
+}
+
+func (b ManifestBuilder) WithK8sPodSelectors(podSelectors []labels.Selector) ManifestBuilder {
+	b.k8sPodSelectors = podSelectors
 	return b
 }
 
@@ -80,7 +88,7 @@ func (b ManifestBuilder) Build() model.Manifest {
 	if b.k8sYAML != "" {
 		return assembleK8s(
 			model.Manifest{Name: b.name},
-			model.K8sTarget{YAML: b.k8sYAML},
+			model.K8sTarget{YAML: b.k8sYAML, ExtraPodSelectors: b.k8sPodSelectors},
 			b.iTargets...)
 	}
 


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/podwatch2:

b2a016e67a48327c5b76e244d8a03c3ecd79d620 (2019-08-23 11:56:12 -0400)
engine: categorize pods by manifest in pod_watch instead of in the reducer