### PR TITLE
tiltfile: add disable_snapshots

### DIFF
--- a/internal/tiltfile/features.go
+++ b/internal/tiltfile/features.go
@@ -41,3 +41,20 @@ func (s *tiltfileState) disableFeature(thread *starlark.Thread, fn *starlark.Bui
 
 	return starlark.None, nil
 }
+
+func (s *tiltfileState) disableSnapshots(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	err := s.unpackArgs(fn.Name(), args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.features.Set(feature.Snapshots, false)
+	if err != nil {
+		if _, ok := err.(feature.ObsoleteError); !ok {
+			return nil, err
+		}
+		s.warnings = append(s.warnings, err.Error())
+	}
+
+	return starlark.None, nil
+}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -275,6 +275,8 @@ const (
 	enableFeatureN  = "enable_feature"
 	disableFeatureN = "disable_feature"
 
+	disableSnapshotsN = "disable_snapshots"
+
 	// other functions
 	failN    = "fail"
 	blobN    = "blob"
@@ -446,6 +448,8 @@ func (s *tiltfileState) predeclared() starlark.StringDict {
 
 	addBuiltin(r, enableFeatureN, s.enableFeature)
 	addBuiltin(r, disableFeatureN, s.disableFeature)
+
+	addBuiltin(r, disableSnapshotsN, s.disableSnapshots)
 
 	addBuiltin(r, setTeamN, s.setTeam)
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3498,6 +3498,16 @@ func TestDisableObsoleteFeature(t *testing.T) {
 	f.loadAssertWarnings("Obsolete feature flag: obsoleteflag")
 }
 
+func TestDisableSnapshots(t *testing.T) {
+	f := newFixture(t)
+	f.setupFoo()
+
+	f.file("Tiltfile", `disable_snapshots()`)
+	f.load()
+
+	f.assertFeature(feature.Snapshots, false)
+}
+
 func TestDockerBuildEntrypoint(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -3852,6 +3862,7 @@ func (f *fixture) newTiltfileLoader() TiltfileLoader {
 		"testflag_enabled":               feature.Value{Enabled: true},
 		"obsoleteflag":                   feature.Value{Status: feature.Obsolete, Enabled: true},
 		feature.MultipleContainersPerPod: feature.Value{Enabled: false},
+		feature.Snapshots:                feature.Value{Enabled: true},
 	}
 	return ProvideTiltfileLoader(f.ta, f.kCli, dcc, f.k8sContext, f.k8sEnv, features)
 }


### PR DESCRIPTION
### Problem

Once we enable snapshots in the UI, an organization might prefer to not have a "share snapshot" button there encouraging their devs to upload their data to TiltCloud.

### Solution

Add a `disable_snapshots` directive that allows a Tiltfile to specify that a project shouldn't give users a "share snapshot" button.
Notes:
1. Maybe at some point we'll want a second `disable_feature` that's meant for long-term use, but I'm leaning against taking on that as part of the snapshots release. If people feel strongly that we should solve the more general problem, we can talk about that.
2. This isn't any form of security since obviously a user could simply comment it out. It's basically just allowing people to take away an attractive nuisance.
3. `disable_feature` already provides this affordance, but the feature flags are more for undocumented / experimental / short-lived behavior.
4. This is still using feature flags as the implementation, but that can be changed later if needed. This unblocks allowing users to use `disable_snapshots`.
