### PR TITLE
logstore: Add a concept of checkpoints and ContinuingStrings, for incremental log printing

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -29,6 +28,7 @@ import (
 	"github.com/windmilleng/tilt/internal/watch"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 )
 
 // When we see a file change, wait this long to see if any other files have changed, and bundle all changes together.
@@ -594,7 +594,7 @@ func handleLogAction(state *store.EngineState, action store.LogAction) {
 
 	var allLogPrefix string
 	if manifestName != "" && !alreadyHasSourcePrefix {
-		allLogPrefix = sourcePrefix(manifestName)
+		allLogPrefix = logstore.SourcePrefix(manifestName)
 	}
 
 	state.Log = model.AppendLog(state.Log, action, allLogPrefix, state.Secrets)
@@ -609,17 +609,6 @@ func handleLogAction(state *store.EngineState, action store.LogAction) {
 		return
 	}
 	ms.CombinedLog = model.AppendLog(ms.CombinedLog, action, "", state.Secrets)
-}
-
-func sourcePrefix(n model.ManifestName) string {
-	max := 12
-	spaces := ""
-	if len(n) > max {
-		n = n[:max-1] + "…"
-	} else {
-		spaces = strings.Repeat(" ", max-len(n))
-	}
-	return fmt.Sprintf("%s%s┊ ", n, spaces)
 }
 
 func handleServiceEvent(ctx context.Context, state *store.EngineState, action k8swatch.ServiceChangeAction) {

--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -10,46 +10,16 @@ import (
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
-type logEvent struct {
-	name    model.ManifestName
-	ts      time.Time
-	message string
-}
-
-func newGlobalLogEvent(message string) logEvent {
-	return newLogEvent("", time.Now(), message)
-}
-
-func newLogEvent(name model.ManifestName, ts time.Time, message string) logEvent {
-	return logEvent{
-		name:    name,
-		ts:      ts,
-		message: message,
-	}
-}
-
-func (l logEvent) Message() []byte {
-	return []byte(l.message)
-}
-
-func (l logEvent) Time() time.Time {
-	return l.ts
-}
-
-func (l logEvent) Source() model.ManifestName {
-	return l.name
-}
-
 func TestLog_AppendUnderLimit(t *testing.T) {
 	l := NewLogStore()
-	l.Append(newGlobalLogEvent("foo"), nil)
-	l.Append(newGlobalLogEvent("bar"), nil)
+	l.Append(newGlobalTestLogEvent("foo"), nil)
+	l.Append(newGlobalTestLogEvent("bar"), nil)
 	assert.Equal(t, "foobar", l.String())
 }
 
 func TestLog_AppendOverLimit(t *testing.T) {
 	l := NewLogStore()
-	l.Append(newGlobalLogEvent("hello\n"), nil)
+	l.Append(newGlobalTestLogEvent("hello\n"), nil)
 	sb := strings.Builder{}
 	for i := 0; i < maxLogLengthInBytes/2; i++ {
 		_, err := sb.WriteString("x\n")
@@ -59,26 +29,26 @@ func TestLog_AppendOverLimit(t *testing.T) {
 	}
 
 	s := sb.String()
-	l.Append(newGlobalLogEvent(s), nil)
+	l.Append(newGlobalTestLogEvent(s), nil)
 	assert.Equal(t, s[:logTruncationTarget], l.String())
 }
 
 func TestLogPrefix(t *testing.T) {
 	l := NewLogStore()
-	l.Append(newGlobalLogEvent("hello\n"), nil)
-	l.Append(newLogEvent("prefix", time.Now(), "bar\nbaz\n"), nil)
-	expected := "hello\nprefix | bar\nprefix | baz\n"
+	l.Append(newGlobalTestLogEvent("hello\n"), nil)
+	l.Append(newTestLogEvent("prefix", time.Now(), "bar\nbaz\n"), nil)
+	expected := "hello\nprefix      ┊ bar\nprefix      ┊ baz\n"
 	assert.Equal(t, expected, l.String())
 }
 
 // Assert that when logs come from two different sources, they get interleaved correctly.
 func TestLogInterleaving(t *testing.T) {
 	l := NewLogStore()
-	l.Append(newGlobalLogEvent("hello ... "), nil)
-	l.Append(newLogEvent("prefix", time.Now(), "START LONG MESSAGE\ngoodbye ... "), nil)
-	l.Append(newGlobalLogEvent("world\nnext line of global log"), nil)
-	l.Append(newLogEvent("prefix", time.Now(), "world\nEND LONG MESSAGE"), nil)
-	expected := "hello ... world\nprefix | START LONG MESSAGE\nprefix | goodbye ... world\nnext line of global log\nprefix | END LONG MESSAGE"
+	l.Append(newGlobalTestLogEvent("hello ... "), nil)
+	l.Append(newTestLogEvent("prefix", time.Now(), "START LONG MESSAGE\ngoodbye ... "), nil)
+	l.Append(newGlobalTestLogEvent("world\nnext line of global log"), nil)
+	l.Append(newTestLogEvent("prefix", time.Now(), "world\nEND LONG MESSAGE"), nil)
+	expected := "hello ... world\nprefix      ┊ START LONG MESSAGE\nprefix      ┊ goodbye ... world\nnext line of global log\nprefix      ┊ END LONG MESSAGE"
 	assert.Equal(t, expected, l.String())
 }
 
@@ -86,7 +56,7 @@ func TestScrubSecret(t *testing.T) {
 	l := NewLogStore()
 	secretSet := model.SecretSet{}
 	secretSet.AddSecret("my-secret", "client-id", []byte("secret"))
-	l.Append(newGlobalLogEvent("hello\nsecret-time!\nc2VjcmV0-time!\ngoodbye"), secretSet)
+	l.Append(newGlobalTestLogEvent("hello\nsecret-time!\nc2VjcmV0-time!\ngoodbye"), secretSet)
 	assert.Equal(t, `hello
 [redacted secret my-secret:client-id]-time!
 [redacted secret my-secret:client-id]-time!
@@ -95,7 +65,7 @@ goodbye`, l.String())
 
 func TestLogTail(t *testing.T) {
 	l := NewLogStore()
-	l.Append(newGlobalLogEvent("1\n2\n3\n4\n5\n"), nil)
+	l.Append(newGlobalTestLogEvent("1\n2\n3\n4\n5\n"), nil)
 	assert.Equal(t, "", l.Tail(0).String())
 	assert.Equal(t, "5\n", l.Tail(1).String())
 	assert.Equal(t, "4\n5\n", l.Tail(2).String())
@@ -107,24 +77,81 @@ func TestLogTail(t *testing.T) {
 
 func TestLogTailPrefixes(t *testing.T) {
 	l := NewLogStore()
-	l.Append(newGlobalLogEvent("1\n2\n"), nil)
-	l.Append(newLogEvent("fe", time.Now(), "3\n4\n"), nil)
-	l.Append(newGlobalLogEvent("5\n"), nil)
+	l.Append(newGlobalTestLogEvent("1\n2\n"), nil)
+	l.Append(newTestLogEvent("fe", time.Now(), "3\n4\n"), nil)
+	l.Append(newGlobalTestLogEvent("5\n"), nil)
 	assert.Equal(t, "", l.Tail(0).String())
 	assert.Equal(t, "5\n", l.Tail(1).String())
-	assert.Equal(t, "fe | 4\n5\n", l.Tail(2).String())
-	assert.Equal(t, "fe | 3\nfe | 4\n5\n", l.Tail(3).String())
-	assert.Equal(t, "2\nfe | 3\nfe | 4\n5\n", l.Tail(4).String())
-	assert.Equal(t, "1\n2\nfe | 3\nfe | 4\n5\n", l.Tail(5).String())
-	assert.Equal(t, "1\n2\nfe | 3\nfe | 4\n5\n", l.Tail(6).String())
+	assert.Equal(t, "fe          ┊ 4\n5\n", l.Tail(2).String())
+	assert.Equal(t, "fe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(3).String())
+	assert.Equal(t, "2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(4).String())
+	assert.Equal(t, "1\n2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(5).String())
+	assert.Equal(t, "1\n2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(6).String())
 }
 
 func TestLogTailParts(t *testing.T) {
 	l := NewLogStore()
-	l.Append(newGlobalLogEvent("a"), nil)
-	l.Append(newLogEvent("fe", time.Now(), "xy"), nil)
-	l.Append(newGlobalLogEvent("bc\n"), nil)
-	l.Append(newLogEvent("fe", time.Now(), "z\n"), nil)
-	assert.Equal(t, "fe | xyz\n", l.Tail(1).String())
-	assert.Equal(t, "abc\nfe | xyz\n", l.Tail(2).String())
+	l.Append(newGlobalTestLogEvent("a"), nil)
+	l.Append(newTestLogEvent("fe", time.Now(), "xy"), nil)
+	l.Append(newGlobalTestLogEvent("bc\n"), nil)
+	l.Append(newTestLogEvent("fe", time.Now(), "z\n"), nil)
+	assert.Equal(t, "fe          ┊ xyz\n", l.Tail(1).String())
+	assert.Equal(t, "abc\nfe          ┊ xyz\n", l.Tail(2).String())
+}
+
+func TestContinuingString(t *testing.T) {
+	l := NewLogStore()
+
+	c1 := l.Checkpoint()
+	assert.Equal(t, "", l.ContinuingString(c1))
+
+	l.Append(newGlobalTestLogEvent("foo"), nil)
+	c2 := l.Checkpoint()
+	assert.Equal(t, "foo", l.ContinuingString(c1))
+
+	l.Append(newGlobalTestLogEvent("bar\n"), nil)
+	assert.Equal(t, "foobar\n", l.ContinuingString(c1))
+	assert.Equal(t, "bar\n", l.ContinuingString(c2))
+}
+
+func TestContinuingStringOneSource(t *testing.T) {
+	l := NewLogStore()
+
+	c1 := l.Checkpoint()
+	assert.Equal(t, "", l.ContinuingString(c1))
+
+	l.Append(newTestLogEvent("fe", time.Now(), "foo"), nil)
+	c2 := l.Checkpoint()
+	assert.Equal(t, "fe          ┊ foo", l.ContinuingString(c1))
+
+	l.Append(newTestLogEvent("fe", time.Now(), "bar\n"), nil)
+	assert.Equal(t, "fe          ┊ foobar\n", l.ContinuingString(c1))
+	assert.Equal(t, "bar\n", l.ContinuingString(c2))
+}
+
+func TestContinuingStringTwoSources(t *testing.T) {
+	l := NewLogStore()
+
+	c1 := l.Checkpoint()
+
+	l.Append(newGlobalTestLogEvent("a"), nil)
+	c2 := l.Checkpoint()
+	assert.Equal(t, "a", l.ContinuingString(c1))
+
+	l.Append(newTestLogEvent("fe", time.Now(), "xy"), nil)
+	c3 := l.Checkpoint()
+	assert.Equal(t, "a\nfe          ┊ xy", l.ContinuingString(c1))
+	assert.Equal(t, "\nfe          ┊ xy", l.ContinuingString(c2))
+
+	l.Append(newGlobalTestLogEvent("bc\n"), nil)
+	c4 := l.Checkpoint()
+	assert.Equal(t, "abc\nfe          ┊ xy", l.ContinuingString(c1))
+	assert.Equal(t, "\nfe          ┊ xy\nbc\n", l.ContinuingString(c2))
+	assert.Equal(t, "\nbc\n", l.ContinuingString(c3))
+
+	l.Append(newTestLogEvent("fe", time.Now(), "z\n"), nil)
+	assert.Equal(t, "abc\nfe          ┊ xyz\n", l.ContinuingString(c1))
+	assert.Equal(t, "\nfe          ┊ xyz\nbc\n", l.ContinuingString(c2))
+	assert.Equal(t, "\nbc\nfe          ┊ z\n", l.ContinuingString(c3))
+	assert.Equal(t, "fe          ┊ z\n", l.ContinuingString(c4))
 }

--- a/pkg/model/logstore/prefix.go
+++ b/pkg/model/logstore/prefix.go
@@ -1,0 +1,19 @@
+package logstore
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+func SourcePrefix(n model.ManifestName) string {
+	max := 12
+	spaces := ""
+	if len(n) > max {
+		n = n[:max-1] + "…"
+	} else {
+		spaces = strings.Repeat(" ", max-len(n))
+	}
+	return fmt.Sprintf("%s%s┊ ", n, spaces)
+}

--- a/pkg/model/logstore/testing.go
+++ b/pkg/model/logstore/testing.go
@@ -1,0 +1,37 @@
+package logstore
+
+import (
+	"time"
+
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+type testLogEvent struct {
+	name    model.ManifestName
+	ts      time.Time
+	message string
+}
+
+func (l testLogEvent) Message() []byte {
+	return []byte(l.message)
+}
+
+func (l testLogEvent) Time() time.Time {
+	return l.ts
+}
+
+func (l testLogEvent) Source() model.ManifestName {
+	return l.name
+}
+
+func newGlobalTestLogEvent(message string) testLogEvent {
+	return newTestLogEvent("", time.Now(), message)
+}
+
+func newTestLogEvent(name model.ManifestName, ts time.Time, message string) testLogEvent {
+	return testLogEvent{
+		name:    name,
+		ts:      ts,
+		message: message,
+	}
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/continuation:

349557cfa6f969b7719d24c8c7baddf75dd2f2cf (2019-12-04 11:27:30 -0500)
logstore: Add a concept of checkpoints and ContinuingStrings, for incremental log printing

ce0e01aa60f2356874962702c8fc4f66d1c8d201 (2019-12-04 11:20:10 -0500)
model: store logs by segment instead of by line
A key API we want to be able to support is "give me all the logs since checkpoint X".
Storing the logs in an append-only data structure makes this much easier to support,
even if it makes it a little bit harder to print the logs line-by-line.

Storing the logs line-by-line meant we had to do backtracking and make things mutable.