### PR TITLE
build: label all docker images with builtby:tilt [ch3659]

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -39,6 +39,8 @@ ADD dir/c.txt .
 		t.Fatal(err)
 	}
 
+	f.assertImageHasLabels(ref, BuiltByTiltLabel)
+
 	pcs := []expectedFile{
 		expectedFile{Path: "/src/a.txt", Contents: "a"},
 		expectedFile{Path: "/src/b.txt", Contents: "a"},

--- a/internal/build/options.go
+++ b/internal/build/options.go
@@ -8,6 +8,8 @@ import (
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
+var BuiltByTiltLabel = map[string]string{"builtby": "tilt"}
+
 func Options(archive io.Reader, args model.DockerBuildArgs, target model.DockerBuildTarget) docker.BuildOptions {
 	return docker.BuildOptions{
 		Context:    archive,
@@ -15,6 +17,7 @@ func Options(archive io.Reader, args model.DockerBuildArgs, target model.DockerB
 		Remove:     shouldRemoveImage(),
 		BuildArgs:  manifestBuildArgsToDockerBuildArgs(args),
 		Target:     string(target),
+		Labels:     BuiltByTiltLabel,
 	}
 }
 

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -411,6 +411,7 @@ func (c *Cli) ImageBuild(ctx context.Context, buildContext io.Reader, options Bu
 	opts.Context = options.Context
 	opts.BuildArgs = options.BuildArgs
 	opts.Dockerfile = options.Dockerfile
+	opts.Labels = options.Labels
 	opts.Tags = options.Tags
 	opts.Target = options.Target
 

--- a/internal/docker/options.go
+++ b/internal/docker/options.go
@@ -7,6 +7,7 @@ type BuildOptions struct {
 	Dockerfile string
 	Remove     bool
 	BuildArgs  map[string]*string
+	Labels     map[string]string
 	Tags       []string
 	Target     string
 }

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
-	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/wmclient/pkg/dirs"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/windmilleng/tilt/internal/build"
 
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/windmilleng/tilt/internal/build"
 	"github.com/windmilleng/wmclient/pkg/dirs"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,19 @@ import (
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 	"github.com/windmilleng/tilt/pkg/model"
 )
+
+func TestDockerImageHasBuiltByLabel(t *testing.T) {
+	f := newIBDFixture(t, k8s.EnvGKE)
+	defer f.TearDown()
+
+	manifest := NewSanchoDockerBuildManifest(f)
+	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, build.BuiltByTiltLabel, f.docker.BuildOptions.Labels)
+}
 
 func TestDockerBuildWithCache(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/label-images:

877d89e565eb86180df12ce810f3e301e71c1ef6 (2019-10-07 17:26:27 -0400)
build: label all docker images with builtby:tilt [ch3659]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics