### PR TITLE
toast: remove prettier, this is no longer necessary

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -30,7 +30,6 @@ tasks:
     command: |
       set -euo pipefail
       swagger-to-ts pkg/webview/view.swagger.json --camelcase --output web/src/view.d.ts
-      cd web && prettier --write src/view.d.ts
       
       
   wire:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/bug:

d498e26f10de6e10c84bfb3b82e653a2291abc93 (2019-10-24 19:04:36 -0400)
toast: remove prettier, this is no longer necessary