### PR TITLE
dockerprune: only prune images if they match a running manifest

### DIFF
--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -6,27 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/windmilleng/tilt/internal/docker"
-	"github.com/windmilleng/tilt/internal/tiltfile"
-
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
 )
 
 type dockerPruneCmd struct {
 	maxAgeStr string
-}
-
-type dpDeps struct {
-	dCli docker.Client
-	tfl  tiltfile.TiltfileLoader
-}
-
-func newDPDeps(dCli docker.Client, tfl tiltfile.TiltfileLoader) dpDeps {
-	return dpDeps{
-		dCli: dCli,
-		tfl:  tfl,
-	}
 }
 
 func (c *dockerPruneCmd) register() *cobra.Command {

--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -6,12 +6,27 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/windmilleng/tilt/internal/docker"
+	"github.com/windmilleng/tilt/internal/tiltfile"
+
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
 )
 
 type dockerPruneCmd struct {
 	maxAgeStr string
+}
+
+type dpDeps struct {
+	dCli docker.Client
+	tfl  tiltfile.TiltfileLoader
+}
+
+func newDPDeps(dCli docker.Client, tfl tiltfile.TiltfileLoader) dpDeps {
+	return dpDeps{
+		dCli: dCli,
+		tfl:  tfl,
+	}
 }
 
 func (c *dockerPruneCmd) register() *cobra.Command {
@@ -44,7 +59,8 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	}
 
 	// TODO: print the commands being run
-	dp.Prune(ctx, maxAge)
+	// ❗️ fix this - load Tiltfile and pass image selectors ❗
+	dp.Prune(ctx, maxAge, nil)
 
 	return nil
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -34,6 +34,18 @@ func ParseNamed(s string) (reference.Named, error) {
 	return reference.ParseNormalizedNamed(s)
 }
 
+func ParseNamedMulti(strs []string) ([]reference.Named, error) {
+	var err error
+	res := make([]reference.Named, len(strs))
+	for i, s := range strs {
+		res[i], err = reference.ParseNormalizedNamed(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func ParseNamedTagged(s string) (reference.NamedTagged, error) {
 	ref, err := reference.ParseNormalizedNamed(s)
 	if err != nil {

--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -92,3 +92,12 @@ func (s RefSelector) String() string {
 	}
 	return s.ref.String()
 }
+
+func MatchesAny(toMatch reference.Named, selectors []RefSelector) bool {
+	for _, sel := range selectors {
+		if sel.Matches(toMatch) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -93,10 +93,12 @@ func (s RefSelector) String() string {
 	return s.ref.String()
 }
 
-func MatchesAny(toMatch reference.Named, selectors []RefSelector) bool {
-	for _, sel := range selectors {
-		if sel.Matches(toMatch) {
-			return true
+func AnyMatch(toMatch []reference.Named, selectors []RefSelector) bool {
+	for _, ref := range toMatch {
+		for _, sel := range selectors {
+			if sel.Matches(ref) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -65,8 +65,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 	var imgSelectors []container.RefSelector
 	for _, m := range state.Manifests() {
 		for _, iTarg := range m.ImageTargets {
-			sel := iTarg.ConfigurationRef
-			sel.AsNamedOnly()
+			sel := container.NameSelector(iTarg.DeploymentRef).WithNameMatch()
 			imgSelectors = append(imgSelectors, sel)
 		}
 	}

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/windmilleng/tilt/internal/container"
 
 	"github.com/windmilleng/tilt/internal/store"

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -27,7 +27,7 @@ var (
 	containersPruned = []string{"containerA", "containerB", "containerC"}
 	numImages        = 3
 	maxAge           = 11 * time.Hour
-	refSelector      = container.NameSelector(container.MustParseNamed("some-ref"))
+	ref              = container.MustParseNamed("some-ref")
 )
 
 var buildHistory = []model.BuildRecord{
@@ -356,8 +356,8 @@ func (dpf *dockerPruneFixture) withDockerManifestUnbuilt() {
 func (dpf *dockerPruneFixture) withDockerManifest(alreadyBuilt bool) {
 	m := model.Manifest{Name: "some-docker-manifest"}.WithImageTarget(
 		model.ImageTarget{
-			ConfigurationRef: refSelector,
-			BuildDetails:     model.DockerBuild{},
+			DeploymentRef: ref,
+			BuildDetails:  model.DockerBuild{},
 		})
 	dpf.withManifestTarget(store.NewManifestTarget(m), alreadyBuilt)
 }


### PR DESCRIPTION
it was a pain to run tilt.build b/c the docker pruner on a servantes run had pruned away
all my tilt.build images/caches

with this PR, the docker pruner only prunes images matching refs currently being run.

I BELIEVE this will mean that we only prune docker caches corresponding to those images -- b/c we're not pruning dangling caches, so we shouldn't delete any that relate to extant images? lmk if this is wrong.

for future PR: apply this behavior to `tilt docker-prune` so it gives an accurate preview