### PR TITLE
tilt: pass tilt callback to register_token

### DIFF
--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -43,6 +43,9 @@ export default class ShareSnapshotModal extends PureComponent<props> {
   }
 
   tiltCloudCopy() {
+    let callbackURL = `${window.location.protocol}//${
+      window.location.host
+    }/api/refresh_tilt_cloud_whoami`
     if (!this.props.tiltCloudUsername) {
       return (
         <div>
@@ -59,6 +62,7 @@ export default class ShareSnapshotModal extends PureComponent<props> {
                 type="hidden"
                 value={cookies.get("Tilt-Token")}
               />
+              <input name="tilt_callback" type="hidden" value={callbackURL} />
             </form>
             to associate this copy of Tilt with your TiltCloud account.
           </div>

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -107,6 +107,11 @@ exports[`ShareSnapshotModal renders with modal open w/o known username 1`] = `
               name="token"
               type="hidden"
             />
+            <input
+              name="tilt_callback"
+              type="hidden"
+              value="http://localhost/api/refresh_tilt_cloud_whoami"
+            />
           </form>
           to associate this copy of Tilt with your TiltCloud account.
         </div>
@@ -173,6 +178,11 @@ exports[`ShareSnapshotModal renders without snapshotUrl 1`] = `
             <input
               name="token"
               type="hidden"
+            />
+            <input
+              name="tilt_callback"
+              type="hidden"
+              value="http://localhost/api/refresh_tilt_cloud_whoami"
             />
           </form>
           to associate this copy of Tilt with your TiltCloud account.


### PR DESCRIPTION
This PR tells Tilt Cloud a callback to notify Tilt when token registration has completed

(the other half of https://github.com/windmilleng/tft/pull/16)