### PR TITLE
logger: fix a logger that wasn't copying bytes correctly

### DIFF
--- a/pkg/logger/deferred.go
+++ b/pkg/logger/deferred.go
@@ -24,7 +24,7 @@ func NewDeferredLogger(ctx context.Context) *DeferredLogger {
 			dLogger.output.Write(level, string(b))
 			return nil
 		}
-		dLogger.entries = append(dLogger.entries, logEntry{level: level, b: b})
+		dLogger.entries = append(dLogger.entries, logEntry{level: level, b: append([]byte{}, b...)})
 		return nil
 	})
 	dLogger.Logger = fLogger

--- a/pkg/logger/deferred_test.go
+++ b/pkg/logger/deferred_test.go
@@ -38,3 +38,21 @@ func TestDeferredLoggerOriginal(t *testing.T) {
 
 	assert.Equal(t, "Hello world\nGoodbye world\n", out1.String())
 }
+
+func TestDeferredLoggerCopiesBytes(t *testing.T) {
+	out := &bytes.Buffer{}
+	logger := NewLogger(DebugLvl, out)
+	ctx := WithLogger(context.Background(), logger)
+	deferLogger := NewDeferredLogger(ctx)
+
+	data := make([]byte, 0, 100)
+	data2 := append(data, []byte("Hello")...)
+	deferLogger.Writer(DebugLvl).Write(data2)
+	data3 := append(data, []byte("Goodbye")...)
+	deferLogger.Writer(DebugLvl).Write(data3)
+
+	assert.Equal(t, "", out.String())
+
+	deferLogger.SetOutput(logger)
+	assert.Equal(t, "HelloGoodbye", out.String())
+}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/deferred:

edf3fe06cc49122cd91dcf1f1cb5b9531e6f472d (2019-10-07 20:50:17 -0400)
logger: fix a logger that wasn't copying bytes correctly