### PR TITLE
docker: rejigger the docker API a bit so that engine tests don't connect to the docker server for auth info

### DIFF
--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 
 	"github.com/windmilleng/tilt/internal/container"
@@ -178,10 +179,9 @@ func (c *FakeClient) CopyToContainerRoot(ctx context.Context, container string, 
 	return nil
 }
 
-func (c *FakeClient) ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error) {
+func (c *FakeClient) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {
 	c.PushCount++
-	c.PushImage = image
-	c.PushOptions = options
+	c.PushImage = ref.String()
 	return NewFakeDockerResponse(c.PushOutput), nil
 }
 

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 
 	"github.com/windmilleng/tilt/internal/container"
@@ -64,8 +65,8 @@ func (c *switchCli) CopyToContainerRoot(ctx context.Context, container string, c
 func (c *switchCli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error {
 	return c.client().ExecInContainer(ctx, cID, cmd, out)
 }
-func (c *switchCli) ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error) {
-	return c.client().ImagePush(ctx, image, options)
+func (c *switchCli) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {
+	return c.client().ImagePush(ctx, ref)
 }
 func (c *switchCli) ImageBuild(ctx context.Context, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
 	return c.client().ImageBuild(ctx, buildContext, options)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -184,8 +184,10 @@ func (ibd *ImageBuildAndDeployer) push(ctx context.Context, ref reference.NamedT
 			return nil, fmt.Errorf("Error pushing to KIND: %v", err)
 		}
 	} else {
-		ps.Printf(ctx, "Pushing to registry")
-		ref, err = ibd.ib.PushImage(ctx, ref, ps.Writer(ctx))
+		ps.Printf(ctx, "Pushing with Docker client")
+		writer := ps.Writer(ctx)
+		ctx = logger.WithLogger(ctx, logger.NewLogger(logger.InfoLvl, writer))
+		ref, err = ibd.ib.PushImage(ctx, ref, writer)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/docker:

92f830e71f31fbf06e4b302e1844d913cca180db (2019-09-11 14:47:55 -0400)
docker: rejigger the docker API a bit so that engine tests don't connect to the docker server for auth info