### PR TITLE
revert the revert of the revert of the revert of podtemplatespec hashes

### DIFF
--- a/integration/onewatch_test.go
+++ b/integration/onewatch_test.go
@@ -4,10 +4,11 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOneWatch(t *testing.T) {
@@ -38,11 +39,9 @@ func TestOneWatch(t *testing.T) {
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "🍄 Two-Up! 🍄")
 
+	// Check that the pods were changed in place, and that we didn't create new ones
 	twoUpPods := f.WaitForAllPodsReady(ctx, "app=onewatch")
-
-	// Assert that the pods were changed in-place, and not that we
-	// created new pods.
-	assert.Equal(t, oneUpPods, twoUpPods)
+	require.Equal(t, oneUpPods, twoUpPods)
 
 	if len(twoUpPods) != 1 {
 		t.Fatalf("Expected one pod, actual: %v", twoUpPods)
@@ -56,6 +55,24 @@ func TestOneWatch(t *testing.T) {
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "🍄 Two-Up! 🍄")
 
+	// Unfortunately "WaitForAllPodsReady" isn't that accurate and can pull in terminating pods
+	// too. Sleep here to increase the chance that pods are in the right state when we check.
+	fmt.Println("> Waiting for dead pods to get into 'terminating' state")
+	time.Sleep(2 * time.Second)
+
 	newTwoUpPods := f.WaitForAllPodsReady(ctx, "app=onewatch")
-	assert.NotEqual(t, twoUpPods, newTwoUpPods)
+	require.NotEqual(t, twoUpPods, newTwoUpPods)
+
+	// Another live update! Make sure that, after the crash rebuild, we're able to run more
+	// live updates (i.e. that we have one and only one pod associated w/ the manifest)
+	f.ReplaceContents("compile.sh", "Two-Up", "Three-Up")
+
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:31234", "🍄 Three-Up! 🍄")
+
+	threeUpPods := f.WaitForAllPodsReady(ctx, "app=onewatch")
+
+	// Check that the pods were changed in place, and that we didn't create new ones
+	require.Equal(t, newTwoUpPods, threeUpPods)
 }

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -34,6 +34,15 @@ const ExampleBuildOutputV1_23 = `{"stream":"Run 1/1 : FROM alpine"}
 	{"stream":"Successfully tagged hi:latest\n"}
 `
 
+// same as ExampleBuildOutput1 but with a different digest
+const ExampleBuildOutput2 = `{"stream":"Run 1/1 : FROM alpine"}
+	{"stream":"\n"}
+	{"stream":" ---\u003e 20372c132963\n"}
+	{"aux":{"ID":"sha256:20372c132963eb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af20372c132963"}}
+	{"stream":"Successfully built 20372c132963\n"}
+	{"stream":"Successfully tagged hi:latest\n"}
+`
+
 const ExamplePushSHA1 = "sha256:cc5f4c463f81c55183d8d737ba2f0d30b3e6f3670dbe2da68f0aac168e93fbb1"
 
 var ExamplePushOutput1 = `{"status":"The push refers to repository [localhost:5005/myimage]"}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -227,14 +227,20 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 
 	// TODO(nick): Do something with this result
 	uids := []types.UID{}
+	podTemplateSpecHashes := []k8s.PodTemplateSpecHash{}
 	for _, entity := range deployed {
 		uid := entity.UID()
 		if uid == "" {
 			return nil, fmt.Errorf("Entity not deployed correctly: %v", entity)
 		}
 		uids = append(uids, entity.UID())
+		hs, err := k8s.ReadPodTemplateSpecHashes(entity)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading pod template spec hashes")
+		}
+		podTemplateSpecHashes = append(podTemplateSpecHashes, hs...)
 	}
-	results[kTarget.ID()] = store.NewK8sDeployResult(kTarget.ID(), uids, deployed)
+	results[kTarget.ID()] = store.NewK8sDeployResult(kTarget.ID(), uids, podTemplateSpecHashes, deployed)
 
 	return results, nil
 }
@@ -328,6 +334,14 @@ func (ibd *ImageBuildAndDeployer) createEntitiesToDeploy(ctx context.Context,
 				}
 			}
 		}
+
+		// This needs to be after all the other injections, to ensure the hash includes the Tilt-generated
+		// image tag, etc
+		e, err := k8s.InjectPodTemplateSpecHashes(e)
+		if err != nil {
+			return nil, errors.Wrap(err, "injecting pod template hash")
+		}
+
 		newK8sEntities = append(newK8sEntities, e)
 	}
 

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -114,7 +114,7 @@ func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*s
 	ns := k8s.NamespaceFromPod(pod)
 	hasSynclet := sidecar.PodSpecContainsSynclet(pod.Spec)
 	runtime := ms.GetOrCreateK8sRuntimeState()
-	isCurrentDeploy := runtime.HasOKPodTemplateSpecHash(pod) // pod is from the most recent Tilt deploy
+	isCurrentDeploy := runtime.HasOKPodTemplateSpecHash(pod) // is pod from the most recent Tilt deploy?
 
 	// Case 1: We haven't seen pods for this ancestor yet.
 	ancestorUID := action.AncestorUID

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -27,7 +27,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 	pod := action.Pod
 	ms := mt.State
 	manifest := mt.Manifest
-	podInfo, isNew := trackPod(ms, action)
+	podInfo, isNew := maybeTrackPod(ms, action)
 	podID := k8s.PodIDFromPod(pod)
 	if podInfo.PodID != podID {
 		// This is an event from an old pod.
@@ -103,10 +103,10 @@ func matchPodChangeToManifest(state *store.EngineState, action k8swatch.PodChang
 }
 
 // Checks the runtime state if we're already tracking this pod.
-// If not, create a new tracking object.
+// If not, AND if the pod matches the current deploy, create a new tracking object.
 // Returns a store.Pod that the caller can mutate, and true
 // if this is the first time we've seen this pod.
-func trackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*store.Pod, bool) {
+func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*store.Pod, bool) {
 	pod := action.Pod
 	podID := k8s.PodIDFromPod(pod)
 	startedAt := pod.CreationTimestamp.Time
@@ -114,24 +114,30 @@ func trackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*store.
 	ns := k8s.NamespaceFromPod(pod)
 	hasSynclet := sidecar.PodSpecContainsSynclet(pod.Spec)
 	runtime := ms.GetOrCreateK8sRuntimeState()
+	isCurrentDeploy := runtime.HasOKPodTemplateSpecHash(pod) // pod is from the most recent Tilt deploy
 
 	// Case 1: We haven't seen pods for this ancestor yet.
 	ancestorUID := action.AncestorUID
 	isAncestorMatch := ancestorUID != ""
 	if runtime.PodAncestorUID == "" ||
 		(isAncestorMatch && runtime.PodAncestorUID != ancestorUID) {
-		runtime.PodAncestorUID = ancestorUID
-		runtime.Pods = make(map[k8s.PodID]*store.Pod)
-		pod := &store.Pod{
+		podInfo := &store.Pod{
 			PodID:      podID,
 			StartedAt:  startedAt,
 			Status:     status,
 			Namespace:  ns,
 			HasSynclet: hasSynclet,
 		}
-		runtime.Pods[podID] = pod
-		ms.RuntimeState = runtime
-		return pod, true
+		if isCurrentDeploy {
+			// Only attach a new pod to the runtime state if it's from the current deploy;
+			// if it's from an old deploy/an old Tilt run, we don't want to be checking it
+			// for status etc.
+			runtime.PodAncestorUID = ancestorUID
+			runtime.Pods = make(map[k8s.PodID]*store.Pod)
+			runtime.Pods[podID] = podInfo
+			ms.RuntimeState = runtime
+		}
+		return podInfo, true
 	}
 
 	podInfo, ok := runtime.Pods[podID]
@@ -145,7 +151,12 @@ func trackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*store.
 			Namespace:  ns,
 			HasSynclet: hasSynclet,
 		}
-		runtime.Pods[podID] = podInfo
+		if isCurrentDeploy {
+			// Only attach a new pod to the runtime state if it's from the current deploy;
+			// if it's from an old deploy/an old Tilt run, we don't want to be checking it
+			// for status etc.
+			runtime.Pods[podID] = podInfo
+		}
 		return podInfo, true
 	}
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -348,11 +348,20 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	}
 
 	manifest := mt.Manifest
-	deployedUIDSet := cb.Result.DeployedUIDSet()
-	if manifest.IsK8s() && len(deployedUIDSet) > 0 {
-		state := ms.GetOrCreateK8sRuntimeState()
-		state.DeployedUIDSet = deployedUIDSet
-		ms.RuntimeState = state
+	if manifest.IsK8s() {
+		deployedUIDSet := cb.Result.DeployedUIDSet()
+		if len(deployedUIDSet) > 0 {
+			state := ms.GetOrCreateK8sRuntimeState()
+			state.DeployedUIDSet = deployedUIDSet
+			ms.RuntimeState = state
+		}
+
+		deployedPodTemplateSpecHashSet := cb.Result.DeployedPodTemplateSpecHashes()
+		if len(deployedPodTemplateSpecHashSet) > 0 {
+			state := ms.GetOrCreateK8sRuntimeState()
+			state.DeployedPodTemplateSpecHashSet = deployedPodTemplateSpecHashSet
+			ms.RuntimeState = state
+		}
 	}
 
 	if mt.Manifest.IsDC() {

--- a/internal/k8s/pod_template.go
+++ b/internal/k8s/pod_template.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	"crypto"
+	"fmt"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+)
+
+const TiltPodTemplateHashLabel = "tilt.dev/pod-template-hash"
+
+type PodTemplateSpecHash string
+
+func HashPodTemplateSpec(spec *v1.PodTemplateSpec) (PodTemplateSpecHash, error) {
+	data, err := defaultJSONIterator.Marshal(spec)
+	if err != nil {
+		return "", errors.Wrap(err, "serializing spec to json")
+	}
+
+	h := crypto.SHA1.New()
+	h.Write(data)
+	return PodTemplateSpecHash(fmt.Sprintf("%x", h.Sum(nil)[:10])), nil
+}
+
+// Iterate through the fields of a k8s entity and add the pod template spec hash on all
+// pod template specs
+func InjectPodTemplateSpecHashes(entity K8sEntity) (K8sEntity, error) {
+	entity = entity.DeepCopy()
+	templateSpecs, err := ExtractPodTemplateSpec(&entity)
+	if err != nil {
+		return K8sEntity{}, err
+	}
+
+	for _, ts := range templateSpecs {
+		h, err := HashPodTemplateSpec(ts)
+		if err != nil {
+			return K8sEntity{}, errors.Wrap(err, "calculating hash")
+		}
+		ts.Labels[TiltPodTemplateHashLabel] = string(h)
+	}
+
+	return entity, nil
+}
+
+// ReadPodTemplateSpecHashes pulls the PodTemplateSpecHash that Tilt injected
+// into this entity's metadata during deploy (if any)
+func ReadPodTemplateSpecHashes(entity K8sEntity) ([]PodTemplateSpecHash, error) {
+	templateSpecs, err := ExtractPodTemplateSpec(&entity)
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []PodTemplateSpecHash
+	for _, ts := range templateSpecs {
+		ret = append(ret, PodTemplateSpecHash(ts.Labels[TiltPodTemplateHashLabel]))
+	}
+
+	return ret, nil
+}

--- a/internal/k8s/pod_template_test.go
+++ b/internal/k8s/pod_template_test.go
@@ -1,0 +1,37 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
+
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+)
+
+func TestInjectPodTemplateHash(t *testing.T) {
+	entities, err := ParseYAMLFromString(testyaml.SanchoYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entities) != 1 {
+		t.Fatalf("Unexpected entities: %+v", entities)
+	}
+
+	orig := entities[0]
+	preInjectOrigYAML, err := SerializeSpecYAML([]K8sEntity{orig})
+	require.NoError(t, err)
+
+	injected, err := InjectPodTemplateSpecHashes(orig)
+	require.NoError(t, err)
+
+	// make sure we haven't mutated the original object
+	postInjectOrigYAML, err := SerializeSpecYAML([]K8sEntity{orig})
+	require.NoError(t, err)
+	require.Equal(t, preInjectOrigYAML, postInjectOrigYAML)
+
+	// make sure the label is set and it's some kind of hash
+	dep := injected.Obj.(*v1.Deployment)
+	require.Regexp(t, `^[0-9a-f]{10,}$`, dep.Spec.Template.Labels[TiltPodTemplateHashLabel])
+}

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -111,6 +111,9 @@ type K8sBuildResult struct {
 	// The UIDs that we deployed to a Kubernetes cluster.
 	DeployedUIDs []types.UID
 
+	// Hashes of the pod template specs that we deployed to a Kubernetes cluster.
+	PodTemplateSpecHashes []k8s.PodTemplateSpecHash
+
 	AppliedEntitiesText string
 }
 
@@ -127,16 +130,17 @@ func (r K8sBuildResult) Facets() []model.Facet {
 }
 
 // For kubernetes deploy targets.
-func NewK8sDeployResult(id model.TargetID, uids []types.UID, appliedEntities []k8s.K8sEntity) BuildResult {
+func NewK8sDeployResult(id model.TargetID, uids []types.UID, hashes []k8s.PodTemplateSpecHash, appliedEntities []k8s.K8sEntity) BuildResult {
 	appliedEntitiesText, err := k8s.SerializeSpecYAML(appliedEntities)
 	if err != nil {
 		appliedEntitiesText = fmt.Sprintf("unable to serialize entities to yaml: %s", err.Error())
 	}
 
 	return K8sBuildResult{
-		id:                  id,
-		DeployedUIDs:        uids,
-		AppliedEntitiesText: appliedEntitiesText,
+		id:                    id,
+		DeployedUIDs:          uids,
+		PodTemplateSpecHashes: hashes,
+		AppliedEntitiesText:   appliedEntitiesText,
 	}
 }
 
@@ -169,6 +173,17 @@ func (set BuildResultSet) DeployedUIDSet() UIDSet {
 		r, ok := r.(K8sBuildResult)
 		if ok {
 			result.Add(r.DeployedUIDs...)
+		}
+	}
+	return result
+}
+
+func (set BuildResultSet) DeployedPodTemplateSpecHashes() PodTemplateSpecHashSet {
+	result := NewPodTemplateSpecHashSet()
+	for _, r := range set {
+		r, ok := r.(K8sBuildResult)
+		if ok {
+			result.Add(r.PodTemplateSpecHashes...)
 		}
 	}
 	return result

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
 
+	"github.com/windmilleng/tilt/internal/k8s"
+
 	tiltanalytics "github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
@@ -407,6 +409,15 @@ func (ms *ManifestState) StartedFirstBuild() bool {
 
 func (ms *ManifestState) MostRecentPod() Pod {
 	return ms.K8sRuntimeState().MostRecentPod()
+}
+
+func (ms *ManifestState) PodWithID(pid k8s.PodID) (*Pod, bool) {
+	for id, pod := range ms.K8sRuntimeState().Pods {
+		if id == pid {
+			return pod, true
+		}
+	}
+	return nil, false
 }
 
 func (ms *ManifestState) HasPendingFileChanges() bool {

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -23,7 +23,7 @@ func TestToJSON(t *testing.T) {
 	state := newState([]model.Manifest{m})
 
 	mState, _ := state.ManifestState("fe")
-	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(m.K8sTarget().ID(), nil, nil)
+	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(m.K8sTarget().ID(), nil, nil, nil)
 
 	buf := bytes.NewBuffer(nil)
 	encoder := CreateEngineStateEncoder(buf)


### PR DESCRIPTION
This is the third attempt at #2439. See that PR for the problem description and solution.

The second attempt, #2519, was reverted because it was making an integration test fail pretty consistently. We're now reasonably sure those failures were due to a pre-existing bug resolved by #2555, and not an issue with #2519 itself. In a branch with #2519 and #2555, the test passed 100x in a row.