### PR TITLE
tilt cloud: don't log http.Response.String()

### DIFF
--- a/internal/cloud/cloud_username_manager.go
+++ b/internal/cloud/cloud_username_manager.go
@@ -91,7 +91,13 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		logger.Get(ctx).Infof("error checking tilt cloud status: %v", resp)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			logger.Get(ctx).Infof("tilt cloud status request failed with status %d. error reading response body: %v", resp.statusCode, err)
+			c.error()
+			return
+		}
+		logger.Get(ctx).Infof("error checking tilt cloud status: code: %d, message: %s", resp.StatusCode, string(body))
 		c.error()
 		return
 	}

--- a/internal/cloud/cloud_username_manager.go
+++ b/internal/cloud/cloud_username_manager.go
@@ -93,7 +93,7 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 	if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			logger.Get(ctx).Infof("tilt cloud status request failed with status %d. error reading response body: %v", resp.statusCode, err)
+			logger.Get(ctx).Infof("tilt cloud status request failed with status %d. error reading response body: %v", resp.StatusCode, err)
 			c.error()
 			return
 		}


### PR DESCRIPTION
no one wants to see this:
```
error checking tilt cloud status: &{500 Internal Server Error 500 HTTP/1.1 1 1 map[Content-Length:[22] Content-Type:[text/plain; charset=utf-8] Date:[Sun, 22 Sep 2019 20:00:32 GMT] X-Content-Type-Options:[nosniff] X-Rate-Limit-Duration:[1] X-Rate-Limit-Limit:[10.00] X-Rate-Limit-Request-Forwarded-For:[] X-Rate-Limit-Request-Remote-Addr:[127.0.0.1:44982]] 0xc000dda700 22 [] false false map[] 0xc0014fff00 <nil>
```