### PR TITLE
logstore: assign span ids to all span types

### DIFF
--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -20,6 +20,7 @@ type ConfigsController struct {
 	tfl                tiltfile.TiltfileLoader
 	dockerClient       docker.Client
 	clock              func() time.Time
+	loadCount          int
 }
 
 func NewConfigsController(tfl tiltfile.TiltfileLoader, dockerClient docker.Client) *ConfigsController {
@@ -73,12 +74,12 @@ func logTiltfileChanges(ctx context.Context, filesChanged map[string]bool) {
 }
 
 func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
-	args []string, filesChanged map[string]bool, tiltfilePath string) {
+	args []string, filesChanged map[string]bool, tiltfilePath string, loadCount int) {
 
 	startTime := cc.clock()
 	st.Dispatch(ConfigsReloadStartedAction{FilesChanged: filesChanged, StartTime: startTime})
 
-	actionWriter := NewTiltfileLogWriter(st)
+	actionWriter := NewTiltfileLogWriter(st, loadCount)
 	ctx = logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), actionWriter))
 
 	state := st.RLockState()
@@ -151,7 +152,10 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
 	}
 
 	// Release the state lock and load the tiltfile in a separate goroutine
-	go cc.loadTiltfile(ctx, st, args, filesChanged, tiltfilePath)
+	cc.loadCount++
+
+	loadCount := cc.loadCount
+	go cc.loadTiltfile(ctx, st, args, filesChanged, tiltfilePath, loadCount)
 }
 
 func requiresDocker(tlr tiltfile.TiltfileLoadResult) bool {

--- a/internal/engine/configs/tiltfile_log_writer.go
+++ b/internal/engine/configs/tiltfile_log_writer.go
@@ -1,21 +1,29 @@
 package configs
 
 import (
+	"fmt"
+
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 )
 
 type tiltfileLogWriter struct {
-	store store.RStore
+	store     store.RStore
+	loadCount int
 }
 
-func NewTiltfileLogWriter(s store.RStore) *tiltfileLogWriter {
-	return &tiltfileLogWriter{s}
+func NewTiltfileLogWriter(s store.RStore, loadCount int) *tiltfileLogWriter {
+	return &tiltfileLogWriter{s, loadCount}
 }
 
 func (w *tiltfileLogWriter) Write(p []byte) (n int, err error) {
 	w.store.Dispatch(TiltfileLogAction{
-		LogEvent: store.NewLogEvent(model.TiltfileManifestName, p),
+		LogEvent: store.NewLogEvent(model.TiltfileManifestName, SpanIDForLoadCount(w.loadCount), p),
 	})
 	return len(p), nil
+}
+
+func SpanIDForLoadCount(loadCount int) logstore.SpanID {
+	return logstore.SpanID(fmt.Sprintf("tilfile:%d", loadCount))
 }

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -245,7 +245,7 @@ func checkForContainerCrash(ctx context.Context, state *store.EngineState, mt *s
 	ms.NeedsRebuildFromCrash = true
 	ms.LiveUpdatedContainerIDs = container.NewIDSet()
 	msg := fmt.Sprintf("Detected a container change for %s. We could be running stale code. Rebuilding and deploying a new image.", ms.Name)
-	le := store.NewLogEvent(ms.Name, []byte(msg+"\n"))
+	le := store.NewLogEvent(ms.Name, "build:0", []byte(msg+"\n"))
 	if len(ms.BuildHistory) > 0 {
 		ms.BuildHistory[0].Log = model.AppendLog(ms.BuildHistory[0].Log, le, "", state.Secrets)
 	}

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 )
 
 // Collects logs from deployed containers.
@@ -217,9 +218,13 @@ type PodLogActionWriter struct {
 func (w PodLogActionWriter) Write(p []byte) (n int, err error) {
 	w.Store.Dispatch(PodLogAction{
 		PodID:    w.PodID,
-		LogEvent: store.NewLogEvent(w.ManifestName, p),
+		LogEvent: store.NewLogEvent(w.ManifestName, SpanIDForPod(w.PodID), p),
 	})
 	return len(p), nil
+}
+
+func SpanIDForPod(podID k8s.PodID) logstore.SpanID {
+	return logstore.SpanID(fmt.Sprintf("pod:%s", podID))
 }
 
 var _ store.Subscriber = &PodLogManager{}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -260,6 +260,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		engineState.CurrentlyBuilding = ""
 	}()
 
+	buildCount := engineState.BuildControllerActionCount
 	engineState.CompletedBuildCount++
 	engineState.BuildControllerActionCount++
 
@@ -273,7 +274,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		p := logger.Red(logger.Get(ctx)).Sprintf("Build Failed:")
 		s := fmt.Sprintf("%s %v", p, err)
 		a := BuildLogAction{
-			LogEvent: store.NewLogEvent(mt.Manifest.Name, []byte(s)),
+			LogEvent: store.NewLogEvent(mt.Manifest.Name, SpanIDForBuildLog(buildCount), []byte(s)),
 		}
 		handleLogAction(engineState, a)
 		handleBuildLogAction(engineState, a)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1264,8 +1264,8 @@ func TestPodEventOrdering(t *testing.T) {
 			}
 
 			f.upper.store.Dispatch(runtimelog.PodLogAction{
-				PodID:    k8s.PodID(podBNow.PodID()),
-				LogEvent: store.NewLogEvent("fe", []byte("pod b log\n")),
+				PodID:    podBNow.PodID(),
+				LogEvent: store.NewLogEvent("fe", runtimelog.SpanIDForPod(podBNow.PodID()), []byte("pod b log\n")),
 			})
 
 			f.WaitUntilManifestState("pod log seen", "fe", func(ms store.ManifestState) bool {
@@ -2815,7 +2815,7 @@ func TestBuildLogAction(t *testing.T) {
 	})
 
 	f.store.Dispatch(BuildLogAction{
-		LogEvent: store.NewLogEvent(manifest.Name, []byte(`a
+		LogEvent: store.NewLogEvent(manifest.Name, SpanIDForBuildLog(1), []byte(`a
 bc
 def
 ghij`)),
@@ -3556,9 +3556,10 @@ func (f *testFixture) startPod(pod *v1.Pod, manifestName model.ManifestName) {
 }
 
 func (f *testFixture) podLog(pod *v1.Pod, manifestName model.ManifestName, s string) {
+	podID := k8s.PodID(pod.Name)
 	f.upper.store.Dispatch(runtimelog.PodLogAction{
-		PodID:    k8s.PodID(pod.Name),
-		LogEvent: store.NewLogEvent(manifestName, []byte(s+"\n")),
+		PodID:    podID,
+		LogEvent: store.NewLogEvent(manifestName, runtimelog.SpanIDForPod(podID), []byte(s+"\n")),
 	})
 
 	f.WaitUntilManifestState("pod log seen", manifestName, func(ms store.ManifestState) bool {

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/store"
@@ -88,14 +89,15 @@ func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {
 
 func TestStateToViewTiltfileLog(t *testing.T) {
 	es := newState([]model.Manifest{})
+	spanID := configs.SpanIDForLoadCount(1)
 	es.LogStore.Append(
-		store.NewLogEvent(store.TiltfileManifestName, []byte("hello")),
+		store.NewLogEvent(store.TiltfileManifestName, spanID, []byte("hello")),
 		nil)
 	v := stateToProtoView(t, *es)
 	r, ok := findResource("(Tiltfile)", v)
 	require.True(t, ok, "no resource named (Tiltfile) found")
 	assert.Equal(t, "hello", string(v.LogList.Segments[0].Text))
-	assert.Equal(t, r.Name, string(v.LogList.Spans[r.Name].ManifestName))
+	assert.Equal(t, r.Name, string(v.LogList.Spans[string(spanID)].ManifestName))
 }
 
 func TestRelativeTiltfilePath(t *testing.T) {

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -29,6 +29,7 @@ type LogAction interface {
 
 type LogEvent struct {
 	mn        model.ManifestName
+	spanID    logstore.SpanID
 	timestamp time.Time
 	msg       []byte
 }
@@ -48,12 +49,13 @@ func (le LogEvent) Message() []byte {
 }
 
 func (le LogEvent) SpanID() logstore.SpanID {
-	return ""
+	return le.spanID
 }
 
-func NewLogEvent(mn model.ManifestName, b []byte) LogEvent {
+func NewLogEvent(mn model.ManifestName, spanID logstore.SpanID, b []byte) LogEvent {
 	return LogEvent{
 		mn:        mn,
+		spanID:    spanID,
 		timestamp: time.Now(),
 		msg:       append([]byte{}, b...),
 	}
@@ -62,6 +64,7 @@ func NewLogEvent(mn model.ManifestName, b []byte) LogEvent {
 func NewGlobalLogEvent(b []byte) LogEvent {
 	return LogEvent{
 		mn:        "",
+		spanID:    "",
 		timestamp: time.Now(),
 		msg:       append([]byte{}, b...),
 	}
@@ -84,6 +87,7 @@ func (kEvt K8sEventAction) ToLogAction(mn model.ManifestName) LogAction {
 
 	return LogEvent{
 		mn:        mn,
+		spanID:    logstore.SpanID(fmt.Sprintf("events:%s", mn)),
 		timestamp: kEvt.Event.LastTimestamp.Time,
 		msg:       []byte(msg),
 	}

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -174,9 +174,9 @@ func (b PodBuilder) WithDeletionTime(deletionTime time.Time) PodBuilder {
 	return b
 }
 
-func (b PodBuilder) PodID() string {
+func (b PodBuilder) PodID() k8s.PodID {
 	if b.podID != "" {
-		return b.podID
+		return k8s.PodID(b.podID)
 	}
 	return "fakePodID"
 }
@@ -385,7 +385,7 @@ func (b PodBuilder) Build() *v1.Pod {
 
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              b.PodID(),
+			Name:              string(b.PodID()),
 			CreationTimestamp: b.buildCreationTime(),
 			DeletionTimestamp: b.buildDeletionTime(),
 			Labels:            labels,


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/newspanid:

91349bf51c2bbb595879144236a553fff016c9fb (2019-12-10 17:25:34 -0500)
logstore: assign span ids to all span types