### PR TITLE
user config: also read from tilt_config.json

### DIFF
--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -58,7 +58,7 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	tlr := deps.tfl.Load(ctx, c.fileName, nil)
+	tlr := deps.tfl.Load(ctx, c.fileName, model.NewUserConfigState(args))
 	if tlr.Error != nil {
 		return tlr.Error
 	}

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -11,6 +11,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 	"github.com/windmilleng/tilt/pkg/logger"
+	"github.com/windmilleng/tilt/pkg/model"
 )
 
 type downCmd struct {
@@ -38,11 +39,11 @@ func (c *downCmd) run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	return c.down(ctx, downDeps)
+	return c.down(ctx, downDeps, args)
 }
 
-func (c *downCmd) down(ctx context.Context, downDeps DownDeps) error {
-	tlr := downDeps.tfl.Load(ctx, c.fileName, nil)
+func (c *downCmd) down(ctx context.Context, downDeps DownDeps, args []string) error {
+	tlr := downDeps.tfl.Load(ctx, c.fileName, model.NewUserConfigState(args))
 	err := tlr.Error
 	if err != nil {
 		return err

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -21,7 +21,7 @@ func TestDown(t *testing.T) {
 	defer f.TearDown()
 
 	f.tfl.Result = tiltfile.TiltfileLoadResult{Manifests: newK8sManifest()}
-	err := f.cmd.down(f.ctx, f.deps)
+	err := f.cmd.down(f.ctx, f.deps, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, f.kCli.DeletedYaml, "sancho")
 }
@@ -32,7 +32,7 @@ func TestDownK8sFails(t *testing.T) {
 
 	f.tfl.Result = tiltfile.TiltfileLoadResult{Manifests: newK8sManifest()}
 	f.kCli.DeleteError = fmt.Errorf("GARBLEGARBLE")
-	err := f.cmd.down(f.ctx, f.deps)
+	err := f.cmd.down(f.ctx, f.deps, nil)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "GARBLEGARBLE")
 	}
@@ -44,7 +44,7 @@ func TestDownDCFails(t *testing.T) {
 
 	f.tfl.Result = tiltfile.TiltfileLoadResult{Manifests: newDCManifest()}
 	f.dcc.DownError = fmt.Errorf("GARBLEGARBLE")
-	err := f.cmd.down(f.ctx, f.deps)
+	err := f.cmd.down(f.ctx, f.deps, nil)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "GARBLEGARBLE")
 	}

--- a/internal/engine/configs/actions.go
+++ b/internal/engine/configs/actions.go
@@ -31,6 +31,7 @@ type ConfigsReloadedAction struct {
 	DockerPruneSettings  model.DockerPruneSettings
 	AnalyticsTiltfileOpt analytics.Opt
 	VersionSettings      model.VersionSettings
+	UserConfigState      model.UserConfigState
 
 	// A checkpoint into the logstore when Tiltfile execution started.
 	// Useful for knowing how far back in time we have to scrub secrets.

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -485,6 +485,8 @@ func handleConfigsReloaded(
 		}
 	}
 
+	state.UserConfigState = event.UserConfigState
+
 	// Add all secrets, even if we failed.
 	state.Secrets.AddAll(event.Secrets)
 
@@ -632,7 +634,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 	engineState.TiltStartTime = action.StartTime
 	engineState.TiltfilePath = action.TiltfilePath
 	engineState.ConfigFiles = action.ConfigFiles
-	engineState.UserArgs = action.UserArgs
+	engineState.UserConfigState.Args = action.UserArgs
 	engineState.AnalyticsUserOpt = action.AnalyticsUserOpt
 	engineState.WatchFiles = action.WatchFiles
 	engineState.CloudAddress = action.CloudAddress

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2634,7 +2634,7 @@ func TestUpperStart(t *testing.T) {
 	})
 
 	f.withState(func(state store.EngineState) {
-		require.Equal(t, []string{"foo", "bar"}, state.UserArgs)
+		require.Equal(t, []string{"foo", "bar"}, state.UserConfigState.Args)
 		require.Equal(t, f.JoinPath("Tiltfile"), state.TiltfilePath)
 		require.Equal(t, tok, state.Token)
 		require.Equal(t, analytics.OptIn, state.AnalyticsEffectiveOpt())
@@ -3092,6 +3092,7 @@ func TestHasEverBeenReadyDC(t *testing.T) {
 
 func TestVersionSettingsStoredOnState(t *testing.T) {
 	f := newTestFixture(t)
+	defer f.TearDown()
 
 	f.Start([]model.Manifest{}, true)
 
@@ -3733,7 +3734,7 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 
 	f.dcc.ServicesOutput = "redis\nserver\n"
 
-	tlr := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), nil)
+	tlr := f.tfl.Load(f.ctx, f.JoinPath("Tiltfile"), model.UserConfigState{})
 	if tlr.Error != nil {
 		f.T().Fatal(tlr.Error)
 	}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -61,9 +61,6 @@ type EngineState struct {
 	TiltIgnoreContents       string
 	PendingConfigFileChanges map[string]time.Time
 
-	// UserArgs are the post-tilt args, e.g., in `tilt up -- --hello goodbye`, it'd be [--hello goodbye]
-	UserArgs []string
-
 	TriggerQueue []model.ManifestName
 
 	IsProfiling bool
@@ -92,6 +89,8 @@ type EngineState struct {
 	WaitingForTiltCloudUsernamePostRegistration bool
 
 	DockerPruneSettings model.DockerPruneSettings
+
+	UserConfigState model.UserConfigState
 }
 
 // Merge analytics opt-in status from different sources.

--- a/internal/tiltfile/config/config_def.go
+++ b/internal/tiltfile/config/config_def.go
@@ -188,6 +188,10 @@ func configSettingDefinitionBuiltin(newConfigValue func() configValue) starkit.F
 		}
 
 		err = starkit.SetState(thread, func(settings Settings) (Settings, error) {
+			if settings.configParseCalled {
+				return settings, fmt.Errorf("%s cannot be called after config.parse is called", fn.Name())
+			}
+
 			if _, ok := settings.configDef.configSettings[name]; ok {
 				return settings, fmt.Errorf("%s defined multiple times", name)
 			}

--- a/internal/tiltfile/config/config_def.go
+++ b/internal/tiltfile/config/config_def.go
@@ -2,24 +2,31 @@ package config
 
 import (
 	"bytes"
-	"errors"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
 
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
 )
 
 type configValue interface {
-	flag() flag.Value
+	flag.Value
+	json.Marshaler
 	starlark() starlark.Value
-	setFromArgs([]string)
+	setFromInterface(interface{}) error
+	IsSet() bool
 }
 
+type configMap map[string]configValue
+
 type configSetting struct {
-	configValue
-	usage string
+	newValue func() configValue
+	usage    string
 }
 
 type ConfigDef struct {
@@ -27,41 +34,133 @@ type ConfigDef struct {
 	configSettings        map[string]configSetting
 }
 
-func (cd ConfigDef) parse(args []string) (v starlark.Value, output string, err error) {
+func (cm configMap) toStarlark() (starlark.Mapping, error) {
+	ret := starlark.NewDict(len(cm))
+	for k, v := range cm {
+		err := ret.SetKey(starlark.String(k), v.starlark())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+// merges settings from config and settings from args, with settings from args trumping
+func mergeConfigMaps(settingsFromConfig, settingsFromArgs configMap) configMap {
+	ret := make(configMap)
+	for k, v := range settingsFromConfig {
+		ret[k] = v
+	}
+
+	for k, v := range settingsFromArgs {
+		if v.IsSet() {
+			ret[k] = v
+		}
+	}
+
+	return ret
+}
+
+// parse any args and merge them into the config
+func (cd ConfigDef) incorporateArgs(config configMap, args []string) (ret configMap, output string, err error) {
+	var settingsFromArgs configMap
+	settingsFromArgs, output, err = cd.parseArgs(args)
+	if err != nil {
+		return nil, output, err
+	}
+
+	config = mergeConfigMaps(config, settingsFromArgs)
+
+	return config, output, nil
+}
+
+func (cd ConfigDef) parse(configPath string, args []string) (v starlark.Value, output string, err error) {
+	config, err := cd.readFromFile(configPath)
+	if err != nil {
+		return starlark.None, "", err
+	}
+
+	config, output, err = cd.incorporateArgs(config, args)
+	if err != nil {
+		return starlark.None, output, err
+	}
+
+	ret, err := config.toStarlark()
+	if err != nil {
+		return nil, output, err
+	}
+
+	return ret, output, nil
+}
+
+// parse command-line args
+func (cd ConfigDef) parseArgs(args []string) (ret configMap, output string, err error) {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	w := &bytes.Buffer{}
 	fs.SetOutput(w)
 
+	ret = make(configMap)
 	for name, def := range cd.configSettings {
+		ret[name] = def.newValue()
 		if name == cd.positionalSettingName {
 			continue
 		}
-		v := def.flag()
-		fs.Var(v, name, def.usage)
+		fs.Var(ret[name], name, def.usage)
 	}
 
 	err = fs.Parse(args)
 	if err != nil {
-		return starlark.None, w.String(), err
+		return nil, w.String(), err
 	}
 
 	if len(fs.Args()) > 0 {
 		if cd.positionalSettingName == "" {
-			return starlark.None, w.String(), errors.New("positional args were specified, but none were expected (no setting defined with args=True)")
+			return nil, w.String(), errors.New("positional args were specified, but none were expected (no setting defined with args=True)")
 		} else {
-			cd.configSettings[cd.positionalSettingName].setFromArgs(fs.Args())
-		}
-	}
-
-	ret := starlark.NewDict(len(cd.configSettings))
-	for name, def := range cd.configSettings {
-		err := ret.SetKey(starlark.String(name), def.starlark())
-		if err != nil {
-			return starlark.None, w.String(), err
+			for _, arg := range fs.Args() {
+				err := ret[cd.positionalSettingName].Set(arg)
+				if err != nil {
+					return nil, w.String(), errors.Wrapf(err, "error setting positional arg %s", cd.positionalSettingName)
+				}
+			}
 		}
 	}
 
 	return ret, w.String(), nil
+}
+
+// parse settings from the config file
+func (cd ConfigDef) readFromFile(tiltConfigPath string) (ret configMap, err error) {
+	ret = make(configMap)
+	r, err := os.Open(tiltConfigPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ret, nil
+		}
+		return nil, errors.Wrapf(err, "error opening %s", tiltConfigPath)
+	}
+	defer func() {
+		_ = r.Close()
+	}()
+
+	m := make(map[string]interface{})
+	err = jsoniter.NewDecoder(r).Decode(&m)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing json from %s", tiltConfigPath)
+	}
+
+	for k, v := range m {
+		def, ok := cd.configSettings[k]
+		if !ok {
+			return nil, fmt.Errorf("%s specified unknown setting name '%s'", tiltConfigPath, k)
+		}
+		ret[k] = def.newValue()
+		err = ret[k].setFromInterface(v)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%s specified invalid value for setting %s", tiltConfigPath, k)
+		}
+	}
+	return ret, nil
 }
 
 // makes a new builtin with the given configValue constructor
@@ -102,8 +201,8 @@ func configSettingDefinitionBuiltin(newConfigValue func() configValue) starkit.F
 			}
 
 			settings.configDef.configSettings[name] = configSetting{
-				configValue: newConfigValue(),
-				usage:       usage,
+				newValue: newConfigValue,
+				usage:    usage,
 			}
 
 			return settings, nil

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -1,12 +1,15 @@
 package config
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/windmilleng/tilt/internal/tiltfile/io"
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
 	"github.com/windmilleng/tilt/internal/tiltfile/value"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -15,22 +18,23 @@ import (
 func TestSetResources(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
-		callFlagsParse    bool
-		argsResources     []model.ManifestName
+		callConfigParse   bool
+		args              []string
 		tiltfileResources []model.ManifestName
 		expectedResources []model.ManifestName
 	}{
 		{"neither", false, nil, nil, []model.ManifestName{"a", "b"}},
 		{"neither, with config.parse", true, nil, nil, []model.ManifestName{"a", "b"}},
-		{"args only", false, []model.ManifestName{"a"}, nil, []model.ManifestName{"a"}},
-		{"args only, with config.parse", true, []model.ManifestName{"a"}, nil, []model.ManifestName{"a", "b"}},
+		{"args only", false, []string{"a"}, nil, []model.ManifestName{"a"}},
+		{"args only, with config.parse", true, []string{"a"}, nil, []model.ManifestName{"a", "b"}},
 		{"tiltfile only", false, nil, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
 		{"tiltfile only, with config.parse", true, nil, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
-		{"both", false, []model.ManifestName{"a"}, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
-		{"both, with config.parse", true, []model.ManifestName{"a"}, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
+		{"both", false, []string{"a"}, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
+		{"both, with config.parse", true, []string{"a"}, []model.ManifestName{"b"}, []model.ManifestName{"b"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			f := NewFixture(t)
+			f := NewFixture(t, model.NewUserConfigState(tc.args))
+			defer f.TearDown()
 
 			setResources := ""
 			if len(tc.tiltfileResources) > 0 {
@@ -41,25 +45,22 @@ func TestSetResources(t *testing.T) {
 				setResources = fmt.Sprintf("config.set_enabled_resources([%s])", strings.Join(rs, ", "))
 			}
 
-			flagsParse := ""
-			if tc.callFlagsParse {
-				flagsParse = "config.parse()"
+			configParse := ""
+			if tc.callConfigParse {
+				configParse = `
+config.define_string_list('resources', args=True)
+config.parse()`
 			}
 
-			tiltfile := fmt.Sprintf("%s\n%s\n", setResources, flagsParse)
+			tiltfile := fmt.Sprintf("%s\n%s\n", setResources, configParse)
 
 			f.File("Tiltfile", tiltfile)
 
 			result, err := f.ExecFile("Tiltfile")
 			require.NoError(t, err)
 
-			var args []string
-			for _, a := range tc.argsResources {
-				args = append(args, string(a))
-			}
-
 			manifests := []model.Manifest{{Name: "a"}, {Name: "b"}}
-			actual, err := MustState(result).EnabledResources(args, manifests)
+			actual, err := MustState(result).EnabledResources(manifests)
 			require.NoError(t, err)
 
 			expectedResourcesByName := make(map[model.ManifestName]bool)
@@ -78,9 +79,11 @@ func TestSetResources(t *testing.T) {
 }
 
 func TestParsePositional(t *testing.T) {
-	foo := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
+	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
 
-	f := NewFixture(t, foo...)
+	f := NewFixture(t, model.NewUserConfigState(args))
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
 cfg = config.parse()
@@ -90,7 +93,7 @@ print(cfg['foo'])
 	_, err := f.ExecFile("Tiltfile")
 	require.NoError(t, err)
 
-	require.Contains(t, f.PrintOutput(), value.StringSliceToList(foo).String())
+	require.Contains(t, f.PrintOutput(), value.StringSliceToList(args).String())
 }
 
 func TestParseKeyword(t *testing.T) {
@@ -100,7 +103,9 @@ func TestParseKeyword(t *testing.T) {
 		args = append(args, []string{"-foo", s}...)
 	}
 
-	f := NewFixture(t, args...)
+	f := NewFixture(t, model.NewUserConfigState(args))
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('foo')
 cfg = config.parse()
@@ -115,7 +120,8 @@ print(cfg['foo'])
 
 func TestParsePositionalAndMultipleInterspersedKeyword(t *testing.T) {
 	args := []string{"-bar", "puerto rico", "-baz", "colombia", "-bar", "venezuela", "-baz", "honduras", "-baz", "guyana", "and", "still"}
-	f := NewFixture(t, args...)
+	f := NewFixture(t, model.NewUserConfigState(args))
+	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
@@ -136,7 +142,9 @@ print("baz:", cfg['baz'])
 }
 
 func TestMultiplePositionalDefs(t *testing.T) {
-	f := NewFixture(t)
+	f := NewFixture(t, model.UserConfigState{})
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
 config.define_string_list('bar', args=True)
@@ -148,7 +156,9 @@ config.define_string_list('bar', args=True)
 }
 
 func TestMultipleArgsSameName(t *testing.T) {
-	f := NewFixture(t)
+	f := NewFixture(t, model.UserConfigState{})
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('foo')
 config.define_string_list('foo')
@@ -160,7 +170,9 @@ config.define_string_list('foo')
 }
 
 func TestUndefinedArg(t *testing.T) {
-	f := NewFixture(t, "-bar", "hello")
+	f := NewFixture(t, model.NewUserConfigState([]string{"-bar", "hello"}))
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('foo')
 config.parse()
@@ -171,8 +183,10 @@ config.parse()
 	require.Equal(t, "flag provided but not defined: -bar", err.Error())
 }
 
-func TestUnprovidedKeywordArg(t *testing.T) {
-	f := NewFixture(t)
+func TestUnprovidedArg(t *testing.T) {
+	f := NewFixture(t, model.UserConfigState{})
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('foo')
 cfg = config.parse()
@@ -180,12 +194,12 @@ print("foo:",cfg['foo'])
 `)
 
 	_, err := f.ExecFile("Tiltfile")
-	require.NoError(t, err)
-	require.Contains(t, f.PrintOutput(), "foo: []")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `key "foo" not in dict`)
 }
 
 func TestUnprovidedPositionalArg(t *testing.T) {
-	f := NewFixture(t)
+	f := NewFixture(t, model.UserConfigState{})
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
 cfg = config.parse()
@@ -193,12 +207,14 @@ print("foo:",cfg['foo'])
 `)
 
 	_, err := f.ExecFile("Tiltfile")
-	require.NoError(t, err)
-	require.Contains(t, f.PrintOutput(), "foo: []")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `key "foo" not in dict`)
 }
 
 func TestProvidedButUnexpectedPositionalArgs(t *testing.T) {
-	f := NewFixture(t, "do", "re", "mi")
+	f := NewFixture(t, model.NewUserConfigState([]string{"do", "re", "mi"}))
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 cfg = config.parse()
 `)
@@ -209,7 +225,9 @@ cfg = config.parse()
 }
 
 func TestUsage(t *testing.T) {
-	f := NewFixture(t, "-bar", "hello")
+	f := NewFixture(t, model.NewUserConfigState([]string{"-bar", "hello"}))
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('foo', usage='what can I foo for you today?')
 config.parse()
@@ -224,7 +242,9 @@ config.parse()
 
 // i.e., tilt up foo bar gets you resources foo and bar
 func TestDefaultTiltBehavior(t *testing.T) {
-	f := NewFixture(t, "foo", "bar")
+	f := NewFixture(t, model.NewUserConfigState([]string{"foo", "bar"}))
+	defer f.TearDown()
+
 	f.File("Tiltfile", `
 config.define_string_list('resources', usage='which resources to load in Tilt', args=True)
 config.set_enabled_resources(config.parse()['resources'])
@@ -234,12 +254,128 @@ config.set_enabled_resources(config.parse()['resources'])
 	require.NoError(t, err)
 
 	manifests := []model.Manifest{{Name: "foo"}, {Name: "bar"}, {Name: "baz"}}
-	actual, err := MustState(result).EnabledResources([]string{"foo", "bar"}, manifests)
+	actual, err := MustState(result).EnabledResources(manifests)
 	require.NoError(t, err)
 	require.Equal(t, manifests[:2], actual)
-
 }
 
-func NewFixture(tb testing.TB, args ...string) *starkit.Fixture {
-	return starkit.NewFixture(tb, NewExtension(args))
+func TestSettingsFromConfigAndArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		config   map[string][]string
+		expected map[string][]string
+	}{
+		{
+			name:   "args only",
+			args:   []string{"-a", "1", "-a", "2", "-b", "3", "-a", "4", "5", "6"},
+			config: nil,
+			expected: map[string][]string{
+				"a": {"1", "2", "4"},
+				"b": {"3"},
+				"c": {"5", "6"},
+			},
+		},
+		{
+			name: "config only",
+			args: nil,
+			config: map[string][]string{
+				"b": {"7", "8"},
+				"c": {"9"},
+			},
+			expected: map[string][]string{
+				"b": {"7", "8"},
+				"c": {"9"},
+			},
+		},
+		{
+			name: "args trump config",
+			args: []string{"-a", "1", "-a", "2", "-a", "4", "5", "6"},
+			config: map[string][]string{
+				"b": {"7", "8"},
+				"c": {"9"},
+			},
+			expected: map[string][]string{
+				"a": {"1", "2", "4"},
+				"b": {"7", "8"},
+				"c": {"5", "6"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFixture(t, model.NewUserConfigState(tc.args))
+			defer f.TearDown()
+
+			f.File("Tiltfile", `
+config.define_string_list('a')
+config.define_string_list('b')
+config.define_string_list('c', args=True)
+cfg = config.parse()
+print("a=", cfg.get('a', 'missing'))
+print("b=", cfg.get('b', 'missing'))
+print("c=", cfg.get('c', 'missing'))
+`)
+			if tc.config != nil {
+				b := &bytes.Buffer{}
+				err := json.NewEncoder(b).Encode(tc.config)
+				require.NoError(t, err)
+				f.File(UserConfigFileName, b.String())
+			}
+
+			_, err := f.ExecFile("Tiltfile")
+			require.NoError(t, err)
+
+			for _, arg := range []string{"a", "b", "c"} {
+				expected := "missing"
+				if vs, ok := tc.expected[arg]; ok {
+					var s []string
+					for _, v := range vs {
+						s = append(s, fmt.Sprintf(`"%s"`, v))
+					}
+					expected = fmt.Sprintf("[%s]", strings.Join(s, ", "))
+				}
+				require.Contains(t, f.PrintOutput(), fmt.Sprintf("%s= %s", arg, expected))
+			}
+		})
+	}
+}
+
+func TestUndefinedArgInConfigFile(t *testing.T) {
+	f := NewFixture(t, model.UserConfigState{})
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+config.define_string_list('foo')
+cfg = config.parse()
+print("foo:",cfg.get('foo', []))
+`)
+
+	f.File(UserConfigFileName, `{"bar": "1"}`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "specified unknown setting name 'bar'")
+}
+
+func TestWrongTypeArgInConfigFile(t *testing.T) {
+	f := NewFixture(t, model.UserConfigState{})
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+config.define_string_list('foo')
+cfg = config.parse()
+print("foo:",cfg.get('foo', []))
+`)
+
+	f.File(UserConfigFileName, `{"foo": "1"}`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "specified invalid value for setting foo: expected array")
+}
+
+func NewFixture(tb testing.TB, userConfigState model.UserConfigState) *starkit.Fixture {
+	ret := starkit.NewFixture(tb, NewExtension(userConfigState), io.NewExtension())
+	ret.UseRealFS()
+	return ret
 }

--- a/internal/tiltfile/config/resources.go
+++ b/internal/tiltfile/config/resources.go
@@ -44,11 +44,13 @@ func setEnabledResources(thread *starlark.Thread, fn *starlark.Builtin, args sta
 }
 
 // for the given args and list of full manifests, figure out which manifests the user actually selected
-func (s Settings) EnabledResources(args []string, manifests []model.Manifest) ([]model.Manifest, error) {
+func (s Settings) EnabledResources(manifests []model.Manifest) ([]model.Manifest, error) {
 	// if the user called set_enabled_resources, that trumps everything
 	if s.enabledResources != nil {
 		return match(manifests, s.enabledResources)
 	}
+
+	args := s.UserConfigState.Args
 
 	// if the user has not called config.parse and has specified args, use those to select which resources
 	if args != nil && !s.configParseCalled {

--- a/internal/tiltfile/git/git_test.go
+++ b/internal/tiltfile/git/git_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestGitRepoPath(t *testing.T) {
 	f := NewFixture(t)
+	defer f.TearDown()
+
 	f.UseRealFS()
 	f.File("Tiltfile", `
 print(local_git_repo('.').paths('.git/index'))
@@ -24,6 +26,8 @@ print(local_git_repo('.').paths('.git/index'))
 
 func TestGitRepoBadMethodCall(t *testing.T) {
 	f := NewFixture(t)
+	defer f.TearDown()
+
 	f.UseRealFS()
 	f.File("Tiltfile", `
 local_git_repo('.').asdf()

--- a/internal/tiltfile/starkit/fixture.go
+++ b/internal/tiltfile/starkit/fixture.go
@@ -6,9 +6,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.starlark.net/starlark"
 )
 
@@ -39,6 +41,7 @@ func (f *Fixture) OnStart(e *Environment) error {
 
 	e.SetPrint(func(t *starlark.Thread, msg string) {
 		_, _ = fmt.Fprintf(f.out, "%s\n", msg)
+		_, _ = fmt.Printf("%s\n", msg)
 	})
 	return nil
 }
@@ -56,6 +59,10 @@ func (f *Fixture) Path() string {
 	return f.path
 }
 
+func (f *Fixture) JoinPath(elem ...string) string {
+	return filepath.Join(append([]string{f.path}, elem...)...)
+}
+
 func (f *Fixture) File(name, contents string) {
 	fullPath := filepath.Join(f.path, name)
 	if f.useRealFS {
@@ -71,8 +78,18 @@ func (f *Fixture) File(name, contents string) {
 }
 
 func (f *Fixture) UseRealFS() {
-	path, err := ioutil.TempDir("", f.tb.Name())
-	assert.NoError(f.tb, err)
+	// '/' is not allowed in filenames, so get that out of there
+	path, err := ioutil.TempDir("", strings.Replace(f.tb.Name(), "/", "_", -1))
+	require.NoError(f.tb, err)
 	f.path = path
 	f.useRealFS = true
+}
+
+func (f *Fixture) TearDown() {
+	if f.useRealFS {
+		err := os.RemoveAll(f.path)
+		if err != nil {
+			fmt.Printf("error cleaning up temp dir: %v", err)
+		}
+	}
 }

--- a/internal/tiltfile/starkit/fixture.go
+++ b/internal/tiltfile/starkit/fixture.go
@@ -41,7 +41,6 @@ func (f *Fixture) OnStart(e *Environment) error {
 
 	e.SetPrint(func(t *starlark.Thread, msg string) {
 		_, _ = fmt.Fprintf(f.out, "%s\n", msg)
-		_, _ = fmt.Printf("%s\n", msg)
 	})
 	return nil
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -9,10 +9,9 @@ import (
 	"strconv"
 	"time"
 
+	wmanalytics "github.com/windmilleng/wmclient/pkg/analytics"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
-
-	wmanalytics "github.com/windmilleng/wmclient/pkg/analytics"
 
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/dockercompose"
@@ -21,6 +20,7 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/sliceutils"
 	tiltfileanalytics "github.com/windmilleng/tilt/internal/tiltfile/analytics"
+	"github.com/windmilleng/tilt/internal/tiltfile/config"
 	"github.com/windmilleng/tilt/internal/tiltfile/dockerprune"
 	"github.com/windmilleng/tilt/internal/tiltfile/io"
 	"github.com/windmilleng/tilt/internal/tiltfile/k8scontext"
@@ -50,6 +50,7 @@ type TiltfileLoadResult struct {
 	DockerPruneSettings model.DockerPruneSettings
 	AnalyticsOpt        wmanalytics.Opt
 	VersionSettings     model.VersionSettings
+	UserConfigState     model.UserConfigState
 }
 
 func (r TiltfileLoadResult) Orchestrator() model.Orchestrator {
@@ -70,7 +71,7 @@ type TiltfileLoader interface {
 	// We want to be very careful not to treat non-zero exit codes like an error.
 	// Because even if the Tiltfile has errors, we might need to watch files
 	// or return partial results (like enabled features).
-	Load(ctx context.Context, filename string, args []string) TiltfileLoadResult
+	Load(ctx context.Context, filename string, userConfigState model.UserConfigState) TiltfileLoadResult
 }
 
 type FakeTiltfileLoader struct {
@@ -83,7 +84,7 @@ func NewFakeTiltfileLoader() *FakeTiltfileLoader {
 	return &FakeTiltfileLoader{}
 }
 
-func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, args []string) TiltfileLoadResult {
+func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, userConfigState model.UserConfigState) TiltfileLoadResult {
 	return tfl.Result
 }
 
@@ -120,7 +121,7 @@ func printWarnings(s *tiltfileState) {
 }
 
 // Load loads the Tiltfile in `filename`
-func (tfl tiltfileLoader) Load(ctx context.Context, filename string, args []string) TiltfileLoadResult {
+func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigState model.UserConfigState) TiltfileLoadResult {
 	start := time.Now()
 	absFilename, err := ospath.RealAbs(filename)
 	if err != nil {
@@ -155,7 +156,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, args []stri
 	privateRegistry := tfl.kCli.PrivateRegistry(ctx)
 	s := newTiltfileState(ctx, tfl.dcCli, tfl.k8sContextExt, privateRegistry, feature.FromDefaults(tfl.fDefaults))
 
-	manifests, result, err := s.loadManifests(absFilename, args)
+	manifests, result, err := s.loadManifests(absFilename, userConfigState)
 
 	ioState, _ := io.GetState(result)
 	tlr.ConfigFiles = sliceutils.AppendWithoutDupes(ioState.Files, s.postExecReadFiles...)
@@ -165,6 +166,9 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, args []stri
 
 	aSettings, _ := tiltfileanalytics.GetState(result)
 	tlr.AnalyticsOpt = aSettings.Opt
+
+	flagsSettings, _ := config.GetState(result)
+	tlr.UserConfigState = flagsSettings.UserConfigState
 
 	tlr.Secrets = s.extractSecrets()
 	tlr.Warnings = s.warnings

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -144,7 +144,7 @@ func (s *tiltfileState) print(_ *starlark.Thread, msg string) {
 //
 // TODO(nick): Eventually this will just return a starkit.Model, which will contain
 // all the mutable state collected by execution.
-func (s *tiltfileState) loadManifests(absFilename string, args []string) ([]model.Manifest, starkit.Model, error) {
+func (s *tiltfileState) loadManifests(absFilename string, userConfigState model.UserConfigState) ([]model.Manifest, starkit.Model, error) {
 	s.logger.Infof("Beginning Tiltfile execution")
 	result, err := starkit.ExecFile(absFilename,
 		s,
@@ -156,7 +156,7 @@ func (s *tiltfileState) loadManifests(absFilename string, args []string) ([]mode
 		dockerprune.NewExtension(),
 		analytics.NewExtension(),
 		version.NewExtension(),
-		config.NewExtension(args),
+		config.NewExtension(userConfigState),
 	)
 	if err != nil {
 		return nil, result, starkit.UnpackBacktrace(err)
@@ -205,8 +205,8 @@ to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, kubeContext
 	}
 	manifests = append(manifests, localManifests...)
 
-	flagsState, _ := config.GetState(result)
-	manifests, err = flagsState.EnabledResources(args, manifests)
+	configSettings, _ := config.GetState(result)
+	manifests, err = configSettings.EnabledResources(manifests)
 	if err != nil {
 		return nil, starkit.Model{}, err
 	}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -156,7 +156,7 @@ func (s *tiltfileState) loadManifests(absFilename string, userConfigState model.
 		dockerprune.NewExtension(),
 		analytics.NewExtension(),
 		version.NewExtension(),
-		config.NewExtension(userConfigState),
+		config.NewExtension(absFilename, userConfigState),
 	)
 	if err != nil {
 		return nil, result, starkit.UnpackBacktrace(err)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -760,7 +760,7 @@ docker_build('gcr.io/bar', 'bar')
 k8s_yaml('bar.yaml')
 `)
 
-	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), []string{"baz"})
+	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), model.NewUserConfigState([]string{"baz"}))
 	err := tlr.Error
 	if assert.Error(t, err) {
 		assert.Equal(t, `You specified some resources that could not be found: "baz"
@@ -4446,7 +4446,7 @@ func (f *fixture) load(args ...string) {
 }
 
 func (f *fixture) loadResourceAssemblyV1(names ...string) {
-	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), names)
+	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), model.NewUserConfigState(names))
 	err := tlr.Error
 	if err != nil {
 		f.t.Fatal(err)
@@ -4458,7 +4458,7 @@ func (f *fixture) loadResourceAssemblyV1(names ...string) {
 // Load the manifests, expecting warnings.
 // Warnings should be asserted later with assertWarnings
 func (f *fixture) loadAllowWarnings(args ...string) {
-	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), args)
+	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), model.NewUserConfigState(args))
 	err := tlr.Error
 	if err != nil {
 		f.t.Fatal(err)
@@ -4485,7 +4485,7 @@ func (f *fixture) loadAssertWarnings(warnings ...string) {
 }
 
 func (f *fixture) loadErrString(msgs ...string) {
-	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), nil)
+	tlr := f.newTiltfileLoader().Load(f.ctx, f.JoinPath("Tiltfile"), model.UserConfigState{})
 	err := tlr.Error
 	if err == nil {
 		f.t.Fatalf("expected error but got nil")

--- a/pkg/model/user_config_state.go
+++ b/pkg/model/user_config_state.go
@@ -1,0 +1,9 @@
+package model
+
+type UserConfigState struct {
+	Args []string
+}
+
+func NewUserConfigState(args []string) UserConfigState {
+	return UserConfigState{Args: args}
+}


### PR DESCRIPTION
This is a scoped-down #2596. 

The behavior implemented by this PR is, when `config.parse` is called:
1. If tilt_config.json specifies any settings, load those.
2. If there are any args on the command line, parse those and have them take precedence over anything in tilt_config.json.
3. in starlark, return whatever config we're left with

Tilt does not write to tilt_config.json.