### PR TITLE
webui: inline display for code in alerts and facets

### DIFF
--- a/web/src/AlertPane.scss
+++ b/web/src/AlertPane.scss
@@ -58,7 +58,6 @@
 
 // Hide all lines by default
 .AlertPane-item code {
-  display: block;
   white-space: pre-wrap;
   height: 0;
   opacity: 0;

--- a/web/src/FacetsPane.scss
+++ b/web/src/FacetsPane.scss
@@ -57,7 +57,6 @@
 }
 
 .FacetsPane-item code {
-  display: block;
   white-space: pre-wrap;
   min-height: $spacing-unit / 2; // Respect blank lines
   height: auto;


### PR DESCRIPTION
#2536 changed our `<code>`s from `display: block` to `display: inline` and added `<br>`s to get newlines.

However, it failed to change `display` for `<code>`s in the alerts or facets pane, so now those are double-spaced.

These should probably all be one css class, but I don't think the week before kubecon is the right time for a css refactor.