### PR TITLE
k8s: Remove run IDs. Add tests to verify that running 'tilt up' twice attaches to the existing pod

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -130,8 +130,17 @@ func (f *fixture) tiltCmd(tiltArgs []string, outWriter io.Writer) *exec.Cmd {
 	return cmd
 }
 
+func (f *fixture) TiltUpCmd(name string) *exec.Cmd {
+	args := []string{"up"}
+	if name != "" {
+		args = append(args, name)
+	}
+	args = append(args, "--watch=false", "--debug", "--hud=false", "--port=0")
+	return f.tiltCmd(args, os.Stdout)
+}
+
 func (f *fixture) TiltUp(name string) {
-	cmd := f.tiltCmd([]string{"up", name, "--watch=false", "--debug", "--hud=false", "--port=0"}, os.Stdout)
+	cmd := f.TiltUpCmd(name)
 	f.runInBackground(cmd)
 }
 

--- a/integration/idempotent/Dockerfile
+++ b/integration/idempotent/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+ADD . .
+ENTRYPOINT busybox httpd -f -p 8000

--- a/integration/idempotent/Tiltfile
+++ b/integration/idempotent/Tiltfile
@@ -1,0 +1,8 @@
+# -*- mode: Python -*-
+
+include('../Tiltfile')
+
+k8s_yaml('deployment.yaml')
+docker_build('idempotent', '.')
+
+k8s_resource("idempotent", port_forwards=["31234:8000"])

--- a/integration/idempotent/deployment.yaml
+++ b/integration/idempotent/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: idempotent
+  namespace: tilt-integration
+  labels:
+    app: idempotent
+spec:
+  selector:
+    matchLabels:
+      app: idempotent
+  template:
+    metadata:
+      labels:
+        app: idempotent
+    spec:
+      containers:
+      - name: idempotent
+        image: idempotent
+        ports:
+        - containerPort: 8000

--- a/integration/idempotent/index.html
+++ b/integration/idempotent/index.html
@@ -1,0 +1,2 @@
+Idempotent One-Up!
+

--- a/integration/idempotent_test.go
+++ b/integration/idempotent_test.go
@@ -1,0 +1,42 @@
+//+build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Assert that if we 'tilt up' in the same repo twice,
+// it attaches to the existing pods without redeploying
+func TestIdempotent(t *testing.T) {
+	f := newK8sFixture(t, "idempotent")
+	defer f.TearDown()
+
+	cmd := f.TiltUpCmd("idempotent")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("First 'tilt up' failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	firstPods := f.WaitForAllPodsReady(ctx, "app=idempotent")
+
+	// Run it again, this time with a watch()
+	f.TiltWatch()
+
+	// Wait until the port-forwarder sets up
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:31234", "Idempotent One-Up!")
+
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	secondPods := f.WaitForAllPodsReady(ctx, "app=idempotent")
+
+	assert.Equal(t, firstPods, secondPods)
+}

--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -222,11 +222,9 @@ func (f *k8sFixture) AllContainersForPodReady(ctx context.Context, pod string) (
 }
 
 func (f *k8sFixture) ForwardPort(name string, portMap string) {
-	outWriter := os.Stdout
-
 	cmd := exec.CommandContext(f.ctx, "kubectl", "port-forward", namespaceFlag, name, portMap)
-	cmd.Stdout = outWriter
-	cmd.Stderr = outWriter
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
 	err := cmd.Start()
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -260,7 +260,6 @@ func (ibd *ImageBuildAndDeployer) createEntitiesToDeploy(ctx context.Context,
 	for _, e := range entities {
 		injectedSynclet := false
 		e, err = k8s.InjectLabels(e, []model.LabelPair{
-			k8s.TiltRunLabel(),
 			k8s.TiltManagedByLabel(),
 			{Key: k8s.ManifestNameLabel, Value: k8sTarget.Name.String()},
 		})

--- a/internal/k8s/labels.go
+++ b/internal/k8s/labels.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/windmilleng/tilt/pkg/model"
@@ -11,18 +10,7 @@ import (
 const ManagedByLabel = "app.kubernetes.io/managed-by"
 const ManagedByValue = "tilt"
 
-const TiltRunIDLabel = "tilt-runid"
-
-var TiltRunID = uuid.New().String()
-
 const ManifestNameLabel = "tilt-manifest"
-
-func TiltRunLabel() model.LabelPair {
-	return model.LabelPair{
-		Key:   TiltRunIDLabel,
-		Value: TiltRunID,
-	}
-}
 
 func TiltManagedByLabel() model.LabelPair {
 	return model.LabelPair{
@@ -38,7 +26,6 @@ func ManagedByTiltSelector() labels.Selector {
 func NewTiltLabelMap() map[string]string {
 	return map[string]string{
 		ManagedByLabel: ManagedByValue,
-		TiltRunIDLabel: TiltRunID,
 	}
 }
 


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch3278/runid:

045ef32abc6b8cd312c594084056885518779366 (2019-09-06 12:21:30 -0400)
k8s: Remove run IDs. Add tests to verify that running 'tilt up' twice attaches to the existing pod