### PR TITLE
engine: triage pods by owner UID rather than by manifest label

### DIFF
--- a/internal/engine/event_watch_manager.go
+++ b/internal/engine/event_watch_manager.go
@@ -80,7 +80,7 @@ func (m *EventWatchManager) createEntry(ctx context.Context, involvedObject v1.O
 		expiresAt:         m.clock.Now().Add(uidMapEntryTTL),
 	}
 
-	e, err := m.kClient.GetByReference(involvedObject)
+	e, err := m.kClient.GetByReference(ctx, involvedObject)
 	if err != nil {
 		// if the lookup was an error, wipe out resourceVersion so that we don't cache a potentially
 		// ephemeral negative result

--- a/internal/engine/service_watch_test.go
+++ b/internal/engine/service_watch_test.go
@@ -27,8 +27,6 @@ func TestServiceWatch(t *testing.T) {
 	manifest := f.addManifest("server")
 	f.addDeployedUID(manifest, uid)
 
-	f.sw.OnChange(f.ctx, f.store)
-
 	ls := k8s.TiltRunSelector()
 	s := servicebuilder.New(f.t, manifest).
 		WithPort(9998).
@@ -72,7 +70,6 @@ func TestServiceWatchDeployIDDelayed(t *testing.T) {
 	f.waitUntilServiceKnown(uid)
 
 	f.addDeployedUID(manifest, uid)
-	f.sw.OnChange(f.ctx, f.store)
 
 	expectedSCA := ServiceChangeAction{
 		Service:      s,
@@ -92,6 +89,8 @@ func (f *swFixture) addManifest(manifestName string) model.Manifest {
 }
 
 func (f *swFixture) addDeployedUID(m model.Manifest, uid types.UID) {
+	defer f.sw.OnChange(f.ctx, f.store)
+
 	state := f.store.LockMutableStateForTesting()
 	defer f.store.UnlockMutableState()
 	mState, ok := state.ManifestState(m.Name)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -77,7 +77,7 @@ type Client interface {
 	// behavior for our use cases.
 	Delete(ctx context.Context, entities []K8sEntity) error
 
-	GetByReference(ref v1.ObjectReference) (K8sEntity, error)
+	GetByReference(ctx context.Context, ref v1.ObjectReference) (K8sEntity, error)
 
 	PodByID(ctx context.Context, podID PodID, n Namespace) (*v1.Pod, error)
 
@@ -360,7 +360,7 @@ func (k K8sClient) actOnEntities(ctx context.Context, cmdArgs []string, entities
 	return k.kubectlRunner.execWithStdin(ctx, args, rawYAML)
 }
 
-func (k K8sClient) GetByReference(ref v1.ObjectReference) (K8sEntity, error) {
+func (k K8sClient) GetByReference(ctx context.Context, ref v1.ObjectReference) (K8sEntity, error) {
 	group := getGroup(ref)
 	kind := ref.Kind
 	namespace := ref.Namespace

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -47,6 +47,18 @@ func (emptyMeta) GetOwnerReferences() []metav1.OwnerReference { return nil }
 var _ k8sMeta = emptyMeta{}
 var _ k8sMeta = &metav1.ObjectMeta{}
 
+func (e K8sEntity) ToObjectReference() v1.ObjectReference {
+	meta := e.meta()
+	apiVersion, kind := e.GVK().ToAPIVersionAndKind()
+	return v1.ObjectReference{
+		Kind:       kind,
+		APIVersion: apiVersion,
+		Name:       meta.GetName(),
+		Namespace:  meta.GetNamespace(),
+		UID:        meta.GetUID(),
+	}
+}
+
 func (e K8sEntity) GVK() schema.GroupVersionKind {
 	gvk := e.Obj.GetObjectKind().GroupVersionKind()
 	if gvk.Empty() {

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -29,7 +29,7 @@ func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity) err
 	return errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) GetByReference(ref v1.ObjectReference) (K8sEntity, error) {
+func (ec *explodingClient) GetByReference(ctx context.Context, ref v1.ObjectReference) (K8sEntity, error) {
 	return K8sEntity{}, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/windmilleng/tilt/internal/container"
+	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -250,9 +251,10 @@ func (c *FakeK8sClient) InjectEntityByName(entities ...K8sEntity) {
 	}
 }
 
-func (c *FakeK8sClient) GetByReference(ref v1.ObjectReference) (K8sEntity, error) {
+func (c *FakeK8sClient) GetByReference(ctx context.Context, ref v1.ObjectReference) (K8sEntity, error) {
 	resp, ok := c.entityByName[ref.Name]
 	if !ok {
+		logger.Get(ctx).Infof("FakeK8sClient.GetByReference: resource not found: %s", ref.Name)
 		return K8sEntity{}, apierrors.NewNotFound(v1.Resource(ref.Kind), ref.Name)
 	}
 	return resp, nil

--- a/internal/k8s/owner_fetcher_test.go
+++ b/internal/k8s/owner_fetcher_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,7 +36,7 @@ func TestVisitOneParent(t *testing.T) {
 	}
 	kCli.InjectEntityByName(NewK8sEntity(rs))
 
-	tree, err := ov.OwnerTreeOf(K8sEntity{Obj: pod})
+	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
 	assert.NoError(t, err)
 	assert.Equal(t, `Pod:pod-a
   ReplicaSet:rs-a`, tree.String())
@@ -81,7 +82,7 @@ func TestVisitTwoParents(t *testing.T) {
 	}
 	kCli.InjectEntityByName(NewK8sEntity(rs), NewK8sEntity(dep))
 
-	tree, err := ov.OwnerTreeOf(K8sEntity{Obj: pod})
+	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
 	assert.NoError(t, err)
 	assert.Equal(t, `Pod:pod-a
   ReplicaSet:rs-a

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/k8s"
@@ -62,6 +64,7 @@ type PodBuilder struct {
 	restartCount      int
 	extraPodLabels    map[string]string
 	skipManifestLabel bool
+	deploymentUID     types.UID
 
 	// keyed by container index -- i.e. the first container will have image: imageRefs[0] and ID: cIDs[0], etc.
 	// If there's no entry at index i, we'll use a dummy value.
@@ -158,6 +161,56 @@ func (b PodBuilder) PodID() string {
 		return b.podID
 	}
 	return "fakePodID"
+}
+
+func (b PodBuilder) buildPodUID() types.UID {
+	return types.UID(fmt.Sprintf("%s-fakeUID", b.PodID()))
+}
+
+func (b PodBuilder) WithDeploymentUID(deploymentUID types.UID) PodBuilder {
+	b.deploymentUID = deploymentUID
+	return b
+}
+
+func (b PodBuilder) buildReplicaSetName() string {
+	return fmt.Sprintf("%s-replicaset", b.manifest.Name)
+}
+
+func (b PodBuilder) buildReplicaSetUID() types.UID {
+	return types.UID(fmt.Sprintf("%s-fakeUID", b.buildReplicaSetName()))
+}
+
+func (b PodBuilder) buildDeploymentName() string {
+	return b.manifest.Name.String()
+}
+
+func (b PodBuilder) DeploymentUID() types.UID {
+	if b.deploymentUID != "" {
+		return b.deploymentUID
+	}
+	return types.UID(fmt.Sprintf("%s-fakeUID", b.buildDeploymentName()))
+}
+
+func (b PodBuilder) buildDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: b.buildDeploymentName(),
+			UID:  b.DeploymentUID(),
+		},
+	}
+}
+
+func (b PodBuilder) buildReplicaSet() *appsv1.ReplicaSet {
+	dep := b.buildDeployment()
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: b.buildReplicaSetName(),
+			UID:  b.buildReplicaSetUID(),
+			OwnerReferences: []metav1.OwnerReference{
+				k8s.RuntimeObjToOwnerRef(dep),
+			},
+		},
+	}
 }
 
 func (b PodBuilder) buildCreationTime() metav1.Time {
@@ -260,6 +313,18 @@ func (b PodBuilder) validateContainerIDs(numContainers int) {
 	}
 }
 
+// Simulates a Pod -> ReplicaSet -> Deployment ref tree
+func (b PodBuilder) ObjectTreeEntities() []k8s.K8sEntity {
+	pod := b.Build()
+	rs := b.buildReplicaSet()
+	dep := b.buildDeployment()
+	return []k8s.K8sEntity{
+		k8s.NewK8sEntity(pod),
+		k8s.NewK8sEntity(rs),
+		k8s.NewK8sEntity(dep),
+	}
+}
+
 func (b PodBuilder) Build() *v1.Pod {
 	entities, err := parseYAMLFromManifest(b.manifest)
 	if err != nil {
@@ -292,6 +357,10 @@ func (b PodBuilder) Build() *v1.Pod {
 			CreationTimestamp: b.buildCreationTime(),
 			DeletionTimestamp: b.buildDeletionTime(),
 			Labels:            b.buildLabels(tSpec),
+			UID:               b.buildPodUID(),
+			OwnerReferences: []metav1.OwnerReference{
+				k8s.RuntimeObjToOwnerRef(b.buildReplicaSet()),
+			},
 		},
 		Spec: spec,
 		Status: v1.PodStatus{


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/podwatch:

30334e83b6572cba08adf6ff55f986c3fc236f31 (2019-08-23 14:52:47 -0400)
engine: triage pods by owner UID rather than by manifest label