### PR TITLE
tiltfile / analytics / configs: removing more fastbuild code

### DIFF
--- a/internal/engine/analytics/analytics_reporter.go
+++ b/internal/engine/analytics/analytics_reporter.go
@@ -59,8 +59,8 @@ func ProvideAnalyticsReporter(a *analytics.TiltAnalytics, st *store.Store) *Anal
 func (ar *AnalyticsReporter) report() {
 	st := ar.store.RLockState()
 	defer ar.store.RUnlockState()
-	var dcCount, k8sCount, fastbuildBaseCount, anyFastbuildCount, liveUpdateCount,
-		unbuiltCount, sameImgMultiContainerLiveUpdate, multiImgLiveUpdate int
+	var dcCount, k8sCount, liveUpdateCount, unbuiltCount,
+		sameImgMultiContainerLiveUpdate, multiImgLiveUpdate int
 	for _, m := range st.Manifests() {
 		var refInjectCounts map[string]int
 		if m.IsK8s() {
@@ -75,13 +75,6 @@ func (ar *AnalyticsReporter) report() {
 		}
 		var seenLU, multiImgLU, multiContainerLU bool
 		for _, it := range m.ImageTargets {
-			if !it.AnyFastBuildInfo().Empty() {
-				anyFastbuildCount++
-				if it.IsFastBuild() {
-					fastbuildBaseCount++
-				}
-				break
-			}
 			if !it.AnyLiveUpdateInfo().Empty() {
 				if !seenLU {
 					seenLU = true
@@ -114,8 +107,6 @@ func (ar *AnalyticsReporter) report() {
 		stats["resource.count"] = strconv.Itoa(len(st.ManifestDefinitionOrder))
 		stats["resource.dockercompose.count"] = strconv.Itoa(dcCount)
 		stats["resource.k8s.count"] = strconv.Itoa(k8sCount)
-		stats["resource.fastbuild.count"] = strconv.Itoa(fastbuildBaseCount)
-		stats["resource.anyfastbuild.count"] = strconv.Itoa(anyFastbuildCount)
 		stats["resource.liveupdate.count"] = strconv.Itoa(liveUpdateCount)
 		stats["resource.unbuiltresources.count"] = strconv.Itoa(unbuiltCount)
 		stats["resource.sameimagemultiplecontainerliveupdate.count"] = strconv.Itoa(sameImgMultiContainerLiveUpdate)

--- a/internal/engine/analytics/analytics_reporter_test.go
+++ b/internal/engine/analytics/analytics_reporter_test.go
@@ -18,12 +18,9 @@ import (
 )
 
 var (
-	fb = model.FastBuild{HotReload: true}                                            // non-empty FastBuild
 	lu = model.LiveUpdate{Steps: []model.LiveUpdateStep{model.LiveUpdateSyncStep{}}} // non-empty LiveUpdate
 
 	imgTargDB       = model.ImageTarget{BuildDetails: model.DockerBuild{}}
-	imgTargFB       = model.ImageTarget{BuildDetails: fb}
-	imgTargDBWithFB = model.ImageTarget{BuildDetails: model.DockerBuild{FastBuild: fb}}
 	imgTargDBWithLU = model.ImageTarget{BuildDetails: model.DockerBuild{LiveUpdate: lu}}
 
 	kTarg = model.K8sTarget{}
@@ -45,9 +42,7 @@ var (
 func TestAnalyticsReporter_Everything(t *testing.T) {
 	tf := newAnalyticsReporterTestFixture()
 
-	tf.addManifest(tf.nextManifest().WithImageTarget(imgTargFB))                               // fastbuild
 	tf.addManifest(tf.nextManifest().WithImageTarget(imgTargDB).WithDeployTarget(kTarg))       // k8s
-	tf.addManifest(tf.nextManifest().WithImageTarget(imgTargDBWithFB))                         // anyfastbuild
 	tf.addManifest(tf.nextManifest().WithImageTarget(imgTargDBWithLU))                         // liveupdate
 	tf.addManifest(tf.nextManifest().WithDeployTarget(kTarg))                                  // k8s, unbuilt
 	tf.addManifest(tf.nextManifest().WithDeployTarget(kTarg))                                  // k8s, unbuilt
@@ -69,11 +64,9 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 
 	expectedTags := map[string]string{
 		"builds.completed_count":                              "3",
-		"resource.count":                                      "11",
+		"resource.count":                                      "9",
 		"resource.dockercompose.count":                        "3",
 		"resource.unbuiltresources.count":                     "3",
-		"resource.fastbuild.count":                            "1",
-		"resource.anyfastbuild.count":                         "2",
 		"resource.liveupdate.count":                           "3",
 		"resource.k8s.count":                                  "4",
 		"resource.sameimagemultiplecontainerliveupdate.count": "0", // tests for this below
@@ -134,7 +127,6 @@ func TestAnalyticsReporter_SameImageMultiContainer_NoIncr(t *testing.T) {
 func TestAnalyticsReporter_TiltfileError(t *testing.T) {
 	tf := newAnalyticsReporterTestFixture()
 
-	tf.addManifest(tf.nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.FastBuild{}}))
 	tf.addManifest(tf.nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.DockerBuild{}}))
 	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))
 	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -161,7 +161,7 @@ func requiresDocker(tlr tiltfile.TiltfileLoadResult) bool {
 
 	for _, m := range tlr.Manifests {
 		for _, iTarget := range m.ImageTargets {
-			if iTarget.IsDockerBuild() || iTarget.IsFastBuild() {
+			if iTarget.IsDockerBuild() {
 				return true
 			}
 		}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -317,10 +317,8 @@ dc_resource('foo', 'gcr.io/foo')
 	m := f.assertNextManifest("foo", db(image("gcr.io/foo")))
 	iTarget := m.ImageTargetAt(0)
 
-	// Make sure there's no fast build / live update in the default case.
+	// Make sure there's no live update in the default case.
 	assert.True(t, iTarget.IsDockerBuild())
-	assert.False(t, iTarget.IsFastBuild())
-	assert.True(t, iTarget.AnyFastBuildInfo().Empty())
 	assert.True(t, iTarget.AnyLiveUpdateInfo().Empty())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
@@ -351,10 +349,8 @@ docker_compose('docker-compose.yml')
 	m := f.assertNextManifest("foo", db(image("gcr.io/as_specified_in_config")))
 	iTarget := m.ImageTargetAt(0)
 
-	// Make sure there's no fast build / live update in the default case.
+	// Make sure there's no live update in the default case.
 	assert.True(t, iTarget.IsDockerBuild())
-	assert.False(t, iTarget.IsFastBuild())
-	assert.True(t, iTarget.AnyFastBuildInfo().Empty())
 	assert.True(t, iTarget.AnyLiveUpdateInfo().Empty())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
@@ -377,7 +373,6 @@ dc_resource('foo', 'fooimage')
 
 	m := f.assertNextManifest("foo", db(image("fooimage")))
 	assert.True(t, m.ImageTargetAt(0).IsDockerBuild())
-	assert.False(t, m.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
 	assert.Equal(t, m.DockerComposeTarget().ConfigPaths, []string{configPath})
@@ -401,11 +396,9 @@ dc_resource('bar', 'gcr.io/bar')
 
 	foo := f.assertNextManifest("foo", db(image("gcr.io/foo")))
 	assert.True(t, foo.ImageTargetAt(0).IsDockerBuild())
-	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	bar := f.assertNextManifest("bar", db(image("gcr.io/bar")))
 	assert.True(t, foo.ImageTargetAt(0).IsDockerBuild())
-	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
 	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, []string{configPath})
@@ -435,11 +428,9 @@ docker_compose('docker-compose.yml')
 
 	foo := f.assertNextManifest("foo", db(image("gcr.io/foo")))
 	assert.True(t, foo.ImageTargetAt(0).IsDockerBuild())
-	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	bar := f.assertNextManifest("bar", db(image("gcr.io/bar")))
 	assert.True(t, foo.ImageTargetAt(0).IsDockerBuild())
-	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
 	assert.Equal(t, foo.DockerComposeTarget().ConfigPaths, []string{configPath})
@@ -483,7 +474,6 @@ dc_resource('foo', img_name)
 
 	foo := f.assertNextManifest("foo", db(image("gcr.io/foo")))
 	assert.True(t, foo.ImageTargetAt(0).IsDockerBuild())
-	assert.False(t, foo.ImageTargetAt(0).IsFastBuild())
 
 	bar := f.assertNextManifest("bar")
 	assert.Empty(t, bar.ImageTargets)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -949,8 +949,7 @@ func (s *tiltfileState) checkForImpossibleLiveUpdates(m model.Manifest) error {
 		isDeployed := m.IsImageDeployed(iTarg)
 
 		// This check only applies to images with live updates.
-		isInPlaceUpdate := !iTarg.AnyFastBuildInfo().Empty() || !iTarg.AnyLiveUpdateInfo().Empty()
-		if !isInPlaceUpdate {
+		if iTarg.AnyLiveUpdateInfo().Empty() {
 			continue
 		}
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -124,10 +124,8 @@ k8s_yaml('foo.yaml')
 
 	iTarget := m.ImageTargetAt(0)
 
-	// Make sure there's no fast build / live update in the default case.
+	// Make sure there's no live update in the default case.
 	assert.True(t, iTarget.IsDockerBuild())
-	assert.False(t, iTarget.IsFastBuild())
-	assert.True(t, iTarget.AnyFastBuildInfo().Empty())
 	assert.True(t, iTarget.AnyLiveUpdateInfo().Empty())
 }
 
@@ -1170,7 +1168,6 @@ k8s_yaml('foo.yaml')
 	f.load()
 	m := f.assertNextManifest("foo", db(image("gcr.io/foo")))
 	assert.True(t, m.ImageTargetAt(0).IsDockerBuild())
-	assert.False(t, m.ImageTargetAt(0).IsFastBuild())
 }
 
 func TestSanchoSidecar(t *testing.T) {


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/fastbuild2:

0b8263b1c117013ef0ac7e1958ef57c605a597a8 (2019-12-02 17:19:45 -0500)
rm fastbuild from configs package

dd00d9f8de39586d7f34afd8ec6cbde4fa83e37d (2019-12-02 17:18:53 -0500)
rm fastbuild from analytics package

7a8c6c9f3f7ea2e8628c5d24817a14e7adc48b2d (2019-12-02 17:15:39 -0500)
rm fastbuild references from tiltfile package

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics