### PR TITLE
engine: watch LocalResource.deps; changes recorded on manifest, trigger build [ch3473]

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -120,6 +120,16 @@ func (c buildAndDeployCall) dc() model.DockerComposeTarget {
 	return model.DockerComposeTarget{}
 }
 
+func (c buildAndDeployCall) local() model.LocalTarget {
+	for _, spec := range c.specs {
+		t, ok := spec.(model.LocalTarget)
+		if ok {
+			return t
+		}
+	}
+	return model.LocalTarget{}
+}
+
 func (c buildAndDeployCall) oneState() store.BuildState {
 	if len(c.state) != 1 {
 		panic(fmt.Sprintf("More than one state: %v", c.state))
@@ -176,7 +186,7 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 	b.buildCount++
 
 	call := buildAndDeployCall{count: b.buildCount, specs: specs, state: state}
-	if call.dc().Empty() && call.k8s().Empty() {
+	if call.dc().Empty() && call.k8s().Empty() && call.local().Empty() {
 		b.t.Fatalf("Invalid call: %+v", call)
 	}
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -86,8 +86,8 @@ type EngineState struct {
 
 func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.ManifestName {
 	result := make([]model.ManifestName, 0)
-	for mn, state := range e.ManifestTargets {
-		manifest := state.Manifest
+	for mn, mt := range e.ManifestTargets {
+		manifest := mt.Manifest
 		for _, iTarget := range manifest.ImageTargets {
 			if iTarget.ID() == id {
 				result = append(result, mn)
@@ -97,6 +97,9 @@ func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.Manife
 			result = append(result, mn)
 		}
 		if manifest.DockerComposeTarget().ID() == id {
+			result = append(result, mn)
+		}
+		if manifest.LocalTarget().ID() == id {
 			result = append(result, mn)
 		}
 	}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1195,7 +1195,8 @@ func (s *tiltfileState) translateLocal() ([]model.Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
-		lt := model.NewLocalTarget(r.cmd, r.deps)
+
+		lt := model.NewLocalTarget(r.cmd, r.deps).WithRepos(reposForPaths(r.deps))
 		m := model.Manifest{
 			Name:        mn,
 			TriggerMode: tm,

--- a/pkg/model/local_target.go
+++ b/pkg/model/local_target.go
@@ -19,6 +19,8 @@ func NewLocalTarget(cmd Cmd, deps []string) LocalTarget {
 	return LocalTarget{Cmd: cmd, deps: deps}
 }
 
+func (lt LocalTarget) Empty() bool { return lt.Cmd.Empty() }
+
 func (lt LocalTarget) WithRepos(repos []LocalGitRepo) LocalTarget {
 	lt.repos = append(append([]LocalGitRepo{}, lt.repos...), repos...)
 	return lt


### PR DESCRIPTION
Hello @jazzdan, @dbentley,

Please review the following commits I made in branch maiamcc/watch-deps:

377135ce50f2c6ea71c9e617dd1e5e2fe78eac2c (2019-09-20 16:21:19 -0400)
test

87afe195124738cfd19d3189798e4c51ac8cde19 (2019-09-20 16:00:32 -0400)
i think this works

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics