### PR TITLE
add a class for precendence when css gets loaded out of order

### DIFF
--- a/web/src/ShareSnapshotModal.scss
+++ b/web/src/ShareSnapshotModal.scss
@@ -1,7 +1,7 @@
 @import "constants";
 @import "ReactModal";
 
-.ShareSnapshotModal {
+.ReactModal__Content.ShareSnapshotModal {
   width: 736px;
 }
 .ShareSnapshotModal-pane {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/styles:

91247c7a62c80a74820fa4db1a549bcdf5df48ce (2019-09-30 11:11:52 -0400)
add a class for precendence when css gets loaded out of order