### PR TITLE
tiltfile: build_args should deserialize blobs to strings

### DIFF
--- a/internal/tiltfile/blob.go
+++ b/internal/tiltfile/blob.go
@@ -1,0 +1,36 @@
+package tiltfile
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+type blob struct {
+	text   string
+	source string
+}
+
+var _ starlark.Value = &blob{}
+
+func newBlob(text string, source string) *blob {
+	return &blob{text: text, source: source}
+}
+
+func (b *blob) String() string {
+	return b.text
+}
+
+func (b *blob) Type() string {
+	return "blob"
+}
+
+func (b *blob) Freeze() {}
+
+func (b *blob) Truth() starlark.Bool {
+	return len(b.text) > 0
+}
+
+func (b *blob) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable type: blob")
+}

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -173,35 +173,6 @@ func (s *tiltfileState) skylarkReadFile(thread *starlark.Thread, fn *starlark.Bu
 	return newBlob(string(bs), fmt.Sprintf("file: %s", p)), nil
 }
 
-type blob struct {
-	text   string
-	source string
-}
-
-var _ starlark.Value = &blob{}
-
-func newBlob(text string, source string) *blob {
-	return &blob{text: text, source: source}
-}
-
-func (b *blob) String() string {
-	return b.text
-}
-
-func (b *blob) Type() string {
-	return "blob"
-}
-
-func (b *blob) Freeze() {}
-
-func (b *blob) Truth() starlark.Bool {
-	return len(b.text) > 0
-}
-
-func (b *blob) Hash() (uint32, error) {
-	return 0, fmt.Errorf("unhashable type: blob")
-}
-
 func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var command string
 	err := s.unpackArgs(fn.Name(), args, kwargs, "command", &command)

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -211,14 +211,14 @@ func skylarkStringDictToGoMap(d *starlark.Dict) (map[string]string, error) {
 	r := map[string]string{}
 
 	for _, tuple := range d.Items() {
-		kV, ok := tuple[0].(starlark.String)
+		kV, ok := AsString(tuple[0])
 		if !ok {
 			return nil, fmt.Errorf("key is not a string: %T (%v)", tuple[0], tuple[0])
 		}
 
 		k := string(kV)
 
-		vV, ok := tuple[1].(starlark.String)
+		vV, ok := AsString(tuple[1])
 		if !ok {
 			return nil, fmt.Errorf("value is not a string: %T (%v)", tuple[1], tuple[1])
 		}

--- a/internal/tiltfile/value.go
+++ b/internal/tiltfile/value.go
@@ -1,0 +1,12 @@
+package tiltfile
+
+import "go.starlark.net/starlark"
+
+// Wrapper around starlark.AsString
+func AsString(x starlark.Value) (string, bool) {
+	b, ok := x.(*blob)
+	if ok {
+		return b.text, true
+	}
+	return starlark.AsString(x)
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/issue2108:

2573c229ba7cb33a06631d31e4e356fbe56c1ce2 (2019-09-06 13:20:26 -0400)
tiltfile: build_args should deserialize blobs to strings