### PR TITLE
cloud: report tiltfile loads like other manifests

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1084,7 +1084,7 @@ func TestHudUpdated(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	assert.Equal(t, 2, len(f.hud.LastView.Resources))
-	assert.Equal(t, view.TiltfileResourceName, f.hud.LastView.Resources[0].Name.String())
+	assert.Equal(t, store.TiltfileManifestName, f.hud.LastView.Resources[0].Name)
 	rv := f.hud.LastView.Resources[1]
 	assert.Equal(t, manifest.Name, model.ManifestName(rv.Name))
 	assert.Equal(t, f.Path(), rv.DirectoriesWatched[0])

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -212,7 +212,7 @@ func (h *Hud) handleScreenEvent(ctx context.Context, dispatch func(action store.
 			}
 			url := h.webURL
 			url.Path = fmt.Sprintf("/r/%s/", r.Name)
-			h.a.Incr("ui.interactions.open_log", map[string]string{"is_tiltfile": strconv.FormatBool(r.Name == view.TiltfileResourceName)})
+			h.a.Incr("ui.interactions.open_log", map[string]string{"is_tiltfile": strconv.FormatBool(r.Name == store.TiltfileManifestName)})
 			_ = browser.OpenURL(url.String())
 		case tcell.KeyRight:
 			i, _ := h.selectedResource()

--- a/internal/hud/renderer_test.go
+++ b/internal/hud/renderer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/rty"
+	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
 
 	"github.com/gdamore/tcell"
@@ -672,7 +673,7 @@ func TestTiltfileResource(t *testing.T) {
 	v := view.View{
 		Resources: []view.Resource{
 			{
-				Name:       view.TiltfileResourceName,
+				Name:       store.TiltfileManifestName,
 				IsTiltfile: true,
 			},
 		},
@@ -688,7 +689,7 @@ func TestTiltfileResourceWithWarning(t *testing.T) {
 	v := view.View{
 		Resources: []view.Resource{
 			{
-				Name:       view.TiltfileResourceName,
+				Name:       store.TiltfileManifestName,
 				IsTiltfile: true,
 				BuildHistory: []model.BuildRecord{
 					{
@@ -714,7 +715,7 @@ func TestTiltfileResourcePending(t *testing.T) {
 	v := view.View{
 		Resources: []view.Resource{
 			{
-				Name:       view.TiltfileResourceName,
+				Name:       store.TiltfileManifestName,
 				IsTiltfile: true,
 				CurrentBuild: model.BuildRecord{
 					Edits:     []string{"Tiltfile"},

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/windmilleng/tilt/internal/cloud/cloudurl"
 	"github.com/windmilleng/tilt/internal/dockercompose"
-	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -124,7 +123,7 @@ func tiltfileResourceView(s store.EngineState) Resource {
 	ltfb.Edits = ospath.FileListDisplayNames([]string{filepath.Dir(s.TiltfilePath)}, ltfb.Edits)
 
 	tr := Resource{
-		Name:         view.TiltfileResourceName,
+		Name:         store.TiltfileManifestName,
 		IsTiltfile:   true,
 		CurrentBuild: ToWebViewBuildRecord(ctfb),
 		BuildHistory: []BuildRecord{

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -587,18 +587,14 @@ func StateToView(s EngineState) view.View {
 	return ret
 }
 
+const TiltfileManifestName = model.ManifestName("(Tiltfile)")
+
 func tiltfileResourceView(s EngineState) view.Resource {
-	ltfb := s.TiltfileState.LastBuild()
-	if !s.TiltfileState.CurrentBuild.Empty() {
-		ltfb.Log = s.TiltfileState.CurrentBuild.Log
-	}
 	tr := view.Resource{
-		Name:         view.TiltfileResourceName,
+		Name:         TiltfileManifestName,
 		IsTiltfile:   true,
 		CurrentBuild: s.TiltfileState.CurrentBuild,
-		BuildHistory: []model.BuildRecord{
-			ltfb,
-		},
+		BuildHistory: s.TiltfileState.BuildHistory,
 	}
 	if !s.TiltfileState.CurrentBuild.Empty() {
 		tr.PendingBuildSince = s.TiltfileState.CurrentBuild.StartTime

--- a/internal/tiltfile/include_test.go
+++ b/internal/tiltfile/include_test.go
@@ -2,6 +2,7 @@ package tiltfile
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,9 +66,10 @@ include('./bar/Tiltfile')
 	f.load()
 
 	// make sure foo/Tiltfile is only loaded once
-	assert.Equal(t,
-		"Beginning Tiltfile execution\nfoo\nSuccessfully loaded Tiltfile\n",
-		f.out.String())
+	assertContainsOnce(
+		t,
+		f.out.String(),
+		"Beginning Tiltfile execution\nfoo\nSuccessfully loaded Tiltfile")
 }
 
 func TestIncludeMissing(t *testing.T) {
@@ -114,9 +116,11 @@ shout()
 `)
 
 	f.load()
-	assert.Equal(t,
-		"Beginning Tiltfile execution\nboo\nSuccessfully loaded Tiltfile\n",
-		f.out.String())
+	assertContainsOnce(
+		t,
+		f.out.String(),
+		"Beginning Tiltfile execution\nboo\nSuccessfully loaded Tiltfile")
+
 }
 
 func TestLoadError(t *testing.T) {
@@ -138,4 +142,9 @@ local('exit 1')
 		fmt.Sprintf("%s/Tiltfile:2:1: in <toplevel>", f.Path()),
 		"cannot load ./foo/Tiltfile",
 		"exit status 1")
+}
+
+func assertContainsOnce(t *testing.T, s, contains string) {
+	assert.Contains(t, s, contains)
+	assert.Equal(t, 1, strings.Count(s, contains))
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -166,8 +166,10 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	tlr.DockerPruneSettings = dps
 
 	printWarnings(s)
-	s.logger.Infof("Successfully loaded Tiltfile")
-	tfl.reportTiltfileLoaded(s.builtinCallCounts, s.builtinArgCounts, time.Since(start))
+
+	duration := time.Since(start)
+	s.logger.Infof("Successfully loaded Tiltfile (%s)", duration)
+	tfl.reportTiltfileLoaded(s.builtinCallCounts, s.builtinArgCounts, duration)
 
 	return tlr
 }


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/tiltfile-load-times:

7152396886f4b0476573c9d4c7d16f0280ab6108 (2019-10-22 12:56:19 -0400)
cloud: report tiltfile loads like other manifests