### PR TITLE
k8s: assert that the watchers emit all existing resources at startup

### DIFF
--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -28,7 +28,7 @@ func TestFixContainerStatusImages(t *testing.T) {
 	assert.NotEqual(t,
 		pod.Spec.Containers[0].Image,
 		pod.Status.ContainerStatuses[0].Image)
-	FixContainerStatusImages(&pod)
+	FixContainerStatusImages(pod)
 	assert.Equal(t,
 		pod.Spec.Containers[0].Image,
 		pod.Status.ContainerStatuses[0].Image)
@@ -48,7 +48,7 @@ func TestWaitForContainerAlreadyAlive(t *testing.T) {
 			},
 		},
 	}
-	f.addObject(&podData)
+	f.addObject(podData)
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Second)
 	defer cancel()
@@ -102,7 +102,7 @@ func TestWaitForContainerSuccess(t *testing.T) {
 	}
 
 	<-f.watchNotify
-	f.updatePod(&newPod)
+	f.updatePod(newPod)
 	err = <-result
 	if err != nil {
 		t.Fatal(err)
@@ -141,7 +141,7 @@ func TestWaitForContainerFailure(t *testing.T) {
 	}
 
 	<-f.watchNotify
-	f.updatePod(&newPod)
+	f.updatePod(newPod)
 	err = <-result
 
 	expected := "Container will never be ready"
@@ -182,7 +182,7 @@ func TestWaitForContainerUnschedulable(t *testing.T) {
 	}
 
 	<-f.watchNotify
-	f.updatePod(&newPod)
+	f.updatePod(newPod)
 	err = <-result
 
 	expected := "Container will never be ready: 0/4 nodes are available: 4 Insufficient cpu."

--- a/internal/k8s/fake_test.go
+++ b/internal/k8s/fake_test.go
@@ -1,0 +1,51 @@
+package k8s
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Common fakes
+
+var resourceVersion = 1
+
+func fakePod(podID PodID, imageID string) *v1.Pod {
+	resourceVersion++
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            string(podID),
+			Namespace:       "default",
+			Labels:          make(map[string]string, 0),
+			ResourceVersion: fmt.Sprintf("%d", resourceVersion),
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node1",
+			Containers: []v1.Container{
+				v1.Container{
+					Name:  "default",
+					Image: imageID,
+				},
+			},
+		},
+	}
+}
+
+func fakeService(name string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func fakeEvent(name string, message string, count int) *v1.Event {
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Message: message,
+		Count:   int32(count),
+	}
+}

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -4,36 +4,12 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 )
 
 const expectedPod = PodID("blorg-fe-6b4477ffcd-xf98f")
 const blorgDevImgStr = "blorg.io/blorgdev/blorg-frontend:tilt-361d98a2d335373f"
-
-var resourceVersion = 1
-
-func fakePod(podID PodID, imageID string) v1.Pod {
-	resourceVersion++
-	return v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            string(podID),
-			Namespace:       "default",
-			Labels:          make(map[string]string, 0),
-			ResourceVersion: fmt.Sprintf("%d", resourceVersion),
-		},
-		Spec: v1.PodSpec{
-			NodeName: "node1",
-			Containers: []v1.Container{
-				v1.Container{
-					Name:  "default",
-					Image: imageID,
-				},
-			},
-		},
-	}
-}
 
 func podList(pods ...v1.Pod) v1.PodList {
 	return v1.PodList{
@@ -42,10 +18,10 @@ func podList(pods ...v1.Pod) v1.PodList {
 }
 
 var fakePodList = podList(
-	fakePod("cockroachdb-0", "cockroachdb/cockroach:v2.0.5"),
-	fakePod("cockroachdb-1", "cockroachdb/cockroach:v2.0.5"),
-	fakePod("cockroachdb-2", "cockroachdb/cockroach:v2.0.5"),
-	fakePod(expectedPod, blorgDevImgStr))
+	*fakePod("cockroachdb-0", "cockroachdb/cockroach:v2.0.5"),
+	*fakePod("cockroachdb-1", "cockroachdb/cockroach:v2.0.5"),
+	*fakePod("cockroachdb-2", "cockroachdb/cockroach:v2.0.5"),
+	*fakePod(expectedPod, blorgDevImgStr))
 
 func (c clientTestFixture) AssertCallExistsWithArg(expectedArg string) {
 	foundMatchingCall := false


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ch3277/list:

9c0fab812bc002366ced4d4d41ba85964995d5a8 (2019-09-05 13:28:52 -0400)
k8s: assert that the watchers emit all existing resources at startup