### PR TITLE
logs: slow down truncation frequency

### DIFF
--- a/pkg/model/log_test.go
+++ b/pkg/model/log_test.go
@@ -41,7 +41,7 @@ func TestLog_AppendOverLimit(t *testing.T) {
 
 	l = AppendLog(l, logEvent{time.Time{}, s}, false, "")
 
-	assert.Equal(t, s, l.String())
+	assert.Equal(t, s[:logTruncationTarget], l.String())
 }
 
 func TestLog_Timestamps(t *testing.T) {


### PR DESCRIPTION
Mitigates at least one case of #1935 

### Problem

When a log exceeds the max buffer size, we remove old lines until we're under the limit. This often happens when a service is rapidly logging a lot of messages.
This has the effect that every time the server logs a new message, we shift the full log buffer. The log view in the web UI scrolls very quickly and it is difficult to read and pretty much impossible to copy/paste.

### Solution

When a log exceeds the max buffer size, instead of truncating to be just under the limit, we truncate to be at half of the limit. This means instead of constantly (with every log message) scrolling the whole buffer a little, we more rarely (with every 60k written) scroll the buffer a whole lot. even if users are logging an extreme 1k/second, this will still give them a minute between scrolls, which might still be suboptimal but should at least make interaction with the log possible.