### PR TITLE
engine: fix resource dep scheduling

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -19,13 +19,14 @@ func NextTargetToBuild(state store.EngineState) *store.ManifestTarget {
 		return nil
 	}
 
-	targets := state.Targets()
+	targets := RemoveTargetsWaitingOnDependencies(state, state.Targets())
 
 	// If any of the manifest targets haven't been built yet, build them now.
 	unbuilt := FindUnbuiltTargets(targets)
-	candidates := RemoveTargetsWaitingOnDependencies(state, unbuilt)
-	if len(candidates) > 0 {
-		return NextUnbuiltTargetToBuild(candidates)
+
+	if len(unbuilt) > 0 {
+		ret := NextUnbuiltTargetToBuild(unbuilt)
+		return ret
 	}
 
 	// Next prioritize builds that crashed and need a rebuilt to have up-to-date code.

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -385,7 +385,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	}
 
 	if mt.Manifest.IsLocal() {
-		ms.RuntimeState = store.LocalRuntimeState{HasFinishedAtLeastOnce: true}
+		ms.RuntimeState = store.LocalRuntimeState{HasSucceededAtLeastOnce: err == nil}
 	}
 
 	if engineState.WatchFiles {

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -22,13 +22,13 @@ type RuntimeState interface {
 // state. In future, we may use this to store runtime state for long-running processes
 // kicked off via a LocalResource.
 type LocalRuntimeState struct {
-	HasFinishedAtLeastOnce bool
+	HasSucceededAtLeastOnce bool
 }
 
 func (LocalRuntimeState) RuntimeState() {}
 
 func (l LocalRuntimeState) HasEverBeenReady() bool {
-	return l.HasFinishedAtLeastOnce
+	return l.HasSucceededAtLeastOnce
 }
 
 var _ RuntimeState = LocalRuntimeState{}


### PR DESCRIPTION
### Problem

The [unit test that checks resource dep scheduling](https://github.com/windmilleng/tilt/blob/8d3235173cd24aee1f2e88268455491fb305a367/internal/engine/buildcontroller_test.go#L842) was failing ~10% of the time.
After investigation, it turns out that the build that should have been blocked was getting returned from [here](https://github.com/windmilleng/tilt/blob/51140205344a27ee79ce27b27d11df30bd2b9387/internal/engine/buildcontrol/build_control.go#L48), which was not affected by the resource deps filter.

### Solution

Apply the resource deps filter to state.Targets directly, instead of just unbuilt targets, which is much cleaner anyway.