### PR TITLE
store: "permanent" errors dont close ui

### DIFF
--- a/internal/engine/build_errors.go
+++ b/internal/engine/build_errors.go
@@ -55,13 +55,13 @@ var _ error = DontFallBackError{}
 
 // A permanent error indicates that the whole build pipeline needs to stop.
 // It will never recover, even on subsequent rebuilds.
-func isPermanentError(err error) bool {
+func isFatalError(err error) bool {
 	cause := errors.Cause(err)
 	return cause == context.Canceled
 }
 
 func shouldFallBackForErr(err error) bool {
-	if isPermanentError(err) {
+	if isFatalError(err) {
 		return false
 	}
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -133,6 +133,9 @@ func (u Upper) Init(ctx context.Context, action InitAction) error {
 }
 
 func upperReducerFn(ctx context.Context, state *store.EngineState, action store.Action) {
+	if state.FatalError != nil {
+		return
+	}
 	logAction, isLogAction := action.(store.LogAction)
 	if isLogAction {
 		handleLogAction(state, logAction)
@@ -204,7 +207,7 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 	}
 
 	if err != nil {
-		state.PermanentError = err
+		state.FatalError = err
 	}
 }
 
@@ -272,7 +275,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	ms.NeedsRebuildFromCrash = false
 
 	if err != nil {
-		if isPermanentError(err) {
+		if isFatalError(err) {
 			return err
 		} else if engineState.WatchFiles {
 			l := logger.Get(ctx)
@@ -661,7 +664,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 
 func handleExitAction(state *store.EngineState, action hud.ExitAction) {
 	if action.Err != nil {
-		state.PermanentError = action.Err
+		state.FatalError = action.Err
 	} else {
 		state.UserExited = true
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -133,9 +133,20 @@ func (u Upper) Init(ctx context.Context, action InitAction) error {
 }
 
 func upperReducerFn(ctx context.Context, state *store.EngineState, action store.Action) {
+	// Allow exitAction and dumpEngineStateAction even if there's a fatal error
+	if exitAction, isExitAction := action.(hud.ExitAction); isExitAction {
+		handleExitAction(state, exitAction)
+		return
+	}
+	if _, isDumpEngineStateAction := action.(hud.DumpEngineStateAction); isDumpEngineStateAction {
+		handleDumpEngineStateAction(ctx, state)
+		return
+	}
+
 	if state.FatalError != nil {
 		return
 	}
+
 	logAction, isLogAction := action.(store.LogAction)
 	if isLogAction {
 		handleLogAction(state, logAction)

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -84,7 +84,7 @@ func (r *Renderer) layout(v view.View, vs view.ViewState) rty.Component {
 
 	ret = r.maybeAddFullScreenLog(v, vs, ret)
 
-	ret = r.maybeAddAlertModal(vs, ret)
+	ret = r.maybeAddAlertModal(v, vs, ret)
 
 	return ret
 }
@@ -105,12 +105,19 @@ func (r *Renderer) maybeAddFullScreenLog(v view.View, vs view.ViewState, layout 
 	return layout
 }
 
-func (r *Renderer) maybeAddAlertModal(vs view.ViewState, layout rty.Component) rty.Component {
-	if vs.AlertMessage != "" {
+func (r *Renderer) maybeAddAlertModal(v view.View, vs view.ViewState, layout rty.Component) rty.Component {
+	alertMsg := ""
+	if v.PermanentError != nil {
+		alertMsg = fmt.Sprintf("Tilt has encountered a permanent error: %s\nOnce you fix this issue you'll need to restart Tilt. In the meantime feel free to browse through the UI.", v.PermanentError.Error())
+	} else if vs.AlertMessage != "" {
+		alertMsg = vs.AlertMessage
+	}
+
+	if alertMsg != "" {
 		l := rty.NewLines()
 		l.Add(rty.TextString(""))
 
-		msg := "   " + vs.AlertMessage + "   "
+		msg := "   " + alertMsg + "   "
 		l.Add(rty.Fg(rty.TextString(msg), tcell.ColorDefault))
 		l.Add(rty.TextString(""))
 

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -107,8 +107,8 @@ func (r *Renderer) maybeAddFullScreenLog(v view.View, vs view.ViewState, layout 
 
 func (r *Renderer) maybeAddAlertModal(v view.View, vs view.ViewState, layout rty.Component) rty.Component {
 	alertMsg := ""
-	if v.PermanentError != nil {
-		alertMsg = fmt.Sprintf("Tilt has encountered a permanent error: %s\nOnce you fix this issue you'll need to restart Tilt. In the meantime feel free to browse through the UI.", v.PermanentError.Error())
+	if v.FatalError != nil {
+		alertMsg = fmt.Sprintf("Tilt has encountered a fatal error: %s\nOnce you fix this issue you'll need to restart Tilt. In the meantime feel free to browse through the UI.", v.FatalError.Error())
 	} else if vs.AlertMessage != "" {
 		alertMsg = vs.AlertMessage
 	}

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -187,7 +187,7 @@ type View struct {
 	Resources      []Resource
 	IsProfiling    bool
 	LogTimestamps  bool
-	PermanentError error
+	FatalError error
 }
 
 func (v View) TiltfileErrorMessage() string {

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -183,10 +183,11 @@ func (r Resource) IsCollapsed(rv ResourceViewState) bool {
 // Client should always hold this as a value struct, and copy it
 // whenever they need to mutate something.
 type View struct {
-	Log           model.Log
-	Resources     []Resource
-	IsProfiling   bool
-	LogTimestamps bool
+	Log            model.Log
+	Resources      []Resource
+	IsProfiling    bool
+	LogTimestamps  bool
+	PermanentError error
 }
 
 func (v View) TiltfileErrorMessage() string {

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -183,11 +183,11 @@ func (r Resource) IsCollapsed(rv ResourceViewState) bool {
 // Client should always hold this as a value struct, and copy it
 // whenever they need to mutate something.
 type View struct {
-	Log            model.Log
-	Resources      []Resource
-	IsProfiling    bool
-	LogTimestamps  bool
-	FatalError error
+	Log           model.Log
+	Resources     []Resource
+	IsProfiling   bool
+	LogTimestamps bool
+	FatalError    error
 }
 
 func (v View) TiltfileErrorMessage() string {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -43,7 +43,7 @@ type EngineState struct {
 	// would require better tools for triaging output to different streams.
 	BuildControllerActionCount int
 
-	PermanentError error
+	FatalError error
 
 	// The user has indicated they want to exit
 	UserExited bool
@@ -565,7 +565,7 @@ func StateToView(s EngineState) view.View {
 	}
 
 	ret.Log = s.Log
-	ret.PermanentError = s.PermanentError
+	ret.FatalError = s.FatalError
 
 	return ret
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -565,6 +565,7 @@ func StateToView(s EngineState) view.View {
 	}
 
 	ret.Log = s.Log
+	ret.PermanentError = s.PermanentError
 
 	return ret
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -169,7 +169,7 @@ func (s *Store) maybeFinished() (bool, error) {
 	state := s.RLockState()
 	defer s.RUnlockState()
 
-	if state.PermanentError != nil {
+	if state.PermanentError == context.Canceled {
 		return true, state.PermanentError
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -63,7 +63,7 @@ func NewStoreForTesting() (st *Store, getActions func() []Action) {
 
 		errorAction, isErrorAction := action.(ErrorAction)
 		if isErrorAction {
-			s.PermanentError = errorAction.Error
+			s.FatalError = errorAction.Error
 		}
 	})
 
@@ -169,8 +169,8 @@ func (s *Store) maybeFinished() (bool, error) {
 	state := s.RLockState()
 	defer s.RUnlockState()
 
-	if state.PermanentError == context.Canceled {
-		return true, state.PermanentError
+	if state.FatalError == context.Canceled {
+		return true, state.FatalError
 	}
 
 	if state.UserExited {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -109,6 +109,6 @@ var TestReducer = Reducer(func(ctx context.Context, s *EngineState, action Actio
 	case CompletedBuildAction:
 		s.CompletedBuildCount++
 	case DoneAction:
-		s.PermanentError = context.Canceled
+		s.FatalError = context.Canceled
 	}
 })

--- a/internal/store/subscriber_test.go
+++ b/internal/store/subscriber_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -107,10 +106,10 @@ func TestSubscriberTeardown(t *testing.T) {
 	s := newFakeSubscriber()
 	st.AddSubscriber(ctx, s)
 
-	go st.Dispatch(NewErrorAction(fmt.Errorf("fake error")))
+	go st.Dispatch(NewErrorAction(context.Canceled))
 	err := st.Loop(ctx)
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "fake error")
+		assert.Contains(t, err.Error(), "context canceled")
 	}
 
 	assert.Equal(t, 1, s.teardownCount)
@@ -139,11 +138,11 @@ func TestSubscriberTeardownOnRemove(t *testing.T) {
 
 	assert.Equal(t, 1, s.teardownCount)
 
-	st.Dispatch(NewErrorAction(fmt.Errorf("fake error")))
+	st.Dispatch(NewErrorAction(context.Canceled))
 
 	err := <-errChan
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "fake error")
+		assert.Contains(t, err.Error(), "context canceled")
 	}
 	assert.Equal(t, 1, s.teardownCount)
 }


### PR DESCRIPTION
Looks like this:

<img width="572" alt="Screen Shot 2019-09-25 at 12 05 58 PM" src="https://user-images.githubusercontent.com/452453/65618799-edd3b180-df8c-11e9-8208-ba9c16a8a6a8.png">

If a permanent, now called "fatal", error happens the Upper loop stops but the UI stays up and you can still browse through it.

Nothing is displayed in the web UI, and I'm not sure if that's a feature or a bug.