### PR TITLE
tiltfile: add a temporary work-around for helm regression

### DIFF
--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -3147,7 +3148,23 @@ k8s_yaml(yml)
 	)
 }
 
+// There's a major helm regression that's breaking everything
+// https://github.com/helm/helm/issues/6708
+func isBuggyHelm(t *testing.T) bool {
+	cmd := exec.Command("helm", "version", "-c", "--short")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Error running helm: %v", err)
+	}
+
+	return strings.Contains(string(out), "v2.15.0")
+}
+
 func TestHelmIncludesRequirements(t *testing.T) {
+	if isBuggyHelm(t) {
+		t.Skipf("Helm v2.15.0 has a major regression, skipping test. See: https://github.com/helm/helm/issues/6708")
+	}
+
 	f := newFixture(t)
 	defer f.TearDown()
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/helm:

130a5e1448cf2c689203e3fb8a10076e8e72e875 (2019-10-21 19:17:00 -0400)
tiltfile: add a temporary work-around for helm regression