### PR TITLE
tiltfile: add resource_deps arg

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -110,3 +110,7 @@
 [[constraint]]
     name = "github.com/moby/buildkit"
     revision = "d5108d038d214c7b30c1e9678882135146163df7"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/looplab/tarjan"

--- a/internal/tiltfile/value/value.go
+++ b/internal/tiltfile/value/value.go
@@ -45,3 +45,21 @@ func ValueToAbsPath(thread *starlark.Thread, v starlark.Value) (string, error) {
 type PathMaker interface {
 	MakeLocalPath(relPath string) string
 }
+
+func SequenceToStringSlice(seq starlark.Sequence) ([]string, error) {
+	if seq == nil {
+		return nil, nil
+	}
+	it := seq.Iterate()
+	defer it.Done()
+	var ret []string
+	var v starlark.Value
+	for it.Next(&v) {
+		s, ok := v.(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("'%v' is a %T, not a string", v, v)
+		}
+		ret = append(ret, string(s))
+	}
+	return ret, nil
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -36,6 +36,10 @@ type Manifest struct {
 	// - automatically, when we detect a change
 	// - manually, when the user tells us to
 	TriggerMode TriggerMode
+
+	// The resource in this manifest will not be built until all of its dependencies have been
+	// ready at least once.
+	ResourceDependencies []ManifestName
 }
 
 func (m Manifest) ID() TargetID {
@@ -187,22 +191,22 @@ func (m Manifest) Validate() error {
 }
 
 func (m1 Manifest) Equal(m2 Manifest) bool {
-	primitivesEq, dockerEq, k8sEq, dcEq, localEq := m1.fieldGroupsEqual(m2)
-	return primitivesEq && dockerEq && k8sEq && dcEq && localEq
+	primitivesEq, dockerEq, k8sEq, dcEq, localEq, depsEq := m1.fieldGroupsEqual(m2)
+	return primitivesEq && dockerEq && k8sEq && dcEq && localEq && depsEq
 }
 
 // ChangesInvalidateBuild checks whether the changes from old => new manifest
 // invalidate our build of the old one; i.e. if we're replacing `old` with `new`,
 // should we perform a full rebuild?
 func ChangesInvalidateBuild(old, new Manifest) bool {
-	_, dockerEq, k8sEq, dcEq, localEq := old.fieldGroupsEqual(new)
+	_, dockerEq, k8sEq, dcEq, localEq, _ := old.fieldGroupsEqual(new)
 
 	// We only need to update for this manifest if any of the field-groups
 	// affecting build+deploy have changed (i.e. a change in primitives doesn't matter)
 	return !dockerEq || !k8sEq || !dcEq || !localEq
 
 }
-func (m1 Manifest) fieldGroupsEqual(m2 Manifest) (primitivesEq, dockerEq, k8sEq, dcEq, localEq bool) {
+func (m1 Manifest) fieldGroupsEqual(m2 Manifest) (primitivesEq, dockerEq, k8sEq, dcEq, localEq, depsEq bool) {
 	primitivesEq = m1.Name == m2.Name && m1.TriggerMode == m2.TriggerMode
 
 	dockerEq = DeepEqual(m1.ImageTargets, m2.ImageTargets)
@@ -219,7 +223,9 @@ func (m1 Manifest) fieldGroupsEqual(m2 Manifest) (primitivesEq, dockerEq, k8sEq,
 	lt2 := m2.LocalTarget()
 	localEq = DeepEqual(lt1, lt2)
 
-	return primitivesEq, dockerEq, dcEq, k8sEq, localEq
+	depsEq = DeepEqual(m1.ResourceDependencies, m2.ResourceDependencies)
+
+	return primitivesEq, dockerEq, dcEq, k8sEq, localEq, depsEq
 }
 
 func (m Manifest) ManifestName() ManifestName {

--- a/vendor/github.com/looplab/tarjan/.gitignore
+++ b/vendor/github.com/looplab/tarjan/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+
+*.sublime-project
+*.sublime-workspace
+
+.DS_Store
+.wercker

--- a/vendor/github.com/looplab/tarjan/LICENSE
+++ b/vendor/github.com/looplab/tarjan/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/looplab/tarjan/README.md
+++ b/vendor/github.com/looplab/tarjan/README.md
@@ -1,0 +1,49 @@
+[![wercker status](https://app.wercker.com/status/78c21e65a51c7d938faf021bd3220916/s "wercker status")](https://app.wercker.com/project/bykey/78c21e65a51c7d938faf021bd3220916)
+[![Coverage Status](https://img.shields.io/coveralls/looplab/tarjan.svg)](https://coveralls.io/r/looplab/tarjan)
+[![GoDoc](https://godoc.org/github.com/looplab/tarjan?status.svg)](https://godoc.org/github.com/looplab/tarjan)
+[![Go Report Card](https://goreportcard.com/badge/looplab/tarjan)](https://goreportcard.com/report/looplab/tarjan)
+
+
+# Tarjan
+
+Tarjan is a graph loop detection function using Tarjan's algorithm.
+
+The algorithm takes a input graph and produces a slice where each item is a slice of strongly connected vertices. The input graph is in form of a map where the key is a graph vertex and the value is the edges in for of a slice of vertices.
+
+Algorithm description:
+http://en.wikipedia.org/wiki/Tarjan’s_strongly_connected_components_algorithm
+
+Based on an implementation by Gustavo Niemeyer (in mgo/txn):
+http://bazaar.launchpad.net/+branch/mgo/v2/view/head:/txn/tarjan.go
+
+Gustavo Niemeyer: http://labix.org
+
+For API docs and examples see http://godoc.org/github.com/looplab/tarjan
+
+
+# Example
+
+```go
+graph := make(map[interface{}][]interface{})
+graph["1"] = []interface{}{"2"}
+graph["2"] = []interface{}{"3"}
+graph["3"] = []interface{}{"1"}
+graph["4"] = []interface{}{"2", "3", "5"}
+graph["5"] = []interface{}{"4", "6"}
+graph["6"] = []interface{}{"3", "7"}
+graph["7"] = []interface{}{"6"}
+graph["8"] = []interface{}{"5", "7", "8"}
+
+output := Connections(graph)
+fmt.Println(output)
+
+// Output:
+// [[3 2 1] [7 6] [5 4] [8]]
+```
+
+
+# License
+
+Tarjan is licensed under Apache License 2.0
+
+http://www.apache.org/licenses/LICENSE-2.0

--- a/vendor/github.com/looplab/tarjan/tarjan.go
+++ b/vendor/github.com/looplab/tarjan/tarjan.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2013 - Max Persson <max@looplab.se>
+// Copyright (c) 2010-2013 - Gustavo Niemeyer <gustavo@niemeyer.net>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tarjan implements a graph loop detection algorithm called Tarjan's algorithm.
+//
+// The algorithm takes a input graph and produces a slice where each item is a
+// slice of strongly connected vertices. The input graph is in form of a map
+// where the key is a graph vertex and the value is the edges in for of a slice
+// of vertices.
+//
+// Algorithm description:
+// http://en.wikipedia.org/wiki/Tarjan’s_strongly_connected_components_algorithm
+//
+// Based on an implementation by Gustavo Niemeyer (in mgo/txn):
+// http://bazaar.launchpad.net/+branch/mgo/v2/view/head:/txn/tarjan.go
+//
+package tarjan
+
+// Connections creates a slice where each item is a slice of strongly connected vertices.
+//
+// If a slice item contains only one vertex there are no loops. A loop on the
+// vertex itself is also a connected group.
+//
+// The example shows the same graph as in the Wikipedia article.
+func Connections(graph map[interface{}][]interface{}) [][]interface{} {
+	g := &data{
+		graph: graph,
+		nodes: make([]node, 0, len(graph)),
+		index: make(map[interface{}]int, len(graph)),
+	}
+	for v := range g.graph {
+		if _, ok := g.index[v]; !ok {
+			g.strongConnect(v)
+		}
+	}
+	return g.output
+}
+
+// data contains all common data for a single operation.
+type data struct {
+	graph  map[interface{}][]interface{}
+	nodes  []node
+	stack  []interface{}
+	index  map[interface{}]int
+	output [][]interface{}
+}
+
+// node stores data for a single vertex in the connection process.
+type node struct {
+	lowlink int
+	stacked bool
+}
+
+// strongConnect runs Tarjan's algorithm recursivley and outputs a grouping of
+// strongly connected vertices.
+func (data *data) strongConnect(v interface{}) *node {
+	index := len(data.nodes)
+	data.index[v] = index
+	data.stack = append(data.stack, v)
+	data.nodes = append(data.nodes, node{lowlink: index, stacked: true})
+	node := &data.nodes[index]
+
+	for _, w := range data.graph[v] {
+		i, seen := data.index[w]
+		if !seen {
+			n := data.strongConnect(w)
+			if n.lowlink < node.lowlink {
+				node.lowlink = n.lowlink
+			}
+		} else if data.nodes[i].stacked {
+			if i < node.lowlink {
+				node.lowlink = i
+			}
+		}
+	}
+
+	if node.lowlink == index {
+		var vertices []interface{}
+		i := len(data.stack) - 1
+		for {
+			w := data.stack[i]
+			stackIndex := data.index[w]
+			data.nodes[stackIndex].stacked = false
+			vertices = append(vertices, w)
+			if stackIndex == index {
+				break
+			}
+			i--
+		}
+		data.stack = data.stack[:i]
+		data.output = append(data.output, vertices)
+	}
+
+	return node
+}

--- a/vendor/github.com/looplab/tarjan/wercker.yml
+++ b/vendor/github.com/looplab/tarjan/wercker.yml
@@ -1,0 +1,33 @@
+box: golang
+
+dev:
+  steps:
+    - internal/watch:
+        code: |
+          go build ./...
+        reload: true
+
+build:
+  steps:
+    - wercker/setup-go-workspace:
+      package-dir: github.com/looplab/tarjan
+
+    - wercker/golint
+
+    - script:
+        name: go get
+        code: |
+          cd $WERCKER_SOURCE_DIR
+          go version
+          go get -t ./...
+
+    - script:
+        name: go build
+        code: |
+          go build ./...
+
+    - script:
+        name: go test
+        code: |
+          go get github.com/mattn/goveralls
+          goveralls -v -service wercker.com


### PR DESCRIPTION
This adds a new `resource_deps` arg to `k8s_resource`, `dc_resource`, and `local_resource`.
It does not yet affect build order.

It does:
1. populate the engine state with those deps so that the build controller will be able to use it in a future PR
2. validate the deps
3. change `tilt up foo` to also get `foo`'s transitive dependencies.