### PR TITLE
tiltfile: also enforce allowed k8s contexts on `local` calls

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -910,13 +910,13 @@ func (s *tiltfileState) allowK8SContexts(thread *starlark.Thread, fn *starlark.B
 	return starlark.None, nil
 }
 
-func (s *tiltfileState) validateK8SContext(context k8s.KubeContext, env k8s.Env) error {
-	if env.IsLocalCluster() {
+func (s *tiltfileState) validateK8SContext() error {
+	if s.kubeEnv == k8s.EnvNone || s.kubeEnv.IsLocalCluster() {
 		return nil
 	}
 
 	for _, c := range s.allowedK8SContexts {
-		if c == context {
+		if c == s.kubeContext {
 			return nil
 		}
 	}
@@ -926,6 +926,6 @@ func (s *tiltfileState) validateK8SContext(context k8s.KubeContext, env k8s.Env)
 If you're sure you want to deploy there, add:
 allow_k8s_contexts('%s')
 to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`,
-		context,
-		context)
+		s.kubeContext,
+		s.kubeContext)
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -145,7 +145,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 			return TiltfileLoadResult{}, err
 		}
 
-		err = s.validateK8SContext(s.kubeContext, s.kubeEnv)
+		err = s.validateK8SContext()
 		if err != nil {
 			return TiltfileLoadResult{}, err
 		}


### PR DESCRIPTION
This addresses #2194 

This approach has some downsides:
1. Using the output of `local` to decide how to call `allowed_k8s_contexts` will no longer work, but we have no evidence of users doing that.
2. If a user has a Tiltfile with `docker_compose` and `local`, ideally they'd be able to use it independent of their k8s state. However, if they have k8s installed and their config pointed at a non-local cluster, they'll now get an error. This is unfortunate, but is at least workaroundable, and gets the default common case back to something more safe.