### PR TITLE
live update: use pipeline logger

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -165,12 +165,12 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdUpTa
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
-	liveUpdateBuildAndDeployer := engine.NewLiveUpdateBuildAndDeployer(dockerContainerUpdater, syncletUpdater, execUpdater, updateMode, env, runtime)
+	clock := build.ProvideClock()
+	liveUpdateBuildAndDeployer := engine.NewLiveUpdateBuildAndDeployer(dockerContainerUpdater, syncletUpdater, execUpdater, updateMode, env, runtime, clock)
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(switchCli, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)
 	cacheBuilder := build.NewCacheBuilder(switchCli)
-	clock := build.ProvideClock()
 	execCustomBuilder := build.NewExecCustomBuilder(switchCli, clock)
 	clusterName := k8s.ProvideClusterName(ctx, config)
 	kindPusher := engine.NewKINDPusher(clusterName)

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -40,7 +40,7 @@ func provideBuildAndDeployer(ctx context.Context, docker2 docker.Client, kClient
 	if err != nil {
 		return nil, err
 	}
-	liveUpdateBuildAndDeployer := NewLiveUpdateBuildAndDeployer(dockerContainerUpdater, syncletUpdater, execUpdater, engineUpdateMode, env, runtime)
+	liveUpdateBuildAndDeployer := NewLiveUpdateBuildAndDeployer(dockerContainerUpdater, syncletUpdater, execUpdater, engineUpdateMode, env, runtime, clock)
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(docker2, labels)
 	imageBuilder := build.DefaultImageBuilder(dockerImageBuilder)


### PR DESCRIPTION
Every `BuildAndDeployer` except `LiveUpdateBuildAndDeployer` logs its progress via `build.PipelineState`.

Using `build.PipelineState` in `LiveUpdateBuildAndDeployer` means:
1. output now looks more consistent across build types
2. we log the build time for live updates, advertising their speed

before: [snapshot](https://cloud.tilt.dev/snapshot/Aay57twLL7bK14p8zx8=)
after: [snapshot](https://cloud.tilt.dev/snapshot/AZDB7twL0utgvs64UDA=)