### PR TITLE
engine: put the log managers into their own subpackage

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -25,6 +25,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
+	"github.com/windmilleng/tilt/internal/engine/runtimelog"
 	"github.com/windmilleng/tilt/internal/feature"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/server"
@@ -65,7 +66,7 @@ var BaseWireSet = wire.NewSet(
 
 	clockwork.NewRealClock,
 	engine.DeployerWireSet,
-	engine.NewPodLogManager,
+	runtimelog.NewPodLogManager,
 	engine.NewPortForwardController,
 	engine.NewBuildController,
 	k8swatch.NewPodWatcher,
@@ -73,7 +74,7 @@ var BaseWireSet = wire.NewSet(
 	k8swatch.NewEventWatchManager,
 	configs.NewConfigsController,
 	engine.NewDockerComposeEventWatcher,
-	engine.NewDockerComposeLogManager,
+	runtimelog.NewDockerComposeLogManager,
 	engine.NewProfilerManager,
 	engine.NewGithubClientFactory,
 	engine.NewTiltVersionChecker,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -28,6 +28,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
+	"github.com/windmilleng/tilt/internal/engine/runtimelog"
 	"github.com/windmilleng/tilt/internal/feature"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/server"
@@ -82,7 +83,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 		return demo.Script{}, err
 	}
 	serviceWatcher := k8swatch.NewServiceWatcher(client, ownerFetcher, nodeIP)
-	podLogManager := engine.NewPodLogManager(client)
+	podLogManager := runtimelog.NewPodLogManager(client)
 	portForwardController := engine.NewPortForwardController(client)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
 	timerMaker := engine.ProvideTimerMaker()
@@ -138,7 +139,7 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics2 *analytics
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, dockerComposeClient, kubeContext, env, defaults)
 	configsController := configs.NewConfigsController(tiltfileLoader, switchCli)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
-	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
+	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
 	analyticsReporter := engine.ProvideAnalyticsReporter(analytics2, storeStore)
 	tiltBuild := provideTiltInfo()
@@ -215,7 +216,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 		return Threads{}, err
 	}
 	serviceWatcher := k8swatch.NewServiceWatcher(client, ownerFetcher, nodeIP)
-	podLogManager := engine.NewPodLogManager(client)
+	podLogManager := runtimelog.NewPodLogManager(client)
 	portForwardController := engine.NewPortForwardController(client)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
 	timerMaker := engine.ProvideTimerMaker()
@@ -271,7 +272,7 @@ func wireThreads(ctx context.Context, analytics2 *analytics.TiltAnalytics) (Thre
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, dockerComposeClient, kubeContext, env, defaults)
 	configsController := configs.NewConfigsController(tiltfileLoader, switchCli)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
-	dockerComposeLogManager := engine.NewDockerComposeLogManager(dockerComposeClient)
+	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
 	analyticsReporter := engine.ProvideAnalyticsReporter(analytics2, storeStore)
 	tiltBuild := provideTiltInfo()
@@ -501,7 +502,7 @@ var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideCluste
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,
-	provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, tiltfile.ProvideTiltfileLoader, clockwork.NewRealClock, engine.DeployerWireSet, engine.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, engine.NewDockerComposeEventWatcher, engine.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.ProvideHttpClient, cloud.NewUsernameManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, engine.NewTiltAnalyticsSubscriber, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
+	provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, tiltfile.ProvideTiltfileLoader, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.ProvideHttpClient, cloud.NewUsernameManager, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, engine.NewTiltAnalyticsSubscriber, engine.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -24,13 +24,6 @@ type BuildLogAction struct {
 
 func (BuildLogAction) Action() {}
 
-type PodLogAction struct {
-	store.LogEvent
-	PodID k8s.PodID
-}
-
-func (PodLogAction) Action() {}
-
 type DeployIDAction struct {
 	TargetID model.TargetID
 	DeployID model.DeployID
@@ -119,12 +112,6 @@ type DockerComposeEventAction struct {
 }
 
 func (DockerComposeEventAction) Action() {}
-
-type DockerComposeLogAction struct {
-	store.LogEvent
-}
-
-func (DockerComposeLogAction) Action() {}
 
 type LatestVersionAction struct {
 	Build model.TiltBuild

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
+	"github.com/windmilleng/tilt/internal/engine/runtimelog"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/synclet/sidecar"
@@ -262,7 +263,7 @@ func prunePods(ms *store.ManifestState) {
 	}
 }
 
-func handlePodLogAction(state *store.EngineState, action PodLogAction) {
+func handlePodLogAction(state *store.EngineState, action runtimelog.PodLogAction) {
 	manifestName := action.Source()
 	ms, ok := state.ManifestState(manifestName)
 	if !ok {

--- a/internal/engine/portforwardcontroller.go
+++ b/internal/engine/portforwardcontroller.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/windmilleng/tilt/internal/engine/runtimelog"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/logger"
@@ -103,10 +104,10 @@ func (m *PortForwardController) OnChange(ctx context.Context, st store.RStore) {
 
 	for _, entry := range toStart {
 		// Treat port-forwarding errors as part of the pod log
-		actionWriter := PodLogActionWriter{
-			store:        st,
-			podID:        entry.podID,
-			manifestName: entry.name,
+		actionWriter := runtimelog.PodLogActionWriter{
+			Store:        st,
+			PodID:        entry.podID,
+			ManifestName: entry.name,
 		}
 		ctx := entry.ctx
 		ctx = logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), actionWriter))

--- a/internal/engine/runtimelog/actions.go
+++ b/internal/engine/runtimelog/actions.go
@@ -1,0 +1,19 @@
+package runtimelog
+
+import (
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+type PodLogAction struct {
+	store.LogEvent
+	PodID k8s.PodID
+}
+
+func (PodLogAction) Action() {}
+
+type DockerComposeLogAction struct {
+	store.LogEvent
+}
+
+func (DockerComposeLogAction) Action() {}

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -1,4 +1,4 @@
-package engine
+package runtimelog
 
 import (
 	"bytes"

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -1,4 +1,4 @@
-package engine
+package runtimelog
 
 import (
 	"context"
@@ -173,9 +173,9 @@ func (m *PodLogManager) consumeLogs(watch PodLogWatch, st store.RStore) {
 	}()
 
 	var actionWriter io.Writer = PodLogActionWriter{
-		store:        st,
-		manifestName: name,
-		podID:        pID,
+		Store:        st,
+		ManifestName: name,
+		PodID:        pID,
 	}
 	if watch.shouldPrefix {
 		prefix := fmt.Sprintf("[%s] ", watch.cName)
@@ -209,15 +209,15 @@ type podLogKey struct {
 }
 
 type PodLogActionWriter struct {
-	store        store.RStore
-	podID        k8s.PodID
-	manifestName model.ManifestName
+	Store        store.RStore
+	PodID        k8s.PodID
+	ManifestName model.ManifestName
 }
 
 func (w PodLogActionWriter) Write(p []byte) (n int, err error) {
-	w.store.Dispatch(PodLogAction{
-		PodID:    w.podID,
-		LogEvent: store.NewLogEvent(w.manifestName, p),
+	w.Store.Dispatch(PodLogAction{
+		PodID:    w.PodID,
+		LogEvent: store.NewLogEvent(w.ManifestName, p),
 	})
 	return len(p), nil
 }

--- a/internal/engine/runtimelog/podlogmanager_test.go
+++ b/internal/engine/runtimelog/podlogmanager_test.go
@@ -1,4 +1,4 @@
-package engine
+package runtimelog
 
 import (
 	"context"

--- a/internal/engine/runtimelog/reader.go
+++ b/internal/engine/runtimelog/reader.go
@@ -1,4 +1,4 @@
-package engine
+package runtimelog
 
 import (
 	"context"

--- a/internal/engine/subscribers.go
+++ b/internal/engine/subscribers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
+	"github.com/windmilleng/tilt/internal/engine/runtimelog"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/store"
@@ -15,13 +16,13 @@ func ProvideSubscribers(
 	hud hud.HeadsUpDisplay,
 	pw *k8swatch.PodWatcher,
 	sw *k8swatch.ServiceWatcher,
-	plm *PodLogManager,
+	plm *runtimelog.PodLogManager,
 	pfc *PortForwardController,
 	fwm *WatchManager,
 	bc *BuildController,
 	cc *configs.ConfigsController,
 	dcw *DockerComposeEventWatcher,
-	dclm *DockerComposeLogManager,
+	dclm *runtimelog.DockerComposeLogManager,
 	pm *ProfilerManager,
 	sm containerupdate.SyncletManager,
 	ar *AnalyticsReporter,

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
+	"github.com/windmilleng/tilt/internal/engine/runtimelog"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/hud/server"
 	"github.com/windmilleng/tilt/internal/k8s"
@@ -170,7 +171,7 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleServiceEvent(ctx, state, action)
 	case store.K8sEventAction:
 		handleK8sEvent(ctx, state, action)
-	case PodLogAction:
+	case runtimelog.PodLogAction:
 		handlePodLogAction(state, action)
 	case BuildLogAction:
 		handleBuildLogAction(state, action)
@@ -186,7 +187,7 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleConfigsReloaded(ctx, state, action)
 	case DockerComposeEventAction:
 		handleDockerComposeEvent(ctx, state, action)
-	case DockerComposeLogAction:
+	case runtimelog.DockerComposeLogAction:
 		handleDockerComposeLogAction(state, action)
 	case server.AppendToTriggerQueueAction:
 		appendToTriggerQueue(state, action.Name)
@@ -597,7 +598,7 @@ func handleBuildLogAction(state *store.EngineState, action BuildLogAction) {
 func handleLogAction(state *store.EngineState, action store.LogAction) {
 	manifestName := action.Source()
 	alreadyHasSourcePrefix := false
-	if _, isDCLog := action.(DockerComposeLogAction); isDCLog {
+	if _, isDCLog := action.(runtimelog.DockerComposeLogAction); isDCLog {
 		// DockerCompose logs are prefixed by the docker-compose engine
 		alreadyHasSourcePrefix = true
 	}
@@ -737,7 +738,7 @@ func handleDockerComposeEvent(ctx context.Context, engineState *store.EngineStat
 	ms.RuntimeState = state
 }
 
-func handleDockerComposeLogAction(state *store.EngineState, action DockerComposeLogAction) {
+func handleDockerComposeLogAction(state *store.EngineState, action runtimelog.DockerComposeLogAction) {
 	manifestName := action.Source()
 	ms, ok := state.ManifestState(manifestName)
 	if !ok {

--- a/internal/engine/version_checker_test.go
+++ b/internal/engine/version_checker_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/windmilleng/tilt/internal/engine/runtimelog"
 	"github.com/windmilleng/tilt/internal/github"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/testutils/bufsync"
@@ -67,7 +68,7 @@ const infiniteDelay = -1
 func newVersionCheckerFixture(t *testing.T) *versionCheckerFixture {
 	out := bufsync.NewThreadSafeBuffer()
 	reducer := func(ctx context.Context, state *store.EngineState, action store.Action) {
-		podLog, ok := action.(PodLogAction)
+		podLog, ok := action.(runtimelog.PodLogAction)
 		if !ok {
 			t.Errorf("Expected action type PodLogAction. Actual: %T", action)
 		}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/runtimelog:

b75d24ab1e41342646b2dcc91259fbc39a41c5d2 (2019-10-11 16:05:08 -0400)
engine: put the log managers into their own subpackage