### PR TITLE
model: store logs by segment instead of by line

### DIFF
--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -118,3 +118,13 @@ func TestLogTailPrefixes(t *testing.T) {
 	assert.Equal(t, "1\n2\nfe | 3\nfe | 4\n5\n", l.Tail(5).String())
 	assert.Equal(t, "1\n2\nfe | 3\nfe | 4\n5\n", l.Tail(6).String())
 }
+
+func TestLogTailParts(t *testing.T) {
+	l := NewLogStore()
+	l.Append(newGlobalLogEvent("a"), nil)
+	l.Append(newLogEvent("fe", time.Now(), "xy"), nil)
+	l.Append(newGlobalLogEvent("bc\n"), nil)
+	l.Append(newLogEvent("fe", time.Now(), "z\n"), nil)
+	assert.Equal(t, "fe | xyz\n", l.Tail(1).String())
+	assert.Equal(t, "abc\nfe | xyz\n", l.Tail(2).String())
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/logsegment:

92040f1d12d0865f74034923ea5e42e24b9baa2a (2019-12-03 19:46:09 -0500)
model: store logs by segment instead of by line
A key API we want to be able to support is "give me all the logs since checkpoint X".
Storing the logs in an append-only data structure makes this much easier to support,
even if it makes it a little bit harder to print the logs line-by-line.

Storing the logs line-by-line meant we had to do backtracking and make things mutable.