### PR TITLE
engine: docker-compose log actions should not contain timestamps or service prefixes

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -99,7 +99,7 @@ func (c *cmdDCClient) StreamLogs(ctx context.Context, configPaths []string, serv
 	for _, config := range configPaths {
 		args = append(args, "-f", config)
 	}
-	args = append(args, "logs", "-f", "-t", serviceName.String())
+	args = append(args, "logs", "--no-color", "-f", serviceName.String())
 	cmd := c.dcCommand(ctx, args)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/engine/runtimelog/docker_compose_log_manager_test.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager_test.go
@@ -1,0 +1,59 @@
+package runtimelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+func TestSimpleWriter(t *testing.T) {
+	st := store.NewTestingStore()
+	log := `Attaching to express-redis-docker_app_1, cache
+cache    | # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+cache    | # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+`
+
+	writer := &DockerComposeLogActionWriter{
+		store:             st,
+		isStartingNewLine: true,
+	}
+	writer.Write([]byte(log))
+
+	actions := st.Actions
+	require.Equal(t, 1, len(actions))
+
+	expected := `# oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+# Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+`
+	assert.Equal(t, expected, string(actions[0].(DockerComposeLogAction).Message()))
+}
+
+func TestBrokenLine(t *testing.T) {
+	st := store.NewTestingStore()
+	log1 := `Attaching to express-redis-docker_app_1, cache
+cache    | # oO0OoO0`
+	log2 := `OoO0Oo Redis is starting oO0OoO0OoO0Oo
+cache    | # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+`
+
+	writer := &DockerComposeLogActionWriter{
+		store:             st,
+		isStartingNewLine: true,
+	}
+	writer.Write([]byte(log1))
+	writer.Write([]byte(log2))
+
+	actions := st.Actions
+	require.Equal(t, 2, len(actions))
+
+	expected1 := `# oO0OoO0`
+	assert.Equal(t, expected1, string(actions[0].(DockerComposeLogAction).Message()))
+
+	expected2 := `OoO0Oo Redis is starting oO0OoO0OoO0Oo
+# Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+`
+	assert.Equal(t, expected2, string(actions[1].(DockerComposeLogAction).Message()))
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -586,14 +586,8 @@ func handleBuildLogAction(state *store.EngineState, action BuildLogAction) {
 
 func handleLogAction(state *store.EngineState, action store.LogAction) {
 	manifestName := action.Source()
-	alreadyHasSourcePrefix := false
-	if _, isDCLog := action.(runtimelog.DockerComposeLogAction); isDCLog {
-		// DockerCompose logs are prefixed by the docker-compose engine
-		alreadyHasSourcePrefix = true
-	}
-
 	var allLogPrefix string
-	if manifestName != "" && !alreadyHasSourcePrefix {
+	if manifestName != "" {
 		allLogPrefix = logstore.SourcePrefix(manifestName)
 	}
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/dclogs:

47aca0da54791dbfa8a14436b4ca8cce5ca7dcbb (2019-12-03 18:26:04 -0500)
engine: docker-compose log actions should not contain timestamps or service prefixes
Per https://github.com/windmilleng/tilt.specs/pull/19, we're moving towards a system
where the engine stores structured logs, and adds the prefixes later.