### PR TITLE
dockerprune: instead of docker.ImagesPrune, only remove tilt-built images with lastTag younger than MaxAge [ch3707]

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -105,7 +105,6 @@ type Client interface {
 	NewVersionError(APIrequired, feature string) error
 	BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)
-	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (types.ImagesPruneReport, error)
 }
 
 type ExitError struct {

--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -77,8 +77,5 @@ func (c explodingClient) BuildCachePrune(ctx context.Context, opts types.BuildCa
 func (c explodingClient) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error) {
 	return types.ContainersPruneReport{}, c.err
 }
-func (c explodingClient) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (types.ImagesPruneReport, error) {
-	return types.ImagesPruneReport{}, c.err
-}
 
 var _ Client = &explodingClient{}

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -96,8 +96,5 @@ func (c *switchCli) BuildCachePrune(ctx context.Context, opts types.BuildCachePr
 func (c *switchCli) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error) {
 	return c.client().ContainersPrune(ctx, pruneFilters)
 }
-func (c *switchCli) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (types.ImagesPruneReport, error) {
-	return c.client().ImagesPrune(ctx, pruneFilters)
-}
 
 var _ Client = &switchCli{}

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -187,9 +187,11 @@ func (dp *DockerPruner) deleteOldImages(ctx context.Context, maxAge time.Duratio
 
 	for imgID, bytes := range toDelete {
 		items, err := dp.dCli.ImageRemove(ctx, imgID, rmOpts)
-		// No good way to detect in-use images from `inspect` output, so just silently ignore
-		if err != nil && !strings.Contains(err.Error(), "image is being used by running container") {
-			logger.Get(ctx).Debugf("[Docker prune] error removing image '%s': %v", imgID, err)
+		if err != nil {
+			// No good way to detect in-use images from `inspect` output, so just ignore those errors
+			if !strings.Contains(err.Error(), "image is being used by running container") {
+				logger.Get(ctx).Debugf("[Docker prune] error removing image '%s': %v", imgID, err)
+			}
 			continue
 		}
 		responseItems = append(responseItems, items...)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3861,17 +3861,6 @@ docker_prune_settings(max_age_mins=111, num_builds=222)
 	assert.Equal(t, model.DockerPruneDefaultInterval, res.Interval) // default
 }
 
-func TestDockerPruneSettingsCantSetNumBuildsAndInterval(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.file("Tiltfile", `
-docker_prune_settings(num_builds=123, interval_hrs=456)
-`)
-
-	f.loadErrString("please pass only one of `num_builds` and `interval_hrs`")
-}
-
 func TestDockerPruneSettingsDefaultsWhenCalled(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
If someone is using Tilt against a cloud cluster, it's not enough to run `docker image prune` -- Image X may be running a container in the cloud, but the local docker daemon doesn't know about it and thinks it's prune-able, but we DON'T want that, as the user is probably actively developing on it.

alternative: list all tilt-built images, and check "last tagged" metadata for a more accurate picture of when the image was last updated; only delete those images where it was last tagged sufficiently long ago.