### PR TITLE
dockerprune: use state.dockerPruneSettings to dictate when/how we prune

### DIFF
--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 
+	"github.com/windmilleng/tilt/internal/engine/buildcontrol"
+
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/sliceutils"
 	"github.com/windmilleng/tilt/internal/store"
@@ -16,17 +18,18 @@ import (
 )
 
 // How often to prune Docker images while Tilt is running
-const dockerPruneInterval = time.Hour
+const defaultInterval = time.Hour
 
 // Prune Docker objects older than this
-// TODO: configurable from Tiltfile for special cases
 const defaultMaxAge = time.Hour * 6
 
 type DockerPruner struct {
 	dCli docker.Client
 
-	started            bool
 	disabledForTesting bool
+
+	lastPruneBuildCount int
+	lastPruneTime       time.Time
 }
 
 var _ store.Subscriber = &DockerPruner{}
@@ -35,8 +38,8 @@ func NewDockerPruner(dCli docker.Client) *DockerPruner {
 	return &DockerPruner{dCli: dCli}
 }
 
-func (dp *DockerPruner) DisableForTesting() {
-	dp.disabledForTesting = true
+func (dp *DockerPruner) DisabledForTesting(disabled bool) {
+	dp.disabledForTesting = disabled
 }
 
 func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
@@ -44,48 +47,71 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 		return
 	}
 
-	if dp.started {
-		return
-	}
-
-	state := st.RLockState()
-	defer st.RUnlockState()
-
-	if state.DockerPruneSettings.Disabled {
-		return
-	}
-
 	if err := dp.sufficientVersionError(); err != nil {
 		return
 	}
 
-	// wait until state has been kinda initialized, and there's at least one Docker build
-	if !state.TiltStartTime.IsZero() && state.LastTiltfileError() == nil && state.HasDockerBuild() {
-		dp.started = true
-		go func() {
-			select {
-			case <-time.After(time.Minute * 2):
-				dp.Prune(ctx, defaultMaxAge) // report once pretty soon after startup...
-			case <-ctx.Done():
-				return
-			}
+	state := st.RLockState()
+	settings := state.DockerPruneSettings
+	inProgBuild := state.CurrentlyBuilding
+	curBuildCount := state.CompletedBuildCount
+	hasDockerBuild := state.HasDockerBuild()
+	nextToBuild := buildcontrol.NextManifestNameToBuild(state)
+	st.RUnlockState()
 
-			for {
-				select {
-				case <-time.After(dockerPruneInterval):
-					// and once every <interval> thereafter
-					dp.Prune(ctx, defaultMaxAge)
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
+	if !settings.Enabled {
+		return
 	}
+
+	// If user doesn't have at least one Docker build, they probably don't care about pruning
+	if !hasDockerBuild {
+		return
+	}
+
+	// Don't prune while we're building or about to build something, in case of weird side-effects.
+	if inProgBuild != "" || nextToBuild != "" {
+		return
+	}
+
+	// Prune as soon after startup as we can (waiting until we've built SOMETHING)
+	if dp.lastPruneTime.IsZero() && curBuildCount > 0 {
+		dp.PruneAndRecordState(ctx, settings.MaxAge, curBuildCount)
+		return
+	}
+
+	// "Prune every X builds" takes precedence over "prune every Y hours"
+	if settings.NumBuilds != 0 {
+		buildsSince := curBuildCount - dp.lastPruneBuildCount
+		if buildsSince >= settings.NumBuilds {
+			dp.PruneAndRecordState(ctx, settings.MaxAge, curBuildCount)
+		}
+		return
+	}
+
+	interval := settings.Interval
+	if interval == 0 {
+		interval = defaultInterval
+	}
+
+	if time.Since(dp.lastPruneTime) >= interval {
+		dp.PruneAndRecordState(ctx, settings.MaxAge, curBuildCount)
+	}
+}
+
+func (dp *DockerPruner) PruneAndRecordState(ctx context.Context, maxAge time.Duration, curBuildCount int) {
+	dp.Prune(ctx, maxAge)
+	dp.lastPruneTime = time.Now()
+	dp.lastPruneBuildCount = curBuildCount
 }
 
 func (dp *DockerPruner) Prune(ctx context.Context, maxAge time.Duration) {
 	// For future: dispatch event with output/errors to be recorded
 	//   in engineState.TiltSystemState on store (analogous to TiltfileState)
+
+	if maxAge == 0 {
+		maxAge = defaultMaxAge
+	}
+
 	err := dp.prune(ctx, maxAge)
 	if err != nil {
 		logger.Get(ctx).Infof("[Docker Prune] error running docker prune: %v", err)

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/pkg/model"
+
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/testutils"
 )
@@ -22,8 +25,16 @@ var (
 	maxAge           = 11 * time.Hour
 )
 
+var buildHistory = []model.BuildRecord{
+	model.BuildRecord{StartTime: time.Now().Add(-24 * time.Hour)},
+}
+
+func twoHrsAgo() time.Time {
+	return time.Now().Add(-2 * time.Hour)
+}
+
 func TestDockerPruneFilters(t *testing.T) {
-	f := newFixture().withPruneOutput(cachesPruned, containersPruned, imagesPruned)
+	f := newFixture(t).withPruneOutput(cachesPruned, containersPruned, imagesPruned)
 	err := f.dp.prune(f.ctx, maxAge)
 	require.NoError(t, err)
 
@@ -43,7 +54,7 @@ func TestDockerPruneFilters(t *testing.T) {
 }
 
 func TestDockerPruneOutput(t *testing.T) {
-	f := newFixture().withPruneOutput(cachesPruned, containersPruned, imagesPruned)
+	f := newFixture(t).withPruneOutput(cachesPruned, containersPruned, imagesPruned)
 	err := f.dp.prune(f.ctx, maxAge)
 	require.NoError(t, err)
 
@@ -57,7 +68,7 @@ func TestDockerPruneOutput(t *testing.T) {
 }
 
 func TestDockerPruneVersionTooLow(t *testing.T) {
-	f := newFixture()
+	f := newFixture(t)
 	f.dCli.ThrowNewVersionError = true
 	err := f.dp.prune(f.ctx, maxAge)
 	require.NoError(t, err) // should log failure but not throw error
@@ -72,7 +83,7 @@ func TestDockerPruneVersionTooLow(t *testing.T) {
 }
 
 func TestDockerPruneSkipCachePruneIfVersionTooLow(t *testing.T) {
-	f := newFixture()
+	f := newFixture(t)
 	f.dCli.BuildCachePruneErr = f.dCli.VersionError("1.2.3", "build prune")
 	err := f.dp.prune(f.ctx, maxAge)
 	require.NoError(t, err) // should log failure but not throw error
@@ -86,7 +97,7 @@ func TestDockerPruneSkipCachePruneIfVersionTooLow(t *testing.T) {
 }
 
 func TestDockerPruneReturnsCachePruneError(t *testing.T) {
-	f := newFixture()
+	f := newFixture(t)
 	f.dCli.BuildCachePruneErr = fmt.Errorf("this is a real error, NOT an API version error")
 	err := f.dp.prune(f.ctx, maxAge) // For all errors besides API version error, expect them to return
 	require.NotNil(t, err)
@@ -99,24 +110,195 @@ func TestDockerPruneReturnsCachePruneError(t *testing.T) {
 	assert.Empty(t, f.dCli.ContainersPruneFilters) // should NOT have called any prune funcs AFTER CachePrune
 }
 
+func TestDockerPrunerSinceNBuilds(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withBuildCount(11)
+	f.withDockerPruneSettings(true, 0, 5, 0)
+	f.dp.lastPruneBuildCount = 5
+	f.dp.lastPruneTime = twoHrsAgo()
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertPrune()
+}
+
+func TestDockerPrunerNotEnoughBuilds(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withBuildCount(11)
+	f.withDockerPruneSettings(true, 0, 10, 0)
+	f.dp.lastPruneBuildCount = 5
+	f.dp.lastPruneTime = twoHrsAgo()
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerSinceInterval(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withDockerPruneSettings(true, 0, 0, 30*time.Minute)
+	f.dp.lastPruneTime = twoHrsAgo()
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertPrune()
+}
+
+func TestDockerPrunerSinceDefaultInterval(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withDockerPruneSettings(true, 0, 0, 0)
+	f.dp.lastPruneTime = time.Now().Add(-1 * (defaultInterval + time.Minute))
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertPrune()
+}
+
+func TestDockerPrunerNotEnoughTimeElapsed(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withDockerPruneSettings(true, 0, 0, 3*time.Hour)
+	f.dp.lastPruneTime = twoHrsAgo()
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerSinceDefaultIntervalNotEnoughTime(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withDockerPruneSettings(true, 0, 0, 0)
+	f.dp.lastPruneTime = time.Now().Add(-1 * defaultInterval).Add(20 * time.Minute)
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerFirstRun(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withBuildCount(5)
+	f.withDockerPruneSettings(true, 0, 10, 0)
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertPrune()
+}
+
+func TestDockerPrunerFirstRunButNoCompletedBuilds(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withBuildCount(0)
+	f.withDockerPruneSettings(true, 0, 10, 0)
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerNoDockerManifests(t *testing.T) {
+	f := newFixture(t)
+	f.withK8sOnlyManifest()
+	f.withBuildCount(11)
+	f.withDockerPruneSettings(true, 0, 5, 0)
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerDisabled(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withDockerPruneSettings(false, 0, 0, 0)
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerCurrentlyBuilding(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withCurrentlyBuilding("idk something")
+	f.withDockerPruneSettings(true, 0, 0, time.Hour)
+	f.dp.lastPruneTime = twoHrsAgo()
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerPendingBuild(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestUnbuilt() // manifest not yet built will be pending, so we should not prune
+	f.withDockerPruneSettings(true, 0, 0, time.Hour)
+	f.dp.lastPruneTime = twoHrsAgo()
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertNoPrune()
+}
+
+func TestDockerPrunerMaxAgeFromSettings(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withBuildCount(5)
+	maxAge := time.Hour
+	f.withDockerPruneSettings(true, maxAge, 10, 0)
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertPrune()
+	untilVals := f.dCli.ImagesPruneFilters.Get("until")
+	require.Len(t, untilVals, 1, "unexpected number of filters for \"until\"")
+	assert.Equal(t, untilVals[0], maxAge.String())
+}
+
+func TestDockerPrunerDefaultMaxAge(t *testing.T) {
+	f := newFixture(t)
+	f.withDockerManifestAlreadyBuilt()
+	f.withBuildCount(5)
+	f.withDockerPruneSettings(true, 0, 10, 0)
+
+	f.dp.OnChange(f.ctx, f.st)
+
+	f.assertPrune()
+	untilVals := f.dCli.ImagesPruneFilters.Get("until")
+	require.Len(t, untilVals, 1, "unexpected number of filters for \"until\"")
+	assert.Equal(t, untilVals[0], defaultMaxAge.String())
+}
+
+// Test currently building
 type dockerPruneFixture struct {
+	t    *testing.T
 	ctx  context.Context
 	logs *bytes.Buffer
+	st   *store.Store
 
 	dCli *docker.FakeClient
 	dp   *DockerPruner
 }
 
-func newFixture() *dockerPruneFixture {
+func newFixture(t *testing.T) *dockerPruneFixture {
 	logs := new(bytes.Buffer)
 	ctx, _, _ := testutils.ForkedCtxAndAnalyticsForTest(logs)
+	st, _ := store.NewStoreForTesting()
 
 	dCli := docker.NewFakeClient()
 	dp := NewDockerPruner(dCli)
 
 	return &dockerPruneFixture{
+		t:    t,
 		ctx:  ctx,
 		logs: logs,
+		st:   st,
 		dCli: dCli,
 		dp:   dp,
 	}
@@ -127,4 +309,84 @@ func (dpf *dockerPruneFixture) withPruneOutput(caches, containers, images []stri
 	dpf.dCli.ContainersPruned = containers
 	dpf.dCli.ImagesPruned = images
 	return dpf
+}
+
+func (dpf *dockerPruneFixture) withDockerManifestAlreadyBuilt() {
+	dpf.withDockerManifest(true)
+}
+
+func (dpf *dockerPruneFixture) withDockerManifestUnbuilt() {
+	dpf.withDockerManifest(false)
+}
+
+func (dpf *dockerPruneFixture) withDockerManifest(alreadyBuilt bool) {
+	m := model.Manifest{Name: "some-docker-manifest"}.WithImageTarget(
+		model.ImageTarget{
+			BuildDetails: model.DockerBuild{},
+		})
+	dpf.withManifestTarget(store.NewManifestTarget(m), alreadyBuilt)
+}
+
+func (dpf *dockerPruneFixture) withK8sOnlyManifest() {
+	m := model.Manifest{Name: "i'm-k8s-only"}.WithDeployTarget(model.K8sTarget{})
+	dpf.withManifestTarget(store.NewManifestTarget(m), true)
+}
+
+func (dpf *dockerPruneFixture) withManifestTarget(mt *store.ManifestTarget, alreadyBuilt bool) {
+	if alreadyBuilt {
+		// spoof build history so we think this manifest has already been built (i.e. isn't pending)
+		mt.State.BuildHistory = buildHistory
+	}
+
+	store := dpf.st.LockMutableStateForTesting()
+	store.UpsertManifestTarget(mt)
+	dpf.st.UnlockMutableState()
+}
+
+func (dpf *dockerPruneFixture) withBuildCount(count int) {
+	store := dpf.st.LockMutableStateForTesting()
+	store.CompletedBuildCount = count
+	dpf.st.UnlockMutableState()
+}
+
+func (dpf *dockerPruneFixture) withCurrentlyBuilding(mn model.ManifestName) {
+	store := dpf.st.LockMutableStateForTesting()
+	store.CurrentlyBuilding = mn
+	dpf.st.UnlockMutableState()
+}
+
+func (dpf *dockerPruneFixture) withDockerPruneSettings(enabled bool, maxAge time.Duration, numBuilds int, interval time.Duration) {
+	settings := model.DockerPruneSettings{
+		Enabled:   enabled,
+		MaxAge:    maxAge,
+		NumBuilds: numBuilds,
+		Interval:  interval,
+	}
+	store := dpf.st.LockMutableStateForTesting()
+	store.DockerPruneSettings = settings
+	dpf.st.UnlockMutableState()
+}
+
+func (dpf *dockerPruneFixture) pruneCalled() bool {
+	// ImagePrune was called -- we use this as a proxy for dp.Prune having been called.
+	return dpf.dCli.ImagesPruneFilters.Len() > 0
+}
+
+func (dpf *dockerPruneFixture) assertPrune() {
+	if !dpf.pruneCalled() {
+		dpf.t.Errorf("expected Prune() to be called, but it was not")
+		dpf.t.FailNow()
+	}
+	if time.Since(dpf.dp.lastPruneTime) > time.Second {
+		dpf.t.Errorf("Prune() was called, but dp.lastPruneTime was not updated/" +
+			"not updated recently")
+		dpf.t.FailNow()
+	}
+}
+
+func (dpf *dockerPruneFixture) assertNoPrune() {
+	if dpf.pruneCalled() {
+		dpf.t.Errorf("Prune() was called, when no calls expected")
+		dpf.t.FailNow()
+	}
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2853,6 +2853,7 @@ type testFixture struct {
 	tfl                   tiltfile.TiltfileLoader
 	ghc                   *github.FakeClient
 	opter                 *testOpter
+	dp                    *dockerprune.DockerPruner
 	tiltVersionCheckDelay time.Duration
 
 	onchangeCh chan bool
@@ -2913,6 +2914,9 @@ func newTestFixture(t *testing.T) *testFixture {
 	ewm := k8swatch.NewEventWatchManager(kCli, of)
 	tcum := cloud.NewUsernameManager(httptest.NewFakeClient())
 
+	dp := dockerprune.NewDockerPruner(dockerClient)
+	dp.DisabledForTesting(true)
+
 	ret := &testFixture{
 		TempDirFixture:        f,
 		ctx:                   ctx,
@@ -2933,11 +2937,9 @@ func newTestFixture(t *testing.T) *testFixture {
 		tfl:                   tfl,
 		ghc:                   ghc,
 		opter:                 to,
+		dp:                    dp,
 		tiltVersionCheckDelay: versionCheckInterval,
 	}
-
-	dp := dockerprune.NewDockerPruner(dockerClient)
-	dp.DisableForTesting()
 
 	tiltVersionCheckTimerMaker := func(d time.Duration) <-chan time.Time {
 		return time.After(ret.tiltVersionCheckDelay)

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -85,15 +85,7 @@ type EngineState struct {
 	TokenKnownUnregistered                      bool // to distinguish whether an empty TiltCloudUsername means "we haven't checked" or "we checked and the token isn't registered"
 	WaitingForTiltCloudUsernamePostRegistration bool
 
-	DockerPruneSettings DockerPruneSettings
-}
-
-type DockerPruneSettings struct {
-	Disabled bool
-}
-
-func defaultDockerPruneSettings() DockerPruneSettings {
-	return DockerPruneSettings{Disabled: true} // for now, always disabled until we can configure it
+	DockerPruneSettings model.DockerPruneSettings
 }
 
 func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.ManifestName {
@@ -284,7 +276,6 @@ func NewState() *EngineState {
 	ret.ManifestTargets = make(map[model.ManifestName]*ManifestTarget)
 	ret.PendingConfigFileChanges = make(map[string]time.Time)
 	ret.Secrets = model.SecretSet{}
-	ret.DockerPruneSettings = defaultDockerPruneSettings()
 	return ret
 }
 

--- a/pkg/model/docker_prune.go
+++ b/pkg/model/docker_prune.go
@@ -1,0 +1,10 @@
+package model
+
+import "time"
+
+type DockerPruneSettings struct {
+	Enabled   bool
+	MaxAge    time.Duration // "prune Docker objects older than X"
+	NumBuilds int           // "prune every Y builds" (takes precedence over "prune every Z hours")
+	Interval  time.Duration // "prune every Z hours"
+}


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/dp-use-settings:

7daad87da01bfbc7bf5ad4eb8e5c80266ae76391 (2019-10-14 20:50:18 -0400)
log something if version insufficient to prune

8f1cf91a58da6c1223cd8c4e524dd3f3c488b770 (2019-10-14 20:12:11 -0400)
dockerprune: use state.dockerPruneSettings to dictate when/how we prune

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics