### PR TITLE
cloud: fix watermark check in update upload

### DIFF
--- a/internal/cloud/update_uploader.go
+++ b/internal/cloud/update_uploader.go
@@ -112,7 +112,7 @@ func (u *UpdateUploader) makeUpdates(st store.RStore) updateTask {
 		for _, record := range status.BuildHistory {
 			// The BuildHistory is stored most-recent first, so we can stop iterating
 			// as soon as we see one newer than the high-water mark.
-			if record.FinishTime.Before(u.lastFinishTime) {
+			if !record.FinishTime.After(u.lastFinishTime) {
 				break
 			}
 

--- a/internal/cloud/update_uploader_test.go
+++ b/internal/cloud/update_uploader_test.go
@@ -55,6 +55,20 @@ func TestTwoUpdates(t *testing.T) {
 	assert.Equal(t, 0, len(f.uu.makeUpdates(f.store).updates()))
 }
 
+func TestWatermark(t *testing.T) {
+	f := newUpdateFixture(t)
+	defer f.TearDown()
+
+	assert.Equal(t, 0, len(f.uu.makeUpdates(f.store).updates()))
+
+	f.AddCompletedBuild("sancho", nil)
+	f.AddCompletedBuild("sancho", nil)
+	assert.Equal(t, 2, len(f.uu.makeUpdates(f.store).updates()))
+
+	f.AddCompletedBuild("blorg", nil)
+	assert.Equal(t, 1, len(f.uu.makeUpdates(f.store).updates()))
+}
+
 type updateFixture struct {
 	*tempdir.TempDirFixture
 	ctx        context.Context


### PR DESCRIPTION
bug: when we look for builds to upload, we iterate in reverse chron until we hit a timestamp prior to the last build we uploaded. This means that we include the last build we uploaded, even though we already uploaded it!