### PR TITLE
engine: record baseline restarts when we first see a pod

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -299,8 +299,9 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		}
 
 		for _, pod := range ms.K8sRuntimeState().Pods {
-			// # of pod restarts from old code (shouldn't be reflected in HUD)
-			pod.OldRestarts = pod.AllContainerRestarts()
+			// Reset the baseline, so that we don't show restarts
+			// from before any live-updates
+			pod.BaselineRestarts = pod.AllContainerRestarts()
 		}
 	}
 

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -154,7 +154,7 @@ func resourceInfoView(mt *store.ManifestTarget) ResourceInfoView {
 			PodStatus:          pod.Status,
 			PodStatusMessage:   strings.Join(pod.StatusMessages, "\n"),
 			AllContainersReady: pod.AllContainersReady(),
-			PodRestarts:        pod.AllContainerRestarts() - pod.OldRestarts,
+			PodRestarts:        pod.AllContainerRestarts() - pod.BaselineRestarts,
 			PodLog:             pod.Log(),
 			YAML:               mt.Manifest.K8sTarget().YAML,
 		}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -609,7 +609,7 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 			PodCreationTime:    pod.StartedAt,
 			PodUpdateStartTime: pod.UpdateStartTime,
 			PodStatus:          pod.Status,
-			PodRestarts:        pod.AllContainerRestarts() - pod.OldRestarts,
+			PodRestarts:        pod.AllContainerRestarts() - pod.BaselineRestarts,
 			PodLog:             pod.CurrentLog,
 			YAML:               mt.Manifest.K8sTarget().YAML,
 		}

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -102,9 +102,9 @@ type Pod struct {
 
 	Containers []Container
 
-	// We want to show the user # of restarts since pod has been running current code,
-	// i.e. OldRestarts - Total Restarts
-	OldRestarts int // # times the pod restarted when it was running old code
+	// We want to show the user # of restarts since some baseline time
+	// i.e. Total Restarts - BaselineRestarts
+	BaselineRestarts int
 }
 
 type Container struct {


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch3417/baseline:

4dc0b7b9d1e0d8f5cc3f0be1a2e8abaff08e6c2f (2019-09-10 11:51:35 -0400)
engine: record baseline restarts when we first see a pod