### PR TITLE
toast: fix broken wire rule

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -16,6 +16,7 @@ tasks:
       - internal
       - pkg
       - synclet
+      - web
       - vendor
       - Makefile
     output_paths:


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/wire:

a3f4a179655f56647020454fa3c8251c932a3b70 (2019-10-24 17:58:17 -0400)
toast: fix broken wire rule