### PR TITLE
web: refactor dot color calculation

### DIFF
--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -323,12 +323,12 @@ func protoPopulateResourceInfoView(mt *store.ManifestTarget, r *proto_webview.Re
 func runtimeStatus(res ResourceInfoView) RuntimeStatus {
 	_, isLocal := res.(*LocalResourceInfo)
 	if isLocal {
-		return RuntimeStatusOK
+		return RuntimeStatusNotApplicable
 	}
 	// if we have no images to build, we have no runtime status monitoring.
 	_, isYAML := res.(*YAMLResourceInfo)
 	if isYAML {
-		return RuntimeStatusOK
+		return RuntimeStatusNotApplicable
 	}
 
 	result, ok := runtimeStatusMap[res.Status()]

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -206,7 +206,7 @@ func TestLocalResource(t *testing.T) {
 	assert.Equal(t, 2, len(v.Resources))
 	r := v.Resources[1]
 	assert.Equal(t, "test", r.Name)
-	assert.Equal(t, RuntimeStatusOK, RuntimeStatus(r.RuntimeStatus))
+	assert.Equal(t, RuntimeStatusNotApplicable, RuntimeStatus(r.RuntimeStatus))
 }
 
 func findResource(n model.ManifestName, view *proto_webview.View) (*proto_webview.Resource, bool) {

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -254,9 +254,10 @@ func (r Resource) LastBuild() BuildRecord {
 type RuntimeStatus string
 
 const (
-	RuntimeStatusOK      RuntimeStatus = "ok"
-	RuntimeStatusPending RuntimeStatus = "pending"
-	RuntimeStatusError   RuntimeStatus = "error"
+	RuntimeStatusOK            RuntimeStatus = "ok"
+	RuntimeStatusPending       RuntimeStatus = "pending"
+	RuntimeStatusError         RuntimeStatus = "error"
+	RuntimeStatusNotApplicable RuntimeStatus = "not_applicable"
 )
 
 type TiltBuild struct {

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -6,9 +6,9 @@ import "./Sidebar.scss"
 import {
   ResourceView,
   TriggerMode,
-  RuntimeStatus,
   Build,
   Resource,
+  ResourceStatus,
 } from "./types"
 import TimeAgo from "react-timeago"
 import { isZeroTime } from "./time"
@@ -21,7 +21,7 @@ import { numberOfAlerts } from "./alerts"
 class SidebarItem {
   name: string
   isTiltfile: boolean
-  status: RuntimeStatus
+  status: ResourceStatus
   hasWarnings: boolean
   hasEndpoints: boolean
   lastDeployTime: string
@@ -131,13 +131,7 @@ class Sidebar extends PureComponent<SidebarProps> {
             to={pb.path(link)}
             title={item.name}
           >
-            <SidebarIcon
-              status={item.status}
-              hasWarning={item.hasWarnings}
-              isBuilding={building}
-              isDirty={item.hasPendingChanges}
-              lastBuild={item.lastBuild}
-            />
+            <SidebarIcon status={item.status} />
             <p className="SidebarItem-name">{item.name}</p>
             {item.alertCount > 0 ? (
               <span className="SidebarItem-alertBadge">{item.alertCount}</span>

--- a/web/src/SidebarIcon.test.tsx
+++ b/web/src/SidebarIcon.test.tsx
@@ -1,134 +1,30 @@
 import React from "react"
 import { mount } from "enzyme"
 import SidebarIcon, { IconType } from "./SidebarIcon"
-import { RuntimeStatus, Build } from "./types"
+import { ResourceStatus } from "./types"
 import { Color } from "./constants"
 
 type Ignore = boolean
 
-const buildWithError = {
-  error: {},
-  startTime: "start time",
-  log: "foobar",
-  finishTime: "finish time",
-  edits: ["foo.go"],
-  isCrashRebuild: false,
-  warnings: [],
-}
-
 const cases: Array<
-  [
-    string,
-    RuntimeStatus,
-    boolean,
-    boolean,
-    Color | Ignore,
-    IconType | Ignore,
-    boolean,
-    Build | null
-  ]
+  [string, ResourceStatus, Color | Ignore, IconType | Ignore]
 > = [
-  [
-    "auto mode, building with any status or warning state → small loader",
-    RuntimeStatus.Pending,
-    false,
-    true,
-    false,
-    false,
-    false,
-    null,
-  ],
-  [
-    "auto mode, status ok and no warning → small green dot",
-    RuntimeStatus.Ok,
-    false,
-    false,
-    Color.green,
-    false,
-    false,
-    null,
-  ],
-  [
-    "auto mode, status error and no warning → small red dot",
-    RuntimeStatus.Error,
-    false,
-    false,
-    Color.red,
-    false,
-    false,
-    null,
-  ],
-  [
-    "auto mode, status error with warnings → small red dot",
-    RuntimeStatus.Error,
-    true,
-    false,
-    Color.red,
-    false,
-    false,
-    null,
-  ],
-  [
-    "auto mode, status ok with warning → small yellow dot",
-    RuntimeStatus.Ok,
-    true,
-    false,
-    Color.yellow,
-    false,
-    false,
-    null,
-  ],
-  [
-    "auto mode, status pending and no warnings → small glowing ring",
-    RuntimeStatus.Pending,
-    false,
-    false,
-    false,
-    IconType.StatusPending,
-    false,
-    null,
-  ],
-  [
-    "auto mode, status pending with warnings → small glowing ring",
-    RuntimeStatus.Pending,
-    true,
-    false,
-    false,
-    IconType.StatusPending,
-    false,
-    null,
-  ],
+  ["pending", ResourceStatus.Pending, false, IconType.StatusPending],
+  ["healthy", ResourceStatus.Healthy, Color.green, IconType.StatusDefault],
+  ["unhealthy", ResourceStatus.Unhealthy, Color.red, IconType.StatusDefault],
+  ["building", ResourceStatus.Building, false, IconType.StatusBuilding],
+  ["none", ResourceStatus.None, Color.gray, IconType.StatusDefault],
 ]
 
-test.each(cases)(
-  "%s",
-  (
-    _,
-    status,
-    hasWarning,
-    isBuilding,
-    fillColor,
-    iconType,
-    isDirty,
-    lastBuild
-  ) => {
-    const root = mount(
-      <SidebarIcon
-        status={status}
-        hasWarning={hasWarning}
-        isBuilding={isBuilding}
-        isDirty={isDirty}
-        lastBuild={lastBuild}
-      />
-    )
+test.each(cases)("%s", (_, status, fillColor, iconType) => {
+  const root = mount(<SidebarIcon status={status} />)
 
-    if (fillColor !== false) {
-      expect(root.find(`svg[fill="${fillColor}"]`)).toHaveLength(1)
-    }
-
-    if (iconType !== false) {
-      let path = `svg.${iconType}`
-      expect(root.find(path)).toHaveLength(1)
-    }
+  if (fillColor !== false) {
+    expect(root.find(`svg[fill="${fillColor}"]`)).toHaveLength(1)
   }
-)
+
+  if (iconType !== false) {
+    let path = `svg.${iconType}`
+    expect(root.find(path)).toHaveLength(1)
+  }
+})

--- a/web/src/SidebarIcon.tsx
+++ b/web/src/SidebarIcon.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react"
-import { TriggerMode, RuntimeStatus, Build } from "./types"
+import { Build, ResourceStatus } from "./types"
 import { Color } from "./constants"
 import { ReactComponent as DotSvg } from "./assets/svg/indicator-auto.svg"
 import { ReactComponent as DotPendingSvg } from "./assets/svg/indicator-auto-pending.svg"
@@ -7,11 +7,7 @@ import { ReactComponent as DotBuildingSvg } from "./assets/svg/indicator-auto-bu
 import "./SidebarIcon.scss"
 
 type SidebarIconProps = {
-  status: RuntimeStatus
-  hasWarning: boolean
-  isBuilding: boolean
-  isDirty: boolean
-  lastBuild: Build | null
+  status: ResourceStatus
 }
 
 // For testing
@@ -23,33 +19,22 @@ export enum IconType {
 
 export default class SidebarIcon extends PureComponent<SidebarIconProps> {
   render() {
-    let props = this.props
-    let fill = Color.green
-    let dirtyBuildWithError =
-      props.isDirty && props.lastBuild && props.lastBuild.error
-
-    if (props.status === RuntimeStatus.Error) {
-      fill = Color.red
-    } else if (props.hasWarning) {
-      fill = Color.yellow
-    } else if (dirtyBuildWithError) {
-      fill = Color.red
-    }
-
-    return <div className="SidebarIcon">{this.renderSvg(fill)}</div>
+    return <div className="SidebarIcon">{this.svg()}</div>
   }
 
-  renderSvg(fill: Color) {
-    let props = this.props
-    if (props.isBuilding) {
-      return this.building()
+  svg() {
+    switch (this.props.status) {
+      case ResourceStatus.Building:
+        return this.building()
+      case ResourceStatus.Pending:
+        return this.pending()
+      case ResourceStatus.Healthy:
+        return this.default(Color.green)
+      case ResourceStatus.Unhealthy:
+        return this.default(Color.red)
+      case ResourceStatus.None:
+        return this.default(Color.gray)
     }
-
-    if (props.status === RuntimeStatus.Pending) {
-      return this.pending()
-    }
-
-    return this.default(fill)
   }
 
   default(fill: Color) {

--- a/web/src/Statusbar.tsx
+++ b/web/src/Statusbar.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as UpdateAvailableSvg } from "./assets/svg/update-availa
 import { combinedStatus, warnings } from "./status"
 import "./Statusbar.scss"
 import { combinedStatusMessage } from "./combinedStatusMessage"
-import { Build, TiltBuild } from "./types"
+import { Build, ResourceStatus, RuntimeStatus, TiltBuild } from "./types"
 import mostRecentBuildToDisplay from "./mostRecentBuild"
 import { Link } from "react-router-dom"
 
@@ -31,8 +31,8 @@ class StatusItem {
     this.warningCount = warnings(res).length
 
     let status = combinedStatus(res)
-    this.up = status === "ok"
-    this.hasError = status === "error"
+    this.up = status === ResourceStatus.Healthy
+    this.hasError = status === ResourceStatus.Unhealthy
     this.currentBuild = res.currentBuild
     this.buildHistory = res.buildHistory
     this.lastBuild = res.buildHistory ? res.buildHistory[0] : null

--- a/web/src/status.test.tsx
+++ b/web/src/status.test.tsx
@@ -1,6 +1,7 @@
 import { oneResource } from "./testdata"
 import { zeroTime } from "./time"
 import { combinedStatus, warnings } from "./status"
+import { ResourceStatus } from "./types"
 
 function emptyResource() {
   let res = oneResource()
@@ -14,7 +15,7 @@ function emptyResource() {
 describe("combinedStatus", () => {
   it("pending when no build info", () => {
     let res = emptyResource()
-    expect(combinedStatus(res)).toBe("pending")
+    expect(combinedStatus(res)).toBe(ResourceStatus.Pending)
   })
 
   it("pending when current build", () => {
@@ -22,7 +23,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.currentBuild = { startTime: ts }
     res.runtimeStatus = "ok"
-    expect(combinedStatus(res)).toBe("pending")
+    expect(combinedStatus(res)).toBe(ResourceStatus.Building)
   })
 
   it("ok when runtime ok", () => {
@@ -30,7 +31,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.buildHistory = [{ startTime: ts }]
     res.runtimeStatus = "ok"
-    expect(combinedStatus(res)).toBe("ok")
+    expect(combinedStatus(res)).toBe(ResourceStatus.Healthy)
   })
 
   it("error when runtime error", () => {
@@ -38,7 +39,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.buildHistory = [{ startTime: ts }]
     res.runtimeStatus = "error"
-    expect(combinedStatus(res)).toBe("error")
+    expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("error when last build error", () => {
@@ -46,7 +47,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.buildHistory = [{ startTime: ts, error: "error" }]
     res.runtimeStatus = "ok"
-    expect(combinedStatus(res)).toBe("error")
+    expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("container restarts aren't errors", () => {
@@ -56,7 +57,7 @@ describe("combinedStatus", () => {
     res.runtimeStatus = "ok"
     if (!res.k8sResourceInfo) throw new Error("missing k8s info")
     res.k8sResourceInfo.podRestarts = 1
-    expect(combinedStatus(res)).toBe("ok")
+    expect(combinedStatus(res)).toBe(ResourceStatus.Healthy)
   })
 
   it("container restarts are warnings", () => {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -40,17 +40,16 @@ export enum RuntimeStatus {
   Ok = "ok",
   Pending = "pending",
   Error = "error",
-  Unknown = "unknown",
+  NotApplicable = "not_applicable",
 }
 
 // What is the status of the resource with respect to Tilt
 export enum ResourceStatus {
-  BuildQueued, // in auto, if you have changed a file but an affected build hasn't started yet. In manual after you have clicked build, before it has started building
-  Building,
-  Error,
-  Warning,
-  Deploying,
-  Deployed, // defer to RuntimeStatus
+  Building, // Tilt is actively doing something (e.g., docker build or kubectl apply)
+  Pending, // not building, healthy, or unhealthy, but presumably on its way to one of those (e.g., queued to build, or ContainerCreating)
+  Healthy, // e.g., build succeeded and pod is running and healthy
+  Unhealthy, // e.g., last build failed, or CrashLoopBackOff
+  None, // e.g., a manual build that has never executed
 }
 
 export type Resource = {


### PR DESCRIPTION
### Problem

The primary motivation is that with the new local resource stuff, we have local resources that are not pending and have never been built, so the dots should probably be gray.

When trying to figure out how to add a status for gray, it seemed `RuntimeStatus` is for the "deployment" status, `ResourceStatus` is for the "tilt resource" status, `combinedStatus` returns a `RuntimeStatus` (but incorporates the build status!), and the logic that checks the various pending / build / error states is split across `combinedStatus` and `SideBarIcon`.

### Solution
Luckily (?), the existing "ResourceStatus" class was never actually used, so...make that map to the dot color, change `combinedStatus` to return a `ResourceStatus`, and get rid of the seemingly redundant logic in `SidebarIcon`.

Also, add a new "not applicable" runtime status for `local_resource`, which hopefully risks less confusion than our previous behavior of having it just always return "ok".