### PR TITLE
engine: start streaming pod log at tthe tilt start time. fixes issue #2263

### DIFF
--- a/internal/engine/podlogmanager.go
+++ b/internal/engine/podlogmanager.go
@@ -68,7 +68,12 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 				stateWatches[key] = true
 
 				existing, isActive := m.watches[key]
-				startWatchTime := time.Unix(0, 0)
+
+				// Only stream logs that have happened since Tilt started.
+				//
+				// TODO(nick): We should really record when we started the `kubectl apply`,
+				// and only stream logs since that happened.
+				startWatchTime := state.TiltStartTime
 				if isActive {
 					if existing.ctx.Err() == nil {
 						// The active pod watcher is still tailing the logs,

--- a/internal/engine/podlogmanager_test.go
+++ b/internal/engine/podlogmanager_test.go
@@ -31,7 +31,9 @@ func TestLogs(t *testing.T) {
 
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!")
 
+	start := time.Now()
 	state := f.store.LockMutableStateForTesting()
+	state.TiltStartTime = start
 	state.WatchFiles = true
 
 	p := store.Pod{
@@ -45,6 +47,7 @@ func TestLogs(t *testing.T) {
 
 	f.plm.OnChange(f.ctx, f.store)
 	f.AssertOutputContains("hello world!")
+	assert.Equal(t, start, f.kClient.LastPodLogStartTime)
 }
 
 func TestLogActions(t *testing.T) {

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -45,6 +45,7 @@ type FakeK8sClient struct {
 	LastPodQueryImage     reference.NamedTagged
 
 	PodLogsByPodAndContainer map[PodAndCName]BufferCloser
+	LastPodLogStartTime      time.Time
 	ContainerLogsError       error
 
 	podWatcherMu sync.Mutex
@@ -265,6 +266,7 @@ func (c *FakeK8sClient) ContainerLogs(ctx context.Context, pID PodID, cName cont
 	}
 
 	// If we have specific logs for this pod/container combo, return those
+	c.LastPodLogStartTime = startTime
 	if buf, ok := c.PodLogsByPodAndContainer[PodAndCName{pID, cName}]; ok {
 		return buf, nil
 	}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/issue2263:

d2399277ea96dbf89abfc608abd168c36ee9235c (2019-10-01 14:47:01 -0400)
engine: start streaming pod log at tthe tilt start time. fixes issue #2263