### PR TITLE
integration: filepath.Base() can return '.'

### DIFF
--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -268,7 +268,7 @@ func (f *k8sFixture) setupNewKubeConfig() {
 	// Create a file with the same basename as the current kubeconfig,
 	// because we sometimes use that for env detection.
 	kubeconfigBaseName := filepath.Base(os.Getenv("KUBECONFIG"))
-	if kubeconfigBaseName == "" {
+	if kubeconfigBaseName == "" || kubeconfigBaseName == "." {
 		kubeconfigBaseName = "config"
 	}
 	f.kubeconfigPath = f.tempDir.JoinPath(kubeconfigBaseName)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/kubeconfig:

79c52ea4208f9b31440d4ae78dcc34f26276c241 (2019-09-06 10:31:23 -0400)
integration: filepath.Base() can return '.'