### PR TITLE
engine: Move all the kubernetes watchers into their own package

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -22,6 +22,7 @@ import (
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/engine/configs"
+	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/feature"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/server"
@@ -67,9 +68,9 @@ var BaseWireSet = wire.NewSet(
 	engine.NewPodLogManager,
 	engine.NewPortForwardController,
 	engine.NewBuildController,
-	engine.NewPodWatcher,
-	engine.NewServiceWatcher,
-	engine.NewEventWatchManager,
+	k8swatch.NewPodWatcher,
+	k8swatch.NewServiceWatcher,
+	k8swatch.NewEventWatchManager,
 	engine.NewImageController,
 	configs.NewConfigsController,
 	engine.NewDockerComposeEventWatcher,

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -1,11 +1,9 @@
 package engine
 
 import (
-	"net/url"
 	"time"
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -18,41 +16,6 @@ import (
 
 func NewErrorAction(err error) store.ErrorAction {
 	return store.NewErrorAction(err)
-}
-
-type PodChangeAction struct {
-	Pod          *v1.Pod
-	ManifestName model.ManifestName
-
-	// The UID that we matched against to associate this pod with Tilt.
-	// Might be the Pod UID itself, or the UID of an ancestor.
-	AncestorUID types.UID
-}
-
-func (PodChangeAction) Action() {}
-
-func NewPodChangeAction(pod *v1.Pod, mn model.ManifestName, ancestorUID types.UID) PodChangeAction {
-	return PodChangeAction{
-		Pod:          pod,
-		ManifestName: mn,
-		AncestorUID:  ancestorUID,
-	}
-}
-
-type ServiceChangeAction struct {
-	Service      *v1.Service
-	ManifestName model.ManifestName
-	URL          *url.URL
-}
-
-func (ServiceChangeAction) Action() {}
-
-func NewServiceChangeAction(service *v1.Service, mn model.ManifestName, url *url.URL) ServiceChangeAction {
-	return ServiceChangeAction{
-		Service:      service,
-		ManifestName: mn,
-		URL:          url,
-	}
 }
 
 type BuildLogAction struct {

--- a/internal/engine/k8swatch/actions.go
+++ b/internal/engine/k8swatch/actions.go
@@ -1,0 +1,45 @@
+package k8swatch
+
+import (
+	"net/url"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+type PodChangeAction struct {
+	Pod          *v1.Pod
+	ManifestName model.ManifestName
+
+	// The UID that we matched against to associate this pod with Tilt.
+	// Might be the Pod UID itself, or the UID of an ancestor.
+	AncestorUID types.UID
+}
+
+func (PodChangeAction) Action() {}
+
+func NewPodChangeAction(pod *v1.Pod, mn model.ManifestName, ancestorUID types.UID) PodChangeAction {
+	return PodChangeAction{
+		Pod:          pod,
+		ManifestName: mn,
+		AncestorUID:  ancestorUID,
+	}
+}
+
+type ServiceChangeAction struct {
+	Service      *v1.Service
+	ManifestName model.ManifestName
+	URL          *url.URL
+}
+
+func (ServiceChangeAction) Action() {}
+
+func NewServiceChangeAction(service *v1.Service, mn model.ManifestName, url *url.URL) ServiceChangeAction {
+	return ServiceChangeAction{
+		Service:      service,
+		ManifestName: mn,
+		URL:          url,
+	}
+}

--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -1,4 +1,4 @@
-package engine
+package k8swatch
 
 import (
 	"context"
@@ -90,7 +90,7 @@ func (m *EventWatchManager) setupWatch(ctx context.Context, st store.RStore, til
 	ch, err := m.kClient.WatchEvents(ctx)
 	if err != nil {
 		err = errors.Wrap(err, "Error watching k8s events\n")
-		st.Dispatch(NewErrorAction(err))
+		st.Dispatch(store.NewErrorAction(err))
 		return
 	}
 	go m.dispatchEventsLoop(ctx, ch, st, tiltStartTime)

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -1,4 +1,4 @@
-package engine
+package k8swatch
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/testutils"
 	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
 	"github.com/windmilleng/tilt/internal/testutils/podbuilder"
@@ -190,7 +191,7 @@ func (f *ewmFixture) addManifest(manifestName model.ManifestName) model.Manifest
 	state.WatchFiles = true
 
 	m := manifestbuilder.New(f, manifestName).
-		WithK8sYAML(SanchoYAML).
+		WithK8sYAML(testyaml.SanchoYAML).
 		Build()
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 	f.store.UnlockMutableState()

--- a/internal/engine/k8swatch/pod_watch.go
+++ b/internal/engine/k8swatch/pod_watch.go
@@ -1,4 +1,4 @@
-package engine
+package k8swatch
 
 import (
 	"context"
@@ -118,7 +118,7 @@ func (w *PodWatcher) OnChange(ctx context.Context, st store.RStore) {
 		ch, err := w.kCli.WatchPods(ctx, pw.labels)
 		if err != nil {
 			err = errors.Wrap(err, "Error watching pods. Are you connected to kubernetes?\n")
-			st.Dispatch(NewErrorAction(err))
+			st.Dispatch(store.NewErrorAction(err))
 			return
 		}
 		go w.dispatchPodChangesLoop(ctx, ch, st)
@@ -297,7 +297,7 @@ func (w *PodWatcher) dispatchPodChangesLoop(ctx context.Context, ch <-chan *v1.P
 
 // copied from https://github.com/kubernetes/kubernetes/blob/aedeccda9562b9effe026bb02c8d3c539fc7bb77/pkg/kubectl/resource_printer.go#L692-L764
 // to match the status column of `kubectl get pods`
-func podStatusToString(pod v1.Pod) string {
+func PodStatusToString(pod v1.Pod) string {
 	reason := string(pod.Status.Phase)
 	if pod.Status.Reason != "" {
 		reason = pod.Status.Reason
@@ -353,7 +353,7 @@ func podStatusToString(pod v1.Pod) string {
 }
 
 // Pull out interesting error messages from the pod status
-func podStatusErrorMessages(pod v1.Pod) []string {
+func PodStatusErrorMessages(pod v1.Pod) []string {
 	result := []string{}
 	if isPodStillInitializing(pod) {
 		for _, container := range pod.Status.InitContainerStatuses {

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -1,4 +1,4 @@
-package engine
+package k8swatch
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/testutils"
 	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
 	"github.com/windmilleng/tilt/internal/testutils/podbuilder"
@@ -187,10 +188,10 @@ func TestPodStatus(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
 			pod := corev1.Pod{Status: c.pod}
-			status := podStatusToString(pod)
+			status := PodStatusToString(pod)
 			assert.Equal(t, c.status, status)
 
-			messages := podStatusErrorMessages(pod)
+			messages := PodStatusErrorMessages(pod)
 			assert.Equal(t, c.messages, messages)
 		})
 	}
@@ -200,7 +201,7 @@ func (f *pwFixture) addManifestWithSelectors(manifestName string, ls ...labels.S
 	state := f.store.LockMutableStateForTesting()
 	state.WatchFiles = true
 	m := manifestbuilder.New(f, model.ManifestName(manifestName)).
-		WithK8sYAML(SanchoYAML).
+		WithK8sYAML(testyaml.SanchoYAML).
 		WithK8sPodSelectors(ls).
 		Build()
 	mt := store.NewManifestTarget(m)

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -1,4 +1,4 @@
-package engine
+package k8swatch
 
 import (
 	"context"
@@ -66,7 +66,7 @@ func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore) {
 	ch, err := w.kCli.WatchServices(ctx, k8s.ManagedByTiltSelector())
 	if err != nil {
 		err = errors.Wrap(err, "Error watching services. Are you connected to kubernetes?\n")
-		st.Dispatch(NewErrorAction(err))
+		st.Dispatch(store.NewErrorAction(err))
 		return
 	}
 
@@ -89,7 +89,7 @@ func (w *ServiceWatcher) setupNewUIDs(ctx context.Context, st store.RStore, newU
 			continue
 		}
 
-		err := dispatchServiceChange(st, service, mn, w.nodeIP)
+		err := DispatchServiceChange(st, service, mn, w.nodeIP)
 		if err != nil {
 			logger.Get(ctx).Infof("error resolving service url %s: %v", service.Name, err)
 		}
@@ -153,7 +153,7 @@ func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-ch
 				continue
 			}
 
-			err := dispatchServiceChange(st, service, manifestName, w.nodeIP)
+			err := DispatchServiceChange(st, service, manifestName, w.nodeIP)
 			if err != nil {
 				logger.Get(ctx).Infof("error resolving service url %s: %v", service.Name, err)
 			}
@@ -163,7 +163,7 @@ func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-ch
 	}
 }
 
-func dispatchServiceChange(st store.RStore, service *v1.Service, mn model.ManifestName, ip k8s.NodeIP) error {
+func DispatchServiceChange(st store.RStore, service *v1.Service, mn model.ManifestName, ip k8s.NodeIP) error {
 	url, err := k8s.ServiceURL(service, ip)
 	if err != nil {
 		return err

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -1,4 +1,4 @@
-package engine
+package k8swatch
 
 import (
 	"context"

--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -1,4 +1,4 @@
-package engine
+package k8swatch
 
 import (
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -8,6 +8,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/windmilleng/tilt/internal/container"
+	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/synclet/sidecar"
@@ -15,7 +16,7 @@ import (
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
-func handlePodChangeAction(ctx context.Context, state *store.EngineState, action PodChangeAction) {
+func handlePodChangeAction(ctx context.Context, state *store.EngineState, action k8swatch.PodChangeAction) {
 	mt := matchPodChangeToManifest(state, action)
 	if mt == nil {
 		return
@@ -34,8 +35,8 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 	// Update the status
 	podInfo.Deleting = pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero()
 	podInfo.Phase = pod.Status.Phase
-	podInfo.Status = podStatusToString(*pod)
-	podInfo.StatusMessages = podStatusErrorMessages(*pod)
+	podInfo.Status = k8swatch.PodStatusToString(*pod)
+	podInfo.StatusMessages = k8swatch.PodStatusErrorMessages(*pod)
 
 	prunePods(ms)
 
@@ -72,7 +73,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 
 // Find the ManifestTarget for the PodChangeAction,
 // and confirm that it matches what we've deployed.
-func matchPodChangeToManifest(state *store.EngineState, action PodChangeAction) *store.ManifestTarget {
+func matchPodChangeToManifest(state *store.EngineState, action k8swatch.PodChangeAction) *store.ManifestTarget {
 	manifestName := action.ManifestName
 	ancestorUID := action.AncestorUID
 	mt, ok := state.ManifestTargets[manifestName]
@@ -97,11 +98,11 @@ func matchPodChangeToManifest(state *store.EngineState, action PodChangeAction) 
 // If not, create a new tracking object.
 // Returns a store.Pod that the caller can mutate, and true
 // if this is the first time we've seen this pod.
-func trackPod(ms *store.ManifestState, action PodChangeAction) (*store.Pod, bool) {
+func trackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*store.Pod, bool) {
 	pod := action.Pod
 	podID := k8s.PodIDFromPod(pod)
 	startedAt := pod.CreationTimestamp.Time
-	status := podStatusToString(*pod)
+	status := k8swatch.PodStatusToString(*pod)
 	ns := k8s.NamespaceFromPod(pod)
 	hasSynclet := sidecar.PodSpecContainsSynclet(pod.Spec)
 	runtime := ms.GetOrCreateK8sRuntimeState()

--- a/internal/engine/subscribers.go
+++ b/internal/engine/subscribers.go
@@ -4,6 +4,7 @@ import (
 	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/internal/containerupdate"
 	"github.com/windmilleng/tilt/internal/engine/configs"
+	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/store"
@@ -11,8 +12,8 @@ import (
 
 func ProvideSubscribers(
 	hud hud.HeadsUpDisplay,
-	pw *PodWatcher,
-	sw *ServiceWatcher,
+	pw *k8swatch.PodWatcher,
+	sw *k8swatch.ServiceWatcher,
 	plm *PodLogManager,
 	pfc *PortForwardController,
 	fwm *WatchManager,
@@ -27,7 +28,7 @@ func ProvideSubscribers(
 	hudsc *server.HeadsUpServerController,
 	tvc *TiltVersionChecker,
 	ta *TiltAnalyticsSubscriber,
-	ewm *EventWatchManager,
+	ewm *k8swatch.EventWatchManager,
 	tcum *cloud.CloudUsernameManager) []store.Subscriber {
 	return []store.Subscriber{
 		hud,

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/engine/configs"
+	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/k8s"
@@ -147,11 +148,11 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleExitAction(state, action)
 	case targetFilesChangedAction:
 		handleFSEvent(ctx, state, action)
-	case PodChangeAction:
+	case k8swatch.PodChangeAction:
 		handlePodChangeAction(ctx, state, action)
 	case store.PodResetRestartsAction:
 		handlePodResetRestartsAction(state, action)
-	case ServiceChangeAction:
+	case k8swatch.ServiceChangeAction:
 		handleServiceEvent(ctx, state, action)
 	case store.K8sEventAction:
 		handleK8sEvent(ctx, state, action)
@@ -583,7 +584,7 @@ func sourcePrefix(n model.ManifestName) string {
 	return fmt.Sprintf("%s%s┊ ", n, spaces)
 }
 
-func handleServiceEvent(ctx context.Context, state *store.EngineState, action ServiceChangeAction) {
+func handleServiceEvent(ctx context.Context, state *store.EngineState, action k8swatch.ServiceChangeAction) {
 	service := action.Service
 	ms, ok := state.ManifestState(action.ManifestName)
 	if !ok {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/watchpackages:

dd509e8300a301907242d1bd997301b54d4b819e (2019-09-20 18:21:35 -0400)
engine: Move all the kubernetes watchers into their own package