### PR TITLE
k8s: rewire the portforwarder into a separate PortForwardClient

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -41,7 +41,7 @@ var K8sWireSet = wire.NewSet(
 	k8s.ProvideClientConfig,
 	k8s.ProvideClientset,
 	k8s.ProvideRESTConfig,
-	k8s.ProvidePortForwarder,
+	k8s.ProvidePortForwardClient,
 	k8s.ProvideConfigNamespace,
 	k8s.ProvideKubectlRunner,
 	k8s.ProvideContainerRuntime,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -62,7 +62,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	env := k8s.ProvideEnv(ctx, config)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
-	portForwarder := k8s.ProvidePortForwarder()
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
@@ -70,7 +70,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	}
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
-	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwarder, namespace, kubectlRunner, clientConfig)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	ownerFetcher := k8s.ProvideOwnerFetcher(client)
 	podWatcher := engine.NewPodWatcher(client, ownerFetcher)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
@@ -193,7 +193,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	env := k8s.ProvideEnv(ctx, config)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
-	portForwarder := k8s.ProvidePortForwarder()
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
@@ -201,7 +201,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	}
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
-	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwarder, namespace, kubectlRunner, clientConfig)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	ownerFetcher := k8s.ProvideOwnerFetcher(client)
 	podWatcher := engine.NewPodWatcher(client, ownerFetcher)
 	nodeIP, err := k8s.DetectNodeIP(ctx, env)
@@ -360,7 +360,7 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	env := k8s.ProvideEnv(ctx, config)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
-	portForwarder := k8s.ProvidePortForwarder()
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
@@ -368,7 +368,7 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	}
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
-	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwarder, namespace, kubectlRunner, clientConfig)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	return runtime, nil
 }
@@ -393,7 +393,7 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 	env := k8s.ProvideEnv(ctx, config)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
-	portForwarder := k8s.ProvidePortForwarder()
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
@@ -401,7 +401,7 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 	}
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
-	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwarder, namespace, kubectlRunner, clientConfig)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
 	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
@@ -432,7 +432,7 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	env := k8s.ProvideEnv(ctx, config)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
-	portForwarder := k8s.ProvidePortForwarder()
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
@@ -440,7 +440,7 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	}
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
-	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwarder, namespace, kubectlRunner, clientConfig)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
 	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
@@ -467,7 +467,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 	env := k8s.ProvideEnv(ctx, config)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
-	portForwarder := k8s.ProvidePortForwarder()
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(config)
 	if err != nil {
@@ -475,7 +475,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 	}
 	int2 := provideKubectlLogLevel()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
-	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwarder, namespace, kubectlRunner, clientConfig)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
 	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
@@ -495,7 +495,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwarder, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
+var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -124,7 +124,7 @@ func provideDockerComposeBuildAndDeployer(
 		k8s.ProvideK8sClient,
 		k8s.ProvideRESTConfig,
 		k8s.ProvideClientset,
-		k8s.ProvidePortForwarder,
+		k8s.ProvidePortForwardClient,
 		k8s.ProvideContainerRuntime,
 		k8s.ProvideKubeConfig,
 	)

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -89,7 +89,7 @@ func provideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 	clientConfig := k8s.ProvideClientConfig()
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
-	portForwarder := k8s.ProvidePortForwarder()
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	config, err := k8s.ProvideKubeConfig(clientConfig)
 	if err != nil {
@@ -101,7 +101,7 @@ func provideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 	}
 	int2 := provideKubectlLogLevelInfo()
 	kubectlRunner := k8s.ProvideKubectlRunner(kubeContext, int2)
-	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwarder, namespace, kubectlRunner, clientConfig)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	updateMode, err := ProvideUpdateMode(updateModeFlag, env, runtime)
 	if err != nil {

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -11,8 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	apiv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/windmilleng/tilt/internal/testutils"
@@ -218,12 +216,12 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 	runtimeAsync := newRuntimeAsync(core)
 	registryAsync := newRegistryAsync(EnvUnknown, core, runtimeAsync)
 	ret.client = K8sClient{
-		env:           EnvUnknown,
-		kubectlRunner: ret.runner,
-		core:          core,
-		portForwarder: fakePortForwarder,
-		runtimeAsync:  runtimeAsync,
-		registryAsync: registryAsync,
+		env:               EnvUnknown,
+		kubectlRunner:     ret.runner,
+		core:              core,
+		portForwardClient: &FakePortForwardClient{},
+		runtimeAsync:      runtimeAsync,
+		registryAsync:     registryAsync,
 	}
 	return ret
 }
@@ -263,9 +261,3 @@ func (c clientTestFixture) setStderr(stderr string) {
 func (c clientTestFixture) setError(err error) {
 	c.runner.err = err
 }
-
-func fakePortForwarder(ctx context.Context, restConfig *rest.Config, core apiv1.CoreV1Interface, namespace string, podID PodID, localPort int, remotePort int) (closer func(), err error) {
-	return nil, nil
-}
-
-var _ PortForwarder = fakePortForwarder


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/wire2:

f4fbb05835a71d90f56cb63d7ccb46b29514dd08 (2019-09-13 14:26:00 -0400)
k8s: rewire the portforwarder into a separate PortForwardClient

5b97a2ca4ae614fbbe0a70726e766e5e188f826d (2019-09-13 14:15:08 -0400)
wire: rejigger how k8s client apis are injected