### PR TITLE
assets: rewrite the prod asset server to use middleware

### DIFF
--- a/pkg/assets/context.go
+++ b/pkg/assets/context.go
@@ -1,0 +1,20 @@
+package assets
+
+import (
+	"context"
+	"net/http"
+)
+
+type PublicPathPrefixContextKey struct{}
+
+func getPublicPathPrefix(r *http.Request) string {
+	val := r.Context().Value(PublicPathPrefixContextKey{})
+	s, _ := val.(string)
+	return s
+}
+
+func appendPublicPathPrefix(prefix string, r *http.Request) *http.Request {
+	key := PublicPathPrefixContextKey{}
+	existingPrefix := getPublicPathPrefix(r)
+	return r.WithContext(context.WithValue(r.Context(), key, existingPrefix+prefix))
+}

--- a/pkg/assets/fake.go
+++ b/pkg/assets/fake.go
@@ -1,0 +1,21 @@
+package assets
+
+import (
+	"context"
+	"net/http"
+)
+
+type fakeServer struct {
+}
+
+func NewFakeServer() fakeServer {
+	return fakeServer{}
+}
+
+func (fakeServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {}
+func (fakeServer) Serve(ctx context.Context) error {
+	return nil
+}
+func (fakeServer) TearDown(ctx context.Context) {}
+
+var _ Server = fakeServer{}

--- a/pkg/assets/middleware.go
+++ b/pkg/assets/middleware.go
@@ -1,0 +1,76 @@
+package assets
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+// Middleware that attaches a server at a subpath.
+// Modeled after http.StripPrefix, but attaches the work it did to the Request Context.
+func StripPrefix(prefix string, h http.Handler) http.Handler {
+	if prefix == "" {
+		return h
+	}
+
+	delegate := http.StripPrefix(prefix, h)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p := strings.TrimPrefix(r.URL.Path, prefix); len(p) < len(r.URL.Path) {
+			// If the prefix was stripped successfully, add it to the context.
+			r = appendPublicPathPrefix(prefix, r)
+		}
+		delegate.ServeHTTP(w, r)
+	})
+}
+
+// Middleware that injects version information into the request.
+// We rewrite the URL to contain the version.
+//
+// If no default version is passed, and we can't find the version in the url path,
+// we will write a 500 error.
+func InferVersion(defaultVersion model.WebVersion, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origPath := r.URL.Path
+
+		if matches := versionRe.FindStringSubmatch(origPath); len(matches) > 1 {
+			h.ServeHTTP(w, appendPublicPathPrefixForVersion(matches[1], r))
+			return
+		}
+		if matches := shaRe.FindStringSubmatch(origPath); len(matches) > 1 {
+			h.ServeHTTP(w, appendPublicPathPrefixForVersion(matches[1], r))
+			return
+		}
+
+		if !(strings.HasPrefix(origPath, "/static/")) {
+			// redirect everything else to the main entry point.
+			origPath = "index.html"
+		}
+
+		version := r.URL.Query().Get(WebVersionKey)
+		if version == "" {
+			version = string(defaultVersion)
+		}
+
+		if version == "" {
+			http.Error(w, fmt.Sprintf("Asset version not found: %s", r.URL.String()),
+				http.StatusInternalServerError)
+			return
+		}
+
+		// Stanza for proxying a request (see http.StripPrefix)
+		r2 := new(http.Request)
+		*r2 = *r
+		r2.URL = new(url.URL)
+		*r2.URL = *r.URL
+		r2.URL.Path = path.Join(string(version), origPath)
+		h.ServeHTTP(w, appendPublicPathPrefixForVersion(version, r2))
+	})
+}
+
+func appendPublicPathPrefixForVersion(version string, r *http.Request) *http.Request {
+	return appendPublicPathPrefix(fmt.Sprintf("/%s", version), r)
+}

--- a/pkg/assets/server.go
+++ b/pkg/assets/server.go
@@ -3,7 +3,6 @@ package assets
 import (
 	"context"
 	"net/http"
-	"net/url"
 )
 
 // The directory where the package.json where our JS source code lives.
@@ -17,12 +16,4 @@ type Server interface {
 	http.Handler
 	Serve(ctx context.Context) error
 	TearDown(ctx context.Context)
-}
-
-func NewFakeServer() Server {
-	loc, err := url.Parse("https://fake.tilt.dev")
-	if err != nil {
-		panic(err)
-	}
-	return prodServer{baseUrl: loc}
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/middleware:

b7e4f7aea6e4292ae0c34ba367978a11776c9aa5 (2019-10-29 14:23:44 -0400)
assets: rewrite the prod asset server to use middleware

953986f1f1f5aac4c8a430bd101eebe917ddfcf9 (2019-10-29 13:03:33 -0400)
assets: rewrite the test to use a test server, rather than reaching into the internals of prodServer