### PR TITLE
ci: always publish assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,6 @@ workflows:
           requires:
             - build-linux
       - publish-assets:
-          requires:
-            - build-js
           filters:
             branches:
               only: master


### PR DESCRIPTION
### Problem

if a master build fails, we don't publish tilt assets, so tilt builds from that sha will create snapshots that don't have assets (e.g. https://cloud.tilt.dev/snapshot/Ae6W2NwL3uAQ_ZHe-so=)

### Solution

Publish assets no matter what. It might be that the js tests fail, but they're still probably better than nothing.