### PR TITLE
tiltfile: pass manifest names from cmdline args around as slice instead of map

### DIFF
--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -78,11 +78,6 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 	startTime := cc.clock()
 	st.Dispatch(ConfigsReloadStartedAction{FilesChanged: filesChanged, StartTime: startTime})
 
-	matching := map[string]bool{}
-	for _, m := range initManifests {
-		matching[string(m)] = true
-	}
-
 	actionWriter := NewTiltfileLogWriter(st)
 	ctx = logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), actionWriter))
 
@@ -94,7 +89,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 	}
 	st.RUnlockState()
 
-	tlr := cc.tfl.Load(ctx, tiltfilePath, matching)
+	tlr := cc.tfl.Load(ctx, tiltfilePath, initManifests)
 	if tlr.Error == nil && len(tlr.Manifests) == 0 {
 		tlr.Error = fmt.Errorf("No resources found. Check out https://docs.tilt.dev/tutorial.html to get started!")
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -107,11 +107,6 @@ func (u Upper) Start(
 	}
 
 	var manifestNames []model.ManifestName
-	matching := map[string]bool{}
-	for _, arg := range args {
-		manifestNames = append(manifestNames, model.ManifestName(arg))
-		matching[arg] = true
-	}
 
 	configFiles := []string{absTfPath}
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -107,6 +107,9 @@ func (u Upper) Start(
 	}
 
 	var manifestNames []model.ManifestName
+	for _, arg := range args {
+		manifestNames = append(manifestNames, model.ManifestName(arg))
+	}
 
 	configFiles := []string{absTfPath}
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -62,7 +62,7 @@ type TiltfileLoader interface {
 	// We want to be very careful not to treat non-zero exit codes like an error.
 	// Because even if the Tiltfile has errors, we might need to watch files
 	// or return partial results (like enabled features).
-	Load(ctx context.Context, filename string, matching map[string]bool) TiltfileLoadResult
+	Load(ctx context.Context, filename string, requestedManifests []model.ManifestName) TiltfileLoadResult
 }
 
 type FakeTiltfileLoader struct {
@@ -75,7 +75,7 @@ func NewFakeTiltfileLoader() *FakeTiltfileLoader {
 	return &FakeTiltfileLoader{}
 }
 
-func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, matching map[string]bool) TiltfileLoadResult {
+func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, requestedManifests []model.ManifestName) TiltfileLoadResult {
 	return tfl.Result
 }
 
@@ -112,7 +112,7 @@ func printWarnings(s *tiltfileState) {
 }
 
 // Load loads the Tiltfile in `filename`
-func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching map[string]bool) TiltfileLoadResult {
+func (tfl tiltfileLoader) Load(ctx context.Context, filename string, requestedManifests []model.ManifestName) TiltfileLoadResult {
 	start := time.Now()
 	absFilename, err := ospath.RealAbs(filename)
 	if err != nil {
@@ -147,7 +147,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, matching ma
 	privateRegistry := tfl.kCli.PrivateRegistry(ctx)
 	s := newTiltfileState(ctx, tfl.dcCli, tfl.k8sContextExt, privateRegistry, feature.FromDefaults(tfl.fDefaults))
 
-	manifests, result, err := s.loadManifests(absFilename, matching)
+	manifests, result, err := s.loadManifests(absFilename, requestedManifests)
 	tlr.Secrets = s.extractSecrets()
 	tlr.ConfigFiles = s.configFiles
 	tlr.Warnings = s.warnings

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -516,7 +516,7 @@ dc_resource('foo', 'gcr.io/foo')
 	f.loadErrString("docker_build/custom_build.entrypoint not supported for Docker Compose resources")
 }
 
-func (f *fixture) assertDcManifest(name string, opts ...interface{}) model.Manifest {
+func (f *fixture) assertDcManifest(name model.ManifestName, opts ...interface{}) model.Manifest {
 	m := f.assertNextManifest(name)
 
 	if !m.IsDC() {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1003,7 +1003,7 @@ func (s *tiltfileState) extractEntities(dest *k8sResource, imageRef container.Re
 	return nil
 }
 
-// If the user requested only a subset of manifests, filter those manifests out.
+// If the user requested only a subset of manifests, get just those manifests
 func match(manifests []model.Manifest, requestedManifests []model.ManifestName) ([]model.Manifest, error) {
 	if len(requestedManifests) == 0 {
 		return manifests, nil

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -773,7 +773,7 @@ docker_build('gcr.io/bar', 'bar')
 k8s_yaml('bar.yaml')
 `)
 
-	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), matchMap("baz"))
+	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), []model.ManifestName{"baz"})
 	err := tlr.Error
 	if assert.Error(t, err) {
 		assert.Equal(t, `You specified some resources that could not be found: "baz"
@@ -1872,7 +1872,7 @@ type k8sKindTest struct {
 	expectImage          bool
 	expectedError        string
 	preamble             string
-	expectedResourceName string
+	expectedResourceName model.ManifestName
 }
 
 func TestK8sKind(t *testing.T) {
@@ -1909,7 +1909,7 @@ k8s_kind(%s)
 				if test.expectedError != "" {
 					t.Fatal("invalid test: cannot expect both workload and error")
 				}
-				expectedResourceName := "mycrd"
+				expectedResourceName := model.ManifestName("mycrd")
 				if test.expectedResourceName != "" {
 					expectedResourceName = test.expectedResourceName
 				}
@@ -4066,24 +4066,16 @@ func (f *fixture) yaml(path string, entities ...k8sOpts) {
 	f.file(path, s)
 }
 
-func matchMap(names ...string) map[string]bool {
-	m := make(map[string]bool, len(names))
-	for _, n := range names {
-		m[n] = true
-	}
-	return m
-}
-
 // Default load. Fails if there are any warnings.
-func (f *fixture) load(names ...string) {
+func (f *fixture) load(names ...model.ManifestName) {
 	f.loadAllowWarnings(names...)
 	if len(f.loadResult.Warnings) != 0 {
 		f.t.Fatalf("Unexpected no warnings. Actual: %s", f.loadResult.Warnings)
 	}
 }
 
-func (f *fixture) loadResourceAssemblyV1(names ...string) {
-	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...))
+func (f *fixture) loadResourceAssemblyV1(names ...model.ManifestName) {
+	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), names)
 	err := tlr.Error
 	if err != nil {
 		f.t.Fatal(err)
@@ -4094,8 +4086,8 @@ func (f *fixture) loadResourceAssemblyV1(names ...string) {
 
 // Load the manifests, expecting warnings.
 // Warnings should be asserted later with assertWarnings
-func (f *fixture) loadAllowWarnings(names ...string) {
-	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), matchMap(names...))
+func (f *fixture) loadAllowWarnings(names ...model.ManifestName) {
+	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), names)
 	err := tlr.Error
 	if err != nil {
 		f.t.Fatal(err)
@@ -4155,7 +4147,7 @@ func (f *fixture) assertNoMoreManifests() {
 // Helper func for asserting that the next manifest is Unresourced
 // k8s YAML containing the given k8s entities.
 func (f *fixture) assertNextManifestUnresourced(expectedEntities ...string) model.Manifest {
-	next := f.assertNextManifest(model.UnresourcedYAMLManifestName.String())
+	next := f.assertNextManifest(model.UnresourcedYAMLManifestName)
 
 	entities, err := k8s.ParseYAML(bytes.NewBufferString(next.K8sTarget().YAML))
 	assert.NoError(f.t, err)
@@ -4171,7 +4163,7 @@ func (f *fixture) assertNextManifestUnresourced(expectedEntities ...string) mode
 type funcOpt func(*testing.T, model.Manifest) bool
 
 // assert functions and helpers
-func (f *fixture) assertNextManifest(name string, opts ...interface{}) model.Manifest {
+func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{}) model.Manifest {
 	if len(f.loadResult.Manifests) == 0 {
 		f.t.Fatalf("no more manifests; trying to find %q (did you call `f.load`?)", name)
 	}


### PR DESCRIPTION
I'm guessing this was a map for historical reasons prior to multiple refactorings, and it's a bit weird for it to still be one now.