### PR TITLE
upload_assets: use subprocess.check_call

### DIFF
--- a/scripts/upload-assets.py
+++ b/scripts/upload-assets.py
@@ -36,12 +36,8 @@ if status == 0:
   sys.exit(1)
 
 os.chdir("web")
-status = os.system('yarn install')
-if status != 0:
-  print("Error executing yarn install")
-  sys.exit(status)
-status = os.system('CI=false yarn run build')
-if status != 0:
-  print("Error executing yarn run build")
-  sys.exit(status)
-os.system('gsutil cp -r build "gs://tilt-static-assets/%s"' % version)
+subprocess.check_call(["yarn", "install"])
+e = os.environ.copy()
+e["CI"] = "false"
+subprocess.check_call(["yarn", "run", "build"], env=e)
+subprocess.check_call(["gsutil", "cp", "-r", "build", "gs://tilt-static-assets/%s" % version])


### PR DESCRIPTION
Dan fixed a couple of omissions, but the actual upload's exit code was still unchecked.

> subprocess.check_call(args, *, stdin=None, stdout=None, stderr=None, shell=False)
> Run command with arguments. Wait for command to complete. If the return code was zero then return, otherwise raise CalledProcessError. The CalledProcessError object will have the return code in the returncode attribute.