### PR TITLE
integration: factor out a TiltDriver class

### DIFF
--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -30,7 +30,7 @@ func newAnalyticsFixture(t *testing.T) *analyticsFixture {
 		k8sFixture: newK8sFixture(t, "analytics"),
 		tempDir:    td,
 	}
-	af.tiltEnviron[WindmillDirEnvVarName] = td.Path()
+	af.tilt.Environ[WindmillDirEnvVarName] = td.Path()
 
 	af.SetupAnalyticsServer()
 
@@ -43,8 +43,8 @@ func (af *analyticsFixture) SetupAnalyticsServer() {
 		af.t.FailNow()
 	}
 	af.mss = mss
-	delete(af.tiltEnviron, "TILT_DISABLE_ANALYTICS")
-	af.tiltEnviron[AnalyticsUrlEnvVarName] = fmt.Sprintf("http://localhost:%d/report", port)
+	delete(af.tilt.Environ, "TILT_DISABLE_ANALYTICS")
+	af.tilt.Environ[AnalyticsUrlEnvVarName] = fmt.Sprintf("http://localhost:%d/report", port)
 }
 
 func (af *analyticsFixture) TearDown() {

--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -19,6 +19,8 @@ func TestCrash(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	out := bytes.NewBuffer(nil)
-	_ = f.tiltCmd([]string{"up", "--watch=false", "--hud=false"}, out).Run()
+	res, err := f.tilt.Up([]string{"--watch=false"}, out)
+	assert.NoError(t, err)
+	<-res.Done()
 	assert.Contains(t, out.String(), "Cannot start Tilt")
 }

--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -40,7 +40,8 @@ type fixture struct {
 	logs          *bufsync.ThreadSafeBuffer
 	cmds          []*exec.Cmd
 	originalFiles map[string]string
-	tiltEnviron   map[string]string
+	tilt          *TiltDriver
+	activeTiltUp  *TiltUpResponse
 	tearingDown   bool
 }
 
@@ -51,6 +52,9 @@ func newFixture(t *testing.T, dir string) *fixture {
 		t.Fatal(err)
 	}
 
+	client := NewTiltDriver()
+	client.Environ["TILT_DISABLE_ANALYTICS"] = "true"
+
 	ctx, cancel := context.WithCancel(context.Background())
 	f := &fixture{
 		t:             t,
@@ -59,10 +63,7 @@ func newFixture(t *testing.T, dir string) *fixture {
 		dir:           dir,
 		logs:          bufsync.NewThreadSafeBuffer(),
 		originalFiles: make(map[string]string),
-		tiltEnviron: map[string]string{
-			"TILT_DISABLE_ANALYTICS": "true",
-			"TILT_K8S_EVENTS":        "true",
-		},
+		tilt:          client,
 	}
 
 	if !installed {
@@ -106,8 +107,9 @@ func (f *fixture) WaitUntil(ctx context.Context, msg string, fun func() (string,
 		}
 
 		select {
+		case <-f.activeTiltDone():
+			f.t.Fatalf("Tilt died while waiting: %v", f.activeTiltErr())
 		case <-ctx.Done():
-			f.KillProcs()
 			f.t.Fatalf("Timed out waiting for expected result (%s)\n"+
 				"Expected: %s\n"+
 				"Actual: %s\n"+
@@ -118,58 +120,62 @@ func (f *fixture) WaitUntil(ctx context.Context, msg string, fun func() (string,
 	}
 }
 
-func (f *fixture) tiltCmd(tiltArgs []string, outWriter io.Writer) *exec.Cmd {
-	outWriter = io.MultiWriter(f.logs, outWriter)
-	cmd := exec.CommandContext(f.ctx, "tilt", tiltArgs...)
-	cmd.Stdout = outWriter
-	cmd.Stderr = outWriter
-	cmd.Env = append(os.Environ())
-	for k, v := range f.tiltEnviron {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+func (f *fixture) activeTiltDone() <-chan struct{} {
+	if f.activeTiltUp != nil {
+		return f.activeTiltUp.Done()
 	}
-	return cmd
+	neverDone := make(chan struct{})
+	return neverDone
 }
 
-func (f *fixture) TiltUpCmd(name string) *exec.Cmd {
-	args := []string{"up"}
-	if name != "" {
-		args = append(args, name)
+func (f *fixture) activeTiltErr() error {
+	if f.activeTiltUp != nil {
+		return f.activeTiltUp.Err()
 	}
-	args = append(args, "--watch=false", "--debug", "--hud=false", "--port=0", "--klog=1")
-	return f.tiltCmd(args, os.Stdout)
+	return nil
+}
+
+func (f *fixture) LogWriter() io.Writer {
+	return io.MultiWriter(f.logs, os.Stdout)
 }
 
 func (f *fixture) TiltUp(name string) {
-	cmd := f.TiltUpCmd(name)
-	f.runInBackground(cmd)
-}
-
-func (f *fixture) runInBackground(cmd *exec.Cmd) {
-	err := cmd.Start()
-	if err != nil {
-		f.t.Fatal(err)
+	args := []string{"--watch=false"}
+	if name != "" {
+		args = append(args, name)
 	}
-
-	f.cmds = append(f.cmds, cmd)
-	go func() {
-		err = cmd.Wait()
+	response, err := f.tilt.Up(args, f.LogWriter())
+	if err != nil {
+		f.t.Fatalf("TiltUp %s: %v", name, err)
+	}
+	select {
+	case <-response.Done():
+		err := response.Err()
 		if err != nil {
-			fmt.Printf("error running command: %v\n", err)
-			if ee, ok := err.(*exec.ExitError); ok {
-				fmt.Printf("stderr: %q\n", ee.Stderr)
-			}
+			f.t.Fatalf("TiltUp %s: %v", name, err)
 		}
-	}()
+	case <-f.ctx.Done():
+		err := f.ctx.Err()
+		if err != nil {
+			f.t.Fatalf("TiltUp %s: %v", name, err)
+		}
+	}
 }
 
 func (f *fixture) TiltWatch() {
-	cmd := f.tiltCmd([]string{"up", "--debug", "--hud=false", "--web-mode=prod", "--no-browser", "--klog=1"}, os.Stdout)
-	f.runInBackground(cmd)
+	response, err := f.tilt.Up(nil, f.LogWriter())
+	if err != nil {
+		f.t.Fatalf("TiltWatch: %v", err)
+	}
+	f.activeTiltUp = response
 }
 
 func (f *fixture) TiltWatchExec() {
-	cmd := f.tiltCmd([]string{"up", "--debug", "--hud=false", "--web-mode=prod", "--no-browser", "--klog=1", "--update-mode", "exec"}, os.Stdout)
-	f.runInBackground(cmd)
+	response, err := f.tilt.Up([]string{"--update-mode=exec"}, f.LogWriter())
+	if err != nil {
+		f.t.Fatalf("TiltWatchExec: %v", err)
+	}
+	f.activeTiltUp = response
 }
 
 func (f *fixture) ReplaceContents(fileBaseName, original, replacement string) {
@@ -201,11 +207,16 @@ func (f *fixture) StartTearDown() {
 		return
 	}
 
-	if f.t.Failed() {
+	isTiltStillUp := f.activeTiltUp != nil && f.activeTiltUp.Err() == nil
+	if f.t.Failed() && isTiltStillUp {
 		fmt.Printf("Test failed, dumping engine state\n----\n")
-		cmd := f.tiltCmd([]string{"dump", "engine"}, os.Stdout)
-		_ = cmd.Run()
+		err := f.tilt.DumpEngine(os.Stdout)
+		if err != nil {
+			fmt.Printf("Error: %v", err)
+		}
 		fmt.Printf("\n----\n")
+
+		f.activeTiltUp.KillAndDumpThreads()
 	}
 
 	f.cancel()
@@ -214,13 +225,11 @@ func (f *fixture) StartTearDown() {
 }
 
 func (f *fixture) KillProcs() {
-	for _, cmd := range f.cmds {
-		process := cmd.Process
-		if process != nil {
-			process.Kill()
-		}
+	if f.activeTiltUp != nil {
+		f.activeTiltUp.Kill()
 	}
 }
+
 func (f *fixture) TearDown() {
 	f.StartTearDown()
 
@@ -240,10 +249,9 @@ func (f *fixture) TearDown() {
 	// If users want to do the same thing in practice, it might be worth
 	// adding better in-product hooks (e.g., `tilt down --preserve-namespace`),
 	// or more scriptability in the Tiltfile.
-	f.tiltEnviron["SKIP_NAMESPACE"] = "true"
+	f.tilt.Environ["SKIP_NAMESPACE"] = "true"
 
-	cmd := f.tiltCmd([]string{"down"}, os.Stdout)
-	err := cmd.Run()
+	err := f.tilt.Down(os.Stdout)
 	if err != nil {
 		f.t.Errorf("Running tilt down: %v", err)
 	}

--- a/integration/idempotent_test.go
+++ b/integration/idempotent_test.go
@@ -16,11 +16,7 @@ func TestIdempotent(t *testing.T) {
 	f := newK8sFixture(t, "idempotent")
 	defer f.TearDown()
 
-	cmd := f.TiltUpCmd("idempotent")
-	err := cmd.Run()
-	if err != nil {
-		t.Fatalf("First 'tilt up' failed: %v", err)
-	}
+	f.TiltUp("idempotent")
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -121,6 +121,8 @@ func (f *k8sFixture) WaitForAllPodsInPhase(ctx context.Context, selector string,
 		}
 
 		select {
+		case <-f.activeTiltDone():
+			f.t.Fatalf("Tilt died while waiting for pods to be ready: %v", f.activeTiltErr())
 		case <-ctx.Done():
 			f.t.Fatalf("Timed out waiting for pods to be ready. Selector: %s. Output:\n:%s\n", selector, output)
 		case <-time.After(200 * time.Millisecond):
@@ -221,7 +223,7 @@ func (f *k8sFixture) setupNewKubeConfig() {
 	}
 	f.kubeconfigPath = f.tempDir.JoinPath(kubeconfigBaseName)
 	f.tempDir.WriteFile(f.kubeconfigPath, string(current))
-	f.fixture.tiltEnviron["KUBECONFIG"] = f.kubeconfigPath
+	f.fixture.tilt.Environ["KUBECONFIG"] = f.kubeconfigPath
 	log.Printf("New kubeconfig: %s", f.kubeconfigPath)
 }
 

--- a/integration/onewatch_exec_test.go
+++ b/integration/onewatch_exec_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestWatchExec(t *testing.T) {
-	t.Skip() // TODO(nick): fix me
-
 	f := newK8sFixture(t, "onewatch_exec")
 	defer f.TearDown()
 

--- a/integration/tilt.go
+++ b/integration/tilt.go
@@ -1,0 +1,122 @@
+package integration
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type TiltDriver struct {
+	Environ map[string]string
+}
+
+func NewTiltDriver() *TiltDriver {
+	return &TiltDriver{
+		Environ: make(map[string]string),
+	}
+}
+
+func (d *TiltDriver) cmd(args []string, out io.Writer) *exec.Cmd {
+	cmd := exec.Command("tilt", args...)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Env = os.Environ()
+	for k, v := range d.Environ {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return cmd
+}
+
+func (d *TiltDriver) DumpEngine(out io.Writer) error {
+	cmd := d.cmd([]string{"dump", "engine"}, out)
+	return cmd.Run()
+}
+
+func (d *TiltDriver) Down(out io.Writer) error {
+	cmd := d.cmd([]string{"down"}, out)
+	return cmd.Run()
+}
+
+func (d *TiltDriver) Up(args []string, out io.Writer) (*TiltUpResponse, error) {
+	mandatoryArgs := []string{"up",
+		// Can't attach a HUD or install browsers in headless mode
+		"--hud=false",
+		"--no-browser",
+
+		// Debug logging for integration tests
+		"--debug",
+		"--klog=1",
+
+		// Even if we're on a debug build, don't start a debug webserver
+		"--web-mode=prod",
+	}
+	cmd := d.cmd(append(mandatoryArgs, args...), out)
+	err := cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan struct{})
+	response := &TiltUpResponse{
+		done:    ch,
+		process: cmd.Process,
+	}
+	go func() {
+		err := cmd.Wait()
+		if err != nil {
+			response.mu.Lock()
+			response.err = err
+			response.mu.Unlock()
+		}
+		close(ch)
+	}()
+	return response, nil
+}
+
+type TiltUpResponse struct {
+	done chan struct{}
+	err  error
+	mu   sync.Mutex
+
+	process *os.Process
+}
+
+func (r *TiltUpResponse) Done() <-chan struct{} {
+	return r.done
+}
+
+func (r *TiltUpResponse) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}
+
+func (r *TiltUpResponse) Kill() error {
+	if r.process == nil {
+		return nil
+	}
+	return r.process.Kill()
+}
+
+// Kill the tilt process and print the goroutine/register state.
+// Useful if you think Tilt is deadlocked but aren't sure why.
+func (r *TiltUpResponse) KillAndDumpThreads() error {
+	if r.process == nil {
+		return nil
+	}
+
+	err := r.process.Signal(syscall.Signal(syscall.SIGINT))
+	if err != nil {
+		return err
+	}
+
+	select {
+	case <-r.Done():
+	case <-time.After(2 * time.Second):
+	}
+	return nil
+}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/driver:

168d32106daf55dddcc714a75f1916c9c7750b66 (2019-11-06 18:25:32 -0500)
integration: factor out a TiltDriver class
named in honor of WebDriver. Drives the Tilt command-line and
actively detects when Tilt crashes during the test