### PR TITLE
docker: use new WithAPIVersionNegotiation Opt to actually negotiate API version w/ server instead of erroring

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
   branch = "master"
   name = "golang.org/x/net"
 
-# Grab an old version to avoid breakage Docker breakage from change to
+# Grab an old version to avoid Docker breakage from change to
 # x/sys/windows.SecurityAttributes (https://github.com/golang/go/issues/34610).
 # Waiting on Docker update to deal w/ the change (https://github.com/moby/moby/pull/40021).
 [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,6 +36,9 @@
   branch = "master"
   name = "golang.org/x/net"
 
+# Grab an old version to avoid breakage Docker breakage from change to
+# x/sys/windows.SecurityAttributes (https://github.com/golang/go/issues/34610).
+# Waiting on Docker update to deal w/ the change (https://github.com/moby/moby/pull/40021).
 [[override]]
   name = "golang.org/x/sys"
   revision = "0c1ff786ef13daa914a3351c5e6b0321aed5960e"

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -255,19 +255,12 @@ func CreateClientOpts(ctx context.Context, env Env) ([]client.Opt, error) {
 	if env.APIVersion != "" {
 		result = append(result, client.WithVersion(env.APIVersion))
 	} else {
-		// NegotateAPIVersion makes the docker client negotiate down to a lower version
-		// if 'defaultVersion' is newer than the server version.
-		result = append(result, client.WithVersion(defaultVersion), NegotiateAPIVersion(ctx))
+		// WithAPIVersionNegotiation makes the Docker client negotiate down to a lower
+		// version if Docker's current API version is newer than the server version.
+		result = append(result, client.WithAPIVersionNegotiation())
 	}
 
 	return result, nil
-}
-
-func NegotiateAPIVersion(ctx context.Context) func(client *client.Client) error {
-	return func(client *client.Client) error {
-		client.NegotiateAPIVersion(ctx)
-		return nil
-	}
 }
 
 type dockerCreds struct {


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/docker-api-negotiation:

6f5397cf624d2d0a15e7c0e0d3eaee3261fcccfe (2019-10-10 18:19:19 -0400)
docker: use new WithAPIVersionNegotiation Opt to actually negotiate API version w/ server instead of erroring
in the old code, we applied `NegotiateAPIVersion` as an opt, i.e. a
function that we ran the `Client` through when we were creating it.
This resulted in us trying to negotiate with the server--which involved
pinging the server--before we had set a scheme on the `Client` (which
happens later in the client creation process). This, the API negotiation
always failed silently, and we would set the lowest possible version on
the client.

c02e957fd47ffe53e23481e8a96110f7fd902855 (2019-10-10 18:17:42 -0400)
rm repeated line

d7bc4a2bb68707fe23273dba529f0047708c684b (2019-10-10 18:04:41 -0400)
get an older version of x/sys because of a bug with x/sys/windows (https://github.com/golang/go/issues/34610)

369f088cad55b42712580373361c15b59c8fe3ed (2019-10-10 17:01:00 -0400)
update docker/docker

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics