### PR TITLE
build: remove redundant build error log

### DIFF
--- a/internal/build/pipeline_state.go
+++ b/internal/build/pipeline_state.go
@@ -49,26 +49,23 @@ func NewPipelineState(ctx context.Context, totalStepCount int, c Clock) *Pipelin
 // and NOT:
 //     defer ps.End(ctx, err)
 func (ps *PipelineState) End(ctx context.Context, err error) {
+	ps.curPipelineStep = 0
+	ps.curBuildStep = 0
+
+	if err != nil {
+		return
+	}
+
 	l := logger.Get(ctx)
 	prefix := logger.Blue(l).Sprint("  │ ")
 
 	elapsed := ps.c.Now().Sub(ps.curPipelineStart)
-
-	if err != nil {
-		prefix := logger.Red(l).Sprint("ERROR:")
-		l.Infof("%s %s", prefix, err.Error())
-		ps.curPipelineStep = 0
-		ps.curBuildStep = 0
-		return
-	}
 
 	for i, duration := range ps.pipelineStepDurations {
 		l.Infof("%sStep %d - %.3fs", prefix, i+1, duration.Seconds())
 	}
 
 	l.Infof("%sDone in: %.3fs \n", prefix, elapsed.Seconds())
-	ps.curPipelineStep = 0
-	ps.curBuildStep = 0
 }
 
 func (ps *PipelineState) StartPipelineStep(ctx context.Context, format string, a ...interface{}) {

--- a/internal/build/testdata/TestPipelineErrored_master
+++ b/internal/build/testdata/TestPipelineErrored_master
@@ -1,4 +1,3 @@
 STEP 1/1 — hello world
     ╎ in ur step
 
-ERROR: oh noes

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -778,7 +778,8 @@ func TestReturnLastUnexpectedError(t *testing.T) {
 	}
 }
 
-func TestDockerBuildErrorLogged(t *testing.T) {
+// errors get logged by the upper, so make sure our builder isn't logging the error redundantly
+func TestDockerBuildErrorNotLogged(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
 	defer f.TearDown()
 
@@ -793,7 +794,7 @@ func TestDockerBuildErrorLogged(t *testing.T) {
 	}
 
 	logs := f.logs.String()
-	require.Equal(t, 1, strings.Count(logs, "no one expects the unexpected error"))
+	require.Equal(t, 0, strings.Count(logs, "no one expects the unexpected error"))
 }
 
 func TestLiveUpdateWithRunFailureReturnsContainerIDs(t *testing.T) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2707,6 +2707,24 @@ alert-injes…┊ ghij`)
 	assert.Nil(t, err)
 }
 
+func TestBuildErrorLoggedOnceByUpper(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	manifest := f.newManifest("alert-injester")
+	err := errors.New("cats and dogs, living together")
+	f.b.nextBuildFailure = err
+
+	f.Start([]model.Manifest{manifest}, true)
+
+	f.waitForCompletedBuildCount(1)
+
+	// so the test name says "once", but the fake builder also logs once, so we get it twice
+	f.withState(func(state store.EngineState) {
+		require.Equal(t, 2, strings.Count(state.Log.String(), err.Error()))
+	})
+}
+
 func TestTiltfileChangedFilesOnlyLoggedAfterFirstBuild(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
addresses the last bit of #2484

### Problem

When a build fails, both the builder and the upper log the build error, in consecutive lines in the log.

### Solution

Make the upper solely responsible for logging build failures.

### Result

Before:
[snapshot](https://cloud.tilt.dev/snapshot/AcSY7NwLj9igAz5fj8s=)
```
vigoda      ┊     ╎ ERROR IN: [3/3] RUN go install github.com/windmilleng/servantes/vigoda
vigoda      ┊ 
vigoda      ┊ ERROR: ImageBuild: executor failed running [/bin/sh -c go install github.com/windmilleng/servantes/vigoda]
Build Failed: ImageBuild: executor failed running [/bin/sh -c go install github.com/windmilleng/servantes/vigoda]
```

After:
[snapshot](https://cloud.tilt.dev/snapshot/AdaX7NwLrr8GA0oLeQs=)
```
vigoda      ┊     ╎ ERROR IN: [3/3] RUN go install github.com/windmilleng/servantes/vigoda
vigoda      ┊ 
vigoda      ┊ Build Failed: ImageBuild: executor failed running [/bin/sh -c go install github.com/windmilleng/servantes/vigoda]
```