### PR TITLE
engine: respect the native docker-compose order. Fixes part of issue #2210

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -655,3 +655,32 @@ func TestBuildControllerUnresourcedYAMLFirst(t *testing.T) {
 	}
 	assert.Equal(t, expectedBuildOrder, observedBuildOrder)
 }
+
+func TestBuildControllerRespectDockerComposeOrder(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	sancho := NewSanchoFastBuildDCManifest(f)
+	redis := manifestbuilder.New(f, "redis").WithDockerCompose().Build()
+	donQuixote := manifestbuilder.New(f, "don-quixote").WithDockerCompose().Build()
+	manifests := []model.Manifest{redis, sancho, donQuixote}
+	f.Start(manifests, true)
+
+	var observedBuildOrder []string
+	for i := 0; i < len(manifests); i++ {
+		call := f.nextCall()
+		observedBuildOrder = append(observedBuildOrder, call.dc().Name.String())
+	}
+
+	// If these were Kubernetes resources, we would try to deploy don-quixote
+	// before sancho, because it doesn't have an image build.
+	//
+	// But this would be wrong, because Docker Compose has stricter ordering requirements, see:
+	// https://docs.docker.com/compose/startup-order/
+	expectedBuildOrder := []string{
+		"redis",
+		"sancho",
+		"don-quixote",
+	}
+	assert.Equal(t, expectedBuildOrder, observedBuildOrder)
+}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/issue2210/order:

92f95f64a721e13cd855de220b4c7b85fb565020 (2019-09-19 17:07:12 -0400)
engine: respect the native docker-compose order. Fixes part of issue #2210