### PR TITLE
engine: use short container id for 'updated' message

### DIFF
--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -158,7 +158,7 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, cu 
 			// likely a infrastructure error. Bail, and fall back to full build.
 			return err
 		} else {
-			logger.Get(ctx).Infof("  → Container %s updated!", cInfo.ContainerID)
+			logger.Get(ctx).Infof("  → Container %s updated!", cInfo.ContainerID.ShortStr())
 			if lastUserBuildFailure != nil {
 				// This build succeeded, but previously at least one failed due to user error.
 				// We may have inconsistent state--bail, and fall back to full build.


### PR DESCRIPTION
```
──┤ Rebuilding: snapshot-frontend ├────────────────────────────────────────────
  → Updating container(s): 37b25b7498
Will delete 1 file(s) from container(s): 37b25b7498
- '/app/snapshot_frontend/create_dev_secrets.sh' (matched local path: '/Users/matt/go/src/github.com/windmilleng/tft/snapshot_frontend/create_dev_secrets.sh')
RUNNING: go install /app/snapshot_frontend
  → Container 37b25b74984a7f81aec99904043a63d19febae0afbd86c43375c715644cfb2e1 updated!
```

now the last line will use the short ID, like the first two times the container ID is referenced