### PR TITLE
snapshot: fix display of username

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -194,7 +194,7 @@ class HUD extends Component<HudProps, HudState> {
     let showSnapshot =
       features.isEnabled("snapshots") && !this.pathBuilder.isSnapshot()
     let snapshotOwner: string | null = null
-    if (features.isEnabled("snapshots") && this.state.View) {
+    if (this.pathBuilder.isSnapshot() && this.state.View) {
       snapshotOwner = this.state.View.TiltCloudUsername
     }
 


### PR DESCRIPTION
### Problem
The "snapshot shared by" message is not showing on snapshots in prod.
This is because this was tested in dev, which does not pass through `cleanSnapshotForPOST`, which disables the snapshots feature, which stops the username from displaying

### Solution
Don't rely on the snapshots feature being enabled to determine whether to show the "snapshot shared by message.

### Testing
We don't currently have a high-fidelity way to test snapshot JS without doing a release.
Tested by, in `AppController.setStateFromSnapshot`:
1. Changing url to "http://localhost/api/snapshot/aaaa"
2. When we get `data` back from the api call, setting `data = cleanSnapshotForPOST(data)`
3. Verifying by setting other properties in cleanSnapshotForPOST to verify that I was seeing a snapshot that had flowed through that function.