### PR TITLE
web: show force rebuild button for resource with a single failed build

### DIFF
--- a/web/src/Sidebar.test.tsx
+++ b/web/src/Sidebar.test.tsx
@@ -203,7 +203,10 @@ describe("sidebar", () => {
   it("trigger button not ready if resource waiting for first build", () => {
     let res = oneResource()
     res.currentBuild = {}
-    res.lastDeployTime = "0001-01-01T00:00:00Z"
+    res.buildHistory = []
+    res.lastDeployTime = ""
+    res.hasPendingChanges = false
+    res.pendingBuildSince = ""
     let items = [new SidebarItem(res)]
 
     const tree = renderer
@@ -228,6 +231,32 @@ describe("sidebar", () => {
     let res = oneResource()
     res.currentBuild = {}
     res.queued = true
+    let items = [new SidebarItem(res)]
+
+    const tree = renderer
+      .create(
+        <MemoryRouter initialEntries={["/"]}>
+          <Sidebar
+            isClosed={false}
+            items={items}
+            selected=""
+            toggleSidebar={null}
+            resourceView={ResourceView.Log}
+            pathBuilder={pathBuilder}
+          />
+        </MemoryRouter>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("shows a trigger button for resource that failed its initial build", () => {
+    let res = oneResource()
+    res.lastDeployTime = ""
+    res.currentBuild = false
+    res.hasPendingChanges = false
+    res.pendingBuildSince = ""
     let items = [new SidebarItem(res)]
 
     const tree = renderer

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -111,7 +111,8 @@ class Sidebar extends PureComponent<SidebarProps> {
       }
 
       let formatter = timeAgoFormatter
-      let hasBuilt = !isZeroTime(item.lastDeployTime)
+      let hasSuccessfullyDeployed = !isZeroTime(item.lastDeployTime)
+      let hasBuilt = item.lastBuild !== null
       let building = !isZeroTime(item.currentBuildStartTime)
       let timeAgo = <TimeAgo date={item.lastDeployTime} formatter={formatter} />
       let isSelected = this.props.selected === item.name
@@ -144,8 +145,8 @@ class Sidebar extends PureComponent<SidebarProps> {
             ) : (
               ""
             )}
-            <span className={`SidebarItem-timeAgo ${hasBuilt ? "" : "empty"}`}>
-              {hasBuilt ? timeAgo : "—"}
+            <span className={`SidebarItem-timeAgo ${hasSuccessfullyDeployed ? "" : "empty"}`}>
+              {hasSuccessfullyDeployed ? timeAgo : "—"}
             </span>
           </Link>
           <SidebarTriggerButton

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -145,7 +145,11 @@ class Sidebar extends PureComponent<SidebarProps> {
             ) : (
               ""
             )}
-            <span className={`SidebarItem-timeAgo ${hasSuccessfullyDeployed ? "" : "empty"}`}>
+            <span
+              className={`SidebarItem-timeAgo ${
+                hasSuccessfullyDeployed ? "" : "empty"
+              }`}
+            >
               {hasSuccessfullyDeployed ? timeAgo : "—"}
             </span>
           </Link>

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -1010,6 +1010,99 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
 </section>
 `;
 
+exports[`sidebar shows a trigger button for resource that failed its initial build 1`] = `
+<section
+  className="Sidebar"
+>
+  <nav
+    className="Sidebar-resources"
+  >
+    <ul
+      className="Sidebar-list"
+    >
+      <li
+        className="SidebarItem SidebarItem--all is-selected"
+      >
+        <a
+          className="SidebarItem-link"
+          href="/"
+          onClick={[Function]}
+          title="All"
+        >
+          <div
+            className="SidebarItem-allIcon"
+          >
+            ┌
+          </div>
+          <span
+            className="SidebarItem-name"
+          >
+            All
+          </span>
+          <span
+            className="SidebarItem-alertBadge"
+          >
+            1
+          </span>
+        </a>
+      </li>
+      <li
+        className="SidebarItem"
+      >
+        <a
+          className="SidebarItem-link"
+          href="/r/vigoda"
+          onClick={[Function]}
+          title="vigoda"
+        >
+          <div
+            className="SidebarIcon"
+          >
+            <svg
+              className="default"
+              fill="#f6685c"
+            >
+              indicator-auto.svg
+            </svg>
+          </div>
+          <p
+            className="SidebarItem-name"
+          >
+            vigoda
+          </p>
+          <span
+            className="SidebarItem-alertBadge"
+          >
+            1
+          </span>
+          <span
+            className="SidebarItem-timeAgo empty"
+          >
+            —
+          </span>
+        </a>
+        <button
+          className="SidebarTriggerButton 
+           isReady"
+          disabled={false}
+          onClick={[Function]}
+          title="Force a rebuild/update for this resource."
+        />
+      </li>
+    </ul>
+  </nav>
+  <button
+    className="Sidebar-toggle"
+    onClick={null}
+  >
+    <svg>
+      chevron.svg
+    </svg>
+     Collapse
+  </button>
+</section>
+`;
+
 exports[`sidebar shows ready + dirty trigger button for manual resource with pending changes 1`] = `
 <section
   className="Sidebar"
@@ -1287,11 +1380,7 @@ exports[`sidebar trigger button not ready if resource waiting for first build 1`
           >
             All
           </span>
-          <span
-            className="SidebarItem-alertBadge"
-          >
-            1
-          </span>
+          
         </a>
       </li>
       <li
@@ -1307,14 +1396,10 @@ exports[`sidebar trigger button not ready if resource waiting for first build 1`
             className="SidebarIcon"
           >
             <svg
-              className="pending"
-              style={
-                Object {
-                  "animation": "glow 1s linear infinite",
-                }
-              }
+              className="default"
+              fill="#20ba31"
             >
-              indicator-auto-pending.svg
+              indicator-auto.svg
             </svg>
           </div>
           <p
@@ -1322,11 +1407,7 @@ exports[`sidebar trigger button not ready if resource waiting for first build 1`
           >
             vigoda
           </p>
-          <span
-            className="SidebarItem-alertBadge"
-          >
-            1
-          </span>
+          
           <span
             className="SidebarItem-timeAgo empty"
           >


### PR DESCRIPTION
### Problem

Repro:
1. change a resource so that it fails to build
2. `tilt up`

Observed: the resource fails to build, and when you mouse over where the rebuild button would be, you get a "Cannot trigger an update while resource is building or build is pending."

Expected: there's a rebuild button

This basically comes down to a great game of telephone:
* In `ManifestState`, we have `LastSuccessfulDeployTime`, which in the webview, we [rename](https://github.com/windmilleng/tilt/blob/0ca6cba0164994765b0ddd6d64a462a93ad0c348/internal/hud/webview/convert.go#L84) to `lastDeployTime`.
* In Sidebar.tsx, we [translate `lastDeployTime` into `hasBuilt`](https://github.com/windmilleng/tilt/blob/e6ddeec04f1f611152cf15a226e6988912a0ca84/web/src/Sidebar.tsx#L114)
* In SidebarTriggerButton.tsx, we [use `hasBuilt`](https://github.com/windmilleng/tilt/blob/e6ddeec04f1f611152cf15a226e6988912a0ca84/web/src/SidebarTriggerButton.tsx#L76) to judge whether it's on the initial build, but really it's indicating whether it's ever successfully built!

### Solution

Change Sidebar.tsx to set `hasBuilt` based on whether there's a build history, rather than looking at `lastDeployTime`.

It'd be nice to also clean up that chain of names (aside from the above, `lastDeployTime` is confusing in a world where not all builds have deploys - the names for the same concept are going from "build" -> "successful deploy" -> "deploy" -> "build" here), but changes to the webview currently come at great cost.