### PR TITLE
integration: update tests to use kind 0.6.0

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -40,6 +40,6 @@ RUN go get gotest.tools/gotestsum
 RUN apt update && apt install -y jq
 
 # install Kind (Kubernetes in Docker)
-RUN curl -fLo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.5.0/kind-linux-amd64 \
+RUN curl -fLo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.6.0/kind-linux-amd64 \
   && chmod +x ./kind-linux-amd64 \
   && mv ./kind-linux-amd64 /go/bin/kind

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
 
   build-integration:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:3b5e271524846d41673978fc48b70e238ada670e19ac6841644c30545d64645d
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:400b39ce81072afbb54f308e42c59821cdfdb57ecbb9849a90c414b9e6668d94
     working_directory: /go/src/github.com/windmilleng/tilt
     steps:
       - checkout
@@ -75,8 +75,7 @@ jobs:
       - run: docker rm portforward || exit 0
       - run: /go/portforward.sh start
       - run: kind create cluster --name=integration
-      - run: "export KUBECONFIG=$(kind get kubeconfig-path --name=integration) &&
-             export APISERVER_PORT=$(kubectl config view -o jsonpath='{.clusters[].cluster.server}' | cut -d: -f 3 -) &&
+      - run: "export APISERVER_PORT=$(kubectl config view -o jsonpath='{.clusters[].cluster.server}' | cut -d: -f 3 -) &&
              /go/portforward.sh -wait $APISERVER_PORT &&
              kubectl get nodes &&
              make integration"

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ ifneq ($(CIRCLECI),true)
 		go test -v -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
 else
 		mkdir -p test-results
-		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./integration -count 1 -v -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
+		gotestsum --format standard-verbose --junitfile test-results/unit-tests.xml -- ./integration -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
 endif
 
 # Run the integration tests on kind


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/kind6:

bc3f9aacb6646f93575c8592ed5ac2bfd4bbdac1 (2019-12-02 15:33:05 -0500)
integration: update tests to use kind 0.6.0