### PR TITLE
tilt: inject labels to LabelSelectors, too

### DIFF
--- a/internal/k8s/extract.go
+++ b/internal/k8s/extract.go
@@ -61,6 +61,25 @@ func extractObjectMetas(obj interface{}, filter func(v reflect.Value) bool) ([]*
 	return result, nil
 }
 
+func extractSelectors(obj interface{}, filter func(v reflect.Value) bool) ([]*metav1.LabelSelector, error) {
+	extracted, err := newExtractor(reflect.TypeOf(metav1.LabelSelector{})).
+		withFilter(filter).
+		extractPointersFrom(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*metav1.LabelSelector, len(extracted))
+	for i, e := range extracted {
+		c, ok := e.(*metav1.LabelSelector)
+		if !ok {
+			return nil, fmt.Errorf("ExtractSelectors: expected LabelSelector, actual %T", e)
+		}
+		result[i] = c
+	}
+	return result, nil
+}
+
 func extractEnvVars(obj interface{}) ([]*v1.EnvVar, error) {
 	extracted, err := newExtractor(reflect.TypeOf(v1.EnvVar{})).extractPointersFrom(obj)
 	if err != nil {

--- a/internal/k8s/label_test.go
+++ b/internal/k8s/label_test.go
@@ -181,9 +181,9 @@ func TestInjectStatefulSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Only inject once: in the top-level metadata and the pod template,
+	// Only inject twice: in the top-level metadata, the pod template, and the match selectors,
 	// not the volume claim template
-	assert.Equal(t, 2, strings.Count(result, "tilt-runid: deadbeef"))
+	assert.Equal(t, 3, strings.Count(result, "tilt-runid: deadbeef"))
 }
 
 func TestSelectorMatchesLabels(t *testing.T) {

--- a/internal/k8s/label_test.go
+++ b/internal/k8s/label_test.go
@@ -55,9 +55,32 @@ func TestInjectLabelDeployment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// We expect both the Deployment and the PodTemplate to get the labels.
-	assert.Equal(t, 2, strings.Count(result, "tier: test"))
-	assert.Equal(t, 2, strings.Count(result, "owner: me"))
+	// We expect the Deployment, the Selector, and the PodTemplate to get the labels.
+	assert.Equal(t, 3, strings.Count(result, "tier: test"))
+	assert.Equal(t, 3, strings.Count(result, "owner: me"))
+}
+
+func TestInjectLabelDeploymentMakeSelectorMatchOnConflict(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.SanchoYAML)
+	newEntity, err := InjectLabels(entity, []model.LabelPair{
+		{
+			Key:   "app",
+			Value: "panza",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We expect the Deployment, the Selector, and the PodTemplate to get the labels.
+	assert.Equal(t, 3, strings.Count(result, "app: panza"))
+	// we've replaced the "app: sancho" in the selector
+	assert.Equal(t, 0, strings.Count(result, "app: sancho"))
 }
 
 func TestInjectLabelDeploymentBeta1(t *testing.T) {
@@ -77,7 +100,7 @@ func TestInjectLabelDeploymentBeta1(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 2, strings.Count(result, "owner: me"))
+	assert.Equal(t, 3, strings.Count(result, "owner: me"))
 
 	// Assert that matchLabels were injected
 	assert.Contains(t, result, "matchLabels")
@@ -102,7 +125,7 @@ func TestInjectLabelDeploymentBeta2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 2, strings.Count(result, "owner: me"))
+	assert.Equal(t, 3, strings.Count(result, "owner: me"))
 
 	// Assert that matchLabels were injected
 	assert.Contains(t, result, "matchLabels")
@@ -127,7 +150,7 @@ func TestInjectLabelExtDeploymentBeta1(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 2, strings.Count(result, "owner: me"))
+	assert.Equal(t, 3, strings.Count(result, "owner: me"))
 
 	// Assert that matchLabels were injected
 	assert.Contains(t, result, "matchLabels")


### PR DESCRIPTION
Fixes #2498 

### Problem

When Tilt applies a k8s object, it injects a `app.kubernetes.io/managed-by` label.
When Tilt applies a k8s object that already *has* a `app.kubernetes.io/managed-by` label, it overwrites it.
When a Deployment already has a `app.kubernetes.io/managed-by` label and a selector matching that label, Tilt updates the label in the meta, but not in the selector, leaving a deployment whose selector does not match its pod, generating a "selector does not match template labels" error on apply.

### Solution

When injecting labels to an object, also inject those labels to any LabelSelectors we find.