### PR TITLE
docker: set client scheme to http so we can ping server to negotiate version

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -229,6 +229,10 @@ func SupportsBuildkit(v types.Version, env Env) bool {
 func CreateClientOpts(ctx context.Context, env Env) ([]func(client *client.Client) error, error) {
 	result := make([]func(client *client.Client) error, 0)
 
+	// Set scheme = HTTP so we can ping the server (otherwise we can't
+	// accurately negotiate versions with the server below).
+	result = append(result, client.WithScheme("http"))
+
 	if env.CertPath != "" {
 		options := tlsconfig.Options{
 			CAFile:             filepath.Join(env.CertPath, "ca.pem"),
@@ -254,7 +258,7 @@ func CreateClientOpts(ctx context.Context, env Env) ([]func(client *client.Clien
 	if env.APIVersion != "" {
 		result = append(result, client.WithVersion(env.APIVersion))
 	} else {
-		// NegotateAPIVersion makes the docker client negotiate down to a lower version
+		// NegotiateAPIVersion makes the docker client negotiate down to a lower version
 		// if 'defaultVersion' is newer than the server version.
 		result = append(result, client.WithVersion(defaultVersion), NegotiateAPIVersion(ctx))
 	}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -229,10 +229,6 @@ func SupportsBuildkit(v types.Version, env Env) bool {
 func CreateClientOpts(ctx context.Context, env Env) ([]func(client *client.Client) error, error) {
 	result := make([]func(client *client.Client) error, 0)
 
-	// Set scheme = HTTP so we can ping the server (otherwise we can't
-	// accurately negotiate versions with the server below).
-	result = append(result, client.WithScheme("http"))
-
 	if env.CertPath != "" {
 		options := tlsconfig.Options{
 			CAFile:             filepath.Join(env.CertPath, "ca.pem"),
@@ -249,6 +245,10 @@ func CreateClientOpts(ctx context.Context, env Env) ([]func(client *client.Clien
 			Transport:     &http.Transport{TLSClientConfig: tlsc},
 			CheckRedirect: client.CheckRedirect,
 		}))
+	} else {
+		// Set scheme = HTTP so we can ping the server (otherwise we can't
+		// accurately negotiate versions with the server below).
+		result = append(result, client.WithScheme("http"))
 	}
 
 	if env.Host != "" {


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch maiamcc/set-scheme-docker-client:

f3c4d6fd7808ebbfae84a473f5261273869dd024 (2019-10-08 14:43:35 -0400)
docker: set client scheme to http so we can ping server to negotiate version

without this change, calls to `NegotiateVersion` (which happens if `$APIVersion` isn't set),
we will always return API v1.24:
- [pinging the server](https://github.com/moby/moby/blob/b3be2802d417d05813d6140b5bc177043288db24/client/client.go#L207) will always error
    b/c of unrecognized scheme (cuz nothing in our options has set the scheme yet); `NegotiateAPIVersion` ignores the error and passes along an empty ping to `negotiateAPIVersionPing`
- given an empty ping, [we default to
v1.24](https://github.com/moby/moby/blob/b3be2802d417d05813d6140b5bc177043288db24/client/client.go#L227)

If we can't accurately discern the user's docker version, we can't use
any features introduced in later versions (e.g. I'm fixing this so that
I can use the `filters` param for `ImagesPrune`).

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics