### PR TITLE
k8s: correctly identify when we have no k8s configs

### DIFF
--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -64,6 +64,9 @@ func ProvideEnv(ctx context.Context, config *api.Config) Env {
 
 	c, ok := config.Contexts[n]
 	if !ok {
+		if n == "" {
+			return EnvNone
+		}
 		return EnvUnknown
 	}
 

--- a/internal/k8s/env_test.go
+++ b/internal/k8s/env_test.go
@@ -67,6 +67,7 @@ func TestProvideEnv(t *testing.T) {
 		},
 	}
 	table := []expectedConfig{
+		{EnvNone, &api.Config{}},
 		{EnvUnknown, &api.Config{CurrentContext: "aws"}},
 		{EnvMinikube, &api.Config{CurrentContext: "minikube", Contexts: minikubeContexts}},
 		{EnvDockerDesktop, &api.Config{CurrentContext: "docker-for-desktop", Contexts: dockerDesktopContexts}},


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/none:

c30bc7f2cd4c8e9a633b36f433ec0a17dba82e2d (2019-09-17 12:55:59 -0400)
k8s: correctly identify when we have no k8s configs