### PR TITLE
Revert "tilt: pass tilt callback to register_token (#2143)"

### DIFF
--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -43,9 +43,6 @@ export default class ShareSnapshotModal extends PureComponent<props> {
   }
 
   tiltCloudCopy() {
-    let callbackURL = `${window.location.protocol}//${
-      window.location.host
-    }/api/refresh_tilt_cloud_whoami`
     if (!this.props.tiltCloudUsername) {
       return (
         <div>
@@ -62,7 +59,6 @@ export default class ShareSnapshotModal extends PureComponent<props> {
                 type="hidden"
                 value={cookies.get("Tilt-Token")}
               />
-              <input name="tilt_callback" type="hidden" value={callbackURL} />
             </form>
             to associate this copy of Tilt with your TiltCloud account.
           </div>

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -107,11 +107,6 @@ exports[`ShareSnapshotModal renders with modal open w/o known username 1`] = `
               name="token"
               type="hidden"
             />
-            <input
-              name="tilt_callback"
-              type="hidden"
-              value="http://localhost/api/refresh_tilt_cloud_whoami"
-            />
           </form>
           to associate this copy of Tilt with your TiltCloud account.
         </div>
@@ -178,11 +173,6 @@ exports[`ShareSnapshotModal renders without snapshotUrl 1`] = `
             <input
               name="token"
               type="hidden"
-            />
-            <input
-              name="tilt_callback"
-              type="hidden"
-              value="http://localhost/api/refresh_tilt_cloud_whoami"
             />
           </form>
           to associate this copy of Tilt with your TiltCloud account.


### PR DESCRIPTION
This reverts commit 69d1589b61400e7b5cb7e67b73d2e407ea3651e8.

This didn't work in prod because can't have a callback to http from https.