### PR TITLE
toast: speed up toast wire from ~70s to ~32s

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -40,7 +40,7 @@ tasks:
       - internal
       - pkg
       - synclet
-      - web
+      - web/web.go
       - vendor
       - Makefile
     output_paths:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/toast:

61ee1b2fc92b15fb1fbc154774d6be15d3c6f9b1 (2019-10-30 18:24:39 -0400)
toast: speed up toast wire from ~70s to ~32s