### PR TITLE
tiltfile: adjust an error message to make it clear that we're not building the image

### DIFF
--- a/internal/tiltfile/build_index.go
+++ b/internal/tiltfile/build_index.go
@@ -100,7 +100,7 @@ func (idx *buildIndex) assertAllMatched() error {
 				matchLines = append(matchLines, fmt.Sprintf("    - %s", match))
 			}
 
-			return fmt.Errorf("Image not used in any resource:\n    ✕ %v\n%s",
+			return fmt.Errorf("Image not used in any deploy config:\n    ✕ %v\n%s\nSkipping this image build",
 				image.configurationRef.String(), strings.Join(matchLines, "\n"))
 		}
 	}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -460,7 +460,12 @@ services:
 docker_build('gcr.typo.io/foo', 'foo')
 docker_compose('docker-compose.yml')
 `)
-	f.loadAssertWarnings("Image not used in any resource:\n    ✕ gcr.typo.io/foo\nDid you mean…\n    - gcr.io/foo\n    - docker.io/library/golang")
+	f.loadAssertWarnings(`Image not used in any deploy config:
+    ✕ gcr.typo.io/foo
+Did you mean…
+    - gcr.io/foo
+    - docker.io/library/golang
+Skipping this image build`)
 }
 
 func TestDockerComposeOnlySomeWithDockerBuild(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4099,13 +4099,14 @@ func (f *fixture) loadAllowWarnings(names ...model.ManifestName) {
 }
 
 func unusedImageWarning(unusedImage string, suggestedImages []string) string {
-	ret := fmt.Sprintf("Image not used in any resource:\n    ✕ %s", unusedImage)
+	ret := fmt.Sprintf("Image not used in any deploy config:\n    ✕ %s", unusedImage)
 	if len(suggestedImages) > 0 {
 		ret = ret + fmt.Sprintf("\nDid you mean…")
 		for _, s := range suggestedImages {
 			ret = ret + fmt.Sprintf("\n    - %s", s)
 		}
 	}
+	ret = ret + fmt.Sprintf("\nSkipping this image build")
 	return ret
 }
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/warning:

664a4936ef3f3d0a77e790090f74bf0ec02ef844 (2019-10-25 11:35:12 -0400)
tiltfile: adjust an error message to make it clear that we're not building the image