### PR TITLE
tilt: fix /api/whoami long_get

### DIFF
--- a/internal/cloud/cloud_username_manager.go
+++ b/internal/cloud/cloud_username_manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -69,7 +70,9 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 	u.Path = "/api/whoami"
 
 	if blocking {
-		u.Query().Set("wait_for_registration", "true")
+		q := url.Values{}
+		q.Set("wait_for_registration", "true")
+		u.RawQuery = q.Encode()
 	}
 
 	req, err := http.NewRequest("GET", u.String(), nil)

--- a/internal/cloud/cloud_username_manager_test.go
+++ b/internal/cloud/cloud_username_manager_test.go
@@ -1,0 +1,81 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/windmilleng/tilt/internal/feature"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/httptest"
+)
+
+const testCloudAddress = "tiltcloud.example.com"
+
+func TestLongGet(t *testing.T) {
+	f := newCloudUsernameManagerTestFixture(t)
+
+	f.httpClient.SetResponse(`{"foo": "bar"}`)
+	f.Run(func(state *store.EngineState) {
+		state.WaitingForTiltCloudUsernamePostRegistration = true
+	})
+
+	f.waitForRequest(fmt.Sprintf("https://%s/api/whoami?wait_for_registration=true", testCloudAddress))
+}
+
+type cloudUsernameManagerTestFixture struct {
+	um         *CloudUsernameManager
+	httpClient *httptest.FakeClient
+	st         *store.Store
+	ctx        context.Context
+	t          *testing.T
+}
+
+func newCloudUsernameManagerTestFixture(t *testing.T) *cloudUsernameManagerTestFixture {
+	st, _ := store.NewStoreForTesting()
+
+	httpClient := httptest.NewFakeClient()
+
+	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
+
+	return &cloudUsernameManagerTestFixture{
+		st:         st,
+		httpClient: httpClient,
+		um:         NewUsernameManager(httpClient),
+		ctx:        ctx,
+		t:          t,
+	}
+}
+
+func (f *cloudUsernameManagerTestFixture) Run(mutateState func(state *store.EngineState)) {
+	state := f.st.LockMutableStateForTesting()
+	state.Features = make(map[string]bool)
+	state.Features[feature.Snapshots] = true
+	state.CloudAddress = testCloudAddress
+	mutateState(state)
+	f.st.UnlockMutableState()
+	f.um.OnChange(f.ctx, f.st)
+}
+
+func (f *cloudUsernameManagerTestFixture) waitForRequest(expectedURL string) {
+	timeout := time.After(time.Second)
+	for {
+		urls := f.httpClient.RequestURLs()
+		if len(urls) > 1 {
+			f.t.Fatalf("%T made more than one http request! requests: %v", f.um, urls)
+		} else if len(urls) == 1 {
+			require.Equal(f.t, expectedURL, urls[0])
+			return
+		} else {
+			select {
+			case <-timeout:
+				f.t.Fatalf("timed out waiting for %T to make http request", f.um)
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+	}
+}

--- a/internal/testutils/httptest/http_client.go
+++ b/internal/testutils/httptest/http_client.go
@@ -1,14 +1,16 @@
 package httptest
 
 import (
+	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 )
 
 type FakeClient struct {
-	requests []http.Request
-	response http.Response
-	err      error
+	Requests []http.Request
+	Response http.Response
+	Err      error
 
 	mu sync.Mutex
 }
@@ -17,10 +19,25 @@ func (fc *FakeClient) Do(req *http.Request) (*http.Response, error) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 
-	fc.requests = append(fc.requests, *req)
-	r := fc.response
+	fc.Requests = append(fc.Requests, *req)
+	r := fc.Response
 
-	return &r, fc.err
+	return &r, fc.Err
+}
+
+func (fc *FakeClient) SetResponse(s string) {
+	fc.Response = http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(strings.NewReader(s)),
+	}
+}
+
+func (fc *FakeClient) RequestURLs() []string {
+	var ret []string
+	for _, req := range fc.Requests {
+		ret = append(ret, req.URL.String())
+	}
+	return ret
 }
 
 func NewFakeClient() *FakeClient {


### PR DESCRIPTION
It turns out `u.Query()` is a read-only copy, so this never worked.