### PR TITLE
logger: fix a bug when printing placeholders to certain types of loggers

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -70,7 +70,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 
 		if redirectErr, ok := err.(RedirectToNextBuilder); ok {
 			s := fmt.Sprintf("falling back to next update method because: %v\n", err)
-			logger.Get(ctx).Write(redirectErr.level, s)
+			logger.Get(ctx).Write(redirectErr.level, []byte(s))
 		} else {
 			lastUnexpectedErr = err
 			if i+1 < len(composite.builders) {

--- a/internal/synclet/client_adapter.go
+++ b/internal/synclet/client_adapter.go
@@ -91,7 +91,7 @@ func (s *SyncletCli) UpdateContainer(
 
 		level := protoLogLevelToLevel(reply.LogMessage.Level)
 
-		logger.Get(ctx).Write(level, string(reply.LogMessage.Message))
+		logger.Get(ctx).Write(level, reply.LogMessage.Message)
 	}
 }
 

--- a/pkg/logger/deferred.go
+++ b/pkg/logger/deferred.go
@@ -21,7 +21,7 @@ func NewDeferredLogger(ctx context.Context) *DeferredLogger {
 		dLogger.mu.Lock()
 		defer dLogger.mu.Unlock()
 		if dLogger.output != nil {
-			dLogger.output.Write(level, string(b))
+			dLogger.output.Write(level, b)
 			return nil
 		}
 		dLogger.entries = append(dLogger.entries, logEntry{level: level, b: append([]byte{}, b...)})
@@ -37,7 +37,7 @@ func (dl *DeferredLogger) SetOutput(l Logger) {
 	defer dl.mu.Unlock()
 	dl.output = l
 	for _, entry := range dl.entries {
-		dl.output.Write(entry.level, string(entry.b))
+		dl.output.Write(entry.level, entry.b)
 	}
 	dl.entries = nil
 }

--- a/pkg/logger/func_logger.go
+++ b/pkg/logger/func_logger.go
@@ -23,18 +23,22 @@ func (l funcLogger) Level() Level {
 }
 
 func (l funcLogger) Infof(format string, a ...interface{}) {
-	l.Write(InfoLvl, fmt.Sprintf(format+"\n", a...))
+	l.WriteString(InfoLvl, fmt.Sprintf(format+"\n", a...))
 }
 
 func (l funcLogger) Verbosef(format string, a ...interface{}) {
-	l.Write(VerboseLvl, fmt.Sprintf(format+"\n", a...))
+	l.WriteString(VerboseLvl, fmt.Sprintf(format+"\n", a...))
 }
 
 func (l funcLogger) Debugf(format string, a ...interface{}) {
-	l.Write(DebugLvl, fmt.Sprintf(format+"\n", a...))
+	l.WriteString(DebugLvl, fmt.Sprintf(format+"\n", a...))
 }
 
-func (l funcLogger) Write(level Level, s string) {
+func (l funcLogger) Write(level Level, bytes []byte) {
+	_ = l.write(level, bytes)
+}
+
+func (l funcLogger) WriteString(level Level, s string) {
 	_ = l.write(level, []byte(s))
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 
@@ -30,7 +29,7 @@ type Logger interface {
 	// log information that is likely to only be of interest to tilt developers
 	Debugf(format string, a ...interface{})
 
-	Write(level Level, s string)
+	Write(level Level, bytes []byte)
 
 	// gets an io.Writer that filters to the specified level for, e.g., passing to a subprocess
 	Writer(level Level) io.Writer
@@ -39,8 +38,6 @@ type Logger interface {
 
 	SupportsColor() bool
 }
-
-var _ Logger = logger{}
 
 type Level int
 
@@ -64,7 +61,7 @@ func Get(ctx context.Context) Logger {
 	panic("Called logger.Get(ctx) on a context with no logger attached!")
 }
 
-func NewLogger(level Level, writer io.Writer) Logger {
+func NewLogger(minLevel Level, writer io.Writer) Logger {
 	// adapted from fatih/color
 	supportsColor := true
 	if os.Getenv("TERM") == "dumb" {
@@ -76,76 +73,17 @@ func NewLogger(level Level, writer io.Writer) Logger {
 			supportsColor = isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
 		}
 	}
-	return logger{level, writer, supportsColor}
+	return NewFuncLogger(supportsColor, minLevel, func(level Level, bytes []byte) error {
+		if minLevel >= level {
+			_, err := writer.Write(bytes)
+			return err
+		}
+		return nil
+	})
 }
 
 func WithLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerContextKey, logger)
-}
-
-type logger struct {
-	level         Level
-	writer        io.Writer
-	supportsColor bool
-}
-
-func (l logger) Level() Level {
-	return l.level
-}
-
-func (l logger) Infof(format string, a ...interface{}) {
-	l.writef(InfoLvl, format+"\n", a...)
-}
-
-func (l logger) Verbosef(format string, a ...interface{}) {
-	l.writef(VerboseLvl, format+"\n", a...)
-}
-
-func (l logger) Debugf(format string, a ...interface{}) {
-	l.writef(DebugLvl, format+"\n", a...)
-}
-
-func (l logger) writef(level Level, format string, a ...interface{}) {
-	if l.level >= level {
-		// swallowing errors because:
-		// 1) if we can't write to the log, what else are we going to do?
-		// 2) a logger interface that returns error becomes really distracting at call sites,
-		//    increasing friction and reducing logging
-		_, _ = fmt.Fprintf(l.writer, format, a...)
-	}
-}
-
-func (l logger) Write(level Level, s string) {
-	if l.level >= level {
-		// swallowing errors because:
-		// 1) if we can't write to the log, what else are we going to do?
-		// 2) a logger interface that returns error becomes really distracting at call sites,
-		//    increasing friction and reducing logging
-		_, _ = fmt.Fprintf(l.writer, s)
-	}
-}
-
-type levelWriter struct {
-	logger logger
-	level  Level
-}
-
-var _ io.Writer = levelWriter{}
-
-func (lw levelWriter) Write(p []byte) (n int, err error) {
-	if lw.logger.level >= lw.level {
-		return lw.logger.writer.Write(p)
-	} else {
-		return len(p), nil
-	}
-}
-
-func (l logger) Writer(level Level) io.Writer {
-	return levelWriter{l, level}
-}
-
-func (l logger) SupportsColor() bool {
-	return l.supportsColor
 }
 
 func getColor(l Logger, c color.Attribute) *color.Color {
@@ -167,7 +105,7 @@ func CtxWithForkedOutput(ctx context.Context, writer io.Writer) context.Context 
 	l := Get(ctx)
 
 	write := func(level Level, b []byte) error {
-		l.Write(level, string(b))
+		l.Write(level, b)
 		if l.Level() >= level {
 			b = append([]byte{}, b...)
 			_, err := writer.Write(b)
@@ -178,11 +116,6 @@ func CtxWithForkedOutput(ctx context.Context, writer io.Writer) context.Context 
 		return nil
 	}
 
-	forkedLogger := funcLogger{
-		supportsColor: l.SupportsColor(),
-		level:         l.Level(),
-		write:         write,
-	}
-
+	forkedLogger := NewFuncLogger(l.SupportsColor(), l.Level(), write)
 	return WithLogger(ctx, forkedLogger)
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -37,3 +37,10 @@ func TestWriteAcrossNestedLoggers(t *testing.T) {
 	assert.Equal(t, "|>ab\n|>cd\n|>e\n", out1.String())
 	assert.Equal(t, ">ab\n>cd\n>e\n", out2.String())
 }
+
+func TestWriteWithFormatPlaceholder(t *testing.T) {
+	out := bytes.NewBuffer(nil)
+	l := NewLogger(InfoLvl, out)
+	l.Write(InfoLvl, []byte("%s"))
+	assert.Equal(t, "%s", out.String())
+}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/logger2:

2594ea06331a1d477fa29018c9a92a577c4ce051 (2019-12-09 20:06:20 -0500)
logger: fix a bug when printing placeholders to certain types of loggers
Noticed that if you wrote l.Write(logger.InfoLvl, "%s"), it would
print "%s(MISSING)" to the output stream.

While I was here, I ended up deleting a bunch of redundant code.