### PR TITLE
cli: make docker-prune cli behavior consistent, make logs useful

### DIFF
--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
 
 	"github.com/windmilleng/tilt/internal/docker"
@@ -49,6 +52,10 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	a.IncrIfUnopted("analytics.up.optdefault")
 	defer a.Flush(time.Second)
 
+	// (Most relevant output from dockerpruner is at the `debug` level)
+	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
+	ctx = logger.WithLogger(ctx, l)
+
 	deps, err := wireDockerPrune(ctx, a)
 	if err != nil {
 		return err
@@ -69,7 +76,7 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	}
 
 	// TODO: print the commands being run
-	dp.Prune(ctx, maxAge, imgSelectors)
+	dp.Prune(ctx, maxAge, imgSelectors, true)
 
 	return nil
 }

--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -18,8 +18,7 @@ import (
 )
 
 type dockerPruneCmd struct {
-	maxAgeStr string
-	fileName  string
+	fileName string
 }
 
 type dpDeps struct {
@@ -40,7 +39,6 @@ func (c *dockerPruneCmd) register() *cobra.Command {
 		Short: "run docker prune as Tilt does",
 	}
 
-	cmd.Flags().StringVar(&c.maxAgeStr, "maxAge", "6h", "max age of image to keep (as go duration string, e.g. 1h30m, 12h")
 	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")
 
 	return cmd
@@ -70,13 +68,8 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 
 	dp := dockerprune.NewDockerPruner(deps.dCli)
 
-	maxAge, err := time.ParseDuration(c.maxAgeStr)
-	if err != nil {
-		return err
-	}
-
 	// TODO: print the commands being run
-	dp.Prune(ctx, maxAge, imgSelectors)
+	dp.Prune(ctx, tlr.DockerPruneSettings.MaxAge, imgSelectors)
 
 	return nil
 }

--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -76,7 +76,7 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	}
 
 	// TODO: print the commands being run
-	dp.Prune(ctx, maxAge, imgSelectors, true)
+	dp.Prune(ctx, maxAge, imgSelectors)
 
 	return nil
 }

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -123,6 +123,11 @@ func wireDemo(ctx context.Context, branch demo.RepoBranch, analytics *analytics.
 	return demo.Script{}, nil
 }
 
+func wireDockerPrune(ctx context.Context, analytics *analytics.TiltAnalytics) (dpDeps, error) {
+	wire.Build(BaseWireSet, newDPDeps)
+	return dpDeps{}, nil
+}
+
 func wireThreads(ctx context.Context, analytics *analytics.TiltAnalytics) (Threads, error) {
 	wire.Build(BaseWireSet, build.ProvideClock)
 	return Threads{}, nil

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -62,13 +62,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 	curBuildCount := state.CompletedBuildCount
 	hasDockerBuild := state.HasDockerBuild()
 	nextToBuild := buildcontrol.NextManifestNameToBuild(state)
-	var imgSelectors []container.RefSelector
-	for _, m := range state.Manifests() {
-		for _, iTarg := range m.ImageTargets {
-			sel := container.NameSelector(iTarg.DeploymentRef).WithNameMatch()
-			imgSelectors = append(imgSelectors, sel)
-		}
-	}
+	imgSelectors := model.RefSelectorsForManifests(state.Manifests())
 	st.RUnlockState()
 
 	if !settings.Enabled {

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -40,7 +40,7 @@ func twoHrsAgo() time.Time {
 
 func TestPruneFilters(t *testing.T) {
 	f, imgSelectors := newFixture(t).withPruneOutput(cachesPruned, containersPruned, numImages)
-	err := f.dp.prune(f.ctx, maxAge, imgSelectors)
+	err := f.dp.prune(f.ctx, maxAge, imgSelectors, false)
 	require.NoError(t, err)
 
 	expectedFilters := filters.NewArgs(
@@ -60,7 +60,7 @@ func TestPruneFilters(t *testing.T) {
 
 func TestPruneOutput(t *testing.T) {
 	f, imgSelectors := newFixture(t).withPruneOutput(cachesPruned, containersPruned, numImages)
-	err := f.dp.prune(f.ctx, maxAge, imgSelectors)
+	err := f.dp.prune(f.ctx, maxAge, imgSelectors, false)
 	require.NoError(t, err)
 
 	logs := f.logs.String()
@@ -72,10 +72,21 @@ func TestPruneOutput(t *testing.T) {
 	assert.Contains(t, logs, "- deleted: build-id-2")
 }
 
+func TestPruneOutputVerbose(t *testing.T) {
+	f := newFixture(t)
+	err := f.dp.prune(f.ctx, maxAge, nil, true)
+	require.NoError(t, err)
+
+	logs := f.logs.String()
+	assert.Contains(t, logs, "[Docker Prune] removed 0 caches, reclaimed 0 bytes")
+	assert.Contains(t, logs, "[Docker Prune] removed 0 containers, reclaimed 0 bytes")
+	assert.Contains(t, logs, "[Docker Prune] removed 0 images, reclaimed 0 bytes")
+}
+
 func TestPruneVersionTooLow(t *testing.T) {
 	f, imgSelectors := newFixture(t).withPruneOutput(cachesPruned, containersPruned, numImages)
 	f.dCli.ThrowNewVersionError = true
-	err := f.dp.prune(f.ctx, maxAge, imgSelectors)
+	err := f.dp.prune(f.ctx, maxAge, imgSelectors, false)
 	require.NoError(t, err) // should log failure but not throw error
 
 	logs := f.logs.String()
@@ -91,7 +102,7 @@ func TestPruneVersionTooLow(t *testing.T) {
 func TestPruneSkipCachePruneIfVersionTooLow(t *testing.T) {
 	f, imgSelectors := newFixture(t).withPruneOutput(cachesPruned, containersPruned, numImages)
 	f.dCli.BuildCachePruneErr = f.dCli.VersionError("1.2.3", "build prune")
-	err := f.dp.prune(f.ctx, maxAge, imgSelectors)
+	err := f.dp.prune(f.ctx, maxAge, imgSelectors, false)
 	require.NoError(t, err) // should log failure but not throw error
 
 	logs := f.logs.String()
@@ -106,7 +117,7 @@ func TestPruneSkipCachePruneIfVersionTooLow(t *testing.T) {
 func TestPruneReturnsCachePruneError(t *testing.T) {
 	f, imgSelectors := newFixture(t).withPruneOutput(cachesPruned, containersPruned, numImages)
 	f.dCli.BuildCachePruneErr = fmt.Errorf("this is a real error, NOT an API version error")
-	err := f.dp.prune(f.ctx, maxAge, imgSelectors)
+	err := f.dp.prune(f.ctx, maxAge, imgSelectors, false)
 	require.NotNil(t, err) // For all errors besides API version error, expect them to return
 	assert.Contains(t, err.Error(), "this is a real error")
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -230,6 +230,17 @@ func (m Manifest) Empty() bool {
 	return m.Equal(Manifest{})
 }
 
+func RefSelectorsForManifests(manifests []Manifest) []container.RefSelector {
+	var res []container.RefSelector
+	for _, m := range manifests {
+		for _, iTarg := range m.ImageTargets {
+			sel := container.NameSelector(iTarg.DeploymentRef).WithNameMatch()
+			res = append(res, sel)
+		}
+	}
+	return res
+}
+
 var _ TargetSpec = Manifest{}
 
 type Sync struct {


### PR DESCRIPTION
`tilt docker-prune` does a docker prune as tilt would (respecting manifests defined in
this dir's tiltfile, etc.)