### PR TITLE
build_control: enforce resource_deps in buildorder

### DIFF
--- a/internal/dockercompose/state.go
+++ b/internal/dockercompose/state.go
@@ -52,11 +52,12 @@ func (evt Event) IsStopEvent() bool {
 }
 
 type State struct {
-	Status      Status
-	ContainerID container.ID
-	CurrentLog  model.Log
-	StartTime   time.Time
-	IsStopping  bool
+	Status        Status
+	ContainerID   container.ID
+	CurrentLog    model.Log
+	StartTime     time.Time
+	IsStopping    bool
+	LastReadyTime time.Time
 }
 
 func (State) RuntimeState() {}
@@ -85,7 +86,16 @@ func (s State) WithStartTime(time time.Time) State {
 	return s
 }
 
+func (s State) WithLastReadyTime(time time.Time) State {
+	s.LastReadyTime = time
+	return s
+}
+
 func (s State) WithStopping(stopping bool) State {
 	s.IsStopping = stopping
 	return s
+}
+
+func (s State) HasEverBeenReady() bool {
+	return !s.LastReadyTime.IsZero()
 }

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -54,15 +54,15 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 		podInfo.BaselineRestarts = podInfo.AllContainerRestarts()
 	}
 
+	if len(podInfo.Containers) == 0 {
+		// not enough info to do anything else
+		return
+	}
+
 	if podInfo.AllContainersReady() {
 		runtime := ms.K8sRuntimeState()
 		runtime.LastReadyTime = time.Now()
 		ms.RuntimeState = runtime
-	}
-
-	if len(podInfo.Containers) == 0 {
-		// not enough info to do anything else
-		return
 	}
 
 	fwdsValid := portForwardsAreValid(manifest, *podInfo)

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -51,6 +52,12 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 		// Tilt run, so we're just attaching to an existing pod
 		// with some old history.
 		podInfo.BaselineRestarts = podInfo.AllContainerRestarts()
+	}
+
+	if podInfo.AllContainersReady() {
+		runtime := ms.K8sRuntimeState()
+		runtime.LastReadyTime = time.Now()
+		ms.RuntimeState = runtime
 	}
 
 	if len(podInfo.Containers) == 0 {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -372,8 +372,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	}
 
 	if mt.Manifest.IsLocal() {
-		// dummy value to indicate that this is a LocalResource (LR's have no runtime state, only build state)
-		ms.RuntimeState = store.LocalRuntimeState{}
+		ms.RuntimeState = store.LocalRuntimeState{HasFinishedAtLeastOnce: true}
 	}
 
 	if engineState.WatchFiles {
@@ -726,6 +725,8 @@ func handleDockerComposeEvent(ctx context.Context, engineState *store.EngineStat
 	if evt.IsStartupEvent() {
 		state = state.WithStartTime(time.Now())
 		state = state.WithStopping(false)
+		// NB: this will differ from StartTime once we support DC health checks
+		state = state.WithLastReadyTime(time.Now())
 	}
 
 	if evt.IsStopEvent() {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3259,7 +3259,9 @@ func (f *testFixture) nextCallComplete(msgAndArgs ...interface{}) buildAndDeploy
 func (f *testFixture) nextCall(msgAndArgs ...interface{}) buildAndDeployCall {
 	msg := "timed out waiting for BuildAndDeployCall"
 	if len(msgAndArgs) > 0 {
-		msg = fmt.Sprintf("timed out waiting for BuildAndDeployCall: %s", msgAndArgs...)
+		format := msgAndArgs[0].(string)
+		args := msgAndArgs[1:]
+		msg = fmt.Sprintf("timed out waiting for BuildAndDeployCall: %s", fmt.Sprintf(format, args...))
 	}
 
 	for {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -434,10 +434,6 @@ func (ms *ManifestState) HasPendingChangesBefore(highWaterMark time.Time) (bool,
 	return ok, earliest
 }
 
-func (ms *ManifestState) BlockDependentManifests() bool {
-	return !ms.RuntimeState.HasEverBeenReady()
-}
-
 var _ model.TargetStatus = &ManifestState{}
 
 type YAMLManifestState struct {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -434,6 +434,10 @@ func (ms *ManifestState) HasPendingChangesBefore(highWaterMark time.Time) (bool,
 	return ok, earliest
 }
 
+func (ms *ManifestState) BlockDependentManifests() bool {
+	return !ms.RuntimeState.HasEverBeenReady()
+}
+
 var _ model.TargetStatus = &ManifestState{}
 
 type YAMLManifestState struct {


### PR DESCRIPTION
1. Add `HasEverBeenReady()` state to each `RuntimeState` implementation
2. Don't select a manifest for building unless `HasEverBeenReady()` is true for all of its resource deps

note: `HasEverBeenReady()`'s behavior in practice is still a bit confusing due to the flashing green dot bug