### PR TITLE
web: move test deps to devDependencies

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -3,10 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@types/enzyme": "^3.9.1",
-    "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/history": "^4.7.2",
-    "@types/jest": "^24.0.11",
     "@types/js-cookie": "^2.2.2",
     "@types/lodash": "^4.14.138",
     "@types/node": "^11.12.0",
@@ -16,7 +13,6 @@
     "@types/react-modal": "^3.8.2",
     "@types/react-router-dom": "^4.3.5",
     "@types/react-select": "^2.0.15",
-    "@types/react-test-renderer": "^16.9.0",
     "@types/react-timeago": "^4.1.0",
     "ansi-to-react": "^5.0.0",
     "history": "^4.9.0",
@@ -30,7 +26,6 @@
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",
     "react-select": "^2.4.2",
-    "react-test-renderer": "^16.9.0",
     "react-timeago": "^4.4.0",
     "typescript": "^3.3.4000"
   },
@@ -52,6 +47,11 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "@types/react-test-renderer": "^16.9.0",
+    "@types/jest": "^24.0.11",
+    "@types/enzyme": "^3.9.1",
+    "@types/enzyme-adapter-react-16": "^1.0.5",
+    "react-test-renderer": "^16.9.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "enzyme-to-json": "^3.3.5",


### PR DESCRIPTION
I'm not sure if I can point to a tangible benefit of this.