### PR TITLE
tiltfile: fix failure stderr logging for kustomize/helm

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -212,11 +212,7 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, c *exec.Cmd, logOutput 
 			return "", fmt.Errorf("command %q failed.\nerror: %v", c.Args, err)
 		}
 
-		errorMessage := fmt.Sprintf("command %q failed.\nerror: %v\nstdout: %q", c.Args, err, stdout.String())
-		exitError, ok := err.(*exec.ExitError)
-		if ok {
-			errorMessage += fmt.Sprintf("\nstderr: %q", string(exitError.Stderr))
-		}
+		errorMessage := fmt.Sprintf("command %q failed.\nerror: %v\nstdout: %q\nstderr: %q", c.Args, err, stdout.String(), stderr.String())
 		return "", errors.New(errorMessage)
 	}
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -326,6 +326,14 @@ k8s_resource("the-deployment", "foo")
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo/.dockerignore", "configMap.yaml", "deployment.yaml", "kustomization.yaml", "service.yaml")
 }
 
+func TestKustomizeError(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", "kustomize('.')")
+	f.loadErrString("unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization'")
+}
+
 func TestKustomization(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
For kustomize and helm, we were reading stderr off of ExitError.Stderr, which is empty since we're redirecting stderr on the `Cmd`.

```
type ExitError struct {
	*os.ProcessState

	// Stderr holds a subset of the standard error output from the
	// Cmd.Output method if standard error was not otherwise being
	// collected.
```