### PR TITLE
web: show fatal error as a modal in web UI

### DIFF
--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -103,6 +103,9 @@ func StateToWebView(s store.EngineState) View {
 	ret.FeatureFlags = s.Features
 	ret.TiltCloudUsername = s.TiltCloudUsername
 	ret.TiltCloudSchemeHost = cloud.URL(s.CloudAddress).String()
+	if s.FatalError != nil {
+		ret.FatalError = s.FatalError.Error()
+	}
 
 	return ret
 }

--- a/internal/hud/webview/testdata/snapshot.json
+++ b/internal/hud/webview/testdata/snapshot.json
@@ -253,5 +253,6 @@
     "Dev": false
   },
   "TiltCloudUsername": "",
-  "TiltCloudSchemeHost": ""
+  "TiltCloudSchemeHost": "",
+  "FatalError": ""
 }

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -180,6 +180,8 @@ type View struct {
 
 	TiltCloudUsername   string
 	TiltCloudSchemeHost string
+
+	FatalError string
 }
 
 func (v View) Resource(n model.ManifestName) (Resource, bool) {

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -1,6 +1,6 @@
 import HUD from "./HUD"
 import { getResourceAlerts } from "./alerts"
-import { Resource } from "./types"
+import { ShowFatalErrorModal } from "./types"
 
 // A Websocket that automatically retries.
 
@@ -92,6 +92,7 @@ class AppController {
         IsSidebarClosed: false,
         SnapshotLink: "",
         showSnapshotModal: false,
+        showFatalErrorModal: ShowFatalErrorModal.Default,
       })
       this.createNewSocket()
       return
@@ -118,6 +119,7 @@ class AppController {
         IsSidebarClosed: false,
         SnapshotLink: "",
         showSnapshotModal: false,
+        showFatalErrorModal: ShowFatalErrorModal.Default,
       })
       this.createNewSocket()
     }, timeout)

--- a/web/src/FatalErrorModal.scss
+++ b/web/src/FatalErrorModal.scss
@@ -1,0 +1,25 @@
+@import "constants";
+@import "ReactModal";
+
+.FatalErrorModal-pane {
+  display: flex;
+  flex-direction: column;
+  font-size: $font-size;
+  padding-top: $spacing-unit * 0.75;
+  padding-bottom: $spacing-unit;
+  padding-left: $spacing-unit;
+  padding-right: $spacing-unit;
+}
+
+.FatalErrorModal-title {
+  margin: 0;
+  font-family: $font-sans-serif;
+  font-size: $font-size-small;
+  text-transform: uppercase;
+  background-color: $color-red;
+  color: $color-white;
+  padding-top: $spacing-unit / 4;
+  padding-bottom: $spacing-unit / 4;
+  padding-left: $spacing-unit;
+  padding-right: $spacing-unit;
+}

--- a/web/src/FatalErrorModal.test.tsx
+++ b/web/src/FatalErrorModal.test.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import ReactModal from "react-modal"
+import renderer from "react-test-renderer"
+import FatalErrorModal from "./FatalErrorModal"
+import { ShowFatalErrorModal } from "./types"
+
+const fakeHandleCloseModal = () => {}
+let originalCreatePortal = ReactDOM.createPortal
+
+describe("FatalErrorModal", () => {
+  beforeEach(() => {
+    ReactModal.setAppElement(document.body)
+    let mock: any = (node: any) => node
+    ReactDOM.createPortal = mock
+  })
+
+  afterEach(() => {
+    ReactDOM.createPortal = originalCreatePortal
+  })
+
+  it("doesn't render if there's no fatal error and the modal hasn't been closed", () => {
+    const tree = renderer
+      .create(
+        <FatalErrorModal
+          error={null}
+          showFatalErrorModal={ShowFatalErrorModal.Default}
+          handleClose={fakeHandleCloseModal}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("does render if there is a fatal error and the modal hasn't been closed", () => {
+    const tree = renderer
+      .create(
+        <FatalErrorModal
+          error={"i'm an error"}
+          showFatalErrorModal={ShowFatalErrorModal.Default}
+          handleClose={fakeHandleCloseModal}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("doesn't render if there is a fatal error and the modal has been closed", () => {
+    const tree = renderer
+      .create(
+        <FatalErrorModal
+          error={"i'm an error"}
+          showFatalErrorModal={ShowFatalErrorModal.Hide}
+          handleClose={fakeHandleCloseModal}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/web/src/FatalErrorModal.tsx
+++ b/web/src/FatalErrorModal.tsx
@@ -12,7 +12,7 @@ type props = {
 export default class FatalErrorModal extends PureComponent<props> {
   render() {
     let showModal =
-      this.props.error !== null &&
+      Boolean(this.props.error) &&
       (this.props.showFatalErrorModal === ShowFatalErrorModal.Default ||
         this.props.showFatalErrorModal === ShowFatalErrorModal.Show)
     return (

--- a/web/src/FatalErrorModal.tsx
+++ b/web/src/FatalErrorModal.tsx
@@ -1,0 +1,35 @@
+import React, { PureComponent } from "react"
+import Modal from "react-modal"
+import { ShowFatalErrorModal } from "./types"
+import "./FatalErrorModal.scss"
+
+type props = {
+  error: string | null
+  showFatalErrorModal: ShowFatalErrorModal
+  handleClose: () => void
+}
+
+export default class FatalErrorModal extends PureComponent<props> {
+  render() {
+    let showModal =
+      this.props.error !== null &&
+      (this.props.showFatalErrorModal === ShowFatalErrorModal.Default ||
+        this.props.showFatalErrorModal === ShowFatalErrorModal.Show)
+    return (
+      <Modal
+        isOpen={showModal}
+        className="FatalErrorModal"
+        onRequestClose={this.props.handleClose}
+      >
+        <h2 className="FatalErrorModal-title">Fatal Error</h2>
+        <div className="FatalErrorModal-pane">
+          <p>Tilt has encountered a fatal error: {this.props.error}</p>
+          <p>
+            Once you fix this issue you'll need to restart Tilt. In the meantime
+            feel free to browse through the UI.
+          </p>
+        </div>
+      </Modal>
+    )
+  }
+}

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -13,7 +13,13 @@ import { History, UnregisterCallback } from "history"
 import { incr, pathToTag } from "./analytics"
 import TopBar from "./TopBar"
 import "./HUD.scss"
-import { TiltBuild, ResourceView, Resource, Snapshot } from "./types"
+import {
+  TiltBuild,
+  ResourceView,
+  Resource,
+  Snapshot,
+  ShowFatalErrorModal,
+} from "./types"
 import AlertPane from "./AlertPane"
 import PreviewList from "./PreviewList"
 import AnalyticsNudge from "./AnalyticsNudge"
@@ -22,6 +28,7 @@ import { numberOfAlerts } from "./alerts"
 import Features from "./feature"
 import ShareSnapshotModal from "./ShareSnapshotModal"
 import cleanStateForSnapshotPOST from "./snapshot_sanitizer"
+import FatalErrorModal from "./FatalErrorModal"
 
 type HudProps = {
   history: History
@@ -39,6 +46,7 @@ type HudView = {
   FeatureFlags: { [featureFlag: string]: boolean }
   TiltCloudUsername: string
   TiltCloudSchemeHost: string
+  FatalError: string | null
 }
 
 type HudState = {
@@ -47,6 +55,7 @@ type HudState = {
   IsSidebarClosed: boolean
   SnapshotLink: string
   showSnapshotModal: boolean
+  showFatalErrorModal: ShowFatalErrorModal
 }
 
 type NewSnapshotResponse = {
@@ -88,6 +97,7 @@ class HUD extends Component<HudProps, HudState> {
         SailEnabled: false,
         SailURL: "",
         NeedsAnalyticsNudge: false,
+        FatalError: null,
         RunningTiltBuild: {
           Version: "",
           Date: "",
@@ -105,6 +115,7 @@ class HUD extends Component<HudProps, HudState> {
       IsSidebarClosed: false,
       SnapshotLink: "",
       showSnapshotModal: false,
+      showFatalErrorModal: ShowFatalErrorModal.Default,
     }
 
     this.toggleSidebar = this.toggleSidebar.bind(this)
@@ -347,9 +358,11 @@ class HUD extends Component<HudProps, HudState> {
     let runningVersion = view && view.RunningTiltBuild
     let latestVersion = view && view.LatestTiltBuild
     let shareSnapshotModal = this.renderShareSnapshotModal(view)
+    let fatalErrorModal = this.renderFatalErrorModal(view)
     return (
       <div className="HUD">
         <AnalyticsNudge needsNudge={needsNudge} />
+        {fatalErrorModal}
         {shareSnapshotModal}
         <Switch>
           <Route
@@ -465,6 +478,19 @@ class HUD extends Component<HudProps, HudState> {
         tiltCloudUsername={tiltCloudUsername}
         tiltCloudSchemeHost={tiltCloudSchemeHost}
         isOpen={this.state.showSnapshotModal}
+      />
+    )
+  }
+
+  renderFatalErrorModal(view: HudView | null) {
+    let error = view && view.FatalError
+    let handleClose = () =>
+      this.setState({ showFatalErrorModal: ShowFatalErrorModal.Hide })
+    return (
+      <FatalErrorModal
+        error={error}
+        showFatalErrorModal={this.state.showFatalErrorModal}
+        handleClose={handleClose}
       />
     )
   }

--- a/web/src/__snapshots__/FatalErrorModal.test.tsx.snap
+++ b/web/src/__snapshots__/FatalErrorModal.test.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FatalErrorModal does render if there is a fatal error and the modal hasn't been closed 1`] = `
+<div
+  className="ReactModal__Overlay ReactModal__Overlay--after-open"
+  onClick={[Function]}
+  onMouseDown={[Function]}
+  style={
+    Object {
+      "backgroundColor": "rgba(255, 255, 255, 0.75)",
+      "bottom": 0,
+      "left": 0,
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    className="ReactModal__Content ReactModal__Content--after-open FatalErrorModal"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    role="dialog"
+    style={Object {}}
+    tabIndex="-1"
+  >
+    <h2
+      className="FatalErrorModal-title"
+    >
+      Fatal Error
+    </h2>
+    <div
+      className="FatalErrorModal-pane"
+    >
+      <p>
+        Tilt has encountered a fatal error: 
+        i'm an error
+      </p>
+      <p>
+        Once you fix this issue you'll need to restart Tilt. In the meantime feel free to browse through the UI.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FatalErrorModal doesn't render if there is a fatal error and the modal has been closed 1`] = `null`;
+
+exports[`FatalErrorModal doesn't render if there's no fatal error and the modal hasn't been closed 1`] = `null`;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -103,3 +103,9 @@ export type Snapshot = {
   SnapshotLink: string
   showSnapshotModal: boolean
 }
+
+export enum ShowFatalErrorModal {
+  Default,
+  Show,
+  Hide,
+}


### PR DESCRIPTION
Looks like this:

<img width="759" alt="Screen Shot 2019-09-26 at 11 28 12 AM" src="https://user-images.githubusercontent.com/452453/65703788-56856180-e053-11e9-81da-cd70ef6dd9d6.png">
