### PR TITLE
tiltfile: don't pick up dockerignores from sync() directories.

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -437,9 +437,6 @@ func reposForPaths(paths []string) []model.LocalGitRepo {
 
 func (s *tiltfileState) reposForImage(image *dockerImage) []model.LocalGitRepo {
 	var paths []string
-	for _, sync := range image.liveUpdate.SyncSteps() {
-		paths = append(paths, sync.LocalPath)
-	}
 	paths = append(paths,
 		image.dbDockerfilePath,
 		image.dbBuildPath,
@@ -479,14 +476,19 @@ func (s *tiltfileState) dockerignoresFromPathsAndContextFilters(paths []string, 
 			continue
 		}
 
-		result = append(result, model.Dockerignore{
-			LocalPath: path,
-			Contents:  ignoreContents,
-		})
-		result = append(result, model.Dockerignore{
-			LocalPath: path,
-			Contents:  onlyContents,
-		})
+		if ignoreContents != "" {
+			result = append(result, model.Dockerignore{
+				LocalPath: path,
+				Contents:  ignoreContents,
+			})
+		}
+
+		if onlyContents != "" {
+			result = append(result, model.Dockerignore{
+				LocalPath: path,
+				Contents:  onlyContents,
+			})
+		}
 
 		contents, err := s.readFile(filepath.Join(path, ".dockerignore"))
 		if err != nil {
@@ -531,10 +533,6 @@ func onlysToDockerignoreContents(onlys []string) string {
 
 func (s *tiltfileState) dockerignoresForImage(image *dockerImage) []model.Dockerignore {
 	var paths []string
-
-	for _, sync := range image.liveUpdate.SyncSteps() {
-		paths = append(paths, sync.LocalPath)
-	}
 	switch image.Type() {
 	case DockerBuild:
 		paths = append(paths, image.dbBuildPath)

--- a/internal/tiltfile/docker_test.go
+++ b/internal/tiltfile/docker_test.go
@@ -1,0 +1,40 @@
+package tiltfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+func TestDockerignoreInSyncDir(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.yaml("fe.yaml", deployment("fe", image("gcr.io/fe")))
+	f.file("Dockerfile", `
+FROM alpine
+ADD ./src /src
+`)
+	f.file("Tiltfile", `
+k8s_yaml('fe.yaml')
+docker_build('gcr.io/fe', '.', live_update=[
+  sync('./src', '/src')
+])
+`)
+	f.file(".dockerignore", "build")
+	f.file("src/index.html", "Hello world!")
+	f.file("src/.dockerignore", "**")
+
+	f.load()
+	m := f.assertNextManifest("fe")
+	assert.Equal(t,
+		[]model.Dockerignore{
+			model.Dockerignore{
+				LocalPath: f.Path(),
+				Contents:  "build",
+			},
+		},
+		m.ImageTargetAt(0).Dockerignores())
+}


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/issue2296/dockerignore:

f1ca72c69aaf2d6dc4d6ceaab91400583cd6637b (2019-10-03 16:36:03 -0700)
tiltfile: don't pick up dockerignores from sync() directories.
confirmed that this test passed before https://github.com/windmilleng/tilt/pull/2256 but failed afterwards

attempt at fixing issue #2296