### PR TITLE
tiltfile: add flags.set_resources

### DIFF
--- a/internal/tiltfile/flags/flags.go
+++ b/internal/tiltfile/flags/flags.go
@@ -4,13 +4,13 @@ import (
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
 
-	"github.com/windmilleng/tilt/internal/tiltfile/value"
-
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+	"github.com/windmilleng/tilt/internal/tiltfile/value"
+	"github.com/windmilleng/tilt/pkg/model"
 )
 
 type Settings struct {
-	Resources []string
+	resources []string
 }
 
 type Extension struct {
@@ -44,7 +44,7 @@ func setResources(thread *starlark.Thread, fn *starlark.Builtin, args starlark.T
 	}
 
 	err = starkit.SetState(thread, func(settings Settings) Settings {
-		settings.Resources = resources
+		settings.resources = resources
 		return settings
 	})
 	if err != nil {
@@ -68,4 +68,17 @@ func GetState(m starkit.Model) (Settings, error) {
 	var state Settings
 	err := m.Load(&state)
 	return state, err
+}
+
+func (s Settings) Resources(args []model.ManifestName) []model.ManifestName {
+	if s.resources == nil {
+		return args
+	}
+
+	var ret []model.ManifestName
+	for _, r := range s.resources {
+		ret = append(ret, model.ManifestName(r))
+	}
+
+	return ret
 }

--- a/internal/tiltfile/flags/flags.go
+++ b/internal/tiltfile/flags/flags.go
@@ -1,0 +1,71 @@
+package flags
+
+import (
+	"github.com/pkg/errors"
+	"go.starlark.net/starlark"
+
+	"github.com/windmilleng/tilt/internal/tiltfile/value"
+
+	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+)
+
+type Settings struct {
+	Resources []string
+}
+
+type Extension struct {
+}
+
+func NewExtension() Extension {
+	return Extension{}
+}
+
+func (e Extension) NewState() interface{} {
+	return Settings{}
+}
+
+func (Extension) OnStart(env *starkit.Environment) error {
+	return env.AddBuiltin("flags.set_resources", setResources)
+}
+
+func setResources(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var slResources starlark.Sequence
+	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
+		"resources",
+		&slResources,
+	)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	resources, err := value.SequenceToStringSlice(slResources)
+	if err != nil {
+		return starlark.None, errors.Wrap(err, "resources must be a list of string")
+	}
+
+	err = starkit.SetState(thread, func(settings Settings) Settings {
+		settings.Resources = resources
+		return settings
+	})
+	if err != nil {
+		return starlark.None, err
+	}
+
+	return starlark.None, nil
+}
+
+var _ starkit.StatefulExtension = Extension{}
+
+func MustState(model starkit.Model) Settings {
+	state, err := GetState(model)
+	if err != nil {
+		panic(err)
+	}
+	return state
+}
+
+func GetState(m starkit.Model) (Settings, error) {
+	var state Settings
+	err := m.Load(&state)
+	return state, err
+}

--- a/internal/tiltfile/flags/flags_test.go
+++ b/internal/tiltfile/flags/flags_test.go
@@ -1,0 +1,32 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+)
+
+func TestEmpty(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+`)
+	result, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	require.Equal(t, 0, len(MustState(result).Resources))
+}
+
+func TestNonEmpty(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+flags.set_resources(['foo', 'bar', 'baz'])
+`)
+	result, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo", "bar", "baz"}, MustState(result).Resources)
+}
+
+func NewFixture(tb testing.TB) *starkit.Fixture {
+	return starkit.NewFixture(tb, NewExtension())
+}

--- a/internal/tiltfile/flags/flags_test.go
+++ b/internal/tiltfile/flags/flags_test.go
@@ -1,30 +1,48 @@
 package flags
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+	"github.com/windmilleng/tilt/pkg/model"
 )
 
-func TestEmpty(t *testing.T) {
-	f := NewFixture(t)
-	f.File("Tiltfile", `
-`)
-	result, err := f.ExecFile("Tiltfile")
-	require.NoError(t, err)
-	require.Equal(t, 0, len(MustState(result).Resources))
-}
+func TestSetResources(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		argsResources     []model.ManifestName
+		tiltfileResources []model.ManifestName
+		expectedResources []model.ManifestName
+	}{
+		{"neither", nil, nil, []model.ManifestName(nil)},
+		{"args only", []model.ManifestName{"a"}, nil, []model.ManifestName{"a"}},
+		{"tiltfile only", nil, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
+		{"both", []model.ManifestName{"a"}, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFixture(t)
 
-func TestNonEmpty(t *testing.T) {
-	f := NewFixture(t)
-	f.File("Tiltfile", `
-flags.set_resources(['foo', 'bar', 'baz'])
-`)
-	result, err := f.ExecFile("Tiltfile")
-	require.NoError(t, err)
-	require.Equal(t, []string{"foo", "bar", "baz"}, MustState(result).Resources)
+			setResources := ""
+			if len(tc.tiltfileResources) > 0 {
+				var rs []string
+				for _, mn := range tc.tiltfileResources {
+					rs = append(rs, fmt.Sprintf("'%s'", mn))
+				}
+				setResources = fmt.Sprintf("flags.set_resources([%s])", strings.Join(rs, ", "))
+			}
+			f.File("Tiltfile", setResources)
+
+			result, err := f.ExecFile("Tiltfile")
+			require.NoError(t, err)
+
+			actual := MustState(result).Resources(tc.argsResources)
+			require.Equal(t, tc.expectedResources, actual)
+		})
+	}
 }
 
 func NewFixture(tb testing.TB) *starkit.Fixture {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -21,6 +21,7 @@ import (
 	"github.com/windmilleng/tilt/internal/sliceutils"
 	"github.com/windmilleng/tilt/internal/tiltfile/analytics"
 	"github.com/windmilleng/tilt/internal/tiltfile/dockerprune"
+	"github.com/windmilleng/tilt/internal/tiltfile/flags"
 	"github.com/windmilleng/tilt/internal/tiltfile/git"
 	"github.com/windmilleng/tilt/internal/tiltfile/include"
 	"github.com/windmilleng/tilt/internal/tiltfile/io"
@@ -156,6 +157,7 @@ func (s *tiltfileState) loadManifests(absFilename string, requested []model.Mani
 		dockerprune.NewExtension(),
 		analytics.NewExtension(),
 		version.NewExtension(),
+		flags.NewExtension(),
 	)
 	if err != nil {
 		return nil, result, starkit.UnpackBacktrace(err)
@@ -203,6 +205,14 @@ to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, kubeContext
 		return nil, result, err
 	}
 	manifests = append(manifests, localManifests...)
+
+	flagsState, _ := flags.GetState(result)
+	if len(flagsState.Resources) > 0 {
+		requested = nil
+		for _, r := range flagsState.Resources {
+			requested = append(requested, model.ManifestName(r))
+		}
+	}
 
 	manifests, err = match(manifests, requested)
 	if err != nil {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -206,13 +206,15 @@ to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, kubeContext
 	}
 	manifests = append(manifests, localManifests...)
 
-	flagsState, _ := flags.GetState(result)
-	if len(flagsState.Resources) > 0 {
-		requested = nil
-		for _, r := range flagsState.Resources {
-			requested = append(requested, model.ManifestName(r))
+	// if none were requested, then default to all
+	if requested == nil {
+		for _, m := range manifests {
+			requested = append(requested, m.Name)
 		}
 	}
+
+	flagsState, _ := flags.GetState(result)
+	requested = flagsState.Resources(requested)
 
 	manifests, err = match(manifests, requested)
 	if err != nil {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4226,48 +4226,6 @@ local_resource('e', 'echo e')
 	}
 }
 
-func TestSetResources(t *testing.T) {
-	for _, tc := range []struct {
-		name              string
-		argsResources     []model.ManifestName
-		tiltfileResources []model.ManifestName
-		expectedResources []model.ManifestName
-	}{
-		{"neither", nil, nil, []model.ManifestName{"a", "b"}},
-		{"args only", []model.ManifestName{"a"}, nil, []model.ManifestName{"a"}},
-		{"tiltfile only", nil, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
-		{"both", []model.ManifestName{"a"}, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			f := newFixture(t)
-			defer f.TearDown()
-
-			setResources := ""
-			if len(tc.tiltfileResources) > 0 {
-				rs := []string{}
-				for _, mn := range tc.tiltfileResources {
-					rs = append(rs, fmt.Sprintf("'%s'", mn))
-				}
-				setResources = fmt.Sprintf("flags.set_resources([%s])", strings.Join(rs, ", "))
-			}
-			f.file("Tiltfile", fmt.Sprintf(`
-local_resource('a', 'echo a')
-local_resource('b', 'echo b')
-%s
-`, setResources))
-
-			f.load(tc.argsResources...)
-
-			var observed []model.ManifestName
-			for _, m := range f.loadResult.Manifests {
-				observed = append(observed, m.Name)
-			}
-
-			require.Equal(t, tc.expectedResources, observed)
-		})
-	}
-}
-
 type fixture struct {
 	ctx context.Context
 	out *bytes.Buffer


### PR DESCRIPTION
(part of https://github.com/windmilleng/tilt.build/pull/325)

This adds a `flags.set_resources` builtin that overrides the resource list specified as positional arguments to `tilt up`