### PR TITLE
cloud: remove snapshots from update-history

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -94,8 +94,8 @@ var (
 func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdUpTags analytics2.CmdUpTags) (CmdUpDeps, error) {
 	v := provideClock()
 	renderer := hud.NewRenderer(v)
-	modelWebPort := provideWebPort()
 	modelWebHost := provideWebHost()
+	modelWebPort := provideWebPort()
 	webURL, err := provideWebURL(modelWebHost, modelWebPort)
 	if err != nil {
 		return CmdUpDeps{}, err
@@ -215,7 +215,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdUpTa
 	analyticsUpdater := analytics2.NewAnalyticsUpdater(analytics3, cmdUpTags)
 	eventWatchManager := k8swatch.NewEventWatchManager(client, ownerFetcher)
 	cloudUsernameManager := cloud.NewUsernameManager(httpClient)
-	updateUploader := cloud.NewUpdateUploader(httpClient, address, snapshotUploader)
+	updateUploader := cloud.NewUpdateUploader(httpClient, address)
 	dockerPruner := dockerprune.NewDockerPruner(switchCli)
 	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, tiltVersionChecker, analyticsUpdater, eventWatchManager, cloudUsernameManager, updateUploader, dockerPruner)
 	upper := engine.NewUpper(ctx, storeStore, v2)
@@ -429,8 +429,8 @@ var BaseWireSet = wire.NewSet(
 	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, provideClock, hud.NewRenderer, hud.NewDefaultHeadsUpDisplay, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
-	provideWebHost,
 	provideWebPort,
+	provideWebHost,
 	provideNoBrowserFlag, server.ProvideHeadsUpServer, provideAssetServer, server.ProvideHeadsUpServerController, dirs.UseWindmillDir, token.GetOrCreateToken, provideCmdUpDeps, engine.NewKINDPusher, wire.Value(feature.MainDefaults),
 )
 

--- a/internal/cloud/update_uploader.go
+++ b/internal/cloud/update_uploader.go
@@ -19,17 +19,15 @@ import (
 type UpdateUploader struct {
 	client HttpClient
 	addr   cloudurl.Address
-	su     SnapshotUploader
 
 	lastCompletedBuildCount int
 	lastFinishTime          time.Time
 }
 
-func NewUpdateUploader(client HttpClient, addr cloudurl.Address, su SnapshotUploader) *UpdateUploader {
+func NewUpdateUploader(client HttpClient, addr cloudurl.Address) *UpdateUploader {
 	return &UpdateUploader{
 		client: client,
 		addr:   addr,
-		su:     su,
 	}
 }
 
@@ -110,12 +108,6 @@ func (u *UpdateUploader) makeUpdates(ctx context.Context, st store.RStore) updat
 
 	// OK, we know we have work to do!
 
-	sID, err := u.su.TakeAndUpload(state)
-	if err != nil {
-		logger.Get(ctx).Infof("error posting snapshot: %v", err)
-		// if the upload failed, snapshotID will be empty, so we'll just send updates without a snapshot
-	}
-
 	highWaterMark := u.lastFinishTime
 	updates := []update{}
 
@@ -147,7 +139,6 @@ func (u *UpdateUploader) makeUpdates(ctx context.Context, st store.RStore) updat
 				IsLiveUpdate:      record.HasBuildType(model.BuildTypeLiveUpdate),
 				Result:            resultCode,
 				ResultDescription: resultDescription,
-				SnapshotID:        snapshotID{string(sID)},
 			})
 		}
 	}

--- a/internal/cloud/update_uploader_test.go
+++ b/internal/cloud/update_uploader_test.go
@@ -39,7 +39,7 @@ func TestOneUpdate(t *testing.T) {
 	if assert.Equal(t, 1, len(requests)) {
 		body, err := ioutil.ReadAll(requests[0].Body)
 		assert.NoError(t, err)
-		expected := `{"team_id":{"id":"fake-team"},"updates":[{"service":{"name":"sancho"},"start_time":"1984-04-04T00:00:00Z","duration":"1m0s","is_live_update":false,"result":0,"result_description":"","snapshot_id":{"id":"snapshot1"}}]}
+		expected := `{"team_id":{"id":"fake-team"},"updates":[{"service":{"name":"sancho"},"start_time":"1984-04-04T00:00:00Z","duration":"1m0s","is_live_update":false,"result":0,"result_description":"","snapshot_id":{"id":""}}]}
 `
 		assert.Equal(t, expected, string(body))
 	}
@@ -61,7 +61,7 @@ func TestTiltfileUpdate(t *testing.T) {
 	if assert.Equal(t, 1, len(requests)) {
 		body, err := ioutil.ReadAll(requests[0].Body)
 		assert.NoError(t, err)
-		expected := `{"team_id":{"id":"fake-team"},"updates":[{"service":{"name":"(Tiltfile)"},"start_time":"1984-04-04T00:00:00Z","duration":"1m0s","is_live_update":false,"result":0,"result_description":"","snapshot_id":{"id":"snapshot1"}}]}
+		expected := `{"team_id":{"id":"fake-team"},"updates":[{"service":{"name":"(Tiltfile)"},"start_time":"1984-04-04T00:00:00Z","duration":"1m0s","is_live_update":false,"result":0,"result_description":"","snapshot_id":{"id":""}}]}
 `
 		assert.Equal(t, expected, string(body))
 	}
@@ -101,15 +101,13 @@ type updateFixture struct {
 	uu         *UpdateUploader
 	store      *store.Store
 	clock      clockwork.FakeClock
-	su         *fakeSnapshotUploader
 }
 
 func newUpdateFixture(t *testing.T) *updateFixture {
 	f := tempdir.NewTempDirFixture(t)
 	httpClient := httptest.NewFakeClient()
 	addr := cloudurl.Address("cloud-test.tilt.dev")
-	su := &fakeSnapshotUploader{}
-	uu := NewUpdateUploader(httpClient, addr, su)
+	uu := NewUpdateUploader(httpClient, addr)
 	st, _ := store.NewStoreForTesting()
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 
@@ -133,7 +131,6 @@ func newUpdateFixture(t *testing.T) *updateFixture {
 		uu:             uu,
 		store:          st,
 		clock:          clockwork.NewFakeClock(),
-		su:             su,
 	}
 }
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3022,7 +3022,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	ghc := &github.FakeClient{}
 	ewm := k8swatch.NewEventWatchManager(kCli, of)
 	tcum := cloud.NewUsernameManager(httptest.NewFakeClient())
-	cuu := cloud.NewUpdateUploader(httptest.NewFakeClient(), "cloud-test.tilt.dev", &fakeSnapshotUploader{})
+	cuu := cloud.NewUpdateUploader(httptest.NewFakeClient(), "cloud-test.tilt.dev")
 
 	dp := dockerprune.NewDockerPruner(dockerClient)
 	dp.DisabledForTesting(true)


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/update:

2986adcc4e10361ba05344976acec1e8dbb2cf80 (2019-11-05 19:28:36 -0500)
cloud: remove snapshots from update-history