### PR TITLE
container: add a wrapper function around FamiliarString() that handles RefSelectors correctly

### DIFF
--- a/internal/build/cache_builder.go
+++ b/internal/build/cache_builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/pkg/logger"
@@ -60,7 +61,7 @@ func (b CacheBuilder) cacheRef(inputs CacheInputs) (CacheRef, error) {
 }
 
 func (b CacheBuilder) makeCacheDockerfile(baseDf dockerfile.Dockerfile, sourceRef reference.NamedTagged, cachePaths []string) dockerfile.Dockerfile {
-	df := dockerfile.Dockerfile(fmt.Sprintf("FROM %s as tilt-source", reference.FamiliarString(sourceRef)))
+	df := dockerfile.Dockerfile(fmt.Sprintf("FROM %s as tilt-source", container.FamiliarString(sourceRef)))
 	df = df.Join(string(baseDf))
 
 	lines := []string{}

--- a/internal/build/custom_builder.go
+++ b/internal/build/custom_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
 	"github.com/windmilleng/tilt/pkg/logger"
 )
@@ -43,8 +44,8 @@ func (b *ExecCustomBuilder) Build(ctx context.Context, ref reference.Named, comm
 
 	l := logger.Get(ctx)
 	l.Infof("Custom Build: Injecting Environment Variables")
-	l.Infof("EXPECTED_REF=%s", reference.FamiliarString(expectedRef))
-	env := append(os.Environ(), fmt.Sprintf("EXPECTED_REF=%s", reference.FamiliarString(expectedRef)))
+	l.Infof("EXPECTED_REF=%s", container.FamiliarString(expectedRef))
+	env := append(os.Environ(), fmt.Sprintf("EXPECTED_REF=%s", container.FamiliarString(expectedRef)))
 
 	for _, e := range b.dCli.Env().AsEnviron() {
 		env = append(env, e)

--- a/internal/container/helpers.go
+++ b/internal/container/helpers.go
@@ -1,0 +1,11 @@
+package container
+
+import "github.com/docker/distribution/reference"
+
+func FamiliarString(ref reference.Reference) string {
+	s, ok := ref.(RefSelector)
+	if ok {
+		return s.RefFamiliarString()
+	}
+	return reference.FamiliarString(ref)
+}

--- a/internal/container/helpers_test.go
+++ b/internal/container/helpers_test.go
@@ -1,0 +1,13 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFamiliarString(t *testing.T) {
+	s := MustParseSelector("golang")
+	assert.Equal(t, "golang", FamiliarString(s))
+	assert.Equal(t, "golang", FamiliarString(s.AsNamedOnly()))
+}

--- a/internal/dockerfile/ast.go
+++ b/internal/dockerfile/ast.go
@@ -49,7 +49,7 @@ func (a AST) traverseImageRefs(visitor func(node *parser.Node, ref reference.Nam
 			}
 			newRef := visitor(node, ref)
 			if newRef != nil {
-				node.Next.Value = reference.FamiliarString(newRef)
+				node.Next.Value = container.FamiliarString(newRef)
 			}
 
 		case command.Copy:
@@ -76,7 +76,7 @@ func (a AST) traverseImageRefs(visitor func(node *parser.Node, ref reference.Nam
 			if newRef != nil {
 				for i, flag := range node.Flags {
 					if strings.HasPrefix(flag, "--from=") {
-						node.Flags[i] = fmt.Sprintf("--from=%s", reference.FamiliarString(newRef))
+						node.Flags[i] = fmt.Sprintf("--from=%s", container.FamiliarString(newRef))
 					}
 				}
 			}

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -3,9 +3,9 @@ package engine
 import (
 	"fmt"
 
-	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/sliceutils"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -76,7 +76,7 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		// a container(s). Check to see if we have enough information about the
 		// container(s) that would need to be updated.
 		if len(state.RunningContainers) == 0 {
-			return nil, RedirectToNextBuilderInfof("don't have info for running container of image %q (often a result of the deployment not yet being ready)", reference.FamiliarString(iTarget.DeploymentRef))
+			return nil, RedirectToNextBuilderInfof("don't have info for running container of image %q (often a result of the deployment not yet being ready)", container.FamiliarString(iTarget.DeploymentRef))
 		}
 
 		filesChanged, err := filesChangedTree(g, iTarget, stateSet)

--- a/internal/engine/image_and_cache_builder.go
+++ b/internal/engine/image_and_cache_builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution/reference"
 
 	"github.com/windmilleng/tilt/internal/build"
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockerfile"
 	"github.com/windmilleng/tilt/internal/ignore"
 	"github.com/windmilleng/tilt/internal/store"
@@ -33,7 +34,7 @@ func NewImageAndCacheBuilder(ib build.ImageBuilder, cb build.CacheBuilder, custb
 func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageTarget, state store.BuildState, ps *build.PipelineState) (reference.NamedTagged, error) {
 	var n reference.NamedTagged
 
-	userFacingRefName := reference.FamiliarString(iTarget.ConfigurationRef)
+	userFacingRefName := container.FamiliarString(iTarget.ConfigurationRef)
 	refToBuild := iTarget.DeploymentRef
 	cacheInputs := icb.createCacheInputs(iTarget)
 	cacheRef, err := icb.cb.FetchCache(ctx, cacheInputs)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -164,7 +164,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 }
 
 func (ibd *ImageBuildAndDeployer) push(ctx context.Context, ref reference.NamedTagged, ps *build.PipelineState, iTarget model.ImageTarget, kTarget model.K8sTarget) (reference.NamedTagged, error) {
-	ps.StartPipelineStep(ctx, "Pushing %s", reference.FamiliarString(ref))
+	ps.StartPipelineStep(ctx, "Pushing %s", container.FamiliarString(ref))
 	defer ps.EndPipelineStep(ctx)
 
 	cbSkip := false

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -99,7 +99,7 @@ func injectImageDigestInContainers(entity K8sEntity, selector container.RefSelec
 		}
 
 		if selector.Matches(existingRef) {
-			c.Image = reference.FamiliarString(injectRef)
+			c.Image = container.FamiliarString(injectRef)
 			c.ImagePullPolicy = policy
 			replaced = true
 		}
@@ -122,7 +122,7 @@ func injectImageDigestInEnvVars(entity K8sEntity, selector container.RefSelector
 		}
 
 		if selector.Matches(existingRef) {
-			envVar.Value = reference.FamiliarString(injectRef)
+			envVar.Value = container.FamiliarString(injectRef)
 			replaced = true
 		}
 	}
@@ -155,7 +155,7 @@ func injectImageInUnstructuredInterface(ui interface{}, injectRef reference.Name
 	case string:
 		ref, err := container.ParseNamed(x)
 		if err == nil && ref.Name() == injectRef.Name() {
-			return reference.FamiliarString(injectRef), true
+			return container.FamiliarString(injectRef), true
 		} else {
 			return x, false
 		}
@@ -191,7 +191,7 @@ func InjectCommand(entity K8sEntity, ref reference.Named, cmd model.Cmd) (K8sEnt
 		// k8s yaml `container` block). This means we don't support injecting commands into CRDs.
 		return e, fmt.Errorf("could not inject command %v into entity: %s. No container found matching ref: %s. "+
 			"Note: command overrides only supported on containers with images, not on CRDs",
-			cmd.Argv, entity.Name(), reference.FamiliarString(ref))
+			cmd.Argv, entity.Name(), container.FamiliarString(ref))
 	}
 
 	return e, nil

--- a/internal/tiltfile/build_index.go
+++ b/internal/tiltfile/build_index.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/schollz/closestmatch"
 
+	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -37,7 +38,7 @@ func (idx *buildIndex) addImage(img *dockerImage) error {
 	name := selector.RefName()
 	_, hasExisting := idx.imagesBySelector[selector.String()]
 	if hasExisting {
-		return fmt.Errorf("Image for ref %q has already been defined", reference.FamiliarString(selector))
+		return fmt.Errorf("Image for ref %q has already been defined", container.FamiliarString(selector))
 	}
 
 	idx.imagesBySelector[selector.String()] = img
@@ -107,7 +108,7 @@ func (idx *buildIndex) assertAllMatched() error {
 			}
 
 			return fmt.Errorf("Image not used in any deploy config:\n    ✕ %v\n%sSkipping this image build",
-				reference.FamiliarString(image.configurationRef), strings.Join(matchLines, ""))
+				container.FamiliarString(image.configurationRef), strings.Join(matchLines, ""))
 		}
 	}
 	return nil

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1547,8 +1547,8 @@ k8s_yaml('auth.yaml')
 
 	m := f.assertNextManifest("auth", deployment("auth"))
 	assert.Equal(t, []string{
-		"docker.io/vandelay/common",
-		"docker.io/vandelay/auth",
+		"vandelay/common",
+		"vandelay/auth",
 	}, f.imageTargetNames(m))
 }
 
@@ -1573,8 +1573,8 @@ k8s_yaml('app.yaml')
 
 	m := f.assertNextManifest("app", deployment("app"), deployment("app-jessie"))
 	assert.Equal(t, []string{
-		"docker.io/vandelay/app",
-		"docker.io/vandelay/app:jessie",
+		"vandelay/app",
+		"vandelay/app:jessie",
 	}, f.imageTargetNames(m))
 }
 
@@ -1597,8 +1597,8 @@ k8s_yaml('app.yaml')
 
 	f.load()
 
-	f.assertNextManifest("app", deployment("app", image("docker.io/vandelay/app")))
-	f.assertNextManifest("app-jessie", deployment("app-jessie", image("docker.io/vandelay/app:jessie")))
+	f.assertNextManifest("app", deployment("app", image("vandelay/app")))
+	f.assertNextManifest("app-jessie", deployment("app-jessie", image("vandelay/app:jessie")))
 }
 
 func TestImagesWithSameNameDifferentManifests(t *testing.T) {
@@ -1623,12 +1623,12 @@ k8s_resource('jessie', image='vandelay/app:jessie')
 
 	m := f.assertNextManifest("jessie", deployment("app-jessie"))
 	assert.Equal(t, []string{
-		"docker.io/vandelay/app:jessie",
+		"vandelay/app:jessie",
 	}, f.imageTargetNames(m))
 
 	m = f.assertNextManifest("app", deployment("app"))
 	assert.Equal(t, []string{
-		"docker.io/vandelay/app",
+		"vandelay/app",
 	}, f.imageTargetNames(m))
 }
 
@@ -1888,7 +1888,7 @@ docker_build('test/mycrd-env', 'env')
 	f.load("mycrd")
 	f.assertNextManifest("mycrd",
 		db(
-			image("docker.io/test/mycrd-env"),
+			image("test/mycrd-env"),
 		),
 		k8sObject("mycrd", "Environment"),
 	)
@@ -1966,7 +1966,7 @@ k8s_kind(%s)
 				f.load(expectedResourceName)
 				var imageOpt interface{}
 				if test.expectImage {
-					imageOpt = db(image("docker.io/test/mycrd-env"))
+					imageOpt = db(image("test/mycrd-env"))
 				} else {
 					imageOpt = funcOpt(func(t *testing.T, m model.Manifest) bool {
 						return assert.Equal(t, 0, len(m.ImageTargets))
@@ -1981,7 +1981,7 @@ k8s_kind(%s)
 					t.Fatal("invalid test: cannot expect image without expecting workload")
 				}
 				if test.expectedError == "" {
-					w := unusedImageWarning("docker.io/test/mycrd-env", []string{})
+					w := unusedImageWarning("test/mycrd-env", []string{})
 					f.loadAssertWarnings(w)
 				} else {
 					f.loadErrString(test.expectedError)
@@ -2022,10 +2022,10 @@ docker_build('test/mycrd-env', 'env')
 	f.load("mycrd")
 	f.assertNextManifest("mycrd",
 		db(
-			image("docker.io/test/mycrd-env"),
+			image("test/mycrd-env"),
 		),
 		db(
-			image("docker.io/test/mycrd-builder"),
+			image("test/mycrd-builder"),
 		),
 		k8sObject("mycrd", "Environment"),
 	)

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -40,7 +40,7 @@ func NewImageTarget(ref container.RefSelector) ImageTarget {
 func ImageID(ref container.RefSelector) TargetID {
 	name := TargetName("")
 	if !ref.Empty() {
-		name = TargetName(ref.String())
+		name = TargetName(container.FamiliarString(ref))
 	}
 	return TargetID{
 		Type: TargetTypeImage,

--- a/pkg/model/target_test.go
+++ b/pkg/model/target_test.go
@@ -20,14 +20,14 @@ func TestTopSort(t *testing.T) {
 	cases := []topSortCase{
 		topSortCase{
 			inputs: []TargetSpec{newDepTarget("a", "b")},
-			err:    "Missing target dependency: docker.io/library/b",
+			err:    "Missing target dependency: b",
 		},
 		topSortCase{
 			inputs: []TargetSpec{
 				newDepTarget("a", "b"),
 				newDepTarget("b", "a"),
 			},
-			err: "Found a cycle at target: docker.io/library/a",
+			err: "Found a cycle at target: a",
 		},
 		topSortCase{
 			inputs: []TargetSpec{
@@ -35,7 +35,7 @@ func TestTopSort(t *testing.T) {
 				newDepTarget("b", "c"),
 				newDepTarget("c", "a"),
 			},
-			err: "Found a cycle at target: docker.io/library/a",
+			err: "Found a cycle at target: a",
 		},
 		topSortCase{
 			inputs: []TargetSpec{


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/dockerio:

279a0349a50fe7d6cfd8816842684bb4fcf27d99 (2019-11-11 11:03:04 -0500)
container: add a wrapper function around FamiliarString() that handles RefSelectors correctly