### PR TITLE
k8s: when injecting labels to match selectors, only update existing values

### DIFF
--- a/internal/k8s/extract.go
+++ b/internal/k8s/extract.go
@@ -80,6 +80,24 @@ func extractSelectors(obj interface{}, filter func(v reflect.Value) bool) ([]*me
 	return result, nil
 }
 
+func extractServiceSpecs(obj interface{}) ([]*v1.ServiceSpec, error) {
+	extracted, err := newExtractor(reflect.TypeOf(v1.ServiceSpec{})).
+		extractPointersFrom(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*v1.ServiceSpec, len(extracted))
+	for i, e := range extracted {
+		c, ok := e.(*v1.ServiceSpec)
+		if !ok {
+			return nil, fmt.Errorf("ExtractSelectors: expected ServiceSpec, actual %T", e)
+		}
+		result[i] = c
+	}
+	return result, nil
+}
+
 func extractEnvVars(obj interface{}) ([]*v1.EnvVar, error) {
 	extracted, err := newExtractor(reflect.TypeOf(v1.EnvVar{})).extractPointersFrom(obj)
 	if err != nil {

--- a/internal/k8s/label.go
+++ b/internal/k8s/label.go
@@ -33,15 +33,26 @@ func OverwriteLabels(entity K8sEntity, labels []model.LabelPair) (K8sEntity, err
 	return injectLabels(entity, labels, true)
 }
 
-func applyLabelsToMap(orig *map[string]string, labels []model.LabelPair, overwrite bool) {
+// labels: labels to be added to `dest`
+// overwrite: if true, merge `labels` into `dest`. if false, replace `dest` with `labels`
+// addNew: if true, add all `labels` to `dest`. if false, only add `labels` whose keys are already in `dest`
+func applyLabelsToMap(dest *map[string]string, labels []model.LabelPair, overwrite bool, addNew bool) {
+	orig := *dest
 	if overwrite {
-		*orig = nil
+		*dest = nil
 	}
 	for _, label := range labels {
-		if *orig == nil {
-			*orig = make(map[string]string, 1)
+		if *dest == nil {
+			*dest = make(map[string]string, 1)
 		}
-		(*orig)[label.Key] = label.Value
+		preexisting := false
+		if orig != nil {
+			_, preexisting = orig[label.Key]
+		}
+
+		if addNew || preexisting {
+			(*dest)[label.Key] = label.Value
+		}
 	}
 }
 
@@ -49,15 +60,6 @@ func applyLabelsToMap(orig *map[string]string, labels []model.LabelPair, overwri
 // (if `overwrite`, replacing existing labels)
 func injectLabels(entity K8sEntity, labels []model.LabelPair, overwrite bool) (K8sEntity, error) {
 	entity = entity.DeepCopy()
-
-	switch obj := entity.Obj.(type) {
-	case *appsv1beta1.Deployment:
-		allowLabelChangesInAppsDeploymentBeta1(obj)
-	case *appsv1beta2.Deployment:
-		allowLabelChangesInAppsDeploymentBeta2(obj)
-	case *extv1beta1.Deployment:
-		allowLabelChangesInExtDeploymentBeta1(obj)
-	}
 
 	// Don't modify persistent volume claims
 	// because they're supposed to be immutable.
@@ -70,14 +72,32 @@ func injectLabels(entity K8sEntity, labels []model.LabelPair, overwrite bool) (K
 	}
 
 	for _, meta := range metas {
-		applyLabelsToMap(&meta.Labels, labels, overwrite)
+		applyLabelsToMap(&meta.Labels, labels, overwrite, true)
+	}
+
+	switch obj := entity.Obj.(type) {
+	case *appsv1beta1.Deployment:
+		allowLabelChangesInAppsDeploymentBeta1(obj)
+	case *appsv1beta2.Deployment:
+		allowLabelChangesInAppsDeploymentBeta2(obj)
+	case *extv1beta1.Deployment:
+		allowLabelChangesInExtDeploymentBeta1(obj)
 	}
 
 	selectors, err := extractSelectors(&entity, func(v reflect.Value) bool {
 		return v.Type() != pvc
 	})
 	for _, selector := range selectors {
-		applyLabelsToMap(&selector.MatchLabels, labels, overwrite)
+		applyLabelsToMap(&selector.MatchLabels, labels, overwrite, false)
+	}
+
+	// ServiceSpecs have a map[string]string instead of a LabelSelector, so handle them specially
+	serviceSpecs, err := extractServiceSpecs(&entity)
+	if err != nil {
+		return K8sEntity{}, err
+	}
+	for _, s := range serviceSpecs {
+		applyLabelsToMap(&s.Selector, labels, overwrite, false)
 	}
 	return entity, nil
 }

--- a/internal/k8s/label_test.go
+++ b/internal/k8s/label_test.go
@@ -1,189 +1,241 @@
 package k8s
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
+	extbeta1 "k8s.io/api/extensions/v1beta1"
+
+	"k8s.io/api/apps/v1beta1"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/apps/v1beta2"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
+type field struct {
+	name string
+	m    map[string]string
+}
+
+func verifyFields(t *testing.T, expected []model.LabelPair, fields []field) {
+	em := make(map[string]string)
+	for _, l := range expected {
+		em[l.Key] = l.Value
+	}
+
+	for _, f := range fields {
+		require.Equal(t, em, f.m, f.name)
+	}
+}
+
 func TestInjectLabelPod(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.LonelyPodYAML)
-	newEntity, err := InjectLabels(entity, []model.LabelPair{
+	lps := []model.LabelPair{
 		{
 			Key:   "tier",
 			Value: "test",
 		},
-	})
+	}
+	newEntity, err := InjectLabels(entity, lps)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
-	if err != nil {
-		t.Fatal(err)
-	}
+	p, ok := newEntity.Obj.(*v1.Pod)
+	require.True(t, ok)
 
-	if !strings.Contains(result, fmt.Sprintf("tier: test")) {
-		t.Errorf("labels did not appear in serialized yaml: %s", result)
-	}
+	verifyFields(t, lps, []field{{"pod.Labels", p.Labels}})
 }
 
 func TestInjectLabelDeployment(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.SanchoYAML)
-	newEntity, err := InjectLabels(entity, []model.LabelPair{
-		{
-			Key:   "tier",
-			Value: "test",
-		},
-		{
-			Key:   "owner",
-			Value: "me",
-		},
+	lps := []model.LabelPair{
+		{Key: "tier", Value: "test"},
+		{Key: "owner", Value: "me"},
+	}
+	newEntity, err := InjectLabels(entity, lps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, ok := newEntity.Obj.(*appsv1.Deployment)
+	require.True(t, ok)
+
+	appLP := model.LabelPair{Key: "app", Value: "sancho"}
+	expectedLPs := append(lps, appLP)
+
+	verifyFields(t, expectedLPs, []field{
+		{"d.Labels", d.Labels},
+		{"d.Spec.Template.Labels", d.Spec.Template.Labels},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// We expect the Deployment, the Selector, and the PodTemplate to get the labels.
-	assert.Equal(t, 3, strings.Count(result, "tier: test"))
-	assert.Equal(t, 3, strings.Count(result, "owner: me"))
+	// matchlabels is not updated
+	verifyFields(t, []model.LabelPair{appLP}, []field{
+		{"d.Spec.Selector.MatchLabels", d.Spec.Selector.MatchLabels},
+	})
 }
 
 func TestInjectLabelDeploymentMakeSelectorMatchOnConflict(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.SanchoYAML)
-	newEntity, err := InjectLabels(entity, []model.LabelPair{
+	lps := []model.LabelPair{
 		{
 			Key:   "app",
 			Value: "panza",
 		},
+	}
+	newEntity, err := InjectLabels(entity, lps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, ok := newEntity.Obj.(*appsv1.Deployment)
+	require.True(t, ok)
+
+	verifyFields(t, lps, []field{
+		{"d.Labels", d.Labels},
+		{"d.Spec.Template.Labels", d.Spec.Template.Labels},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// We expect the Deployment, the Selector, and the PodTemplate to get the labels.
-	assert.Equal(t, 3, strings.Count(result, "app: panza"))
-	// we've replaced the "app: sancho" in the selector
-	assert.Equal(t, 0, strings.Count(result, "app: sancho"))
+	// matchlabels only gets its existing 'app' label updated, it doesn't get any new labels added
+	verifyFields(t, []model.LabelPair{{"app", "panza"}}, []field{
+		{"d.Spec.Selector.MatchLabels", d.Spec.Selector.MatchLabels},
+	})
 }
 
 func TestInjectLabelDeploymentBeta1(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.SanchoBeta1YAML)
-	newEntity, err := InjectLabels(entity, []model.LabelPair{
+	lps := []model.LabelPair{
 		{
 			Key:   "owner",
 			Value: "me",
 		},
+	}
+	newEntity, err := InjectLabels(entity, lps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, ok := newEntity.Obj.(*v1beta1.Deployment)
+	require.True(t, ok)
+
+	expectedLPs := append(lps, model.LabelPair{Key: "app", Value: "sancho"})
+
+	verifyFields(t, expectedLPs, []field{
+		{"d.Labels", d.Labels},
+		{"d.Spec.Template.Labels", d.Spec.Template.Labels},
+		{"d.Spec.Selector.MatchLabels", d.Spec.Selector.MatchLabels},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, 3, strings.Count(result, "owner: me"))
-
-	// Assert that matchLabels were injected
-	assert.Contains(t, result, "matchLabels")
-	assert.Equal(t, 2, strings.Count(testyaml.SanchoBeta1YAML, "app: sancho"))
-	assert.Equal(t, 3, strings.Count(result, "app: sancho"))
 }
 
 func TestInjectLabelDeploymentBeta2(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.SanchoBeta2YAML)
-	newEntity, err := InjectLabels(entity, []model.LabelPair{
+	lps := []model.LabelPair{
 		{
 			Key:   "owner",
 			Value: "me",
 		},
+	}
+	newEntity, err := InjectLabels(entity, lps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, ok := newEntity.Obj.(*v1beta2.Deployment)
+	require.True(t, ok)
+
+	expectedLPs := append(lps, model.LabelPair{Key: "app", Value: "sancho"})
+
+	verifyFields(t, expectedLPs, []field{
+		{"d.Labels", d.Labels},
+		{"d.Spec.Template.Labels", d.Spec.Template.Labels},
+		{"d.Spec.Selector.MatchLabels", d.Spec.Selector.MatchLabels},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, 3, strings.Count(result, "owner: me"))
-
-	// Assert that matchLabels were injected
-	assert.Contains(t, result, "matchLabels")
-	assert.Equal(t, 2, strings.Count(testyaml.SanchoBeta1YAML, "app: sancho"))
-	assert.Equal(t, 3, strings.Count(result, "app: sancho"))
 }
 
 func TestInjectLabelExtDeploymentBeta1(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.SanchoExtBeta1YAML)
-	newEntity, err := InjectLabels(entity, []model.LabelPair{
+	lps := []model.LabelPair{
 		{
 			Key:   "owner",
 			Value: "me",
 		},
+	}
+	newEntity, err := InjectLabels(entity, lps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, ok := newEntity.Obj.(*extbeta1.Deployment)
+	require.True(t, ok)
+
+	expectedLPs := append(lps, model.LabelPair{Key: "app", Value: "sancho"})
+
+	verifyFields(t, expectedLPs, []field{
+		{"d.Labels", d.Labels},
+		{"d.Spec.Template.Labels", d.Spec.Template.Labels},
+		{"d.Spec.Selector.MatchLabels", d.Spec.Selector.MatchLabels},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, 3, strings.Count(result, "owner: me"))
-
-	// Assert that matchLabels were injected
-	assert.Contains(t, result, "matchLabels")
-	assert.Equal(t, 2, strings.Count(testyaml.SanchoBeta1YAML, "app: sancho"))
-	assert.Equal(t, 3, strings.Count(result, "app: sancho"))
 }
 
 func TestInjectStatefulSet(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.RedisStatefulSetYAML)
-	newEntity, err := InjectLabels(entity, []model.LabelPair{
+	lps := []model.LabelPair{
 		{
 			Key:   "tilt-runid",
 			Value: "deadbeef",
 		},
+	}
+	newEntity, err := InjectLabels(entity, lps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedLPs := append(lps, []model.LabelPair{
+		{"app", "redis"},
+		{"chart", "redis-5.1.3"},
+		{"release", "test"},
+	}...)
+
+	ss := newEntity.Obj.(*v1beta2.StatefulSet)
+	verifyFields(t, append(expectedLPs, model.LabelPair{"heritage", "Tiller"}), []field{
+		{"ss.Labels", ss.Labels},
 	})
-	if err != nil {
-		t.Fatal(err)
+	verifyFields(t, append(expectedLPs, model.LabelPair{"role", "master"}), []field{
+		{"ss.Spec.Template.Labels", ss.Spec.Template.Labels},
+	})
+	verifyFields(t, []model.LabelPair{{"app", "redis"}, {"release", "test"}, {"role", "master"}}, []field{
+		{"ss.Spec.Selector.MatchLabels", ss.Spec.Selector.MatchLabels},
+	})
+
+	verifyFields(t, []model.LabelPair{{"app", "redis"}, {"component", "master"}, {"heritage", "Tiller"}, {"release", "test"}}, []field{
+		{"ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Labels", ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Labels},
+	})
+}
+
+func TestInjectService(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.DoggosServiceYaml)
+	lps := []model.LabelPair{
+		{"foo", "bar"},
+		{"app", "cattos"},
 	}
+	newEntity, err := InjectLabels(entity, lps)
+	require.NoError(t, err)
 
-	podTmpl := newEntity.Obj.(*v1beta2.StatefulSet).Spec.Template
-	vcTmpl := newEntity.Obj.(*v1beta2.StatefulSet).Spec.VolumeClaimTemplates[0]
+	svc, ok := newEntity.Obj.(*v1.Service)
+	require.True(t, ok)
 
-	assert.Equal(t, "deadbeef", podTmpl.ObjectMeta.Labels["tilt-runid"])
-	assert.Equal(t, "", vcTmpl.ObjectMeta.Labels["tilt-runid"])
+	expectedLPs := append(lps, model.LabelPair{"whosAGoodBoy", "imAGoodBoy"})
+	verifyFields(t, expectedLPs, []field{
+		{"svc.Labels", svc.Labels},
+	})
 
-	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Only inject twice: in the top-level metadata, the pod template, and the match selectors,
-	// not the volume claim template
-	assert.Equal(t, 3, strings.Count(result, "tilt-runid: deadbeef"))
+	// selector only gets existing labels updated
+	verifyFields(t, []model.LabelPair{{"app", "cattos"}}, []field{
+		{"svc.Spec.Selector", svc.Spec.Selector},
+	})
 }
 
 func TestSelectorMatchesLabels(t *testing.T) {

--- a/internal/k8s/label_test.go
+++ b/internal/k8s/label_test.go
@@ -100,7 +100,7 @@ func TestInjectLabelDeploymentMakeSelectorMatchOnConflict(t *testing.T) {
 		{"d.Spec.Template.Labels", d.Spec.Template.Labels},
 	})
 	// matchlabels only gets its existing 'app' label updated, it doesn't get any new labels added
-	verifyFields(t, []model.LabelPair{{"app", "panza"}}, []field{
+	verifyFields(t, []model.LabelPair{{Key: "app", Value: "panza"}}, []field{
 		{"d.Spec.Selector.MatchLabels", d.Spec.Selector.MatchLabels},
 	})
 }
@@ -194,32 +194,43 @@ func TestInjectStatefulSet(t *testing.T) {
 	}
 
 	expectedLPs := append(lps, []model.LabelPair{
-		{"app", "redis"},
-		{"chart", "redis-5.1.3"},
-		{"release", "test"},
+		{Key: "app", Value: "redis"},
+		{Key: "chart", Value: "redis-5.1.3"},
+		{Key: "release", Value: "test"},
 	}...)
 
 	ss := newEntity.Obj.(*v1beta2.StatefulSet)
-	verifyFields(t, append(expectedLPs, model.LabelPair{"heritage", "Tiller"}), []field{
+	verifyFields(t, append(expectedLPs, model.LabelPair{Key: "heritage", Value: "Tiller"}), []field{
 		{"ss.Labels", ss.Labels},
 	})
-	verifyFields(t, append(expectedLPs, model.LabelPair{"role", "master"}), []field{
+	verifyFields(t, append(expectedLPs, model.LabelPair{Key: "role", Value: "master"}), []field{
 		{"ss.Spec.Template.Labels", ss.Spec.Template.Labels},
 	})
-	verifyFields(t, []model.LabelPair{{"app", "redis"}, {"release", "test"}, {"role", "master"}}, []field{
-		{"ss.Spec.Selector.MatchLabels", ss.Spec.Selector.MatchLabels},
-	})
+	verifyFields(t,
+		[]model.LabelPair{
+			{Key: "app", Value: "redis"},
+			{Key: "release", Value: "test"},
+			{Key: "role", Value: "master"},
+		}, []field{
+			{"ss.Spec.Selector.MatchLabels", ss.Spec.Selector.MatchLabels},
+		})
 
-	verifyFields(t, []model.LabelPair{{"app", "redis"}, {"component", "master"}, {"heritage", "Tiller"}, {"release", "test"}}, []field{
-		{"ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Labels", ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Labels},
-	})
+	verifyFields(t,
+		[]model.LabelPair{
+			{Key: "app", Value: "redis"},
+			{Key: "component", Value: "master"},
+			{Key: "heritage", Value: "Tiller"},
+			{Key: "release", Value: "test"},
+		}, []field{
+			{"ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Labels", ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Labels},
+		})
 }
 
 func TestInjectService(t *testing.T) {
 	entity := parseOneEntity(t, testyaml.DoggosServiceYaml)
 	lps := []model.LabelPair{
-		{"foo", "bar"},
-		{"app", "cattos"},
+		{Key: "foo", Value: "bar"},
+		{Key: "app", Value: "cattos"},
 	}
 	newEntity, err := InjectLabels(entity, lps)
 	require.NoError(t, err)
@@ -227,13 +238,13 @@ func TestInjectService(t *testing.T) {
 	svc, ok := newEntity.Obj.(*v1.Service)
 	require.True(t, ok)
 
-	expectedLPs := append(lps, model.LabelPair{"whosAGoodBoy", "imAGoodBoy"})
+	expectedLPs := append(lps, model.LabelPair{Key: "whosAGoodBoy", Value: "imAGoodBoy"})
 	verifyFields(t, expectedLPs, []field{
 		{"svc.Labels", svc.Labels},
 	})
 
 	// selector only gets existing labels updated
-	verifyFields(t, []model.LabelPair{{"app", "cattos"}}, []field{
+	verifyFields(t, []model.LabelPair{{Key: "app", Value: "cattos"}}, []field{
 		{"svc.Spec.Selector", svc.Spec.Selector},
 	})
 }


### PR DESCRIPTION
Resolves #2576

### Problem

#2500 made label injection also inject to `MatchSelector`s, not just `ObjectMeta.Labels`, to address #2498. This unfortunately added another bug: now we might be adding labels when there were none, and incorrectly changing behavior. e.g., a NetworkPolicy's namespaceSelector might be used to let an ingress talk to a namespace. If the NetworkPolicy is deployed by Tilt and the namespace is not, then Tilt will inject managed-by: tilt into the NetworkPolicy's namespaceSelector, and it will no longer match the intended namespace.

Tangentially: we were never injecting labels into Service's selectors, because they're not of type `MatchSelector`.

### Solution

1. When injecting labels into a selector, only update the value of an existing key. Don't add new keys.
2. Inject labels into Service's selectors (using the behavior from (1)).

### Result

I'm pretty sure it's still possible to construct yaml that produces surprising behavior, but I don't think we can totally escape that as long as we're injecting labels.