### PR TITLE
tiltfile: throw error if user attempts to use '~' in paths in tiltifle

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -194,7 +194,11 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 	}
 	for _, valueFile := range valueFiles {
 		cmd = append(cmd, "--values", valueFile)
-		s.recordConfigFile(starkit.AbsPath(thread, valueFile))
+		absPath, err := starkit.AbsPath(thread, valueFile)
+		if err != nil {
+			return nil, err
+		}
+		s.recordConfigFile(absPath)
 	}
 
 	stdout, err := s.execLocalCmd(thread, exec.Command(cmd[0], cmd[1:]...), false)

--- a/internal/tiltfile/git/git.go
+++ b/internal/tiltfile/git/git.go
@@ -21,8 +21,12 @@ func (Extension) OnStart(env *starkit.Environment) error {
 }
 
 func NewGitRepo(t *starlark.Thread, path string) (*Repo, error) {
-	absPath := starkit.AbsPath(t, path)
-	_, err := os.Stat(absPath)
+	absPath, err := starkit.AbsPath(t, path)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = os.Stat(absPath)
 	if err != nil {
 		return nil, fmt.Errorf("Reading paths %s: %v", absPath, err)
 	}

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -150,8 +150,13 @@ func (s *tiltfileState) liveUpdateSync(thread *starlark.Thread, fn *starlark.Bui
 		return nil, err
 	}
 
+	localPath, err := starkit.AbsPath(thread, localPath)
+	if err != nil {
+		return nil, err
+	}
+
 	ret := liveUpdateSyncStep{
-		localPath:  starkit.AbsPath(thread, localPath),
+		localPath:  localPath,
 		remotePath: remotePath,
 		position:   thread.CallFrame(1).Pos,
 	}

--- a/internal/tiltfile/starkit/environment.go
+++ b/internal/tiltfile/starkit/environment.go
@@ -146,7 +146,11 @@ func (e *Environment) start(path string) (Model, error) {
 }
 
 func (e *Environment) load(t *starlark.Thread, path string) (starlark.StringDict, error) {
-	return e.exec(t, AbsPath(t, path))
+	absPath, err := AbsPath(t, path)
+	if err != nil {
+		return nil, err
+	}
+	return e.exec(t, absPath)
 }
 
 func (e *Environment) exec(t *starlark.Thread, path string) (starlark.StringDict, error) {

--- a/internal/tiltfile/starkit/path.go
+++ b/internal/tiltfile/starkit/path.go
@@ -1,18 +1,25 @@
 package starkit
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	"go.starlark.net/starlark"
 )
 
 // We want to resolve paths relative to the dir where the currently executing file lives,
 // not relative to the working directory.
-func AbsPath(t *starlark.Thread, path string) string {
-	if filepath.IsAbs(path) {
-		return path
+func AbsPath(t *starlark.Thread, path string) (string, error) {
+	if strings.HasPrefix(path, "~/") || path == "~" {
+		return "", fmt.Errorf(
+			"Tiltfile does not support expansion of '~', please provide an absolute path (you provided: %q)", path)
 	}
-	return filepath.Join(AbsWorkingDir(t), path)
+
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	return filepath.Join(AbsWorkingDir(t), path), nil
 }
 
 func AbsWorkingDir(t *starlark.Thread) string {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2273,6 +2273,13 @@ k8s_yaml('')
 	f.loadErrString("error reading yaml file")
 }
 
+func TestTildeInPathNotSupported(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.file("Tiltfile", `docker_build('gcr.io/awesome-image', '~/my/docker/context')`)
+	f.loadErrString("Tiltfile does not support expansion of '~'")
+}
+
 func TestParseJSON(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/internal/tiltfile/value/value.go
+++ b/internal/tiltfile/value/value.go
@@ -36,7 +36,7 @@ func ValueToAbsPath(thread *starlark.Thread, v starlark.Value) (string, error) {
 
 	str, ok := v.(starlark.String)
 	if ok {
-		return starkit.AbsPath(thread, string(str)), nil
+		return starkit.AbsPath(thread, string(str))
 	}
 
 	return "", fmt.Errorf("expected path | string. Actual type: %T", v)


### PR DESCRIPTION
Error messages should be more explicit about the behavior a user hit in #2423