### PR TITLE
k8s: sort k8s entities on manifest creation

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -244,7 +244,7 @@ func (k K8sClient) Upsert(ctx context.Context, entities []K8sEntity) ([]K8sEntit
 
 	result := make([]K8sEntity, 0, len(entities))
 
-	mutable, immutable := SortedMutableAndImmutableEntities(entities)
+	mutable, immutable := MutableAndImmutableEntities(entities)
 
 	if len(mutable) > 0 {
 		newEntities, err := k.applyEntitiesAndMaybeForce(ctx, mutable)

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -59,7 +59,6 @@ func (l entityList) Less(i, j int) bool {
 	// Sort entities by the priority of their Kind
 	indexI := kustomize.TypeOrders[l[i].GVK().Kind]
 	indexJ := kustomize.TypeOrders[l[j].GVK().Kind]
-
 	if indexI != indexJ {
 		return indexI < indexJ
 	}
@@ -69,7 +68,7 @@ func (l entityList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
 
 func SortedEntities(entities []K8sEntity) []K8sEntity {
 	entList := entityList(CopyEntities(entities))
-	sort.Sort(entList)
+	sort.Stable(entList)
 	return []K8sEntity(entList)
 }
 
@@ -231,12 +230,10 @@ func CopyEntities(entities []K8sEntity) []K8sEntity {
 	return res
 }
 
-// SortedMutableAndImmutableEntities returns two lists of k8s entities: mutable ones (that can simply be
+// MutableAndImmutableEntities returns two lists of k8s entities: mutable ones (that can simply be
 // `kubectl apply`'d), and immutable ones (such as jobs and pods, which will need to be `--force`'d).
-// The entities will be sorted such that entities on which others may depend will be applied first
-// (e.g. a PersistentVolumeClaim depends on the corresponding PersistentVolume, so apply the PV first).
-func SortedMutableAndImmutableEntities(entities entityList) (mutable, immutable []K8sEntity) {
-	sort.Sort(entities)
+// (We assume input entities are already sorted in a safe order to apply -- see kustomize/ordering.go.)
+func MutableAndImmutableEntities(entities entityList) (mutable, immutable []K8sEntity) {
 	for _, e := range entities {
 		if e.ImmutableOnceCreated() {
 			immutable = append(immutable, e)

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -65,8 +65,13 @@ func (l entityList) Less(i, j int) bool {
 	}
 	return i < j
 }
-
 func (l entityList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+
+func SortedEntities(entities []K8sEntity) []K8sEntity {
+	entList := entityList(CopyEntities(entities))
+	sort.Sort(entList)
+	return []K8sEntity(entList)
+}
 
 func (e K8sEntity) ToObjectReference() v1.ObjectReference {
 	meta := e.meta()
@@ -216,6 +221,14 @@ func (e K8sEntity) ImmutableOnceCreated() bool {
 
 func (e K8sEntity) DeepCopy() K8sEntity {
 	return NewK8sEntity(e.Obj.DeepCopyObject())
+}
+
+func CopyEntities(entities []K8sEntity) []K8sEntity {
+	res := make([]K8sEntity, len(entities))
+	for i, e := range entities {
+		res[i] = e.DeepCopy()
+	}
+	return res
 }
 
 // SortedMutableAndImmutableEntities returns two lists of k8s entities: mutable ones (that can simply be

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -15,14 +15,15 @@ func NewTarget(
 	extraPodSelectors []labels.Selector,
 	dependencyIDs []model.TargetID,
 	refInjectCounts map[string]int) (model.K8sTarget, error) {
-	yaml, err := SerializeSpecYAML(entities)
+	sorted := SortedEntities(entities)
+	yaml, err := SerializeSpecYAML(sorted)
 	if err != nil {
 		return model.K8sTarget{}, err
 	}
 
 	// Use a min component count of 2 for computing names,
 	// so that the resource type appears
-	displayNames := UniqueNames(entities, 2)
+	displayNames := UniqueNames(sorted, 2)
 
 	return model.K8sTarget{
 		Name:              name,

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 )
 

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+)
+
+func TestNewTargetSortsK8sEntities(t *testing.T) {
+	entities := MustParseYAMLFromString(t, testyaml.PostgresYAML)
+	entities[1], entities[3] = entities[3], entities[1] // swap some stuff around for more significant sorting
+	targ, err := NewTarget("foo", entities, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet"}
+
+	actual, err := ParseYAMLFromString(targ.YAML)
+	require.NoError(t, err)
+
+	assertKindOrder(t, expectedKindOrder, actual, "result of `NewTarget` should contain sorted YAML")
+
+	expectedDisplayNames := []string{
+		"postgres-pv-volume:persistentvolume",
+		"postgres-pv-claim:persistentvolumeclaim",
+		"postgres-config:configmap",
+		"postgres:service",
+		"postgres:statefulset",
+	}
+	assert.Equal(t, expectedDisplayNames, targ.DisplayNames)
+}

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -9,12 +9,11 @@ import (
 )
 
 func TestNewTargetSortsK8sEntities(t *testing.T) {
-	entities := MustParseYAMLFromString(t, testyaml.PostgresYAML)
-	entities[1], entities[3] = entities[3], entities[1] // swap some stuff around for more significant sorting
+	entities := MustParseYAMLFromString(t, testyaml.OutOfOrderYaml)
 	targ, err := NewTarget("foo", entities, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet"}
+	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet", "Job", "Pod"}
 
 	actual, err := ParseYAMLFromString(targ.YAML)
 	require.NoError(t, err)
@@ -27,6 +26,8 @@ func TestNewTargetSortsK8sEntities(t *testing.T) {
 		"postgres-config:configmap",
 		"postgres:service",
 		"postgres:statefulset",
+		"blorg-job:job",
+		"sleep:pod",
 	}
 	assert.Equal(t, expectedDisplayNames, targ.DisplayNames)
 }


### PR DESCRIPTION
follow-up to #2364 -- as of that PR we apply the k8s entities in the correct order,
but only sort them just before `apply`ing, so log output still reflects the
unsorted order. e.g. even though we applied `PersistentVolumes` before
`PersistentVolumeClaims`, logs would show:

```
──┤ Building: uncategorized ├──────────────────────────────────────────────
STEP 1/1 — Deploying
  │ Injecting images into Kubernetes YAML
  │ Applying via kubectl:
  │    task-pv-claim:persistentvolumeclaim
  │    task-pv-volume:persistentvolume
  ```
  with this PR, we now sort sort YAML entities into safe application order
  (i.e. make our best guess as to resources that other resources will depend
  on, and put those first) _at the time of manifest creation_. Thus we no
  longer need to sort just before calling `apply`, and logging is accurate:

  ```
  ──┤ Building: uncategorized ├──────────────────────────────────────────────
STEP 1/1 — Deploying
  │ Injecting images into Kubernetes YAML
  │ Applying via kubectl:
  │    task-pv-volume:persistentvolume
  │    task-pv-claim:persistentvolumeclaim
  │ Step 1 - 0.344s
  │ Done in: 0.344s
  ```