### PR TITLE
containerupdate: tar shouldn't echo the files processed. no other container updater does this and it looks weird

### DIFF
--- a/internal/containerupdate/exec_updater.go
+++ b/internal/containerupdate/exec_updater.go
@@ -49,7 +49,7 @@ func (cu *ExecUpdater) UpdateContainer(ctx context.Context, cInfo store.Containe
 	}
 
 	err := cu.kCli.Exec(ctx, cInfo.PodID, cInfo.ContainerName, cInfo.Namespace,
-		[]string{"tar", "-C", "/", "-x", "-v", "-f", "-"}, archiveToCopy, w, w)
+		[]string{"tar", "-C", "/", "-x", "-f", "-"}, archiveToCopy, w, w)
 	if err != nil {
 		return err
 	}

--- a/internal/containerupdate/exec_updater_test.go
+++ b/internal/containerupdate/exec_updater_test.go
@@ -81,7 +81,7 @@ func TestUpdateContainerTarsArchive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedCmd := []string{"tar", "-C", "/", "-x", "-v", "-f", "-"}
+	expectedCmd := []string{"tar", "-C", "/", "-x", "-f", "-"}
 	if assert.Len(t, f.kCli.ExecCalls, 1, "expect exactly 1 k8s exec call") {
 		call := f.kCli.ExecCalls[0]
 		assert.Equal(t, expectedCmd, call.Cmd)


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/tar:

e8829bf0e7665cd6a01b8416def38389fa427f7d (2019-10-22 19:01:18 -0400)
containerupdate: tar shouldn't echo the files processed. no other container updater does this and it looks weird