### PR TITLE
web: fix selection behavior by using margin instead of padding

### DIFF
--- a/web/src/LogPane.scss
+++ b/web/src/LogPane.scss
@@ -1,7 +1,7 @@
 @import "constants.scss";
 
 .LogPane {
-  padding: $spacing-unit / 2 0;
+  margin: $spacing-unit / 2 0;
   width: 100%;
 }
 
@@ -20,7 +20,7 @@
 .logEnd {
   animation: blink 1s infinite;
   animation-timing-function: ease;
-  padding-left: $spacing-unit / 2;
+  margin-left: $spacing-unit / 2;
 }
 
 .LogPane-empty {
@@ -28,8 +28,8 @@
 }
 
 .LogPane .logLine {
-  padding-left: $spacing-unit / 2;
-  padding-right: $spacing-unit / 2;
+  margin-left: $spacing-unit / 2;
+  margin-right: $spacing-unit / 2;
 }
 
 .LogPane code {


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/ch4102/webui:

4aebdf9f2c5ac94e1362ced1e349357a90c9a7ec (2019-12-10 15:42:21 -0500)
web: fix selection behavior by using margin instead of padding
Fixes https://github.com/windmilleng/tilt/issues/2645