### PR TITLE
klog: ignore too old resource version warnings

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -81,10 +81,11 @@ type tiltCmd interface {
 
 func preCommand(ctx context.Context, a *analytics.TiltAnalytics) (context.Context, func() error) {
 	cleanup := func() error { return nil }
-	initKlog()
 	l := logger.NewLogger(logLevel(verbose, debug), os.Stdout)
 	ctx = logger.WithLogger(ctx, l)
 	ctx = analytics.WithAnalytics(ctx, a)
+
+	initKlog(l.Writer(logger.InfoLvl))
 
 	if trace {
 		backend, err := tracer.StringToTracerBackend(traceType)

--- a/internal/cli/klog.go
+++ b/internal/cli/klog.go
@@ -55,6 +55,7 @@ func newFilteredWriter(underlying io.Writer, filterFunc func(s string) bool) io.
 }
 
 // everything on google indicates this warning is useless and should be ignored
+// https://github.com/kubernetes/kubernetes/issues/22024
 var isResourceVersionTooOldRegexp = regexp.MustCompile("reflector.go.*watch of.*ended with: too old resource version")
 
 // HACK(nick): The Kubernetes libs we use sometimes use klog to log things to

--- a/internal/cli/klog.go
+++ b/internal/cli/klog.go
@@ -3,13 +3,59 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"regexp"
 
 	"k8s.io/klog"
 )
 
 var klogLevel = 0
+
+type filteredWriter struct {
+	underlying io.Writer
+	filterFunc func(s string) bool
+	leftover   []byte
+}
+
+func (fw *filteredWriter) Write(buf []byte) (int, error) {
+	buf = append(fw.leftover, buf...)
+	start := 0
+	written := 0
+	for i, b := range buf {
+		if b == '\n' {
+			end := i
+			if buf[i-1] == '\r' {
+				end--
+			}
+			s := string(buf[start:end])
+
+			if !fw.filterFunc(s) {
+				n, err := fw.underlying.Write(buf[start : i+1])
+				written += n
+				if err != nil {
+					fw.leftover = append([]byte{}, buf[i+1:]...)
+					return written, err
+				}
+			}
+
+			start = i + 1
+		}
+	}
+
+	fw.leftover = append([]byte{}, buf[start:]...)
+
+	return written, nil
+}
+
+// lines matching `filterFunc` will not be output to the underlying writer
+func newFilteredWriter(underlying io.Writer, filterFunc func(s string) bool) io.Writer {
+	return &filteredWriter{underlying: underlying, filterFunc: filterFunc}
+}
+
+// everything on google indicates this warning is useless and should be ignored
+var isResourceVersionTooOldRegexp = regexp.MustCompile("reflector.go.*watch of.*ended with: too old resource version")
 
 // HACK(nick): The Kubernetes libs we use sometimes use klog to log things to
 // os.Stderr. There are no API hooks to configure this. And printing to Stderr
@@ -17,9 +63,13 @@ var klogLevel = 0
 //
 // Fortunately, klog does initialize itself from flags, so we can backdoor
 // configure it by setting our own flags. Don't do this at home!
-func initKlog() {
+func initKlog(w io.Writer) {
 	var tmpFlagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(tmpFlagSet)
+	if klogLevel == 0 {
+		w = newFilteredWriter(w, isResourceVersionTooOldRegexp.MatchString)
+	}
+	klog.SetOutput(w)
 
 	flags := []string{
 		"--stderrthreshold", "FATAL",

--- a/internal/cli/klog_test.go
+++ b/internal/cli/klog_test.go
@@ -2,17 +2,17 @@ package cli
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/klog"
 )
 
 func TestResourceVersionTooOldWarningsSilenced(t *testing.T) {
-	initKlog()
-
 	out := bytes.NewBuffer(nil)
-	klog.SetOutput(out)
+	initKlog(out)
 
 	PrintWatchEndedV4()
 	klog.Flush()
@@ -29,10 +29,8 @@ func TestResourceVersionTooOldWarningsPrinted(t *testing.T) {
 	defer func() {
 		klogLevel = 0
 	}()
-	initKlog()
-
 	out := bytes.NewBuffer(nil)
-	klog.SetOutput(out)
+	initKlog(out)
 
 	PrintWatchEndedV4()
 	klog.Flush()
@@ -44,4 +42,50 @@ func PrintWatchEndedV4() {
 }
 func PrintWatchEndedWarning() {
 	klog.Warningf("watch ended")
+}
+
+func TestFilteredWriter(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		input          []string
+		expectedOutput string
+	}{
+		{
+			name:           "normal",
+			input:          []string{"abc\n", "foobar\n", "def\n"},
+			expectedOutput: "abc\ndef\n",
+		},
+		{
+			name:           "all one line",
+			input:          []string{"abc\nfoobar\ndef\n"},
+			expectedOutput: "abc\ndef\n",
+		},
+		{
+			name:           "lines split across writes",
+			input:          []string{"ab", "c\n", "foo", "ba", "r\n", "de", "f", "\n"},
+			expectedOutput: "abc\ndef\n",
+		},
+		{
+			name: "actual warning we want to suppress",
+			input: []string{
+				"hello\n",
+				"W1021 14:53:11.799222 68992 reflector.go:299] github.com/windmilleng/tilt/internal/k8s/watch.go:172: " +
+					"watch of *v1.Pod ended with: too old resource version: 191906663 (191912819)\n",
+				"goodbye\n"},
+			expectedOutput: "hello\ngoodbye\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := bytes.NewBuffer(nil)
+			fw := newFilteredWriter(out, func(s string) bool {
+				return strings.Contains(s, "foobar") || isResourceVersionTooOldRegexp.MatchString(s)
+			})
+			for _, s := range tc.input {
+				_, err := fw.Write([]byte(s))
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedOutput, out.String())
+		})
+	}
 }


### PR DESCRIPTION
Resolves #2406

We previously fixed a different instance of this.
#1955 used the same approach to hide a very similar, but different warning.
At some point, K8s changed that warning to not be a warning, so #1955 was reverted: #2029
Basically, [in this code](https://github.com/windmilleng/tilt/blob/90aa4750036b819c9f8da2fa4bf90901b8a43019/vendor/k8s.io/client-go/tools/cache/reflector.go#L297). The old warning was on line 297 and the warning addressed by this PR is hitting line 299.

This is apparently because this warning is not setting its `ReasonForError` to `metav1.StatusReasonExpired`, so [`IsResourceExpired`](https://github.com/windmilleng/tilt/blob/90aa4750036b819c9f8da2fa4bf90901b8a43019/vendor/k8s.io/apimachinery/pkg/api/errors/errors.go#L490) returns false.

I spent 15 minutes trying to track down what was failing to set the `ReasonForError`, and figured it wasn't worth the time, especially given I don't have a repro for this. Since the old warning was something only relatively recently fixed, it seems quite possible that we want this behavior to mitigate the warnings in older clusters anyway.