### PR TITLE
engine: move next-manifest-to-build logic to its own package so it can be accessed elsewhere (ultimately needed for DockerPruner to check if there's a pending build)

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -1,0 +1,146 @@
+package buildcontrol
+
+import (
+	"time"
+
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+// NOTE(maia): we eventually want to move the BuildController into its own package
+// (as we do with all subscribers), but for now, just move the underlying functions
+// so they can be used from elsewhere.
+
+// Algorithm to choose a manifest to build next.
+func NextTargetToBuild(state store.EngineState) *store.ManifestTarget {
+	// Don't build anything if there are pending config file changes.
+	// We want the Tiltfile to re-run first.
+	if len(state.PendingConfigFileChanges) > 0 {
+		return nil
+	}
+
+	targets := state.Targets()
+
+	// If any of the manifest target's haven't been built yet, build them now.
+	unbuilt := FindUnbuiltTargets(targets)
+	if len(unbuilt) > 0 {
+		return NextUnbuiltTargetToBuild(unbuilt)
+	}
+
+	// Next prioritize builds that crashed and need a rebuilt to have up-to-date code.
+	for _, mt := range targets {
+		if mt.State.NeedsRebuildFromCrash {
+			return mt
+		}
+	}
+
+	// Next prioritize builds that are have been manually triggered.
+	if len(state.TriggerQueue) > 0 {
+		mn := state.TriggerQueue[0]
+		mt, ok := state.ManifestTargets[mn]
+		if ok {
+			return mt
+		}
+	}
+
+	return EarliestPendingAutoTriggerTarget(targets)
+}
+
+func NextManifestNameToBuild(state store.EngineState) model.ManifestName {
+	mt := NextTargetToBuild(state)
+	if mt == nil {
+		return ""
+	}
+	return mt.Manifest.Name
+}
+
+// Helper function for ordering targets that have never been built before.
+func NextUnbuiltTargetToBuild(unbuilt []*store.ManifestTarget) *store.ManifestTarget {
+	// unresourced YAML goes first
+	unresourced := FindUnresourcedYAML(unbuilt)
+	if unresourced != nil {
+		return unresourced
+	}
+
+	// Local resources come before all cluster resources (b/c LR's may
+	// change things on disk that cluster resources then pull in).
+	localTargets := FindLocalTargets(unbuilt)
+	if len(localTargets) > 0 {
+		return localTargets[0]
+	}
+
+	// If this is Kubernetes, unbuilt resources go first.
+	// (If this is Docker Compose, we want to trust the ordering
+	// that docker-compose put things in.)
+	deployOnlyK8sTargets := FindDeployOnlyK8sManifestTargets(unbuilt)
+	if len(deployOnlyK8sTargets) > 0 {
+		return deployOnlyK8sTargets[0]
+	}
+
+	return unbuilt[0]
+}
+
+func FindUnresourcedYAML(targets []*store.ManifestTarget) *store.ManifestTarget {
+	for _, target := range targets {
+		if target.Manifest.ManifestName() == model.UnresourcedYAMLManifestName {
+			return target
+		}
+	}
+	return nil
+}
+
+func FindDeployOnlyK8sManifestTargets(targets []*store.ManifestTarget) []*store.ManifestTarget {
+	result := []*store.ManifestTarget{}
+	for _, target := range targets {
+		if target.Manifest.IsK8s() && len(target.Manifest.ImageTargets) == 0 {
+			result = append(result, target)
+		}
+	}
+	return result
+}
+
+func FindLocalTargets(targets []*store.ManifestTarget) []*store.ManifestTarget {
+	result := []*store.ManifestTarget{}
+	for _, target := range targets {
+		if target.Manifest.IsLocal() {
+			result = append(result, target)
+		}
+	}
+	return result
+}
+
+// Go through all the manifests, and check:
+// 1) all pending file changes, and
+// 2) all pending manifest changes
+// The earliest one is the one we want.
+//
+// If no targets are pending, return nil
+func EarliestPendingAutoTriggerTarget(targets []*store.ManifestTarget) *store.ManifestTarget {
+	var choice *store.ManifestTarget
+	earliest := time.Now()
+
+	for _, mt := range targets {
+		ok, newTime := mt.State.HasPendingChangesBefore(earliest)
+		if ok {
+			if mt.Manifest.TriggerMode == model.TriggerModeManual {
+				// Don't trigger update of a manual manifest just b/c if has
+				// pending changes; must come through the TriggerQueue, above.
+				continue
+			}
+			choice = mt
+			earliest = newTime
+		}
+	}
+
+	return choice
+}
+
+func FindUnbuiltTargets(targets []*store.ManifestTarget) []*store.ManifestTarget {
+	result := []*store.ManifestTarget{}
+	for _, target := range targets {
+		if !target.State.StartedFirstBuild() {
+			result = append(result, target)
+		}
+	}
+	return result
+}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/engine/buildcontrol"
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/logger"
@@ -33,140 +34,6 @@ func NewBuildController(b BuildAndDeployer) *BuildController {
 	}
 }
 
-// Algorithm to choose a manifest to build next.
-func nextTargetToBuild(state store.EngineState) *store.ManifestTarget {
-	// Don't build anything if there are pending config file changes.
-	// We want the Tiltfile to re-run first.
-	if len(state.PendingConfigFileChanges) > 0 {
-		return nil
-	}
-
-	targets := state.Targets()
-
-	// If any of the manifest target's haven't been built yet, build them now.
-	unbuilt := findUnbuiltTargets(targets)
-	if len(unbuilt) > 0 {
-		return nextUnbuiltTargetToBuild(unbuilt)
-	}
-
-	// Next prioritize builds that crashed and need a rebuilt to have up-to-date code.
-	for _, mt := range targets {
-		if mt.State.NeedsRebuildFromCrash {
-			return mt
-		}
-	}
-
-	// Next prioritize builds that are have been manually triggered.
-	if len(state.TriggerQueue) > 0 {
-		mn := state.TriggerQueue[0]
-		mt, ok := state.ManifestTargets[mn]
-		if ok {
-			return mt
-		}
-	}
-
-	return earliestPendingAutoTriggerTarget(targets)
-}
-
-// Go through all the manifests, and check:
-// 1) all pending file changes, and
-// 2) all pending manifest changes
-// The earliest one is the one we want.
-//
-// If no targets are pending, return nil
-func earliestPendingAutoTriggerTarget(targets []*store.ManifestTarget) *store.ManifestTarget {
-	var choice *store.ManifestTarget
-	earliest := time.Now()
-
-	for _, mt := range targets {
-		ok, newTime := mt.State.HasPendingChangesBefore(earliest)
-		if ok {
-			if mt.Manifest.TriggerMode == model.TriggerModeManual {
-				// Don't trigger update of a manual manifest just b/c if has
-				// pending changes; must come through the TriggerQueue, above.
-				continue
-			}
-			choice = mt
-			earliest = newTime
-		}
-	}
-
-	return choice
-}
-
-// Helper function for ordering targets that have never been built before.
-func nextUnbuiltTargetToBuild(unbuilt []*store.ManifestTarget) *store.ManifestTarget {
-	// unresourced YAML goes first
-	unresourced := findUnresourcedYAML(unbuilt)
-	if unresourced != nil {
-		return unresourced
-	}
-
-	// Local resources come before all cluster resources (b/c LR's may
-	// change things on disk that cluster resources then pull in).
-	localTargets := findLocalTargets(unbuilt)
-	if len(localTargets) > 0 {
-		return localTargets[0]
-	}
-
-	// If this is Kubernetes, unbuilt resources go first.
-	// (If this is Docker Compose, we want to trust the ordering
-	// that docker-compose put things in.)
-	deployOnlyK8sTargets := findDeployOnlyK8sManifestTargets(unbuilt)
-	if len(deployOnlyK8sTargets) > 0 {
-		return deployOnlyK8sTargets[0]
-	}
-
-	return unbuilt[0]
-}
-
-func findUnbuiltTargets(targets []*store.ManifestTarget) []*store.ManifestTarget {
-	result := []*store.ManifestTarget{}
-	for _, target := range targets {
-		if !target.State.StartedFirstBuild() {
-			result = append(result, target)
-		}
-	}
-	return result
-}
-
-func findUnresourcedYAML(targets []*store.ManifestTarget) *store.ManifestTarget {
-	for _, target := range targets {
-		if target.Manifest.ManifestName() == model.UnresourcedYAMLManifestName {
-			return target
-		}
-	}
-	return nil
-}
-
-func findDeployOnlyK8sManifestTargets(targets []*store.ManifestTarget) []*store.ManifestTarget {
-	result := []*store.ManifestTarget{}
-	for _, target := range targets {
-		if target.Manifest.IsK8s() && len(target.Manifest.ImageTargets) == 0 {
-			result = append(result, target)
-		}
-	}
-	return result
-}
-
-func findLocalTargets(targets []*store.ManifestTarget) []*store.ManifestTarget {
-	result := []*store.ManifestTarget{}
-	for _, target := range targets {
-		if target.Manifest.IsLocal() {
-			result = append(result, target)
-		}
-	}
-	return result
-}
-
-func nextManifestNameToBuild(state store.EngineState) model.ManifestName {
-	mt := nextTargetToBuild(state)
-	if mt == nil {
-		return ""
-	}
-	return mt.Manifest.Name
-}
-
 func (c *BuildController) needsBuild(ctx context.Context, st store.RStore) (buildEntry, bool) {
 	state := st.RLockState()
 	defer st.RUnlockState()
@@ -177,7 +44,7 @@ func (c *BuildController) needsBuild(ctx context.Context, st store.RStore) (buil
 		return buildEntry{}, false
 	}
 
-	mt := nextTargetToBuild(state)
+	mt := buildcontrol.NextTargetToBuild(state)
 	if mt == nil {
 		return buildEntry{}, false
 	}


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/move-build-control:

fec0acf2ff98096f9cc4f84a6089e2c3c7f6db81 (2019-10-14 18:13:20 -0400)
engine: move next-manifest-to-build logic to its own package so it can be accessed elsewhere

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics