### PR TITLE
websocket: simple throttle to fix cpu issues [ch3997]

### DIFF
--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -102,13 +102,16 @@ func (ws WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore) {
 	}
 
 	// A simple throttle -- don't call ws.OnChange too many times in quick succession,
-	// it eats up a lot of CPU/allocates a lot of memory.
-	// This is safe b/c the only thing ws.OnChange blocks is subsequent ws.OnChange calls.
+	//     it eats up a lot of CPU/allocates a lot of memory.
+	// This is safe b/c (as long as we're not holding a lock on the state, which
+	//     at this point in the code, we're not) the only thing ws.OnChange blocks
+	//     is subsequent ws.OnChange calls.
 	//
 	// In future, we can solve this problem more elegantly:
 	// - if multiple OnChange's come in within 100 ms, only call one (right now, if 10 OnChanges come in
 	//     in quick succession, we'll make 10 OnChange calls, each 100ms apart, and most will be no-ops)
-	// - replace our JSON marshaling with jsoniter (would involve writing our own proto marshaling code)
+	// - replace our JSON marshaling with jsoniter (would require either working around the lack
+	//     of an `EmitDefaults` option in jsoniter, or writing our own proto marshaling code)
 	time.Sleep(time.Millisecond * 100)
 }
 

--- a/internal/hud/server/websocket_test.go
+++ b/internal/hud/server/websocket_test.go
@@ -129,7 +129,7 @@ func (c *fakeConn) WriteJSON(v interface{}) error {
 
 func (c *fakeConn) AssertNextWriteMsg(t *testing.T) msg {
 	select {
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(150 * time.Millisecond):
 		t.Fatal("timed out waiting for WriteJSON")
 	case msg := <-c.writeCh:
 		return msg


### PR DESCRIPTION
Hello @jazzdan, @nicks,

I can spend an hourish on a more elegant/less kludgey solution but this
might be the fastest and simplest way to fix the CPU issues here.

We diagnosed the CPU issues in #2597 as coming from a high volume of
websocket sends (due to the high volume of log messages in the chart
in question). in particular, the problem was the `json.Marshal` to send
proto messages over the websocket; both that `json.Marshal` isn't cheap
in terms of CPU, but that it allocates a lot of memory (that we then
immediately throw away--so garbage collection was taking up a non-trivial
amount of CPU as well).

Alternatives considered:
1. replace `json.Marshal` (or `jsonpb.Encode`) with [`jsoniter`](https://github.com/json-iterator/go),
which is much more performant in terms of CPU and memory alloc. This was
too hard -- we'd either have to come up with a solution for `EmitDefaults` (a setting
which `jsonpb` has but `jsoniter`... doesn't?) or dig into the proto translation
code and replace the `json.Marshal` at a lower level
2. actually elegant throttling; if multiple `OnChange` calls come in over a short period
of time, execute the first, and then <TIMEOUT> later, execute the last. This would
involve concurrency acrobatics, and is doable but the solution in this PR seemed
faster and more straightforward.