### PR TITLE
build: fix up custom_build to work with non-docker builders like buildah

### DIFF
--- a/internal/build/custom_builder_test.go
+++ b/internal/build/custom_builder_test.go
@@ -20,7 +20,7 @@ func TestCustomBuildSuccess(t *testing.T) {
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
-	ref, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "")
+	ref, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "", false)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -28,18 +28,26 @@ func TestCustomBuildSuccess(t *testing.T) {
 	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-11cd0eb38bc3ceb9"), ref)
 }
 
+func TestCustomBuildSuccessWithoutDocker(t *testing.T) {
+	f := newFakeCustomBuildFixture(t)
+
+	ref, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "", true)
+	assert.NoError(f.t, err)
+	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-build-1551202573"), ref)
+}
+
 func TestCustomBuildCmdFails(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
 
-	_, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "false", "")
+	_, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "false", "", false)
 	// TODO(dmiller) better error message
-	assert.EqualError(t, err, "exit status 1")
+	assert.EqualError(t, err, "Custom build command failed: exit status 1")
 }
 
 func TestCustomBuildImgNotFound(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
 
-	_, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "")
+	_, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "", false)
 	assert.Contains(t, err.Error(), "fake docker client error: object not found")
 }
 
@@ -48,7 +56,7 @@ func TestCustomBuildExpectedTag(t *testing.T) {
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:the-tag"] = types.ImageInspect{ID: string(sha)}
-	ref, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "the-tag")
+	ref, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "the-tag", false)
 	if err != nil {
 		f.t.Fatal(err)
 	}

--- a/internal/engine/image_and_cache_builder.go
+++ b/internal/engine/image_and_cache_builder.go
@@ -73,7 +73,7 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 	case model.CustomBuild:
 		ps.StartPipelineStep(ctx, "Building Custom Build: [%s]", userFacingRefName)
 		defer ps.EndPipelineStep(ctx)
-		ref, err := icb.custb.Build(ctx, refToBuild, bd.Command, bd.Tag)
+		ref, err := icb.custb.Build(ctx, refToBuild, bd.Command, bd.Tag, bd.DisablePush)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/issue2589:

0ff01c034b3a92ed03b3531dd433b4e147369d71 (2019-11-25 13:00:45 -0500)
build: fix up custom_build to work with non-docker builders like buildah
Currently, custom_build checks to make sure that your local docker registry
has the built image. This doesn't work if you don't have docker installed at all.

Long-term, I think we probably need to rethink the custom_build API to be richer
than a single shell command (and also provide 'tag' and 'push' commands).