### PR TITLE
build: add skips_local_docker=True to custom_build, for custom_builds that don't use docker at all

### DIFF
--- a/internal/build/custom_builder_test.go
+++ b/internal/build/custom_builder_test.go
@@ -28,7 +28,7 @@ func TestCustomBuildSuccess(t *testing.T) {
 	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-11cd0eb38bc3ceb9"), ref)
 }
 
-func TestCustomBuildSuccessWithoutDocker(t *testing.T) {
+func TestCustomBuildSuccessSkipsLocalDocker(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
 
 	ref, err := f.cb.Build(f.ctx, container.MustParseNamed("gcr.io/foo/bar"), "true", "", true)

--- a/internal/engine/image_and_cache_builder.go
+++ b/internal/engine/image_and_cache_builder.go
@@ -73,7 +73,7 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 	case model.CustomBuild:
 		ps.StartPipelineStep(ctx, "Building Custom Build: [%s]", userFacingRefName)
 		defer ps.EndPipelineStep(ctx)
-		ref, err := icb.custb.Build(ctx, refToBuild, bd.Command, bd.Tag, bd.DisablePush)
+		ref, err := icb.custb.Build(ctx, refToBuild, bd.Command, bd.Tag, bd.SkipsLocalDocker)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -170,7 +170,7 @@ func (ibd *ImageBuildAndDeployer) push(ctx context.Context, ref reference.NamedT
 
 	cbSkip := false
 	if iTarget.IsCustomBuild() {
-		cbSkip = iTarget.CustomBuildInfo().DisablePush
+		cbSkip = iTarget.CustomBuildInfo().SkipsPush()
 	}
 
 	// We can also skip the push of the image if it isn't used

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -44,8 +44,9 @@ type dockerImage struct {
 	// Whether this has been matched up yet to a deploy resource.
 	matched bool
 
-	dependencyIDs []model.TargetID
-	disablePush   bool
+	dependencyIDs    []model.TargetID
+	disablePush      bool
+	skipsLocalDocker bool
 
 	liveUpdate model.LiveUpdate
 }
@@ -223,6 +224,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 	var liveUpdateVal, ignoreVal starlark.Value
 	var matchInEnvVars bool
 	var entrypoint string
+	var skipsLocalDocker bool
 
 	err := s.unpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
@@ -230,6 +232,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		"deps", &deps,
 		"tag?", &tag,
 		"disable_push?", &disablePush,
+		"skips_local_docker?", &skipsLocalDocker,
 		"live_update?", &liveUpdateVal,
 		"match_in_env_vars?", &matchInEnvVars,
 		"ignore?", &ignoreVal,
@@ -285,6 +288,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		customDeps:       localDeps,
 		customTag:        tag,
 		disablePush:      disablePush,
+		skipsLocalDocker: skipsLocalDocker,
 		liveUpdate:       liveUpdate,
 		matchInEnvVars:   matchInEnvVars,
 		ignores:          ignores,

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1060,11 +1060,12 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 			})
 		case CustomBuild:
 			r := model.CustomBuild{
-				Command:     image.customCommand,
-				Deps:        image.customDeps,
-				Tag:         image.customTag,
-				DisablePush: image.disablePush,
-				LiveUpdate:  lu,
+				Command:          image.customCommand,
+				Deps:             image.customDeps,
+				Tag:              image.customTag,
+				DisablePush:      image.disablePush,
+				SkipsLocalDocker: image.skipsLocalDocker,
+				LiveUpdate:       lu,
 			}
 			iTarget = iTarget.WithBuildDetails(r)
 			// TODO(dbentley): validate that syncs is a subset of deps

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -277,9 +277,10 @@ type CustomBuild struct {
 	// export $EXPECTED_REF=name:expected_tag )
 	Tag string
 
-	Fast        FastBuild
-	LiveUpdate  LiveUpdate // Optionally, can use LiveUpdate to update this build in place.
-	DisablePush bool
+	Fast             FastBuild
+	LiveUpdate       LiveUpdate // Optionally, can use LiveUpdate to update this build in place.
+	DisablePush      bool
+	SkipsLocalDocker bool
 }
 
 func (CustomBuild) buildDetails() {}
@@ -287,6 +288,10 @@ func (CustomBuild) buildDetails() {}
 func (cb CustomBuild) WithTag(t string) CustomBuild {
 	cb.Tag = t
 	return cb
+}
+
+func (cb CustomBuild) SkipsPush() bool {
+	return cb.SkipsLocalDocker || cb.DisablePush
 }
 
 var _ TargetSpec = ImageTarget{}


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch3983/push:

3edcfc75d7a71cf1653623a336ac5927946cf611 (2019-11-25 17:54:51 -0500)
build: add skips_local_docker=True to custom_build, for custom_builds that don't use docker at all