### PR TITLE
Revert "tilt cloud: don't log http.Response.String() (#2240)"

### DIFF
--- a/internal/cloud/cloud_username_manager.go
+++ b/internal/cloud/cloud_username_manager.go
@@ -91,13 +91,7 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			logger.Get(ctx).Infof("tilt cloud status request failed with status %d. error reading response body: %v", resp.StatusCode, err)
-			c.error()
-			return
-		}
-		logger.Get(ctx).Infof("error checking tilt cloud status: code: %d, message: %s", resp.StatusCode, string(body))
+		logger.Get(ctx).Infof("error checking tilt cloud status: %v", resp)
 		c.error()
 		return
 	}


### PR DESCRIPTION
This reverts commit 4846be75a75e00f62fb342e4b623ea770324d63f.