### PR TITLE
integration: TestLiveUpdateAfterCrashRebuild: fix live update

### DIFF
--- a/integration/live_update_after_crash_rebuild/Dockerfile
+++ b/integration/live_update_after_crash_rebuild/Dockerfile
@@ -2,4 +2,4 @@ FROM busybox
 WORKDIR /app
 ADD . .
 RUN ./compile.sh
-ENTRYPOINT busybox httpd -f -p 8000
+ENTRYPOINT ./start.sh busybox httpd -f -p 8000

--- a/integration/live_update_after_crash_rebuild/Tiltfile
+++ b/integration/live_update_after_crash_rebuild/Tiltfile
@@ -8,9 +8,9 @@ docker_build('gcr.io/windmill-test-containers/integration/live_update_after_cras
              '.',
              dockerfile='Dockerfile',
              live_update=[
-               sync('.', '/src'),
-               run('/src/compile.sh'),
-               run('/src/restart.sh'),
+               sync('.', '/app'),
+               run('/app/compile.sh'),
+               run('/app/restart.sh'),
              ])
 
 k8s_resource("live-update-after-crash-rebuild", port_forwards=["31234:8000"])


### PR DESCRIPTION
1. we're using restart.sh but didn't run it with start.sh
2. the dockerfile writes to /app, but the live_update config thinks it's in /src

(note: this only allow live update to actually work - there's still the weird pod flakiness after this)