### PR TITLE
Make snapshot highlights default behavior

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -22,7 +22,6 @@ const MultipleContainersPerPod = "multiple_containers_per_pod"
 const Events = "events"
 const Snapshots = "snapshots"
 const UpdateHistory = "update_history"
-const SnapshotHighlights = "snapshot_highlights"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -49,10 +48,6 @@ var MainDefaults = Defaults{
 		Status:  Active,
 	},
 	UpdateHistory: Value{
-		Enabled: false,
-		Status:  Active,
-	},
-	SnapshotHighlights: Value{
 		Enabled: false,
 		Status:  Active,
 	},

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -186,13 +186,6 @@ class HUD extends Component<HudProps, HudState> {
       .catch(err => console.error(err))
   }
 
-  highlightsEnabled(): boolean {
-    return (
-      !this.pathBuilder.isSnapshot() &&
-      this.getFeatures().isEnabled("snapshot_highlights")
-    )
-  }
-
   private getFeatures(): Features {
     if (this.state.View) {
       return new Features(this.state.View.FeatureFlags)
@@ -233,10 +226,6 @@ class HUD extends Component<HudProps, HudState> {
     if (this.pathBuilder.isSnapshot() && this.state.View) {
       snapshotOwner = this.state.View.TiltCloudUsername
     }
-
-    let highlightsEnabled =
-      !this.pathBuilder.isSnapshot() &&
-      this.getFeatures().isEnabled("snapshot_highlights")
 
     let sidebarRoute = (t: ResourceView, props: RouteComponentProps<any>) => {
       let name = props.match.params.name
@@ -331,7 +320,6 @@ class HUD extends Component<HudProps, HudState> {
             handleSetHighlight={this.handleSetHighlight}
             handleClearHighlight={this.handleClearHighlight}
             highlight={this.state.snapshotHighlight}
-            highlightsEnabled={highlightsEnabled}
             modalIsOpen={this.state.showSnapshotModal}
           />
         </>
@@ -426,7 +414,6 @@ class HUD extends Component<HudProps, HudState> {
                 handleSetHighlight={this.handleSetHighlight}
                 handleClearHighlight={this.handleClearHighlight}
                 highlight={this.state.snapshotHighlight}
-                highlightsEnabled={highlightsEnabled}
                 modalIsOpen={this.state.showSnapshotModal}
               />
             )}

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -17,7 +17,6 @@ it("renders without crashing", () => {
       handleSetHighlight={fakeHandleSetHighlight}
       handleClearHighlight={fakeHandleClearHighlight}
       highlight={null}
-      highlightsEnabled={false}
       modalIsOpen={false}
     />,
     div
@@ -35,7 +34,6 @@ it("renders logs", () => {
         handleSetHighlight={fakeHandleSetHighlight}
         handleClearHighlight={fakeHandleClearHighlight}
         highlight={null}
-        highlightsEnabled={false}
         modalIsOpen={false}
       />
     )
@@ -383,7 +381,6 @@ it("renders logs with leading whitespace and ANSI codes", () => {
         handleSetHighlight={fakeHandleSetHighlight}
         handleClearHighlight={fakeHandleClearHighlight}
         highlight={null}
-        highlightsEnabled={false}
         modalIsOpen={false}
       />
     )
@@ -406,7 +403,6 @@ it("renders highlighted lines", () => {
         handleSetHighlight={fakeHandleSetHighlight}
         handleClearHighlight={fakeHandleClearHighlight}
         highlight={highlight}
-        highlightsEnabled={false}
         modalIsOpen={false}
       />
     )

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -14,7 +14,6 @@ type LogPaneProps = {
   handleSetHighlight: (highlight: SnapshotHighlight) => void
   handleClearHighlight: () => void
   highlight: SnapshotHighlight | null
-  highlightsEnabled: boolean
   modalIsOpen: boolean
 }
 
@@ -46,11 +45,9 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
     }
     window.addEventListener("scroll", this.refreshAutoScroll, { passive: true })
     window.addEventListener("wheel", this.handleWheel, { passive: true })
-    if (this.props.highlightsEnabled) {
-      document.addEventListener("selectionchange", this.handleSelectionChange, {
-        passive: true,
-      })
-    }
+    document.addEventListener("selectionchange", this.handleSelectionChange, {
+      passive: true,
+    })
   }
 
   componentDidUpdate(prevProps: LogPaneProps) {
@@ -68,12 +65,7 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
     if (this.rafID) {
       clearTimeout(this.rafID)
     }
-    if (this.props.highlightsEnabled) {
-      document.removeEventListener(
-        "selectionchange",
-        this.handleSelectionChange
-      )
-    }
+    document.removeEventListener("selectionchange", this.handleSelectionChange)
   }
 
   private handleSelectionChange() {


### PR DESCRIPTION
We haven't cut a release with this flag, so I'm removing it entirely. (Instead of setting it to `Noop` → `Obsolete`, which seems too scrupulous for this case.)