### PR TITLE
integration: fix TestLiveUpdateAfterCrashRebuild issues

### DIFF
--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -311,3 +311,113 @@ func (f *k8sFixture) TearDown() {
 	f.fixture.TearDown()
 	f.tempDir.TearDown()
 }
+
+// waits for pods to be in a specified state, or times out and fails
+type podWaiter struct {
+	disallowedPodIDs map[string]bool
+	f                *k8sFixture
+	selector         string
+	expectedPhase    v1.PodPhase
+	expectedPodCount int // or -1 for no expectation
+	timeout          time.Duration
+}
+
+func (f *k8sFixture) newPodWaiter(selector string) podWaiter {
+	return podWaiter{
+		f:                f,
+		selector:         selector,
+		expectedPodCount: -1,
+		disallowedPodIDs: make(map[string]bool),
+		timeout:          time.Minute,
+	}
+}
+
+func (pw podWaiter) podPhases() (map[string]string, string) {
+	cmd := exec.Command("kubectl", "get", "pods",
+		namespaceFlag, "--selector="+pw.selector, "-o=template",
+		"--template", "{{range .items}}{{.metadata.name}} {{.status.phase}}{{println}}{{end}}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		pw.f.t.Fatal(errors.Wrap(err, "get pods"))
+	}
+
+	ret := make(map[string]string)
+
+	outStr := string(out)
+	lines := strings.Split(outStr, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		elements := strings.Split(line, " ")
+		if len(elements) < 2 {
+			pw.f.t.Fatalf("Unexpected output of kubect get pods: %s", outStr)
+		}
+
+		name, phase := elements[0], elements[1]
+
+		ret[name] = phase
+	}
+
+	return ret, outStr
+}
+
+// if a test is transitioning from one pod id to another, it should disallow the old pod id here
+// simply waiting for pod state does not suffice - it leaves us with a race condition:
+// an old pod matching the label is up
+// we run some command causing a new pod matching the label to come up
+// while the deployment controller is swapping from the old pod to the new pod, there will be at least a moment
+// in which both pods exist. we want to ensure we've made it past the point where the old pod is gone
+func (pw podWaiter) withDisallowedPodIDs(podIDs []string) podWaiter {
+	pw.disallowedPodIDs = make(map[string]bool)
+	for _, podID := range podIDs {
+		pw.disallowedPodIDs[podID] = true
+	}
+	return pw
+}
+
+func (pw podWaiter) withExpectedPodCount(count int) podWaiter {
+	pw.expectedPodCount = count
+	return pw
+}
+
+func (pw podWaiter) withExpectedPhase(phase v1.PodPhase) podWaiter {
+	pw.expectedPhase = phase
+	return pw
+}
+
+func (pw podWaiter) withTimeout(timeout time.Duration) podWaiter {
+	pw.timeout = timeout
+	return pw
+}
+
+func (pw podWaiter) wait() []string {
+	ctx, cancel := context.WithTimeout(pw.f.ctx, pw.timeout)
+	defer cancel()
+	for {
+		okToReturn := true
+		podPhases, output := pw.podPhases()
+		var podIDs []string
+		for podID, phase := range podPhases {
+			if (pw.expectedPhase != "" && string(pw.expectedPhase) != phase) || pw.disallowedPodIDs[podID] {
+				okToReturn = false
+				break
+			}
+			podIDs = append(podIDs, podID)
+		}
+		if okToReturn &&
+			(pw.expectedPodCount == -1 || pw.expectedPodCount == len(podPhases)) {
+			return podIDs
+		}
+
+		select {
+		case <-pw.f.activeTiltDone():
+			pw.f.t.Fatalf("Tilt died while waiting for pods to be ready: %v", pw.f.activeTiltErr())
+		case <-ctx.Done():
+			pw.f.t.Fatalf("Timed out waiting for pods to be ready. Selector: %s. Output:\n:%s\n", pw.selector, output)
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}

--- a/integration/live_update_after_crash_rebuild/Dockerfile
+++ b/integration/live_update_after_crash_rebuild/Dockerfile
@@ -2,4 +2,4 @@ FROM busybox
 WORKDIR /app
 ADD . .
 RUN ./compile.sh
-ENTRYPOINT busybox httpd -f -p 8000
+ENTRYPOINT ./start.sh busybox httpd -f -p 8000

--- a/integration/live_update_after_crash_rebuild/Tiltfile
+++ b/integration/live_update_after_crash_rebuild/Tiltfile
@@ -8,9 +8,9 @@ docker_build('gcr.io/windmill-test-containers/integration/live_update_after_cras
              '.',
              dockerfile='Dockerfile',
              live_update=[
-               sync('.', '/src'),
-               run('/src/compile.sh'),
-               run('/src/restart.sh'),
+               sync('.', '/app'),
+               run('/app/compile.sh'),
+               run('/app/restart.sh'),
              ])
 
 k8s_resource("live-update-after-crash-rebuild", port_forwards=["31234:8000"])


### PR DESCRIPTION
Three problems:
1. We're using restart.sh but not start.sh
2. The dockerfile is using /src, but the live update config is using /app
3. `WaitForAllPodsReady` can give us old pods that are in the process of terminating