### PR TITLE
dc: make image actually optional

### DIFF
--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -93,11 +93,12 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 		return nil, fmt.Errorf("dc_resource: `name` must not be empty")
 	}
 
-	var imageRefAsStr string
+	var imageRefAsStr *string
 	switch imageVal := imageVal.(type) {
 	case nil: // optional arg, this is fine
 	case starlark.String:
-		imageRefAsStr = string(imageVal)
+		s := string(imageVal)
+		imageRefAsStr = &s
 	default:
 		return nil, fmt.Errorf("image arg must be a string; got %T", imageVal)
 	}
@@ -109,11 +110,13 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 
 	svc.TriggerMode = triggerMode
 
-	normalized, err := container.ParseNamed(imageRefAsStr)
-	if err != nil {
-		return nil, err
+	if imageRefAsStr != nil {
+		normalized, err := container.ParseNamed(*imageRefAsStr)
+		if err != nil {
+			return nil, err
+		}
+		svc.imageRefFromUser = normalized
 	}
-	svc.imageRefFromUser = normalized
 
 	return starlark.None, nil
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3088,9 +3088,9 @@ func TestTriggerModeDC(t *testing.T) {
 			case TriggerModeUnset:
 				dcResourceDirective = ""
 			case TriggerModeManual:
-				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', trigger_mode=TRIGGER_MODE_MANUAL)"
+				dcResourceDirective = "dc_resource('foo', trigger_mode=TRIGGER_MODE_MANUAL)"
 			case TriggerModeAuto:
-				dcResourceDirective = "dc_resource('foo', 'gcr.io/foo', trigger_mode=TRIGGER_MODE_AUTO)"
+				dcResourceDirective = "dc_resource('foo', trigger_mode=TRIGGER_MODE_AUTO)"
 			}
 
 			f.file("Tiltfile", fmt.Sprintf(`
@@ -3869,6 +3869,20 @@ k8s_yaml('secret.yaml')
 	assert.Equal(t, "client-secret", secrets["world"].Key)
 	assert.Equal(t, "world", string(secrets["world"].Value))
 	assert.Equal(t, "d29ybGQ=", string(secrets["world"].ValueEncoded))
+}
+
+func TestDCResourceNoImage(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+	f.file("docker-compose.yml", simpleConfig)
+	f.file("Tiltfile", `
+docker_compose('docker-compose.yml')
+dc_resource('foo', trigger_mode=TRIGGER_MODE_AUTO)
+`)
+
+	f.load()
 }
 
 func TestDockerPruneSettings(t *testing.T) {


### PR DESCRIPTION
this previously generated an "invalid reference format" error, since we were happily passing `nil` to `ParseNamed`