### PR TITLE
logstore: add a thread-safe log reader

### DIFF
--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -66,13 +66,13 @@ goodbye`, l.String())
 func TestLogTail(t *testing.T) {
 	l := NewLogStore()
 	l.Append(newGlobalTestLogEvent("1\n2\n3\n4\n5\n"), nil)
-	assert.Equal(t, "", l.Tail(0).String())
-	assert.Equal(t, "5\n", l.Tail(1).String())
-	assert.Equal(t, "4\n5\n", l.Tail(2).String())
-	assert.Equal(t, "3\n4\n5\n", l.Tail(3).String())
-	assert.Equal(t, "2\n3\n4\n5\n", l.Tail(4).String())
-	assert.Equal(t, "1\n2\n3\n4\n5\n", l.Tail(5).String())
-	assert.Equal(t, "1\n2\n3\n4\n5\n", l.Tail(6).String())
+	assert.Equal(t, "", l.Tail(0))
+	assert.Equal(t, "5\n", l.Tail(1))
+	assert.Equal(t, "4\n5\n", l.Tail(2))
+	assert.Equal(t, "3\n4\n5\n", l.Tail(3))
+	assert.Equal(t, "2\n3\n4\n5\n", l.Tail(4))
+	assert.Equal(t, "1\n2\n3\n4\n5\n", l.Tail(5))
+	assert.Equal(t, "1\n2\n3\n4\n5\n", l.Tail(6))
 }
 
 func TestLogTailPrefixes(t *testing.T) {
@@ -80,13 +80,13 @@ func TestLogTailPrefixes(t *testing.T) {
 	l.Append(newGlobalTestLogEvent("1\n2\n"), nil)
 	l.Append(newTestLogEvent("fe", time.Now(), "3\n4\n"), nil)
 	l.Append(newGlobalTestLogEvent("5\n"), nil)
-	assert.Equal(t, "", l.Tail(0).String())
-	assert.Equal(t, "5\n", l.Tail(1).String())
-	assert.Equal(t, "fe          ┊ 4\n5\n", l.Tail(2).String())
-	assert.Equal(t, "fe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(3).String())
-	assert.Equal(t, "2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(4).String())
-	assert.Equal(t, "1\n2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(5).String())
-	assert.Equal(t, "1\n2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(6).String())
+	assert.Equal(t, "", l.Tail(0))
+	assert.Equal(t, "5\n", l.Tail(1))
+	assert.Equal(t, "fe          ┊ 4\n5\n", l.Tail(2))
+	assert.Equal(t, "fe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(3))
+	assert.Equal(t, "2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(4))
+	assert.Equal(t, "1\n2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(5))
+	assert.Equal(t, "1\n2\nfe          ┊ 3\nfe          ┊ 4\n5\n", l.Tail(6))
 }
 
 func TestLogTailParts(t *testing.T) {
@@ -95,8 +95,8 @@ func TestLogTailParts(t *testing.T) {
 	l.Append(newTestLogEvent("fe", time.Now(), "xy"), nil)
 	l.Append(newGlobalTestLogEvent("bc\n"), nil)
 	l.Append(newTestLogEvent("fe", time.Now(), "z\n"), nil)
-	assert.Equal(t, "fe          ┊ xyz\n", l.Tail(1).String())
-	assert.Equal(t, "abc\nfe          ┊ xyz\n", l.Tail(2).String())
+	assert.Equal(t, "fe          ┊ xyz\n", l.Tail(1))
+	assert.Equal(t, "abc\nfe          ┊ xyz\n", l.Tail(2))
 }
 
 func TestContinuingString(t *testing.T) {

--- a/pkg/model/logstore/reader.go
+++ b/pkg/model/logstore/reader.go
@@ -1,0 +1,37 @@
+package logstore
+
+import "sync"
+
+// Thread-safe reading a log store, outside of the Store state loop.
+type Reader struct {
+	mu    *sync.RWMutex
+	store *LogStore
+}
+
+func NewReader(mu *sync.RWMutex, store *LogStore) Reader {
+	return Reader{mu: mu, store: store}
+}
+
+func (r Reader) Checkpoint() Checkpoint {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.store.Checkpoint()
+}
+
+func (r Reader) String() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.store.String()
+}
+
+func (r Reader) ContinuingString(c Checkpoint) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.store.ContinuingString(c)
+}
+
+func (r Reader) Tail(n int) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.store.Tail(n)
+}

--- a/pkg/model/logstore/reader_test.go
+++ b/pkg/model/logstore/reader_test.go
@@ -1,0 +1,30 @@
+package logstore
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReader(t *testing.T) {
+	l := NewLogStore()
+	r := NewReader(&sync.RWMutex{}, l)
+
+	c1 := r.Checkpoint()
+	assert.Equal(t, "", r.ContinuingString(c1))
+
+	l.Append(newGlobalTestLogEvent("foo"), nil)
+	c2 := r.Checkpoint()
+	assert.Equal(t, "foo", r.ContinuingString(c1))
+
+	l.Append(newGlobalTestLogEvent("bar\n"), nil)
+	_ = c2
+	assert.Equal(t, "foobar\n", r.String())
+	assert.Equal(t, "foobar\n", r.ContinuingString(c1))
+	assert.Equal(t, "bar\n", r.ContinuingString(c2))
+
+	l.Append(newGlobalTestLogEvent("abc\n"), nil)
+	assert.Equal(t, "abc\n", l.Tail(1))
+	assert.Equal(t, "abc\n", r.Tail(1))
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/logstoremutex:

7842dd295c5430cbf9200d51c9e60241de3b4628 (2019-12-04 13:02:54 -0500)
logstore: add a thread-safe log reader