### PR TITLE
web: Use the structured logstore in the web client

### DIFF
--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -102,7 +102,8 @@ func TestStateToViewTiltfileLog(t *testing.T) {
 	v := stateToProtoView(t, *es)
 	r, ok := findResource("(Tiltfile)", v)
 	require.True(t, ok, "no resource named (Tiltfile) found")
-	assert.Equal(t, "hello", r.CombinedLog)
+	assert.Equal(t, "hello", string(v.LogList.Segments[0].Text))
+	assert.Equal(t, r.Name, string(v.LogList.Spans[r.Name].ManifestName))
 }
 
 func TestRelativeTiltfilePath(t *testing.T) {

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -5,8 +5,8 @@ import {
   WebView,
   Snapshot,
   Resource,
-  HudState,
 } from "./types"
+import HudState from "./HudState"
 import PathBuilder from "./PathBuilder"
 
 interface HudInt {

--- a/web/src/HudState.tsx
+++ b/web/src/HudState.tsx
@@ -1,0 +1,19 @@
+import {
+  WebView,
+  ShowFatalErrorModal,
+  SnapshotHighlight,
+  SocketState,
+} from "./types"
+import LogStore from "./LogStore"
+
+type HudState = {
+  view: WebView
+  isSidebarClosed: boolean
+  snapshotLink: string
+  showSnapshotModal: boolean
+  showFatalErrorModal: ShowFatalErrorModal
+  snapshotHighlight: SnapshotHighlight | undefined
+  socketState: SocketState
+  logStore?: LogStore
+}
+export default HudState

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -129,13 +129,3 @@ export type Snapshot = {
   path?: string
   snapshotHighlight?: SnapshotHighlight | null
 }
-
-export type HudState = {
-  view: WebView
-  isSidebarClosed: boolean
-  snapshotLink: string
-  showSnapshotModal: boolean
-  showFatalErrorModal: ShowFatalErrorModal
-  snapshotHighlight: SnapshotHighlight | undefined
-  socketState: SocketState
-}


### PR DESCRIPTION
Hello @jazzdan, @hyu,

Please review the following commits I made in branch nicks/clientlogs2:

769b39842e66aca083a0da852b2e9ab7160d6a8d (2019-12-06 18:02:29 -0500)
web: Use the structured logstore in the web client

e43b4eacebeb87d29ba0ac56eb4c83b3506e16be (2019-12-06 16:32:59 -0500)
web: add a client-side logstore
currently, this is a straight port of the server-side logstore

over time, we expect this logstore to have much richer methods
for filtering logs by manifest, log level, etc