### PR TITLE
hud: remove SnapshotMessage. AFAICT, this is dead code, bc we no longer load this exact route

### DIFF
--- a/web/src/HUD.scss
+++ b/web/src/HUD.scss
@@ -30,6 +30,3 @@
   color: $color-gray-lightest;
 }
 
-.SnapshotMessage {
-  margin-top: $spacing-unit;
-}

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -473,23 +473,6 @@ class HUD extends Component<HudProps, HudState> {
         return <FacetsPane resource={fr} />
       }
     }
-    let snapshotRoute = () => {
-      return (
-        <div className="SnapshotMessage">
-          <h1>Welcome to a Tilt snapshot!</h1>
-          <p>
-            In here you can look around and check out a "snapshot" of a Tilt
-            session.
-          </p>
-          <p>
-            Snapshots are static freeze frame points in time. Nothing will
-            change. Feel free to poke around and see what the person who sent
-            you this snapshot saw when they sent it to you.
-          </p>
-          <p>Have fun!</p>
-        </div>
-      )
-    }
 
     return (
       <Switch>
@@ -516,11 +499,6 @@ class HUD extends Component<HudProps, HudState> {
           )}
         />
         <Route exact path={this.path("/r/:name")} render={logsRoute} />
-        <Route
-          exact
-          path={this.path("/snapshot/:snap_id")}
-          render={snapshotRoute}
-        />
         <Route
           exact
           path={this.path("/r/:name/k8s")}


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/deadcode:

0e00a5deb73179623d3543e621d85e6566ad2b6e (2019-11-01 17:52:03 -0400)
hud: remove SnapshotMessage. AFAICT, this is dead code, bc we no longer load this exact route