### PR TITLE
engine: sleep a bit after initial build of local resource to avoid race condition [ch3559]

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -305,7 +305,7 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 
 	for _, spec := range specs {
 		id := spec.ID()
-		if id.Type != model.TargetTypeImage && id.Type != model.TargetTypeDockerCompose {
+		if id.Type != model.TargetTypeImage && id.Type != model.TargetTypeDockerCompose && id.Type != model.TargetTypeLocal {
 			continue
 		}
 


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/race-cond:

d5e5c75e2ecfdad876e5d518702feccfad7da0bb (2019-09-26 17:13:36 -0400)
engine: sleep a bit after initial build of local resource to avoid race condition

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics