### PR TITLE
tiltfile: record tiltfile load time

### DIFF
--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -112,11 +112,17 @@ func TestOptedIn(t *testing.T) {
 		observedEventNames = append(observedEventNames, c.Name)
 	}
 
+	var observedTimerNames []string
+	for _, c := range f.mss.ma.Timers {
+		observedTimerNames = append(observedTimerNames, c.Name)
+	}
+
 	// just check that a couple metrics were successfully reported rather than asserting an exhaustive list
 	// the goal is to ensure that analytics is working in general, not to test which specific metrics are reported
 	// and we don't want to have to update this every time we change which metrics we report
 	assert.Contains(t, observedEventNames, "tilt.cmd.up")
 	assert.Contains(t, observedEventNames, "tilt.tiltfile.loaded")
+	assert.Contains(t, observedTimerNames, "tilt.tiltfile.load")
 }
 
 func TestOptedOut(t *testing.T) {


### PR DESCRIPTION
would have been better to have this metric in place so we could better
compare the effect that LocalResource had on it whoops, but I think
it's still good to keep an eye on, and may give us useful info --
we can at least see if the second round of LocalResource reduces tiltfile
load times at all.