### PR TITLE
tilt: update current version to v0.10.15

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.10.14"
+const devVersion = "0.10.15"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.10.14"
+VERSION="0.10.15"
 BREW=$(which brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/upgrade:

c6593b970807356b47828ffbe96f477aaec62d1c (2019-10-28 16:50:39 -0400)
tilt: update current version to v0.10.15