### PR TITLE
engine: fix force rebuild after failed build

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -543,6 +543,8 @@ func TestBuildControllerManualTriggerWithoutFileChangesForceUpdates(t *testing.T
 	})
 }
 
+// it should be a force update if there have been no file changes since the last build
+// make sure file changes prior to the last build are ignored for this purpose
 func TestBuildControllerManualTriggerWithFileChangesSinceLastSuccessfulBuildButBeforeLastBuild(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
### Problem

#### repro
1. `tilt up` and successfully deploy a service that has live_update configured
2. make a change to the service's code such that live_update runs and fails
3. click force update in the web UI

#### observed
the force update is a live update

#### expected
the force update is an image build

This is because we determine whether a triggered build is a forced update by checking if `PendingFileChanges` is non-empty. Since we only clear `PendingFileChanges` on successful builds, this means that if we've made a change and then failed the build, then subsequent build triggers will not set ForceUpdate.

### Solution

Instead of setting ForceUpdate iff there are any files in `PendingFileChanges`, set ForceUpdate iff there are any files in `PendingFileChanges` with a timestamp since the last build's start time.