### PR TITLE
pseudocode for docker pruner

### DIFF
--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -111,15 +111,16 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 	}
 
 	st.Dispatch(ConfigsReloadedAction{
-		Manifests:                     tlr.Manifests,
-		ConfigFiles:                   tlr.ConfigFiles,
-		TiltIgnoreContents:            tlr.TiltIgnoreContents,
-		FinishTime:                    cc.clock(),
-		Err:                           tlr.Error,
-		Warnings:                      tlr.Warnings,
-		Features:                      tlr.FeatureFlags,
-		TeamName:                      tlr.TeamName,
-		Secrets:                       tlr.Secrets,
+		Manifests:          tlr.Manifests,
+		ConfigFiles:        tlr.ConfigFiles,
+		TiltIgnoreContents: tlr.TiltIgnoreContents,
+		FinishTime:         cc.clock(),
+		Err:                tlr.Error,
+		Warnings:           tlr.Warnings,
+		Features:           tlr.FeatureFlags,
+		TeamName:           tlr.TeamName,
+		Secrets:            tlr.Secrets,
+		// TODO: tlr.dockerprunedisabled/maxagesecs
 		GlobalLogLineCountAtExecStart: globalLogLineCountAtExecStart,
 	})
 }

--- a/internal/engine/docker_pruner.go
+++ b/internal/engine/docker_pruner.go
@@ -1,0 +1,76 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+// How often to prune Docker images while Tilt is running
+// TODO: configurable from Tiltfile for special cases
+const dockerPruneInterval = time.Hour * 12
+
+type DockerPruner struct {
+	dCli docker.Client
+
+	started            bool
+	disabledForTesting bool
+}
+
+func NewDockerPruner(dCli docker.Client) *DockerPruner {
+	return &DockerPruner{dCli: dCli}
+}
+
+func (dp *DockerPruner) DisableForTesting() {
+	dp.disabledForTesting = true
+}
+
+func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
+	if dp.disabledForTesting {
+		return
+	}
+
+	if dp.started {
+		return
+	}
+
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	// wait until state has been kinda initialized
+	if !state.TiltStartTime.IsZero() && state.LastTiltfileError() == nil {
+		dp.started = true
+		go func() {
+			select {
+			case <-time.After(time.Minute * 2):
+				dp.prune(ctx, st) // report once pretty soon after startup...
+			case <-ctx.Done():
+				return
+			}
+
+			for {
+				select {
+				case <-time.After(dockerPruneInterval):
+					// and once every <interval> thereafter
+					dp.prune(ctx, st)
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+}
+
+func (dp *DockerPruner) prune(ctx context.Context, st store.RStore) {
+	// TODO:
+	//   - prune images with label: builtby=tilt and older than timestamp X
+	//   - (timestamp configurable in Tiltfile)
+	//   - write useful output / errors to log
+	//
+	// For future: dispatch event with output/errors to be recorded
+	//   in engineState.TiltSystemState on store (analogous to TiltfileState)
+}
+
+var _ store.Subscriber = &BuildController{}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -483,6 +483,7 @@ func handleConfigsReloaded(
 	state *store.EngineState,
 	event configs.ConfigsReloadedAction,
 ) {
+	// TODO: store dockerPruneDisabled/maxAgeSecs
 	manifests := event.Manifests
 	if state.InitialBuildsQueued == 0 {
 		state.InitialBuildsQueued = len(manifests)
@@ -539,7 +540,6 @@ func handleConfigsReloaded(
 				}
 			}
 		}
-
 		return
 	}
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -153,6 +153,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	tlr.Error = err
 	tlr.Manifests = manifests
 	tlr.TeamName = s.teamName
+	// TODO: tlr.dockerPruneDisabled / MaxAgeSecs...
 
 	printWarnings(s)
 	s.logger.Infof("Successfully loaded Tiltfile")

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -86,6 +86,9 @@ type tiltfileState struct {
 
 	teamName string
 
+	dockerPruneDisabled   bool
+	dockerPruneMaxAgeSecs int64
+
 	logger   logger.Logger
 	warnings []string
 }
@@ -282,9 +285,10 @@ const (
 	disableSnapshotsN = "disable_snapshots"
 
 	// other functions
-	failN    = "fail"
-	blobN    = "blob"
-	setTeamN = "set_team"
+	failN               = "fail"
+	blobN               = "blob"
+	setTeamN            = "set_team"
+	dockerPruneOptionsN = "docker_prune_options"
 )
 
 type triggerMode int
@@ -456,6 +460,8 @@ func (s *tiltfileState) predeclared() starlark.StringDict {
 	addBuiltin(r, disableSnapshotsN, s.disableSnapshots)
 
 	addBuiltin(r, setTeamN, s.setTeam)
+
+	addBuiltin(r, dockerPruneOptionsN, s.dockerPruneOptions)
 
 	s.predeclaredMap = r
 
@@ -1246,6 +1252,20 @@ func (s *tiltfileState) setTeam(thread *starlark.Thread, fn *starlark.Builtin, a
 	}
 
 	s.teamName = teamName
+
+	return starlark.None, nil
+}
+
+func (s *tiltfileState) dockerPruneOptions(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var disable bool
+	var maxAgeSecs int64
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
+		"disable?", &disable,
+		"max_age_secs?", &maxAgeSecs); err != nil {
+		return nil, err
+	}
+	s.dockerPruneDisabled = disable
+	s.dockerPruneMaxAgeSecs = maxAgeSecs
 
 	return starlark.None, nil
 }


### PR DESCRIPTION
Hello @,

Please review the following commits I made in branch maiamcc/docker-pruner-pseudocode:

74d85df8c91fa7aa516e138dea3c3626a7d77349 (2019-10-07 18:42:36 -0400)
tiltfile to tweak settings

393abebb624bbe53583a6946106b3357e35b577b (2019-10-07 18:35:10 -0400)
pseudocode for docker pruner itself

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics