### PR TITLE
build: improve error message when docker did not return a digest

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -479,7 +479,7 @@ func (d *dockerImageBuilder) getDigestFromDockerOutput(ctx context.Context, outp
 		return digest.Digest(data.ID), nil
 	}
 
-	return "", fmt.Errorf("Could not find image digest in docker output")
+	return "", fmt.Errorf("Docker is not responding. Maybe Docker is out of disk space? Try running `docker system prune`")
 }
 
 func getDigestFromAux(aux json.RawMessage) (digest.Digest, error) {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/issue1967:

51557f125f78251239e6c2ad9526da887ab2b497 (2019-09-03 11:28:41 -0400)
build: improve error message when docker did not return a digest