### PR TITLE
Let TILT_SYNCLET_IMAGE variable override Docker image

### DIFF
--- a/internal/synclet/sidecar/sidecar.go
+++ b/internal/synclet/sidecar/sidecar.go
@@ -26,7 +26,7 @@ func getImageName() string {
 // When we deploy Tilt for development, we override this with LDFLAGS
 var SyncletTag = "v20190904"
 
-const SyncletImageEnvVar = "SYNCLET_IMAGE"
+const SyncletImageEnvVar = "TILT_SYNCLET_IMAGE"
 const SyncletImageName = "gcr.io/windmill-public-containers/tilt-synclet"
 const SyncletContainerName = "tilt-synclet"
 

--- a/internal/synclet/sidecar/sidecar.go
+++ b/internal/synclet/sidecar/sidecar.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"fmt"
+	"os"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -14,9 +15,18 @@ func syncletPrivileged() *bool {
 	return &val
 }
 
+func getImageName() string {
+	v := os.Getenv(SyncletImageEnvVar)
+	if v == "" {
+		return SyncletImageName
+	}
+	return v
+}
+
 // When we deploy Tilt for development, we override this with LDFLAGS
 var SyncletTag = "v20190904"
 
+const SyncletImageEnvVar = "SYNCLET_IMAGE"
 const SyncletImageName = "gcr.io/windmill-public-containers/tilt-synclet"
 const SyncletContainerName = "tilt-synclet"
 
@@ -24,7 +34,7 @@ var SyncletImageRef = container.MustParseNamed(SyncletImageName)
 
 var SyncletContainer = v1.Container{
 	Name:            SyncletContainerName,
-	Image:           fmt.Sprintf("%s:%s", SyncletImageName, SyncletTag),
+	Image:           fmt.Sprintf("%s:%s", getImageName(), SyncletTag),
 	ImagePullPolicy: v1.PullIfNotPresent,
 	Resources:       v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("0Mi")}},
 	VolumeMounts: []v1.VolumeMount{


### PR DESCRIPTION
This is the least invasive way I could think of to plumb a custom image name through, since command line parsing happens far from the `sidecar` package.

Given how `SyncletContainer` is built (once per execution), the only simple test would be for `getImageName()` and that would be trivial, hence no new tests.

All of the above to say that this could be a more complex change, but I will wait until the owners state a preference (if any).