### PR TITLE
dockercompose: move config yaml parsing into the dockercompose package

### DIFF
--- a/internal/dockercompose/config.go
+++ b/internal/dockercompose/config.go
@@ -1,0 +1,142 @@
+package dockercompose
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// Go representations of docker-compose.yml
+// (Add fields as we need to support more things)
+type Config struct {
+	Services map[string]ServiceConfig
+}
+
+// We use a custom Unmarshal method here so that we can store the RawYAML in addition
+// to unmarshaling the fields we care about into structs.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	aux := struct {
+		Services map[string]interface{} `yaml:"services"`
+	}{}
+	err := unmarshal(&aux)
+	if err != nil {
+		return err
+	}
+
+	if c.Services == nil {
+		c.Services = make(map[string]ServiceConfig)
+	}
+
+	for k, v := range aux.Services {
+		b, err := yaml.Marshal(v) // so we can unmarshal it again
+		if err != nil {
+			return err
+		}
+
+		svcConf := &ServiceConfig{}
+		err = yaml.Unmarshal(b, svcConf)
+		if err != nil {
+			return err
+		}
+
+		svcConf.RawYAML = b
+		c.Services[k] = *svcConf
+	}
+	return nil
+}
+
+type ServiceConfig struct {
+	RawYAML []byte      // We store this to diff against when docker-compose.yml is edited to see if the manifest has changed
+	Build   BuildConfig `yaml:"build"`
+	Image   string      `yaml:"image"`
+	Volumes Volumes     `yaml:"volumes"`
+	Ports   Ports       `yaml:"ports"`
+}
+
+type BuildConfig struct {
+	Context    string `yaml:"context"`
+	Dockerfile string `yaml:"dockerfile"`
+}
+
+type Volumes []Volume
+
+type Volume struct {
+	Source string
+}
+
+func (v *Volumes) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var sliceType []interface{}
+	err := unmarshal(&sliceType)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling volumes")
+	}
+
+	for _, volume := range sliceType {
+		// Volumes syntax documented here: https://docs.docker.com/compose/compose-file/#volumes
+		// This implementation far from comprehensive. It will silently ignore:
+		// 1. "short" syntax using volume keys instead of paths
+		// 2. all "long" syntax volumes
+		// Ideally, we'd let the user know we didn't handle their case, but getting a ctx here is not easy
+		switch a := volume.(type) {
+		case string:
+			parts := strings.Split(a, ":")
+			*v = append(*v, Volume{Source: parts[0]})
+		}
+	}
+
+	return nil
+}
+
+type Ports []Port
+type Port struct {
+	Published int `yaml:"published"`
+}
+
+func (p *Ports) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var sliceType []interface{}
+	err := unmarshal(&sliceType)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling ports")
+	}
+
+	for _, portSpec := range sliceType {
+		// Port syntax documented here:
+		// https://docs.docker.com/compose/compose-file/#ports
+		// ports aren't critical, so on any error we want to continue quietly.
+		//
+		// Fortunately, `docker-compose config` does a lot of normalization for us,
+		// like resolving port ranges and ensuring the protocol (tcp vs udp)
+		// is always included.
+		switch portSpec := portSpec.(type) {
+		case string:
+			withoutProtocol := strings.Split(portSpec, "/")[0]
+			parts := strings.Split(withoutProtocol, ":")
+			publishedPart := parts[0]
+			if len(parts) == 3 {
+				// For "127.0.0.1:3000:3000"
+				publishedPart = parts[1]
+			}
+			port, err := strconv.Atoi(publishedPart)
+			if err != nil {
+				continue
+			}
+			*p = append(*p, Port{Published: port})
+		case map[interface{}]interface{}:
+			var portStruct Port
+			b, err := yaml.Marshal(portSpec) // so we can unmarshal it again
+			if err != nil {
+				continue
+			}
+
+			err = yaml.Unmarshal(b, &portStruct)
+			if err != nil {
+				continue
+			}
+			*p = append(*p, portStruct)
+		}
+	}
+
+	return nil
+}

--- a/internal/dockercompose/read.go
+++ b/internal/dockercompose/read.go
@@ -1,0 +1,63 @@
+package dockercompose
+
+import (
+	"context"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v2"
+)
+
+func ReadConfigAndServiceNames(ctx context.Context, dcc DockerComposeClient,
+	configPaths []string) (conf Config, svcNames []string, err error) {
+	// calls to `docker-compose config` take a bit, and we need two,
+	// so do them in parallel to make things faster
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+
+		configOut, err := dcc.Config(ctx, configPaths)
+
+		if err != nil {
+			return err
+		}
+
+		err = yaml.Unmarshal([]byte(configOut), &conf)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		svcNames, err = serviceNames(ctx, dcc, configPaths)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	err = g.Wait()
+	return conf, svcNames, err
+}
+
+func serviceNames(ctx context.Context, dcc DockerComposeClient, configPaths []string) ([]string, error) {
+	servicesText, err := dcc.Services(ctx, configPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceNames := strings.Split(servicesText, "\n")
+
+	var result []string
+
+	for _, name := range serviceNames {
+		if name == "" {
+			continue
+		}
+		result = append(result, name)
+	}
+
+	return result, nil
+}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3260,7 +3260,7 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 
 	f.WriteFile("Tiltfile", `docker_compose('docker-compose.yml')`)
 
-	var dcConfig tiltfile.DcConfig
+	var dcConfig dockercompose.Config
 	err = yaml.Unmarshal(dcpc, &dcConfig)
 	if err != nil {
 		f.T().Fatal(err)


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/dc:

11af908036cee0006e66db183d5fd0093f434837 (2019-09-18 13:01:50 -0400)
dockercompose: move config yaml parsing into the dockercompose package