### PR TITLE
engine: build LocalResources before cluster resources (k8s / DC) [ch3474]

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -101,6 +101,13 @@ func nextUnbuiltTargetToBuild(unbuilt []*store.ManifestTarget) *store.ManifestTa
 		return unresourced
 	}
 
+	// Local resources come before all cluster resources (b/c LR's may
+	// change things on disk that cluster resources then pull in).
+	localTargets := findLocalTargets(unbuilt)
+	if len(localTargets) > 0 {
+		return localTargets[0]
+	}
+
 	// If this is Kubernetes, unbuilt resources go first.
 	// (If this is Docker Compose, we want to trust the ordering
 	// that docker-compose put things in.)
@@ -135,6 +142,16 @@ func findDeployOnlyK8sManifestTargets(targets []*store.ManifestTarget) []*store.
 	result := []*store.ManifestTarget{}
 	for _, target := range targets {
 		if target.Manifest.IsK8s() && len(target.Manifest.ImageTargets) == 0 {
+			result = append(result, target)
+		}
+	}
+	return result
+}
+
+func findLocalTargets(targets []*store.ManifestTarget) []*store.ManifestTarget {
+	result := []*store.ManifestTarget{}
+	for _, target := range targets {
+		if target.Manifest.IsLocal() {
 			result = append(result, target)
 		}
 	}

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -184,7 +184,7 @@ func TestLocalResource(t *testing.T) {
 	cmd := model.Cmd{
 		Argv: []string{"make", "test"},
 	}
-	lt := model.NewLocalTarget(cmd, []string{"/foo/bar", "/baz/qux"})
+	lt := model.NewLocalTarget("my-local", cmd, []string{"/foo/bar", "/baz/qux"})
 	m := model.Manifest{
 		Name: "test",
 	}.WithDeployTarget(lt)

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -111,7 +111,7 @@ func (b ManifestBuilder) Build() model.Manifest {
 	}
 
 	if b.localCmd != "" {
-		lt := model.NewLocalTarget(model.ToShellCmd(b.localCmd), b.localDeps)
+		lt := model.NewLocalTarget(model.TargetName(b.name), model.ToShellCmd(b.localCmd), b.localDeps)
 		return model.Manifest{Name: b.name}.WithDeployTarget(lt)
 	}
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1196,7 +1196,7 @@ func (s *tiltfileState) translateLocal() ([]model.Manifest, error) {
 			return nil, err
 		}
 
-		lt := model.NewLocalTarget(r.cmd, r.deps).WithRepos(reposForPaths(r.deps))
+		lt := model.NewLocalTarget(model.TargetName(r.name), r.cmd, r.deps).WithRepos(reposForPaths(r.deps))
 		m := model.Manifest{
 			Name:        mn,
 			TriggerMode: tm,

--- a/pkg/model/local_target.go
+++ b/pkg/model/local_target.go
@@ -7,6 +7,7 @@ import (
 )
 
 type LocalTarget struct {
+	Name TargetName
 	Cmd  Cmd
 	deps []string // a list of ABSOLUTE file paths that are dependencies of this target
 
@@ -15,8 +16,12 @@ type LocalTarget struct {
 
 var _ TargetSpec = LocalTarget{}
 
-func NewLocalTarget(cmd Cmd, deps []string) LocalTarget {
-	return LocalTarget{Cmd: cmd, deps: deps}
+func NewLocalTarget(name TargetName, cmd Cmd, deps []string) LocalTarget {
+	return LocalTarget{
+		Name: name,
+		Cmd:  cmd,
+		deps: deps,
+	}
 }
 
 func (lt LocalTarget) Empty() bool { return lt.Cmd.Empty() }
@@ -28,7 +33,7 @@ func (lt LocalTarget) WithRepos(repos []LocalGitRepo) LocalTarget {
 
 func (lt LocalTarget) ID() TargetID {
 	return TargetID{
-		Name: TargetName(lt.Cmd.String()),
+		Name: lt.Name,
 		Type: TargetTypeLocal,
 	}
 }


### PR DESCRIPTION
Hello @jazzdan, @dbentley,

Please review the following commits I made in branch maiamcc/local-resources-first:

4e6c71daa88b4be6b2b1b3e6077c7077a2c717fb (2019-09-20 17:17:14 -0400)
engine: build LocalResources before cluster resources (k8s / DC) [ch3474]

514116f1af406cd7602af28a626b7864304562f5 (2019-09-20 17:15:13 -0400)
model: LocalTarget.Name

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics