### PR TITLE
k8s: handle parallel fetch() calls better. This happens a lot with events

### DIFF
--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -64,7 +64,8 @@ type FakeK8sClient struct {
 	Runtime  container.Runtime
 	Registry container.Registry
 
-	entityByName map[string]K8sEntity
+	entityByName            map[string]K8sEntity
+	getByReferenceCallCount int
 
 	ExecCalls  []ExecCall
 	ExecErrors []error
@@ -76,14 +77,6 @@ type ExecCall struct {
 	Ns    Namespace
 	Cmd   []string
 	Stdin []byte
-}
-
-type GetKey struct {
-	Group           string
-	Kind            string
-	Namespace       string
-	Name            string
-	ResourceVersion string
 }
 
 type fakeServiceWatch struct {
@@ -252,6 +245,7 @@ func (c *FakeK8sClient) InjectEntityByName(entities ...K8sEntity) {
 }
 
 func (c *FakeK8sClient) GetByReference(ctx context.Context, ref v1.ObjectReference) (K8sEntity, error) {
+	c.getByReferenceCallCount++
 	resp, ok := c.entityByName[ref.Name]
 	if !ok {
 		logger.Get(ctx).Infof("FakeK8sClient.GetByReference: resource not found: %s", ref.Name)

--- a/internal/k8s/owner_fetcher_test.go
+++ b/internal/k8s/owner_fetcher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,51 @@ func TestVisitOneParent(t *testing.T) {
 	kCli := &FakeK8sClient{}
 	ov := ProvideOwnerFetcher(kCli)
 
+	pod, rs := fakeOneParentChain()
+	kCli.InjectEntityByName(NewK8sEntity(rs))
+
+	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
+	assert.NoError(t, err)
+	assert.Equal(t, `Pod:pod-a
+  ReplicaSet:rs-a`, tree.String())
+}
+
+func TestVisitTwoParents(t *testing.T) {
+	kCli := &FakeK8sClient{}
+	ov := ProvideOwnerFetcher(kCli)
+
+	pod, rs, dep := fakeTwoParentChain()
+	kCli.InjectEntityByName(NewK8sEntity(rs), NewK8sEntity(dep))
+
+	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
+	assert.NoError(t, err)
+	assert.Equal(t, `Pod:pod-a
+  ReplicaSet:rs-a
+    Deployment:dep-a`, tree.String())
+}
+
+func TestOwnerFetcherParallelism(t *testing.T) {
+	kCli := &FakeK8sClient{}
+	ov := ProvideOwnerFetcher(kCli)
+
+	pod, rs := fakeOneParentChain()
+	kCli.InjectEntityByName(NewK8sEntity(rs))
+
+	count := 30
+	g, ctx := errgroup.WithContext(context.Background())
+	for i := 0; i < count; i++ {
+		g.Go(func() error {
+			_, err := ov.OwnerTreeOf(ctx, NewK8sEntity(pod))
+			return err
+		})
+	}
+
+	err := g.Wait()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, kCli.getByReferenceCallCount)
+}
+
+func fakeOneParentChain() (*v1.Pod, *appsv1.ReplicaSet) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pod-a",
@@ -34,18 +80,10 @@ func TestVisitOneParent(t *testing.T) {
 			UID:  "rs-a-uid",
 		},
 	}
-	kCli.InjectEntityByName(NewK8sEntity(rs))
-
-	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
-	assert.NoError(t, err)
-	assert.Equal(t, `Pod:pod-a
-  ReplicaSet:rs-a`, tree.String())
+	return pod, rs
 }
 
-func TestVisitTwoParents(t *testing.T) {
-	kCli := &FakeK8sClient{}
-	ov := ProvideOwnerFetcher(kCli)
-
+func fakeTwoParentChain() (*v1.Pod, *appsv1.ReplicaSet, *appsv1.Deployment) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pod-a",
@@ -80,11 +118,5 @@ func TestVisitTwoParents(t *testing.T) {
 			UID:  "dep-a-uid",
 		},
 	}
-	kCli.InjectEntityByName(NewK8sEntity(rs), NewK8sEntity(dep))
-
-	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
-	assert.NoError(t, err)
-	assert.Equal(t, `Pod:pod-a
-  ReplicaSet:rs-a
-    Deployment:dep-a`, tree.String())
+	return pod, rs, dep
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/owner:

9b9ce21d1139d2f87c52f3c18ac5ac09541deef1 (2019-09-05 18:02:55 -0400)
k8s: handle parallel fetch() calls better. This happens a lot with events