### PR TITLE
build controller: don't set ForceUpdate on crash rebuild

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -225,7 +225,8 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 	//  out that it's a force update when creating the BuildEntry (in `needsBuild`), store that
 	//  as the BuildReason, and pass the whole BuildEntry to the builder (so the builder can
 	//  know whether to skip in-place builds)
-	if !anyFilesChangedSinceLastBuild {
+	// if we're on a crash rebuild, then there won't have been any files changed for that reason
+	if !ms.NeedsRebuildFromCrash && !anyFilesChangedSinceLastBuild {
 		for k, v := range result {
 			result[k] = v.WithNeedsForceUpdate(true)
 		}

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -328,6 +328,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.podEvent(pb.WithContainerID("funnyContainerID").Build(), manifest.Name)
 	call = f.nextCall()
 	assert.True(t, call.oneState().OneContainerInfo().Empty())
+	assert.False(t, call.oneState().NeedsForceUpdate)
 	f.waitForCompletedBuildCount(3)
 
 	f.withManifestState("fe", func(ms store.ManifestState) {


### PR DESCRIPTION
### Problem

When we do a crash rebuild, we get:
```
live-update…┊ falling back to next update method because: Force update (triggered manually, not automatically, with no dirty files)
```
even though there's no force update involved

### Solution

This is because we're inferring force update from whether there are any file changes, which is error-prone!
It turns out there are also no file changes for crash rebuild!

### Result

This doesn't really have any impact other than wrong verbose logging since either way the effect is to make sure we do an image build instead of a live update, but it's still confusing when debugging.

The refactor suggested in buildcontroller.go (proactively specify force build in the BuildEntry instead of grossly mutating the BuildResult) would have avoided this.