### PR TITLE
dockerfile: when reinserting directives from a parsed dockerfile, do so in determinisitic order (fix flaky test)

### DIFF
--- a/internal/dockerfile/ast.go
+++ b/internal/dockerfile/ast.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -118,7 +119,10 @@ func (a AST) Print() (Dockerfile, error) {
 	currentLine := 1
 
 	directiveFmt := "# %s = %s\n"
-	for k, v := range a.directives {
+	for _, k := range sortedKeys(a.directives) {
+		// order of directives in a docker makes no semantic difference; we
+		// rehydrate directives in sorted order so output is deterministic
+		v := a.directives[k]
 		_, err := fmt.Fprintf(buf, directiveFmt, k, v)
 		if err != nil {
 			return "", err
@@ -239,4 +243,13 @@ func fmtLabel(node *parser.Node) string {
 
 func newReader(df Dockerfile) io.Reader {
 	return bytes.NewBufferString(string(df))
+}
+
+func sortedKeys(m map[string]string) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/dockerfile/ast_test.go
+++ b/internal/dockerfile/ast_test.go
@@ -89,15 +89,26 @@ RUN echo bye
 `)
 }
 
-func TestPrintMultipleDirectives(t *testing.T) {
-	t.Skipf("Broken by aaa50e5adb83efdde909dec8b00eaa1c5f737276, Maia will fix")
-	assertPrintSame(t, `# foo = bar
-# baz = beep
+func TestMultipleDirectivesOrderDeterministic(t *testing.T) {
+	orig := `# z = zzz
+# y = yyy
+# x = xxx
+# b = bbb
+# a = aaa
 
 FROM golang:10
-RUN echo hi
-RUN echo bye
-`)
+`
+	// directives should be sorted alphabetically by key-
+	expected := `# a = aaa
+# b = bbb
+# x = xxx
+# y = yyy
+# z = zzz
+
+FROM golang:10
+`
+
+	assertPrint(t, orig, expected)
 }
 
 // Convert the dockerfile into an AST, print it, and then


### PR DESCRIPTION
```
go test github.com/windmilleng/tilt/internal/dockerfile -run Directive -count 1000
ok  	github.com/windmilleng/tilt/internal/dockerfile	0.144s
```