### PR TITLE
watch: ignore resourceVersion

### DIFF
--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -69,7 +69,10 @@ func TestPodWatchChangeEventBeforeUID(t *testing.T) {
 	f.assertObservedPods(p)
 }
 
-func TestPodWatchOldResourceVersion(t *testing.T) {
+// We had a bug where if newPod.resourceVersion < oldPod.resourceVersion (using string comparison!)
+// then we'd ignore the new pod. This meant, e.g., once we got an update for resourceVersion "9", we'd
+// ignore updates for resourceVersions "10" through "89" and "100" through "899"
+func TestPodWatchResourceVersionStringLessThan(t *testing.T) {
 	f := newPWFixture(t)
 	defer f.TearDown()
 

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -96,28 +96,6 @@ func (w *ServiceWatcher) setupNewUIDs(ctx context.Context, st store.RStore, newU
 	}
 }
 
-// Record the service update, and return true if this is newer than
-// the state we already know about.
-func (w *ServiceWatcher) recordServiceUpdate(service *v1.Service) bool {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	uid := service.UID
-	oldService, ok := w.knownServices[uid]
-
-	// In "real" code, if we get two service updates with the same resource version,
-	// we can safely ignore the new one. But dispatching a spurious event
-	// in this case makes testing much easier, because the test harness doesn't need
-	// to keep track of ResourceVersions
-	olderThanKnown := ok && oldService.ResourceVersion > service.ResourceVersion
-	if olderThanKnown {
-		return false
-	}
-
-	w.knownServices[uid] = service
-	return true
-}
-
 // Match up the service update to a manifest.
 //
 // The division between triageServiceUpdate and recordServiceUpdate is a bit artificial,
@@ -127,6 +105,8 @@ func (w *ServiceWatcher) triageServiceUpdate(service *v1.Service) model.Manifest
 	defer w.mu.Unlock()
 
 	uid := service.UID
+	w.knownServices[uid] = service
+
 	manifestName, ok := w.knownDeployedUIDs[uid]
 	if !ok {
 		return ""
@@ -141,11 +121,6 @@ func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-ch
 		case service, ok := <-ch:
 			if !ok {
 				return
-			}
-
-			ok = w.recordServiceUpdate(service)
-			if !ok {
-				continue
 			}
 
 			manifestName := w.triageServiceUpdate(service)

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -55,13 +55,14 @@ type PodBuilder struct {
 	t        testing.TB
 	manifest model.Manifest
 
-	podID          string
-	phase          string
-	creationTime   time.Time
-	deletionTime   time.Time
-	restartCount   int
-	extraPodLabels map[string]string
-	deploymentUID  types.UID
+	podID           string
+	phase           string
+	creationTime    time.Time
+	deletionTime    time.Time
+	restartCount    int
+	extraPodLabels  map[string]string
+	deploymentUID   types.UID
+	resourceVersion string
 
 	// keyed by container index -- i.e. the first container will have image: imageRefs[0] and ID: cIDs[0], etc.
 	// If there's no entry at index i, we'll use a dummy value.
@@ -96,6 +97,11 @@ func (b PodBuilder) RestartCount() int {
 
 func (b PodBuilder) WithRestartCount(restartCount int) PodBuilder {
 	b.restartCount = restartCount
+	return b
+}
+
+func (b PodBuilder) WithResourceVersion(rv string) PodBuilder {
+	b.resourceVersion = rv
 	return b
 }
 
@@ -354,6 +360,7 @@ func (b PodBuilder) Build() *v1.Pod {
 			OwnerReferences: []metav1.OwnerReference{
 				k8s.RuntimeObjToOwnerRef(b.buildReplicaSet()),
 			},
+			ResourceVersion: b.resourceVersion,
 		},
 		Spec: spec,
 		Status: v1.PodStatus{


### PR DESCRIPTION
Potentially addresses #2374 (or, at least, addresses a cause of it, which may or may not be the only cause)

### Problem

As an optimization, when one of Tilt's watchers gets an update for an object from a K8s informer, it checks to see if its resourceVersion is older than the last resourceVersion it saw, and if so, ignores it.
Unfortunately:
1. resourceVersion is a string, and Tilt is using string comparison (so, e.g., if we see resourceVersion "9", we'll then ignore "10" through "89" and "100" through "899")
2. the comment on resourceVersion says clients must treat it as opaque

### Solution

Simply remove the resourceVersion check. Theoretically the K8s informer provides us updates in order, so it does us no good.