### PR TITLE
engine: redact secrets from the log

### DIFF
--- a/internal/engine/configs/actions.go
+++ b/internal/engine/configs/actions.go
@@ -25,6 +25,10 @@ type ConfigsReloadedAction struct {
 	Features   map[string]bool
 	TeamName   string
 	Secrets    model.SecretSet
+
+	// The length of the global log when Tiltfile execution started.
+	// Useful for knowing how far back in time we have to scrub secrets.
+	GlobalLogLineCountAtExecStart int
 }
 
 func (ConfigsReloadedAction) Action() {}

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -87,6 +87,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 	ctx = logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), actionWriter))
 
 	state := st.RLockState()
+	globalLogLineCountAtExecStart := state.Log.LineCount()
 	firstBuild := !state.TiltfileState.StartedFirstBuild()
 	if !firstBuild {
 		logTiltfileChanges(ctx, filesChanged)
@@ -110,15 +111,16 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 	}
 
 	st.Dispatch(ConfigsReloadedAction{
-		Manifests:          tlr.Manifests,
-		ConfigFiles:        tlr.ConfigFiles,
-		TiltIgnoreContents: tlr.TiltIgnoreContents,
-		FinishTime:         cc.clock(),
-		Err:                tlr.Error,
-		Warnings:           tlr.Warnings,
-		Features:           tlr.FeatureFlags,
-		TeamName:           tlr.TeamName,
-		Secrets:            tlr.Secrets,
+		Manifests:                     tlr.Manifests,
+		ConfigFiles:                   tlr.ConfigFiles,
+		TiltIgnoreContents:            tlr.TiltIgnoreContents,
+		FinishTime:                    cc.clock(),
+		Err:                           tlr.Error,
+		Warnings:                      tlr.Warnings,
+		Features:                      tlr.FeatureFlags,
+		TeamName:                      tlr.TeamName,
+		Secrets:                       tlr.Secrets,
+		GlobalLogLineCountAtExecStart: globalLogLineCountAtExecStart,
 	})
 }
 

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -228,9 +228,9 @@ func checkForContainerCrash(ctx context.Context, state *store.EngineState, mt *s
 	msg := fmt.Sprintf("Detected a container change for %s. We could be running stale code. Rebuilding and deploying a new image.", ms.Name)
 	le := store.NewLogEvent(ms.Name, []byte(msg+"\n"))
 	if len(ms.BuildHistory) > 0 {
-		ms.BuildHistory[0].Log = model.AppendLog(ms.BuildHistory[0].Log, le, state.LogTimestamps, "")
+		ms.BuildHistory[0].Log = model.AppendLog(ms.BuildHistory[0].Log, le, state.LogTimestamps, "", state.Secrets)
 	}
-	ms.CurrentBuild.Log = model.AppendLog(ms.CurrentBuild.Log, le, state.LogTimestamps, "")
+	ms.CurrentBuild.Log = model.AppendLog(ms.CurrentBuild.Log, le, state.LogTimestamps, "", state.Secrets)
 	handleLogAction(state, le)
 }
 
@@ -288,7 +288,7 @@ func handlePodLogAction(state *store.EngineState, action PodLogAction) {
 	}
 
 	podInfo := runtime.Pods[podID]
-	podInfo.CurrentLog = model.AppendLog(podInfo.CurrentLog, action, state.LogTimestamps, "")
+	podInfo.CurrentLog = model.AppendLog(podInfo.CurrentLog, action, state.LogTimestamps, "", state.Secrets)
 }
 
 func handlePodResetRestartsAction(state *store.EngineState, action store.PodResetRestartsAction) {

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -90,7 +90,8 @@ func TestStateToViewTiltfileLog(t *testing.T) {
 		es.TiltfileState.CombinedLog,
 		store.NewLogEvent("Tiltfile", []byte("hello")),
 		false,
-		"")
+		"",
+		nil)
 	v := StateToWebView(*es)
 	r, ok := v.Resource("(Tiltfile)")
 	require.True(t, ok, "no resource named (Tiltfile) found")

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -58,6 +58,16 @@ func (le LogEvent) Message() []byte {
 	return le.msg
 }
 
+func (le *LogEvent) ScrubSecret(secret model.Secret) {
+	le.msg = secret.Scrub(le.msg)
+}
+
+func (le *LogEvent) ScrubSecretSet(secrets model.SecretSet) {
+	for _, s := range secrets {
+		le.ScrubSecret(s)
+	}
+}
+
 func NewLogEvent(mn model.ManifestName, b []byte) LogEvent {
 	return LogEvent{
 		mn:        mn,

--- a/pkg/model/log_test.go
+++ b/pkg/model/log_test.go
@@ -23,7 +23,7 @@ func (l logEvent) Time() time.Time {
 
 func TestLog_AppendUnderLimit(t *testing.T) {
 	l := NewLog("foo")
-	l = AppendLog(l, logEvent{time.Time{}, "bar"}, false, "")
+	l = AppendLog(l, logEvent{time.Time{}, "bar"}, false, "", nil)
 	assert.Equal(t, "foobar", l.String())
 }
 
@@ -39,7 +39,7 @@ func TestLog_AppendOverLimit(t *testing.T) {
 
 	s := sb.String()
 
-	l = AppendLog(l, logEvent{time.Time{}, s}, false, "")
+	l = AppendLog(l, logEvent{time.Time{}, s}, false, "", nil)
 
 	assert.Equal(t, s[:logTruncationTarget], l.String())
 }
@@ -55,7 +55,7 @@ func TestLog_Timestamps(t *testing.T) {
 
 	// appended text has a newline in the middle of the text (which should get a timestamp)
 	// and at the end of the text (which shouldn't)
-	l = AppendLog(l, logEvent{ts, "bar\nbaz\n"}, true, "")
+	l = AppendLog(l, logEvent{ts, "bar\nbaz\n"}, true, "", nil)
 
 	expected := "hello\n2019/03/06 12:34:56 bar\n2019/03/06 12:34:56 baz\n"
 	assert.Equal(t, expected, l.String())
@@ -63,9 +63,20 @@ func TestLog_Timestamps(t *testing.T) {
 
 func TestLogPrefix(t *testing.T) {
 	l := NewLog("hello\n")
-	l = AppendLog(l, logEvent{time.Now(), "bar\nbaz\n"}, false, "prefix | ")
+	l = AppendLog(l, logEvent{time.Now(), "bar\nbaz\n"}, false, "prefix | ", nil)
 	expected := "hello\nprefix | bar\nprefix | baz\n"
 	assert.Equal(t, expected, l.String())
+}
+
+func TestScrubSecret(t *testing.T) {
+	l := NewLog("")
+	secretSet := SecretSet{}
+	secretSet.AddSecret("my-secret", "client-id", []byte("secret"))
+	l = AppendLog(l, logEvent{time.Now(), "hello\nsecret-time!\nc2VjcmV0-time!\ngoodbye"}, false, "", secretSet)
+	assert.Equal(t, `hello
+[redacted secret my-secret:client-id]-time!
+[redacted secret my-secret:client-id]-time!
+goodbye`, l.String())
 }
 
 func TestLogTail(t *testing.T) {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch3434/secrets:

c20a75171cb0e71009d56c25edc767c821c60a1a (2019-09-24 12:56:23 -0400)
engine: redact secrets from the log

a0f815816a3ffdcc8b8ab9b84bf1ea1b8617a7d0 (2019-09-23 17:51:09 -0400)
engine: load secrets into the engine state