### PR TITLE
websocket: update comment about 'throttle'

### DIFF
--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -107,11 +107,9 @@ func (ws WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore) {
 	//     at this point in the code, we're not) the only thing ws.OnChange blocks
 	//     is subsequent ws.OnChange calls.
 	//
-	// In future, we can solve this problem more elegantly:
-	// - if multiple OnChange's come in within 100 ms, only call one (right now, if 10 OnChanges come in
-	//     in quick succession, we'll make 10 OnChange calls, each 100ms apart, and most will be no-ops)
-	// - replace our JSON marshaling with jsoniter (would require either working around the lack
-	//     of an `EmitDefaults` option in jsoniter, or writing our own proto marshaling code)
+	// In future, we can maybe solve this problem more elegantly by replacing our JSON
+	//     marshaling with jsoniter (would require either working around the lack of an
+	//     `EmitDefaults` option in jsoniter, or writing our own proto marshaling code).
 	time.Sleep(time.Millisecond * 100)
 }
 


### PR DESCRIPTION
DB on slack re: "if multiple OnChange's come in within 100 ms, only call one (right now, if 10 OnChanges come in in quick succession, we'll make 10 OnChange calls, each 100ms apart, and most will be no-ops)":
> Are you sure about this? I think the dirtybit in the subscriber means it will only call it a second time...

a quick glance through the code supports DB's point (though it's a little gnarly, i'm not 100% sure). updating comment to reflect.