### PR TITLE
store: remove EngineState.InitialBuildsQueued

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -259,7 +259,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	defer func() {
 		engineState.CurrentlyBuilding = ""
 
-		if engineState.CompletedBuildCount == engineState.InitialBuildsQueued {
+		if engineState.InitialBuildsCompleted() {
 			logger.Get(ctx).Debugf("[timing.py] finished initial build") // hook for timing.py
 		}
 	}()
@@ -469,9 +469,6 @@ func handleConfigsReloaded(
 	event configs.ConfigsReloadedAction,
 ) {
 	manifests := event.Manifests
-	if state.InitialBuildsQueued == 0 {
-		state.InitialBuildsQueued = len(manifests)
-	}
 
 	b := state.TiltfileState.CurrentBuild
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -31,10 +31,6 @@ type EngineState struct {
 	CurrentlyBuilding model.ManifestName
 	WatchFiles        bool
 
-	// How many builds were queued on startup (i.e., how many manifests there were
-	// after initial Tiltfile load)
-	InitialBuildsQueued int
-
 	// How many builds have been completed (pass or fail) since starting tilt
 	CompletedBuildCount int
 
@@ -226,6 +222,25 @@ func (e *EngineState) HasDockerBuild() bool {
 		}
 	}
 	return false
+}
+
+func (e *EngineState) InitialBuildsCompleted() bool {
+	if e.ManifestTargets == nil || len(e.ManifestTargets) == 0 {
+		return false
+	}
+
+	for _, mt := range e.ManifestTargets {
+		if mt.Manifest.TriggerMode != model.TriggerModeAuto {
+			continue
+		}
+
+		ms, _ := e.ManifestState(mt.Manifest.Name)
+		if ms == nil || ms.LastBuild().Empty() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // TODO(nick): This will eventually implement TargetStatus

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -181,8 +181,8 @@ func (s *Store) maybeFinished() (bool, error) {
 		return false, nil
 	}
 
-	finished := !state.WatchFiles &&
-		state.CompletedBuildCount == state.InitialBuildsQueued
+	finished := !state.WatchFiles && state.InitialBuildsCompleted()
+
 	return finished, nil
 }
 


### PR DESCRIPTION
### Problem

EngineState.InitialBuildsQueued was only used to compare to CompletedBuildCount as a way of determining if we'd built all the resources. Doing so relies on incorrect assumptions about build order and trigger modes. The new "ALL BUILDS ARE MANUAL" feature stretches these incorrect assumptions further.

### Solution

Remove the field and check what we care about more directly.