### PR TITLE
internal/engine: store address of Tilt Cloud on Engine

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -146,7 +146,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 
 	g.Go(func() error {
 		defer cancel()
-		return upper.Start(ctx, args, threads.tiltBuild, c.watch, c.fileName, c.hud, threads.sailMode, a.Opt())
+		return upper.Start(ctx, args, threads.tiltBuild, c.watch, c.fileName, c.hud, threads.sailMode, a.Opt(), threads.token, string(threads.cloudAddress))
 	})
 
 	err = g.Wait()

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/demo"
 	"github.com/windmilleng/tilt/internal/docker"
@@ -111,6 +112,7 @@ var BaseWireSet = wire.NewSet(
 
 	dirs.UseWindmillDir,
 	token.GetOrCreateToken,
+	cloud.ProvideAddress,
 
 	provideThreads,
 	engine.NewKINDPusher,
@@ -129,14 +131,16 @@ func wireThreads(ctx context.Context, analytics *analytics.TiltAnalytics) (Threa
 }
 
 type Threads struct {
-	hud       hud.HeadsUpDisplay
-	upper     engine.Upper
-	tiltBuild model.TiltBuild
-	sailMode  model.SailMode
+	hud          hud.HeadsUpDisplay
+	upper        engine.Upper
+	tiltBuild    model.TiltBuild
+	sailMode     model.SailMode
+	token        token.Token
+	cloudAddress cloud.Address
 }
 
-func provideThreads(h hud.HeadsUpDisplay, upper engine.Upper, b model.TiltBuild, sailMode model.SailMode) Threads {
-	return Threads{h, upper, b, sailMode}
+func provideThreads(h hud.HeadsUpDisplay, upper engine.Upper, b model.TiltBuild, sailMode model.SailMode, token token.Token, cloudAddress cloud.Address) Threads {
+	return Threads{h, upper, b, sailMode, token, cloudAddress}
 }
 
 func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/containerupdate"
 	"github.com/windmilleng/tilt/internal/demo"
@@ -156,7 +157,8 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
 	httpClient := server.ProvideHttpClient()
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient, httpClient)
+	address := cloud.ProvideAddress()
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient, httpClient, address)
 	modelNoBrowser := provideNoBrowserFlag()
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL, modelNoBrowser)
 	githubClientFactory := engine.NewGithubClientFactory()
@@ -165,15 +167,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	clockworkClock := clockwork.NewRealClock()
 	eventWatchManager := engine.NewEventWatchManager(k8sClient, clockworkClock)
 	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, imageController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, sailClient, tiltVersionChecker, tiltAnalyticsSubscriber, eventWatchManager)
-	windmillDir, err := dirs.UseWindmillDir()
-	if err != nil {
-		return demo.Script{}, err
-	}
-	tokenToken, err := token.GetOrCreateToken(windmillDir)
-	if err != nil {
-		return demo.Script{}, err
-	}
-	upper := engine.NewUpper(ctx, storeStore, v2, tokenToken)
+	upper := engine.NewUpper(ctx, storeStore, v2)
 	script := demo.NewScript(upper, headsUpDisplay, k8sClient, env, storeStore, branch, runtime, tiltfileLoader)
 	return script, nil
 }
@@ -301,7 +295,8 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	sailDialer := client.ProvideSailDialer()
 	sailClient := client.ProvideSailClient(sailURL, sailRoomer, sailDialer)
 	httpClient := server.ProvideHttpClient()
-	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient, httpClient)
+	address := cloud.ProvideAddress()
+	headsUpServer := server.ProvideHeadsUpServer(storeStore, assetsServer, analytics2, sailClient, httpClient, address)
 	modelNoBrowser := provideNoBrowserFlag()
 	headsUpServerController := server.ProvideHeadsUpServerController(modelWebPort, headsUpServer, assetsServer, webURL, modelNoBrowser)
 	githubClientFactory := engine.NewGithubClientFactory()
@@ -310,6 +305,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	clockworkClock := clockwork.NewRealClock()
 	eventWatchManager := engine.NewEventWatchManager(k8sClient, clockworkClock)
 	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, imageController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, sailClient, tiltVersionChecker, tiltAnalyticsSubscriber, eventWatchManager)
+	upper := engine.NewUpper(ctx, storeStore, v2)
 	windmillDir, err := dirs.UseWindmillDir()
 	if err != nil {
 		return Threads{}, err
@@ -318,8 +314,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	if err != nil {
 		return Threads{}, err
 	}
-	upper := engine.NewUpper(ctx, storeStore, v2, tokenToken)
-	threads := provideThreads(headsUpDisplay, upper, tiltBuild, sailMode)
+	threads := provideThreads(headsUpDisplay, upper, tiltBuild, sailMode, tokenToken, address)
 	return threads, nil
 }
 
@@ -513,18 +508,20 @@ var BaseWireSet = wire.NewSet(
 	provideWebPort,
 	provideWebDevPort,
 	provideNoBrowserFlag, server.ProvideHeadsUpServer, assets.ProvideAssetServer, server.ProvideHeadsUpServerController, server.ProvideHttpClient, provideSailMode,
-	provideSailURL, client.SailWireSet, dirs.UseWindmillDir, token.GetOrCreateToken, provideThreads, engine.NewKINDPusher, wire.Value(feature.MainDefaults),
+	provideSailURL, client.SailWireSet, dirs.UseWindmillDir, token.GetOrCreateToken, cloud.ProvideAddress, provideThreads, engine.NewKINDPusher, wire.Value(feature.MainDefaults),
 )
 
 type Threads struct {
-	hud       hud.HeadsUpDisplay
-	upper     engine.Upper
-	tiltBuild model.TiltBuild
-	sailMode  model.SailMode
+	hud          hud.HeadsUpDisplay
+	upper        engine.Upper
+	tiltBuild    model.TiltBuild
+	sailMode     model.SailMode
+	token        token.Token
+	cloudAddress cloud.Address
 }
 
-func provideThreads(h hud.HeadsUpDisplay, upper engine.Upper, b model.TiltBuild, sailMode model.SailMode) Threads {
-	return Threads{h, upper, b, sailMode}
+func provideThreads(h hud.HeadsUpDisplay, upper engine.Upper, b model.TiltBuild, sailMode model.SailMode, token2 token.Token, cloudAddress cloud.Address) Threads {
+	return Threads{h, upper, b, sailMode, token2, cloudAddress}
 }
 
 type DownDeps struct {

--- a/internal/cloud/url.go
+++ b/internal/cloud/url.go
@@ -2,13 +2,25 @@ package cloud
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/windmilleng/tilt/internal/token"
 )
 
-//TODO TFT: change snapshot url to be cloud.tilt.dev
-const Domain = "alerts.tilt.dev"
+// an address like cloud.tilt.dev or localhost:10450
+type Address string
 
-func RegisterTokenURL(t token.Token) string {
-	return fmt.Sprintf("https://%s/register_token?token=%s", Domain, t)
+const addressEnvName = "TILT_CLOUD_ADDRESS"
+
+func ProvideAddress() Address {
+	address := os.Getenv(addressEnvName)
+	if address == "" {
+		address = "alerts.tilt.dev"
+	}
+
+	return Address(address)
+}
+
+func RegisterTokenURL(cloudAddress string, t token.Token) string {
+	return fmt.Sprintf("https://%s/register_token?token=%s", cloudAddress, t)
 }

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -115,7 +115,8 @@ type InitAction struct {
 
 	AnalyticsOpt analytics.Opt
 
-	Token token.Token
+	CloudAddress string
+	Token        token.Token
 }
 
 func (InitAction) Action() {}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2377,7 +2377,7 @@ func TestDockerComposeBuildCompletedSetsStatusToUpIfSuccessful(t *testing.T) {
 func TestEmptyTiltfile(t *testing.T) {
 	f := newTestFixture(t)
 	f.WriteFile("Tiltfile", "")
-	go f.upper.Start(f.ctx, []string{}, model.TiltBuild{}, false, f.JoinPath("Tiltfile"), true, model.SailModeDisabled, analytics.OptIn)
+	go f.upper.Start(f.ctx, []string{}, model.TiltBuild{}, false, f.JoinPath("Tiltfile"), true, model.SailModeDisabled, analytics.OptIn, token.Token("unit test token"), "nonexistent.example.com")
 	f.WaitUntil("build is set", func(st store.EngineState) bool {
 		return !st.TiltfileState.LastBuild().Empty()
 	})
@@ -2829,7 +2829,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	tvc := NewTiltVersionChecker(func() github.Client { return ghc }, tiltVersionCheckTimerMaker)
 
 	subs := ProvideSubscribers(fakeHud, pw, sw, plm, pfc, fwm, bc, ic, cc, dcw, dclm, pm, sm, ar, hudsc, sc, tvc, tas, ewm)
-	ret.upper = NewUpper(ctx, st, subs, token.Token("unit test token"))
+	ret.upper = NewUpper(ctx, st, subs)
 
 	go func() {
 		fakeHud.Run(ctx, ret.upper.Dispatch, hud.DefaultRefreshInterval)

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -103,7 +103,7 @@ func StateToWebView(s store.EngineState) View {
 	ret.RunningTiltBuild = s.TiltBuildInfo
 	ret.LatestTiltBuild = s.LatestTiltBuild
 	ret.FeatureFlags = s.Features
-	ret.RegisterTokenURL = cloud.RegisterTokenURL(s.Token)
+	ret.RegisterTokenURL = cloud.RegisterTokenURL(s.CloudAddress, s.Token)
 
 	return ret
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -79,8 +79,9 @@ type EngineState struct {
 
 	Features map[string]bool
 
-	TeamName string
-	Token    token.Token
+	CloudAddress string
+	Token        token.Token
+	TeamName     string
 }
 
 func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.ManifestName {


### PR DESCRIPTION
Ugh, I realize now why this is less-than-great, but fixing it would be a distraction.

(For posterity: I think the right thing is to have:

type Client interface {
  UploadSnapshot(data) ID
  SnapshotURL(ID) string
  RegisterTokenURL() string
  Whoami() )string
})

This would hide what the address is, and make it easier to add in dummy implementations for testing so we're more sure it's not making requests