### PR TITLE
store: Replace the old global log store with a new global log store

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1042,7 +1042,7 @@ func TestLogsLongResourceName(t *testing.T) {
 	// and tries to limit how much it checks the formatting
 	f.withState(func(state store.EngineState) {
 		expectedLine := fmt.Sprintf("Building:%s", mn)
-		assert.Contains(t, state.Log.String(), expectedLine)
+		assert.Contains(t, state.LogStore.String(), expectedLine)
 	})
 
 	err := f.Stop()

--- a/internal/engine/configs/actions.go
+++ b/internal/engine/configs/actions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 )
 
 type ConfigsReloadStartedAction struct {
@@ -31,9 +32,9 @@ type ConfigsReloadedAction struct {
 	AnalyticsTiltfileOpt analytics.Opt
 	VersionSettings      model.VersionSettings
 
-	// The length of the global log when Tiltfile execution started.
+	// A checkpoint into the logstore when Tiltfile execution started.
 	// Useful for knowing how far back in time we have to scrub secrets.
-	GlobalLogLineCountAtExecStart int
+	CheckpointAtExecStart logstore.Checkpoint
 }
 
 func (ConfigsReloadedAction) Action() {}

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -82,7 +82,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 	ctx = logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), actionWriter))
 
 	state := st.RLockState()
-	globalLogLineCountAtExecStart := state.Log.LineCount()
+	checkpointAtExecStart := state.LogStore.Checkpoint()
 	firstBuild := !state.TiltfileState.StartedFirstBuild()
 	if !firstBuild {
 		logTiltfileChanges(ctx, filesChanged)
@@ -110,19 +110,19 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 	}
 
 	st.Dispatch(ConfigsReloadedAction{
-		Manifests:                     tlr.Manifests,
-		ConfigFiles:                   tlr.ConfigFiles,
-		TiltIgnoreContents:            tlr.TiltIgnoreContents,
-		FinishTime:                    cc.clock(),
-		Err:                           tlr.Error,
-		Warnings:                      tlr.Warnings,
-		Features:                      tlr.FeatureFlags,
-		TeamName:                      tlr.TeamName,
-		Secrets:                       tlr.Secrets,
-		AnalyticsTiltfileOpt:          tlr.AnalyticsOpt,
-		DockerPruneSettings:           tlr.DockerPruneSettings,
-		GlobalLogLineCountAtExecStart: globalLogLineCountAtExecStart,
-		VersionSettings:               tlr.VersionSettings,
+		Manifests:             tlr.Manifests,
+		ConfigFiles:           tlr.ConfigFiles,
+		TiltIgnoreContents:    tlr.TiltIgnoreContents,
+		FinishTime:            cc.clock(),
+		Err:                   tlr.Error,
+		Warnings:              tlr.Warnings,
+		Features:              tlr.FeatureFlags,
+		TeamName:              tlr.TeamName,
+		Secrets:               tlr.Secrets,
+		AnalyticsTiltfileOpt:  tlr.AnalyticsOpt,
+		DockerPruneSettings:   tlr.DockerPruneSettings,
+		CheckpointAtExecStart: checkpointAtExecStart,
+		VersionSettings:       tlr.VersionSettings,
 	})
 }
 

--- a/internal/hud/fake_hud.go
+++ b/internal/hud/fake_hud.go
@@ -41,7 +41,7 @@ func (h *FakeHud) Run(ctx context.Context, dispatch func(action store.Action), r
 
 func (h *FakeHud) OnChange(ctx context.Context, st store.RStore) {
 	state := st.RLockState()
-	view := store.StateToView(state)
+	view := store.StateToView(state, st.StateMutex())
 	st.RUnlockState()
 
 	err := h.update(view, h.viewState)

--- a/internal/hud/tabview.go
+++ b/internal/hud/tabview.go
@@ -8,6 +8,7 @@ import (
 	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/rty"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 )
 
 type TabView struct {
@@ -37,9 +38,12 @@ func (v *TabView) Build() rty.Component {
 
 func (v *TabView) log() string {
 	var ret model.Log
+	var reader logstore.Reader
+	var readerEmpty = true
 	switch v.tabState {
 	case view.TabAllLog:
-		ret = v.view.Log
+		reader = v.view.LogReader
+		readerEmpty = reader.Empty()
 	case view.TabBuildLog:
 		_, resource := selectedResource(v.view, v.viewState)
 		if !resource.CurrentBuild.Empty() {
@@ -56,6 +60,8 @@ func (v *TabView) log() string {
 
 	if !ret.Empty() {
 		return ret.Tail(logLineCount).String()
+	} else if !readerEmpty {
+		return reader.String()
 	} else {
 		return "(no logs received)"
 	}

--- a/internal/hud/text.go
+++ b/internal/hud/text.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/gdamore/tcell"
 
+	"github.com/windmilleng/tilt/internal/hud/view"
 	"github.com/windmilleng/tilt/internal/rty"
 )
 
 // The most lines we can reasonably put in the log pane. If the log pane sticks
 // around in the long term, we might want to compute this dynamically based on
 // the window size.
-const logLineCount = 50
+const logLineCount = view.LogLineCount
 
 func deployTimeText(t time.Time) rty.Component {
 	sb := rty.NewStringBuilder()

--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -6,7 +6,10 @@ import (
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 )
+
+const LogLineCount = 50
 
 const TiltfileResourceName = "(Tiltfile)"
 
@@ -183,7 +186,7 @@ func (r Resource) IsCollapsed(rv ResourceViewState) bool {
 // Client should always hold this as a value struct, and copy it
 // whenever they need to mutate something.
 type View struct {
-	Log         model.Log
+	LogReader   logstore.Reader
 	Resources   []Resource
 	IsProfiling bool
 	FatalError  error
@@ -212,14 +215,14 @@ func (v View) Resource(n model.ManifestName) (Resource, bool) {
 }
 
 type ViewState struct {
-	ShowNarration         bool
-	NarrationMessage      string
-	Resources             []ResourceViewState
-	ProcessedLogByteCount int
-	AlertMessage          string
-	TabState              TabState
-	SelectedIndex         int
-	TiltLogState          TiltLogState
+	ShowNarration    bool
+	NarrationMessage string
+	Resources        []ResourceViewState
+	ProcessedLogs    logstore.Checkpoint
+	AlertMessage     string
+	TabState         TabState
+	SelectedIndex    int
+	TiltLogState     TiltLogState
 }
 
 type TabState int

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -130,7 +130,7 @@ func StateToProtoView(s store.EngineState) (*proto_webview.View, error) {
 		ret.Resources = append(ret.Resources, r)
 	}
 
-	ret.Log = s.Log.String()
+	ret.Log = s.LogStore.String()
 	ret.NeedsAnalyticsNudge = NeedsNudge(s)
 	ret.RunningTiltBuild = &proto_webview.TiltBuild{
 		Version:   s.TiltBuildInfo.Version,

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/windmilleng/wmclient/pkg/analytics"
@@ -18,6 +19,7 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/token"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 )
 
 type EngineState struct {
@@ -51,8 +53,8 @@ type EngineState struct {
 	// We recovered from a panic(). We need to clean up the RTY and print the error.
 	PanicExited error
 
-	// The full log stream for tilt. This might deserve gc or file storage at some point.
-	Log model.Log `testdiff:"ignore"`
+	// All logs in Tilt, stored in a structured format.
+	LogStore *logstore.LogStore `testdiff:"ignore"`
 
 	TiltfilePath             string
 	ConfigFiles              []string
@@ -315,7 +317,7 @@ type ManifestState struct {
 
 func NewState() *EngineState {
 	ret := &EngineState{}
-	ret.Log = model.Log{}
+	ret.LogStore = logstore.NewLogStore()
 	ret.ManifestTargets = make(map[model.ManifestName]*ManifestTarget)
 	ret.PendingConfigFileChanges = make(map[string]time.Time)
 	ret.Secrets = model.SecretSet{}
@@ -559,7 +561,7 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []string) {
 	return endpoints
 }
 
-func StateToView(s EngineState) view.View {
+func StateToView(s EngineState, mu *sync.RWMutex) view.View {
 	ret := view.View{
 		IsProfiling: s.IsProfiling,
 	}
@@ -635,7 +637,7 @@ func StateToView(s EngineState) view.View {
 		ret.Resources = append(ret.Resources, r)
 	}
 
-	ret.Log = s.Log
+	ret.LogReader = logstore.NewReader(mu, s.LogStore)
 	ret.FatalError = s.FatalError
 
 	return ret

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ func TestStateToViewMultipleSyncs(t *testing.T) {
 	}
 	ms.MutableBuildStatus(m.ImageTargets[0].ID()).PendingFileChanges =
 		map[string]time.Time{"/a/b/d": time.Now(), "/a/b/c/d/e": time.Now()}
-	v := StateToView(*state)
+	v := StateToView(*state, &sync.RWMutex{})
 
 	if !assert.Equal(t, 2, len(v.Resources)) {
 		return
@@ -59,7 +60,7 @@ func TestStateToViewPortForwards(t *testing.T) {
 		},
 	})
 	state := newState([]model.Manifest{m})
-	v := StateToView(*state)
+	v := StateToView(*state, &sync.RWMutex{})
 	res, _ := v.Resource(m.Name)
 	assert.Equal(t,
 		[]string{"http://localhost:7000/", "http://localhost:8000/"},
@@ -70,7 +71,7 @@ func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {
 	m, err := k8s.NewK8sOnlyManifestFromYAML(testyaml.SanchoYAML)
 	assert.NoError(t, err)
 	state := newState([]model.Manifest{m})
-	v := StateToView(*state)
+	v := StateToView(*state, &sync.RWMutex{})
 
 	assert.Equal(t, 2, len(v.Resources))
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,6 +20,7 @@ type RStore interface {
 	Dispatch(action Action)
 	RLockState() EngineState
 	RUnlockState()
+	StateMutex() *sync.RWMutex
 }
 
 // A central state store, modeled after the Reactive programming UX pattern.
@@ -73,6 +74,10 @@ func NewStoreForTesting() (st *Store, getActions func() []Action) {
 		return append([]Action{}, actions...)
 	}
 	return NewStore(reducer, false), getActions
+}
+
+func (s *Store) StateMutex() *sync.RWMutex {
+	return &s.stateMu
 }
 
 func (s *Store) AddSubscriber(ctx context.Context, sub Subscriber) {

--- a/internal/store/testing_store.go
+++ b/internal/store/testing_store.go
@@ -27,6 +27,10 @@ func (s *TestingStore) SetState(state EngineState) {
 	s.state = &state
 }
 
+func (s *TestingStore) StateMutex() *sync.RWMutex {
+	return &s.stateMu
+}
+
 func (s *TestingStore) RLockState() EngineState {
 	s.stateMu.RLock()
 	return *(s.state)

--- a/pkg/model/logstore/reader.go
+++ b/pkg/model/logstore/reader.go
@@ -18,6 +18,12 @@ func (r Reader) Checkpoint() Checkpoint {
 	return r.store.Checkpoint()
 }
 
+func (r Reader) Empty() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.store.Empty()
+}
+
 func (r Reader) String() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/logstore2:

835eec16ff871cbbc12bf74f95d93ab886233e85 (2019-12-04 15:09:13 -0500)
store: Replace the old global log store with a new global log store