### PR TITLE
bump version to 0.10.9

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.10.8"
+const devVersion = "0.10.9"
 
 var globalTiltInfo model.TiltBuild
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.10.8"
+VERSION="0.10.9"
 BREW=$(which brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/bump-0.10.9:

a2ec4d7c45927b083b5e4d643bc00cdc5ffce24f (2019-09-24 16:07:23 -0400)
bump version to 0.10.9

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics