### PR TITLE
tiltfile: dc_resource cleanup

### DIFF
--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -473,11 +473,14 @@ func (s *tiltfileState) assembleDC() error {
 	}
 
 	for _, svc := range s.dc.services {
-		if svc.ImageRef != nil {
-			builder := s.buildIndex.findBuilderForConsumedImage(svc.ImageRef)
+		if svc.ImageRef() != nil {
+			builder := s.buildIndex.findBuilderForConsumedImage(svc.ImageRef())
 			if builder != nil {
 				svc.DependencyIDs = append(svc.DependencyIDs, builder.ID())
 			}
+			// TODO(maia): throw warning if
+			//  a. there is an img ref from config, and img ref from user doesn't match
+			//  b. there is no img ref from config, and img ref from user is not of form .*_<svc_name>
 		}
 	}
 	return nil


### PR DESCRIPTION
Hello @nicks, @jazzdan,

in re #2208:
- make dc_resource.image optional (because we CAN auto-associate)
- add tests for auto-associate vs explicit associate
- comments for missing behavior -- i.e. ability to override dc's
    expected image with the one specified by the user
- groundwork for warning user when their specified image
    won't be recognized by DC (WE can say that the image is
    associated with that service, but `docker-compose up` still
    looks for the image specified in `Image`, OR for an image
    of name <directory>_<service>. If we don't support that yet,
    we should at least warn users