### PR TITLE
tiltfile: extensions should reset state in OnStart

### DIFF
--- a/internal/tiltfile/dockerprune/docker_prune.go
+++ b/internal/tiltfile/dockerprune/docker_prune.go
@@ -17,16 +17,15 @@ type Extension struct {
 }
 
 func NewExtension() *Extension {
-	return &Extension{
-		settings: model.DockerPruneSettings{
-			Enabled:  true,
-			MaxAge:   model.DockerPruneDefaultMaxAge,
-			Interval: model.DockerPruneDefaultInterval,
-		},
-	}
+	return &Extension{}
 }
 
 func (e *Extension) OnStart(env *starkit.Environment) error {
+	e.settings = model.DockerPruneSettings{
+		Enabled:  true,
+		MaxAge:   model.DockerPruneDefaultMaxAge,
+		Interval: model.DockerPruneDefaultInterval,
+	}
 	return env.AddBuiltin("docker_prune_settings", e.dockerPruneSettings)
 }
 

--- a/internal/tiltfile/dockerprune/docker_prune_test.go
+++ b/internal/tiltfile/dockerprune/docker_prune_test.go
@@ -1,0 +1,35 @@
+package dockerprune
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+func TestDockerPrune(t *testing.T) {
+	f, ext := NewFixture(t)
+
+	f.File("Tiltfile", `
+docker_prune_settings(disable=True, max_age_mins=1)
+`)
+	err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.False(t, ext.Settings().Enabled)
+	assert.Equal(t, time.Minute, ext.Settings().MaxAge)
+
+	f.File("Tiltfile.empty", `
+`)
+	err = f.ExecFile("Tiltfile.empty")
+	assert.NoError(t, err)
+	assert.True(t, ext.Settings().Enabled)
+	assert.Equal(t, model.DockerPruneDefaultMaxAge, ext.Settings().MaxAge)
+}
+
+func NewFixture(tb testing.TB) (*starkit.Fixture, *Extension) {
+	ext := NewExtension()
+	return starkit.NewFixture(tb, ext), ext
+}

--- a/internal/tiltfile/k8scontext/k8scontext.go
+++ b/internal/tiltfile/k8scontext/k8scontext.go
@@ -15,7 +15,7 @@ import (
 type Extension struct {
 	context            k8s.KubeContext
 	env                k8s.Env
-	allowedK8SContexts []k8s.KubeContext
+	allowedK8sContexts []k8s.KubeContext
 }
 
 func NewExtension(context k8s.KubeContext, env k8s.Env) *Extension {
@@ -26,6 +26,8 @@ func NewExtension(context k8s.KubeContext, env k8s.Env) *Extension {
 }
 
 func (e *Extension) OnStart(env *starkit.Environment) error {
+	e.allowedK8sContexts = nil
+
 	err := env.AddBuiltin("allow_k8s_contexts", e.allowK8sContexts)
 	if err != nil {
 		return err
@@ -51,7 +53,7 @@ func (e *Extension) IsAllowed() bool {
 		return true
 	}
 
-	for _, c := range e.allowedK8SContexts {
+	for _, c := range e.allowedK8sContexts {
 		if c == e.context {
 			return true
 		}
@@ -71,7 +73,7 @@ func (e *Extension) allowK8sContexts(thread *starlark.Thread, fn *starlark.Built
 	for _, c := range value.ValueOrSequenceToSlice(contexts) {
 		switch val := c.(type) {
 		case starlark.String:
-			e.allowedK8SContexts = append(e.allowedK8SContexts, k8s.KubeContext(val))
+			e.allowedK8sContexts = append(e.allowedK8sContexts, k8s.KubeContext(val))
 		default:
 			return nil, fmt.Errorf("allow_k8s_contexts contexts must be a string or a sequence of strings; found a %T", val)
 

--- a/internal/tiltfile/k8scontext/k8scontext_test.go
+++ b/internal/tiltfile/k8scontext/k8scontext_test.go
@@ -1,0 +1,31 @@
+package k8scontext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+)
+
+func TestAllowK8sContext(t *testing.T) {
+	f, ext := NewFixture(t, "gke-blorg", k8s.EnvGKE)
+
+	f.File("Tiltfile", `
+allow_k8s_contexts('gke-blorg')
+`)
+	err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.Equal(t, []k8s.KubeContext{"gke-blorg"}, ext.allowedK8sContexts)
+	assert.True(t, ext.IsAllowed())
+
+	err = f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.Equal(t, []k8s.KubeContext{"gke-blorg"}, ext.allowedK8sContexts)
+}
+
+func NewFixture(tb testing.TB, ctx k8s.KubeContext, env k8s.Env) (*starkit.Fixture, *Extension) {
+	ext := NewExtension(ctx, env)
+	return starkit.NewFixture(tb, ext), ext
+}


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/k8scontext:

17b2e34f0c0a894d7f86b8404cefd689322a3083 (2019-10-15 13:52:26 -0400)
tiltfile: extensions should reset state in OnStart