### PR TITLE
New custom-synclet-release target to push to custom registry with custom tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,11 @@ synclet-release:
 	docker push $(SYNCLET_IMAGE):$(TAG)
 	sed -i 's/var SyncletTag = ".*"/var SyncletTag = "$(TAG)"/' internal/synclet/sidecar/sidecar.go
 
+custom-synclet-release:
+	$(eval TAG := $(if $(SYNCLET_TAG),$(SYNCLET_TAG),$(shell date +v%Y%m%d)))
+	docker build -t $(SYNCLET_IMAGE):$(TAG) -f synclet/Dockerfile .
+	docker push $(SYNCLET_IMAGE):$(TAG)
+
 release:
 	goreleaser --rm-dist
 


### PR DESCRIPTION
Let's say you want to build a private synclet image and you want to build it with an arbitrary tag that matches an existing tilt binary, not the current date... this change allows you to do that.