### PR TITLE
webview: remove yaml

### DIFF
--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -47,7 +47,6 @@ type K8sResourceInfo struct {
 	PodStatus          string
 	PodRestarts        int
 	PodLog             model.Log
-	YAML               string
 }
 
 var _ ResourceInfoView = K8sResourceInfo{}

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -156,7 +156,6 @@ func resourceInfoView(mt *store.ManifestTarget) ResourceInfoView {
 			AllContainersReady: pod.AllContainersReady(),
 			PodRestarts:        pod.VisibleContainerRestarts(),
 			PodLog:             pod.Log(),
-			YAML:               mt.Manifest.K8sTarget().YAML,
 		}
 	}
 }

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -48,7 +48,6 @@ type K8sResourceInfo struct {
 	AllContainersReady bool
 	PodRestarts        int
 	PodLog             model.Log
-	YAML               string
 }
 
 var _ ResourceInfoView = K8sResourceInfo{}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -611,7 +611,6 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 			PodStatus:          pod.Status,
 			PodRestarts:        pod.VisibleContainerRestarts(),
 			PodLog:             pod.CurrentLog,
-			YAML:               mt.Manifest.K8sTarget().YAML,
 		}
 	}
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -74,7 +74,6 @@ export type K8sResourceInfo = {
   PodStatusMessage: string
   PodRestarts: number
   PodLog: string
-  YAML: string
   Endpoints: Array<string>
 }
 export type DCResourceInfo = {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/logs:

36f6f4ba84f6decefa28068c2fc67a6c26777c64 (2019-09-20 15:26:43 -0400)
webview: remove yaml
If we bring this back, we would want to scrub it for secrets or use a `kubectl
describe`-like formatter that does scrubbing. But right now it's dead code.