### PR TITLE
store: fix a bug where tilt hangs indefinitely if it hits a FatalError while hud=false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,10 @@ shorttest:
 
 integration:
 ifneq ($(CIRCLECI),true)
-		go test -v -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
+		go test -v -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
 else
 		mkdir -p test-results
-		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./integration -v -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
+		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./integration -count 1 -v -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
 endif
 
 # Run the integration tests on kind

--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -1,0 +1,24 @@
+//+build integration
+
+package integration
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Make sure that Tilt crashes if there are two tilts running
+func TestCrash(t *testing.T) {
+	f := newK8sFixture(t, "oneup")
+	defer f.TearDown()
+
+	f.TiltWatch()
+	time.Sleep(500 * time.Millisecond)
+
+	out := bytes.NewBuffer(nil)
+	_ = f.tiltCmd([]string{"up", "--watch=false", "--hud=false"}, out).Run()
+	assert.Contains(t, out.String(), "Cannot start Tilt")
+}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -51,6 +51,7 @@ type InitAction struct {
 
 	CloudAddress string
 	Token        token.Token
+	HUDEnabled   bool
 }
 
 func (InitAction) Action() {}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -90,7 +90,7 @@ func (u Upper) Start(
 	b model.TiltBuild,
 	watch bool,
 	fileName string,
-	useActionWriter bool,
+	hudEnabled bool,
 	analyticsUserOpt analytics.Opt,
 	token token.Token,
 	cloudAddress string,
@@ -123,6 +123,7 @@ func (u Upper) Start(
 		AnalyticsUserOpt: analyticsUserOpt,
 		Token:            token,
 		CloudAddress:     cloudAddress,
+		HUDEnabled:       hudEnabled,
 	})
 }
 
@@ -665,6 +666,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 	engineState.WatchFiles = action.WatchFiles
 	engineState.CloudAddress = action.CloudAddress
 	engineState.Token = action.Token
+	engineState.HUDEnabled = action.HUDEnabled
 
 	// NOTE(dmiller): this kicks off a Tiltfile build
 	engineState.PendingConfigFileChanges[action.TiltfilePath] = time.Now()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -510,7 +510,10 @@ func TestFirstBuildFailsWhileNotWatching(t *testing.T) {
 	f.SetNextBuildFailure(buildFailedToken)
 
 	f.setManifests([]model.Manifest{manifest})
-	err := f.upper.Init(f.ctx, InitAction{TiltfilePath: f.JoinPath("Tiltfile")})
+	err := f.upper.Init(f.ctx, InitAction{
+		TiltfilePath: f.JoinPath("Tiltfile"),
+		HUDEnabled:   true,
+	})
 	require.Nil(t, err)
 	f.WaitUntilManifestState("build has failed", manifest.ManifestName(), func(st store.ManifestState) bool {
 		return st.LastBuild().Error != nil
@@ -3079,6 +3082,7 @@ func (f *testFixture) startWithInitManifests(initManifests []model.ManifestName,
 	ia := InitAction{
 		WatchFiles:   watchFiles,
 		TiltfilePath: f.JoinPath("Tiltfile"),
+		HUDEnabled:   true,
 	}
 	for _, o := range initOptions {
 		ia = o(ia)
@@ -3445,6 +3449,7 @@ func (f *testFixture) loadAndStart() {
 	ia := InitAction{
 		WatchFiles:   true,
 		TiltfilePath: f.JoinPath("Tiltfile"),
+		HUDEnabled:   true,
 	}
 	f.Init(ia)
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -41,6 +41,7 @@ type EngineState struct {
 	BuildControllerActionCount int
 
 	FatalError error
+	HUDEnabled bool
 
 	// The user has indicated they want to exit
 	UserExited bool

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -177,6 +177,10 @@ func (s *Store) maybeFinished() (bool, error) {
 		return true, nil
 	}
 
+	if state.FatalError != nil && !state.HUDEnabled {
+		return true, state.FatalError
+	}
+
 	if len(state.ManifestTargets) == 0 {
 		return false, nil
 	}


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/fatal2:

d1d4c1fc319a1f9f07b8369b4b1af51bea15e27f (2019-11-05 21:52:35 -0500)
store: fix a bug where tilt hangs indefinitely if it hits a FatalError while hud=false