### PR TITLE
upper_test: fix nextCallComplete race condition

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3269,7 +3269,7 @@ func (f *testFixture) WaitUntilManifestState(msg string, name model.ManifestName
 
 func (f *testFixture) nextCallComplete(msgAndArgs ...interface{}) buildAndDeployCall {
 	call := f.nextCall(msgAndArgs...)
-	f.waitForCompletedBuildCount(call.count)
+	f.waitForCompletedBuildCountAtLeast(call.count)
 	return call
 }
 
@@ -3361,6 +3361,12 @@ func (f *testFixture) notifyAndWaitForPodStatus(pod *v1.Pod, mn model.ManifestNa
 
 	f.WaitUntilManifestState("pod status change seen", mn, func(state store.ManifestState) bool {
 		return pred(state.MostRecentPod())
+	})
+}
+
+func (f *testFixture) waitForCompletedBuildCountAtLeast(count int) {
+	f.WaitUntil(fmt.Sprintf("%d builds done", count), func(state store.EngineState) bool {
+		return state.CompletedBuildCount >= count
 	})
 }
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3269,7 +3269,7 @@ func (f *testFixture) WaitUntilManifestState(msg string, name model.ManifestName
 
 func (f *testFixture) nextCallComplete(msgAndArgs ...interface{}) buildAndDeployCall {
 	call := f.nextCall(msgAndArgs...)
-	f.waitForCompletedBuildCountAtLeast(call.count)
+	f.waitForCompletedBuildCount(call.count)
 	return call
 }
 
@@ -3364,15 +3364,9 @@ func (f *testFixture) notifyAndWaitForPodStatus(pod *v1.Pod, mn model.ManifestNa
 	})
 }
 
-func (f *testFixture) waitForCompletedBuildCountAtLeast(count int) {
-	f.WaitUntil(fmt.Sprintf("%d builds done", count), func(state store.EngineState) bool {
-		return state.CompletedBuildCount >= count
-	})
-}
-
 func (f *testFixture) waitForCompletedBuildCount(count int) {
 	f.WaitUntil(fmt.Sprintf("%d builds done", count), func(state store.EngineState) bool {
-		return state.CompletedBuildCount == count
+		return state.CompletedBuildCount >= count
 	})
 }
 


### PR DESCRIPTION
1. test starts the engine with two manifests
2. engine completes initial builds of both manifests
3. test calls `nextCallComplete()` twice

After (2), `EngineState.CompletedBuildCount` is 2
In the first call in (3), `nextCall` returns a `call` with `count == 1`, so `nextCallComplete` blocks until `CompletedBuildCount` is 1, which it will never be.

Since CompletedBuildCount is monotonic, `>=` seems good enough.