### PR TITLE
engine: don't fall back on docker build failures

### DIFF
--- a/internal/engine/build_errors.go
+++ b/internal/engine/build_errors.go
@@ -38,7 +38,10 @@ type DontFallBackError struct {
 	error
 }
 
-func WrapDontFallBackError(err error) DontFallBackError {
+func WrapDontFallBackError(err error) error {
+	if err == nil {
+		return nil
+	}
 	return DontFallBackError{err}
 }
 

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -155,12 +155,13 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		return store.NewImageBuildResult(iTarget.ID(), ref), nil
 	})
 	if err != nil {
-		return store.BuildResultSet{}, err
+		return store.BuildResultSet{}, WrapDontFallBackError(err)
 	}
 
 	// (If we pass an empty list of refs here (as we will do if only deploying
 	// yaml), we just don't inject any image refs into the yaml, nbd.
-	return ibd.deploy(ctx, st, ps, iTargetMap, kTarget, q.results, anyInPlaceBuild)
+	brs, err := ibd.deploy(ctx, st, ps, iTargetMap, kTarget, q.results, anyInPlaceBuild)
+	return brs, WrapDontFallBackError(err)
 }
 
 func (ibd *ImageBuildAndDeployer) push(ctx context.Context, ref reference.NamedTagged, ps *build.PipelineState, iTarget model.ImageTarget, kTarget model.K8sTarget) (reference.NamedTagged, error) {


### PR DESCRIPTION
#2484 observes that we log docker build failures three times.

The middle of these three is because `ImageBuildAndDeployer` was not wrapping its errors in `DontFallBackOn`.

In `CompositeBuildAndDeployer`, we log "unexpected" errors [if they are not on the last builder](https://github.com/windmilleng/tilt/blob/354fbada1d5ced7fac563c67b3e00cda037d9bbf/internal/engine/build_and_deployer.go#L76). Since the introduction of `LocalTargetBuildAndDeployer, `ImageBuildAndDeployer` is no longer the last builder, so it's no longer getting suppressed by that check.

There's probably some rearchitecting we could do to make this all cleaner, but this at least is a small change that makes `ImageBuildAndDeployer` consistent with the other `BuildAndDeployers` and addresses part of the problem.