### PR TITLE
webui: use linebreaks instead of display: block to separate lines

### DIFF
--- a/web/src/AnsiLine.tsx
+++ b/web/src/AnsiLine.tsx
@@ -8,9 +8,12 @@ type AnsiLineProps = {
 
 let AnsiLine = React.memo(function(props: AnsiLineProps) {
   return (
-    <Ansi linkify={false} useClasses={true} className={props.className}>
-      {props.line}
-    </Ansi>
+    <React.Fragment>
+      <Ansi linkify={false} useClasses={true} className={props.className}>
+        {props.line}
+      </Ansi>
+      <br />
+    </React.Fragment>
   )
 })
 

--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -33,7 +33,6 @@
 }
 
 .LogPane code {
-  display: block;
   white-space: pre-wrap;
   min-height: $spacing-unit / 2; // Respect blank lines
 }

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -436,7 +436,7 @@ it("scrolls to highlighted lines in snapshot", () => {
 
   expect(wrapper.instance().highlightRef.current).not.toBeNull()
   expect(fakeScrollIntoView.mock.instances).toHaveLength(1)
-  expect(fakeScrollIntoView.mock.instances[0]).toBeInstanceOf(HTMLDivElement)
+  expect(fakeScrollIntoView.mock.instances[0]).toBeInstanceOf(HTMLSpanElement)
   expect(fakeScrollIntoView).toBeCalledTimes(1)
 })
 

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -219,14 +219,14 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
       }
 
       let el = (
-        <div
+        <span
           ref={i === 0 ? this.highlightRef : null}
           key={key}
           data-lineid={i}
           className={`logLine ${shouldHighlight ? "highlighted" : ""}`}
         >
           <AnsiLine line={l} />
-        </div>
+        </span>
       )
       logLines.push(el)
     }

--- a/web/src/__snapshots__/AlertPane.test.tsx.snap
+++ b/web/src/__snapshots__/AlertPane.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`renders multiple lines of a crash log 1`] = `
             Eeeeek the container crashed
           </span>
         </code>
+        <br />
         <code>
           <span
             className={null}
@@ -56,6 +57,7 @@ exports[`renders multiple lines of a crash log 1`] = `
             no but really it crashed
           </span>
         </code>
+        <br />
       </section>
       <div />
     </li>
@@ -128,6 +130,7 @@ exports[`renders one container start error 1`] = `
             Eeeeek there is a problem
           </span>
         </code>
+        <br />
       </section>
       <div />
     </li>
@@ -183,6 +186,7 @@ exports[`renders one container start error 2`] = `
             Eeeeek there is a problem
           </span>
         </code>
+        <br />
       </section>
       <div />
     </li>
@@ -238,6 +242,7 @@ exports[`renders one container unrecognized error 1`] = `
             Detailed message on GarbleError
           </span>
         </code>
+        <br />
       </section>
       <div />
     </li>
@@ -293,6 +298,7 @@ exports[`renders warnings 1`] = `
             Eeeeek the container crashed
           </span>
         </code>
+        <br />
       </section>
       <div />
     </li>
@@ -339,6 +345,7 @@ exports[`renders warnings 1`] = `
             Hi I'm a warning
           </span>
         </code>
+        <br />
       </section>
       <div />
     </li>
@@ -394,6 +401,7 @@ exports[`shows that a container has restarted 1`] = `
             Eeeeek the container crashed
           </span>
         </code>
+        <br />
       </section>
       <button
         className="AlertPane-dismissButton"
@@ -454,6 +462,7 @@ exports[`shows that a crash rebuild has occurred 1`] = `
             Eeeeek the container crashed
           </span>
         </code>
+        <br />
       </section>
       <div />
     </li>

--- a/web/src/__snapshots__/LogPane.test.tsx.snap
+++ b/web/src/__snapshots__/LogPane.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`renders highlighted lines 1`] = `
 <section
   className="LogPane"
 >
-  <div
+  <span
     className="logLine "
     data-lineid={0}
   >
@@ -16,8 +16,9 @@ exports[`renders highlighted lines 1`] = `
         hello
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={1}
   >
@@ -29,8 +30,9 @@ exports[`renders highlighted lines 1`] = `
         world
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={2}
   >
@@ -42,8 +44,9 @@ exports[`renders highlighted lines 1`] = `
         foo
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={3}
   >
@@ -55,7 +58,8 @@ exports[`renders highlighted lines 1`] = `
         bar
       </span>
     </code>
-  </div>
+    <br />
+  </span>
   <p
     className="logEnd"
   >
@@ -68,7 +72,7 @@ exports[`renders logs 1`] = `
 <section
   className="LogPane"
 >
-  <div
+  <span
     className="logLine "
     data-lineid={0}
   >
@@ -80,8 +84,9 @@ exports[`renders logs 1`] = `
         hello
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={1}
   >
@@ -93,8 +98,9 @@ exports[`renders logs 1`] = `
         world
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={2}
   >
@@ -106,8 +112,9 @@ exports[`renders logs 1`] = `
         foo
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={3}
   >
@@ -119,7 +126,8 @@ exports[`renders logs 1`] = `
         bar
       </span>
     </code>
-  </div>
+    <br />
+  </span>
   <p
     className="logEnd"
   >
@@ -132,7 +140,7 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
 <section
   className="LogPane"
 >
-  <div
+  <span
     className="logLine "
     data-lineid={0}
   >
@@ -144,8 +152,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         [32mStarting Tilt (v0.7.10-dev, built 2019-04-10)…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={1}
   >
@@ -157,8 +166,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Beginning Tiltfile execution
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={2}
   >
@@ -170,8 +180,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"whoami"\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={3}
   >
@@ -183,8 +194,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Installing Tilt NodeJS dependencies…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={4}
   >
@@ -196,8 +208,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/fe.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={5}
   >
@@ -209,8 +222,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/vigoda.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={6}
   >
@@ -222,8 +236,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/snack.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={7}
   >
@@ -235,8 +250,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/doggos.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={8}
   >
@@ -248,8 +264,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/fortune.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={9}
   >
@@ -261,8 +278,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/hypothesizer.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={10}
   >
@@ -274,8 +292,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/spoonerisms.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={11}
   >
@@ -287,8 +306,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/emoji.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={12}
   >
@@ -300,8 +320,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/words.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={13}
   >
@@ -313,8 +334,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/secrets.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={14}
   >
@@ -326,8 +348,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/job.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={15}
   >
@@ -339,8 +362,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/sleeper.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={16}
   >
@@ -352,8 +376,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/hello_world.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={17}
   >
@@ -365,8 +390,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/tick.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={18}
   >
@@ -378,8 +404,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] WARNING: This Tiltfile is using k8s resource assembly version 1, which has been deprecated. It will no longer be supported after 2019-04-17. Sorry for the inconvenience! See https://tilt.dev/resource_assembly_migration.html for information on how to migrate.
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={19}
   >
@@ -391,8 +418,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={20}
   >
@@ -404,8 +432,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Successfully loaded Tiltfile
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={21}
   >
@@ -429,14 +458,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={22}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={23}
   >
@@ -466,8 +497,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={24}
   >
@@ -491,8 +523,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={25}
   >
@@ -516,8 +549,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={26}
   >
@@ -541,14 +575,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={27}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={28}
   >
@@ -572,8 +608,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 4.138s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={29}
   >
@@ -597,20 +634,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 4.138s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={30}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={31}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={32}
   >
@@ -640,8 +680,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={33}
   >
@@ -665,8 +706,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={34}
   >
@@ -690,8 +732,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={35}
   >
@@ -715,14 +758,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={36}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={37}
   >
@@ -746,8 +791,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 0.556s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={38}
   >
@@ -771,20 +817,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 0.556s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={39}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={40}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={41}
   >
@@ -814,8 +863,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={42}
   >
@@ -839,8 +889,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={43}
   >
@@ -864,8 +915,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={44}
   >
@@ -889,14 +941,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={45}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={46}
   >
@@ -920,8 +974,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 0.450s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={47}
   >
@@ -945,20 +1000,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 0.450s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={48}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={49}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={50}
   >
@@ -988,8 +1046,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={51}
   >
@@ -1013,8 +1072,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/fe]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={52}
   >
@@ -1026,8 +1086,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={53}
   >
@@ -1039,14 +1100,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={54}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={55}
   >
@@ -1058,14 +1121,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN apt update && apt install -y unzip time make
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={56}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={57}
   >
@@ -1077,14 +1142,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENV PROTOC_VERSION 3.5.1
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={58}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={59}
   >
@@ -1096,14 +1163,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN wget https://github.com/google/protobuf/releases/download/v\${PROTOC_VERSION}/protoc-\${PROTOC_VERSION}-linux-x86_64.zip &&       unzip protoc-\${PROTOC_VERSION}-linux-x86_64.zip -d protoc &&       mv protoc/bin/protoc /usr/bin/protoc
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={60}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={61}
   >
@@ -1115,14 +1184,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN go get github.com/golang/protobuf/protoc-gen-go
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={62}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={63}
   >
@@ -1134,8 +1205,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD . /go/src/github.com/windmilleng/servantes/fe
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={64}
   >
@@ -1147,8 +1219,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN go install github.com/windmilleng/servantes/fe
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={65}
   >
@@ -1160,20 +1233,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENTRYPOINT /go/bin/fe
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={66}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={67}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={68}
   >
@@ -1197,8 +1273,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={69}
   >
@@ -1210,8 +1287,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 24 MB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={70}
   >
@@ -1235,8 +1313,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={71}
   >
@@ -1248,8 +1327,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/6] FROM docker.io/library/golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={72}
   >
@@ -1261,8 +1341,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/6] RUN apt update && apt install -y unzip time make
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={73}
   >
@@ -1274,8 +1355,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [3/6] RUN wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip &&   unzip protoc-3.5.1-linux-x86_64.zip -d protoc &&   mv protoc/bin/protoc /usr/bin/protoc
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={74}
   >
@@ -1287,8 +1369,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [4/6] RUN go get github.com/golang/protobuf/protoc-gen-go
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={75}
   >
@@ -1300,8 +1383,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [5/6] ADD . /go/src/github.com/windmilleng/servantes/fe
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={76}
   >
@@ -1313,14 +1397,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [6/6] RUN go install github.com/windmilleng/servantes/fe
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={77}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={78}
   >
@@ -1344,8 +1430,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Pushing gcr.io/windmill-public-containers/servantes/fe:tilt-2540b7769f4b0e45
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={79}
   >
@@ -1357,14 +1444,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Skipping push
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={80}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={81}
   >
@@ -1388,8 +1477,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={82}
   >
@@ -1413,8 +1503,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={83}
   >
@@ -1438,14 +1529,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={84}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={85}
   >
@@ -1469,8 +1562,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 7.630s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={86}
   >
@@ -1494,8 +1588,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 2 - 0.000s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={87}
   >
@@ -1519,8 +1614,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 3 - 0.249s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={88}
   >
@@ -1544,20 +1640,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 7.880s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={89}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={90}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={91}
   >
@@ -1587,8 +1686,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={92}
   >
@@ -1612,8 +1712,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/vigoda]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={93}
   >
@@ -1625,8 +1726,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={94}
   >
@@ -1638,14 +1740,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={95}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={96}
   >
@@ -1657,8 +1761,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD . /go/src/github.com/windmilleng/servantes/vigoda
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={97}
   >
@@ -1670,14 +1775,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN go install github.com/windmilleng/servantes/vigoda
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={98}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={99}
   >
@@ -1689,14 +1796,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENTRYPOINT /go/bin/vigoda
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={100}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={101}
   >
@@ -1720,8 +1829,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={102}
   >
@@ -1733,8 +1843,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 8.7 kB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={103}
   >
@@ -1758,8 +1869,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={104}
   >
@@ -1771,8 +1883,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/3] FROM docker.io/library/golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={105}
   >
@@ -1784,8 +1897,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/3] ADD . /go/src/github.com/windmilleng/servantes/vigoda
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={106}
   >
@@ -1797,14 +1911,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [3/3] RUN go install github.com/windmilleng/servantes/vigoda
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={107}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={108}
   >
@@ -1828,8 +1944,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Pushing gcr.io/windmill-public-containers/servantes/vigoda:tilt-2d369271c8091f68
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={109}
   >
@@ -1841,14 +1958,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Skipping push
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={110}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={111}
   >
@@ -1872,8 +1991,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={112}
   >
@@ -1897,8 +2017,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={113}
   >
@@ -1922,14 +2043,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={114}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={115}
   >
@@ -1953,8 +2076,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 1.017s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={116}
   >
@@ -1978,8 +2102,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 2 - 0.000s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={117}
   >
@@ -2003,8 +2128,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 3 - 0.168s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={118}
   >
@@ -2028,20 +2154,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 1.185s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={119}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={120}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={121}
   >
@@ -2071,8 +2200,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={122}
   >
@@ -2096,8 +2226,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/snack]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={123}
   >
@@ -2109,8 +2240,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={124}
   >
@@ -2122,14 +2254,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={125}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={126}
   >
@@ -2141,8 +2275,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD . /go/src/github.com/windmilleng/servantes/snack
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={127}
   >
@@ -2154,14 +2289,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN go install github.com/windmilleng/servantes/snack
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={128}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={129}
   >
@@ -2173,14 +2310,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENTRYPOINT /go/bin/snack
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={130}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={131}
   >
@@ -2204,8 +2343,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={132}
   >
@@ -2217,8 +2357,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 9.7 kB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={133}
   >
@@ -2242,8 +2383,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={134}
   >
@@ -2255,8 +2397,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/3] FROM docker.io/library/golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={135}
   >
@@ -2268,8 +2411,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Starting Tilt webpack server…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={136}
   >
@@ -2281,8 +2425,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           fe          ┊ 2019/04/10 15:37:37 Starting Servantes FE on :8080
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={137}
   >
@@ -2294,8 +2439,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/3] ADD . /go/src/github.com/windmilleng/servantes/snack
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={138}
   >
@@ -2307,14 +2453,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [3/3] RUN go install github.com/windmilleng/servantes/snack
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={139}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={140}
   >
@@ -2338,8 +2486,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Pushing gcr.io/windmill-public-containers/servantes/snack:tilt-731280d503bbbcf5
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={141}
   >
@@ -2351,14 +2500,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Skipping push
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={142}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={143}
   >
@@ -2382,8 +2533,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={144}
   >
@@ -2407,8 +2559,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={145}
   >
@@ -2432,14 +2585,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={146}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={147}
   >
@@ -2463,8 +2618,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 2.878s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={148}
   >
@@ -2488,8 +2644,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 2 - 0.000s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={149}
   >
@@ -2513,8 +2670,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 3 - 0.322s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={150}
   >
@@ -2538,20 +2696,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 3.200s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={151}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={152}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={153}
   >
@@ -2581,8 +2742,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={154}
   >
@@ -2606,8 +2768,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/doggos]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={155}
   >
@@ -2619,8 +2782,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={156}
   >
@@ -2632,14 +2796,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={157}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={158}
   >
@@ -2651,8 +2817,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD . /go/src/github.com/windmilleng/servantes/doggos
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={159}
   >
@@ -2664,14 +2831,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN go install github.com/windmilleng/servantes/doggos
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={160}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={161}
   >
@@ -2683,14 +2852,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENTRYPOINT /go/bin/doggos
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={162}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={163}
   >
@@ -2714,8 +2885,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={164}
   >
@@ -2727,8 +2899,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 7.7 kB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={165}
   >
@@ -2752,8 +2925,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={166}
   >
@@ -2765,8 +2939,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           vigoda      ┊ 2019/04/10 15:37:39 Starting Vigoda Health Check Service on :8081
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={167}
   >
@@ -2778,8 +2953,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/3] FROM docker.io/library/golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={168}
   >
@@ -2791,8 +2967,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/3] ADD . /go/src/github.com/windmilleng/servantes/doggos
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={169}
   >
@@ -2804,14 +2981,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [3/3] RUN go install github.com/windmilleng/servantes/doggos
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={170}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={171}
   >
@@ -2835,8 +3014,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Pushing gcr.io/windmill-public-containers/servantes/doggos:tilt-28a4e6fab0991d2f
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={172}
   >
@@ -2848,14 +3028,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Skipping push
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={173}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={174}
   >
@@ -2879,8 +3061,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/sidecar]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={175}
   >
@@ -2892,8 +3075,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={176}
   >
@@ -2905,14 +3089,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM alpine
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={177}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={178}
   >
@@ -2924,8 +3110,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD loud_sidecar.sh /
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={179}
   >
@@ -2937,20 +3124,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENTRYPOINT ["/loud_sidecar.sh"]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={180}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={181}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={182}
   >
@@ -2974,8 +3164,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={183}
   >
@@ -2987,8 +3178,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 4.6 kB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={184}
   >
@@ -3012,8 +3204,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={185}
   >
@@ -3025,8 +3218,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           vigoda      ┊ 2019/04/10 15:37:41 Server status: All good
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={186}
   >
@@ -3038,8 +3232,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/2] FROM docker.io/library/alpine
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={187}
   >
@@ -3051,14 +3246,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/2] ADD loud_sidecar.sh /
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={188}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={189}
   >
@@ -3082,8 +3279,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Pushing gcr.io/windmill-public-containers/servantes/sidecar:tilt-4fb31b5179f3ad01
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={190}
   >
@@ -3095,14 +3293,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Skipping push
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={191}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={192}
   >
@@ -3126,8 +3326,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={193}
   >
@@ -3151,8 +3352,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={194}
   >
@@ -3176,14 +3378,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={195}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={196}
   >
@@ -3207,8 +3411,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 1.629s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={197}
   >
@@ -3232,8 +3437,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 2 - 0.000s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={198}
   >
@@ -3257,8 +3463,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 3 - 2.024s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={199}
   >
@@ -3282,8 +3489,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 4 - 0.000s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={200}
   >
@@ -3307,8 +3515,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 5 - 0.218s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={201}
   >
@@ -3332,20 +3541,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 3.871s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={202}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={203}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={204}
   >
@@ -3375,8 +3587,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={205}
   >
@@ -3400,8 +3613,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/fortune]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={206}
   >
@@ -3413,8 +3627,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={207}
   >
@@ -3426,14 +3641,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={208}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={209}
   >
@@ -3445,14 +3662,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN apt update && apt install -y unzip time make
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={210}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={211}
   >
@@ -3464,14 +3683,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENV PROTOC_VERSION 3.5.1
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={212}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={213}
   >
@@ -3483,14 +3704,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN wget https://github.com/google/protobuf/releases/download/v\${PROTOC_VERSION}/protoc-\${PROTOC_VERSION}-linux-x86_64.zip &&       unzip protoc-\${PROTOC_VERSION}-linux-x86_64.zip -d protoc &&       mv protoc/bin/protoc /usr/bin/protoc
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={214}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={215}
   >
@@ -3502,14 +3725,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN go get github.com/golang/protobuf/protoc-gen-go
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={216}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={217}
   >
@@ -3521,8 +3746,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD . /go/src/github.com/windmilleng/servantes/fortune
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={218}
   >
@@ -3534,8 +3760,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN cd /go/src/github.com/windmilleng/servantes/fortune && make proto
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={219}
   >
@@ -3547,14 +3774,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN go install github.com/windmilleng/servantes/fortune
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={220}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={221}
   >
@@ -3566,20 +3795,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENTRYPOINT /go/bin/fortune
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={222}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={223}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={224}
   >
@@ -3603,8 +3835,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={225}
   >
@@ -3616,8 +3849,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 16 kB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={226}
   >
@@ -3641,8 +3875,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={227}
   >
@@ -3654,8 +3889,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           snack       ┊ 2019/04/10 15:37:41 Starting Snack Service on :8083
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={228}
   >
@@ -3667,8 +3903,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           vigoda      ┊ 2019/04/10 15:37:43 Server status: All good
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={229}
   >
@@ -3680,8 +3917,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/7] FROM docker.io/library/golang:1.10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={230}
   >
@@ -3693,8 +3931,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/7] RUN apt update && apt install -y unzip time make
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={231}
   >
@@ -3706,8 +3945,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [3/7] RUN wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip &&   unzip protoc-3.5.1-linux-x86_64.zip -d protoc &&   mv protoc/bin/protoc /usr/bin/protoc
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={232}
   >
@@ -3719,8 +3959,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [4/7] RUN go get github.com/golang/protobuf/protoc-gen-go
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={233}
   >
@@ -3732,8 +3973,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [5/7] ADD . /go/src/github.com/windmilleng/servantes/fortune
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={234}
   >
@@ -3745,8 +3987,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [6/7] RUN cd /go/src/github.com/windmilleng/servantes/fortune && make proto
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={235}
   >
@@ -3758,14 +4001,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [7/7] RUN go install github.com/windmilleng/servantes/fortune
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={236}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={237}
   >
@@ -3789,8 +4034,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Pushing gcr.io/windmill-public-containers/servantes/fortune:tilt-7e4331cb0b073360
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={238}
   >
@@ -3802,14 +4048,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Skipping push
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={239}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={240}
   >
@@ -3833,8 +4081,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={241}
   >
@@ -3858,8 +4107,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={242}
   >
@@ -3883,14 +4133,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={243}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={244}
   >
@@ -3914,8 +4166,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 1.634s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={245}
   >
@@ -3939,8 +4192,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 2 - 0.000s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={246}
   >
@@ -3964,8 +4218,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 3 - 0.279s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={247}
   >
@@ -3989,20 +4244,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 1.914s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={248}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={249}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={250}
   >
@@ -4032,8 +4290,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={251}
   >
@@ -4057,8 +4316,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/hypothesizer]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={252}
   >
@@ -4070,8 +4330,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={253}
   >
@@ -4083,14 +4344,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM python:3.6
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={254}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={255}
   >
@@ -4102,8 +4365,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD . /app
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={256}
   >
@@ -4115,14 +4379,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN cd /app && pip install -r requirements.txt
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={257}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={258}
   >
@@ -4146,8 +4412,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={259}
   >
@@ -4159,8 +4426,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 6.1 kB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={260}
   >
@@ -4184,8 +4452,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={261}
   >
@@ -4197,8 +4466,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           vigoda      ┊ 2019/04/10 15:37:45 Server status: All good
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={262}
   >
@@ -4210,8 +4480,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/3] FROM docker.io/library/python:3.6@sha256:fcbf363c285f331894b33f2577e0426182b989c750133a989abaaa4edea324e9
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={263}
   >
@@ -4223,8 +4494,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/3] ADD . /app
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={264}
   >
@@ -4236,14 +4508,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [3/3] RUN cd /app && pip install -r requirements.txt
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={265}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={266}
   >
@@ -4267,8 +4541,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Pushing gcr.io/windmill-public-containers/servantes/hypothesizer:tilt-e2e22b5b98437e29
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={267}
   >
@@ -4280,14 +4555,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Skipping push
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={268}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={269}
   >
@@ -4311,8 +4588,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Deploying
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={270}
   >
@@ -4336,8 +4614,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Parsing Kubernetes config YAML
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={271}
   >
@@ -4361,14 +4640,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Applying via kubectl
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={272}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={273}
   >
@@ -4392,8 +4673,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 1 - 2.119s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={274}
   >
@@ -4417,8 +4699,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 2 - 0.000s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={275}
   >
@@ -4442,8 +4725,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Step 3 - 0.517s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={276}
   >
@@ -4467,20 +4751,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Done in: 2.636s
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={277}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={278}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={279}
   >
@@ -4510,8 +4797,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
          ├──────────────────────────────────────────────
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={280}
   >
@@ -4535,8 +4823,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building Dockerfile: [docker.io/library/spoonerisms]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={281}
   >
@@ -4548,8 +4837,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           Building Dockerfile:
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={282}
   >
@@ -4561,14 +4851,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             FROM node:10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={283}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={284}
   >
@@ -4580,8 +4872,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD package.json /app/package.json
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={285}
   >
@@ -4593,8 +4886,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD yarn.lock /app/yarn.lock
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={286}
   >
@@ -4606,14 +4900,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             RUN cd /app && yarn install
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={287}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={288}
   >
@@ -4625,14 +4921,16 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ADD src /app
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={289}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={290}
   >
@@ -4644,20 +4942,23 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
             ENTRYPOINT [ "node", "/app/index.js" ]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={291}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={292}
   >
     <code />
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={293}
   >
@@ -4681,8 +4982,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Tarring context…
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={294}
   >
@@ -4694,8 +4996,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ Created tarball (size: 459 kB)
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={295}
   >
@@ -4719,8 +5022,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
         Building image
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={296}
   >
@@ -4732,8 +5036,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Beginning Tiltfile execution
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={297}
   >
@@ -4745,8 +5050,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"whoami"\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={298}
   >
@@ -4758,8 +5064,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile]        HI
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={299}
   >
@@ -4771,8 +5078,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/fe.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={300}
   >
@@ -4784,8 +5092,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/vigoda.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={301}
   >
@@ -4797,8 +5106,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/snack.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={302}
   >
@@ -4810,8 +5120,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/doggos.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={303}
   >
@@ -4823,8 +5134,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/fortune.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={304}
   >
@@ -4836,8 +5148,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/hypothesizer.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={305}
   >
@@ -4849,8 +5162,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/spoonerisms.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={306}
   >
@@ -4862,8 +5176,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/emoji.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={307}
   >
@@ -4875,8 +5190,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/words.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={308}
   >
@@ -4888,8 +5204,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/secrets.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={309}
   >
@@ -4901,8 +5218,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/job.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={310}
   >
@@ -4914,8 +5232,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/sleeper.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={311}
   >
@@ -4927,8 +5246,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/hello_world.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={312}
   >
@@ -4940,8 +5260,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Running \`"m4 -Dvarowner=dan "deploy/tick.yaml""\`
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={313}
   >
@@ -4953,8 +5274,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           vigoda      ┊ 2019/04/10 15:37:47 Server status: All good
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={314}
   >
@@ -4966,8 +5288,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] WARNING: This Tiltfile is using k8s resource assembly version 1, which has been deprecated. It will no longer be supported after 2019-04-17. Sorry for the inconvenience! See https://tilt.dev/resource_assembly_migration.html for information on how to migrate.
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={315}
   >
@@ -4979,8 +5302,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={316}
   >
@@ -4992,8 +5316,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           [Tiltfile] Successfully loaded Tiltfile
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={317}
   >
@@ -5005,8 +5330,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           doggos      ┊ [doggos] 2019/04/10 15:37:45 Starting Doggos Service on :8083
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={318}
   >
@@ -5018,8 +5344,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           doggos      ┊ [sidecar] I'm a loud sidecar! [Wed Apr 10 15:37:46 UTC 2019]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={319}
   >
@@ -5031,8 +5358,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           doggos      ┊ [sidecar] I'm a loud sidecar! [Wed Apr 10 15:37:48 UTC 2019]
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={320}
   >
@@ -5044,8 +5372,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
           doggos      ┊ [doggos] 2019/04/10 15:37:49 Heartbeat
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={321}
   >
@@ -5057,8 +5386,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [1/5] FROM docker.io/library/node:10
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={322}
   >
@@ -5070,8 +5400,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [2/5] ADD package.json /app/package.json
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={323}
   >
@@ -5083,8 +5414,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [3/5] ADD yarn.lock /app/yarn.lock
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={324}
   >
@@ -5096,8 +5428,9 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [4/5] RUN cd /app && yarn install
       </span>
     </code>
-  </div>
-  <div
+    <br />
+  </span>
+  <span
     className="logLine "
     data-lineid={325}
   >
@@ -5109,7 +5442,8 @@ exports[`renders logs with leading whitespace and ANSI codes 1`] = `
               ╎ [5/5] ADD src /app
       </span>
     </code>
-  </div>
+    <br />
+  </span>
   <p
     className="logEnd"
   >


### PR DESCRIPTION
Resolves #2524 

### Problem

In some cases, copy/pasting from Tilt into a rich text editor causes linebreaks to be lost.
We render log lines as individual `<div>s` and rely on their `display: block` behavior to get us newline behavior. Apparently some versions of some text editors do not know how to handle this, and so text gets pasted without newlines.

### Solution

Drop the `display: block` and `<div>`s on our log lines, and render then with `<span>` and `<br>`s instead.

I was unfortunately unable to repro this bug in the first place, so I haven't been able to verify the fix but the users who reported the bug also reported that making the analogous change in the chrome developer console resolved the issue.