### PR TITLE
engine: when we fail to get the running container info, print the error on Redirect so it shows up in the right resource view

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -200,12 +200,10 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 				if manifest.IsK8s() {
 					cInfos, err := store.RunningContainersForTargetForOnePod(iTarget, ms.K8sRuntimeState())
 					if err != nil {
-						// Couldn't get running container info; surface an error IF target has LiveUpdate instructions.
-						if !iTarget.AnyFastBuildInfo().Empty() || !iTarget.AnyLiveUpdateInfo().Empty() {
-							logger.Get(ctx).Infof("CANNOT PERFORM LIVE UPDATE ON IMAGE %s:\n\t%v", iTarget.ID(), err)
-						}
+						buildState = buildState.WithRunningContainerError(err)
+					} else {
+						buildState = buildState.WithRunningContainers(cInfos)
 					}
-					buildState = buildState.WithRunningContainers(cInfos)
 				}
 
 				if manifest.IsDC() {

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -71,8 +71,11 @@ func TestBuildControllerTooManyPodsForLiveUpdateErrorMessage(t *testing.T) {
 	assert.NoError(t, err)
 	f.assertAllBuildsConsumed()
 
-	assert.Contains(t, f.log.String(), "can only get container info for a single pod",
-		"should print error message when trying to get Running Containers for manifest with more than one pod")
+	err = call.oneState().RunningContainerError
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "can only get container info for a single pod",
+			"should print error message when trying to get Running Containers for manifest with more than one pod")
+	}
 }
 
 func TestBuildControllerTooManyPodsForDockerBuildNoErrorMessage(t *testing.T) {

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -63,6 +63,10 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 			return nil, SilentRedirectToNextBuilderf("In-place build requires either FastBuild or LiveUpdate")
 		}
 
+		if state.RunningContainerError != nil {
+			return nil, RedirectToNextBuilderInfof("%v", state.RunningContainerError)
+		}
+
 		// Now that we have fast build information, we know this CAN be updated in
 		// a container(s). Check to see if we have enough information about the
 		// container(s) that would need to be updated.

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -221,6 +221,9 @@ type BuildState struct {
 	FilesChangedSet map[string]bool
 
 	RunningContainers []ContainerInfo
+
+	// If we had an error retrieving running containers
+	RunningContainerError error
 }
 
 func NewBuildState(result BuildResult, files []string) BuildState {
@@ -236,6 +239,11 @@ func NewBuildState(result BuildResult, files []string) BuildState {
 
 func (b BuildState) WithRunningContainers(cInfos []ContainerInfo) BuildState {
 	b.RunningContainers = cInfos
+	return b
+}
+
+func (b BuildState) WithRunningContainerError(err error) BuildState {
+	b.RunningContainerError = err
 	return b
 }
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/containerrunning:

663ed1dc14fe74d72be56d3544c2174f112882eb (2019-10-22 17:15:23 -0400)
engine: when we fail to get the running container info, print the error on Redirect so it shows up in the right resource view