### PR TITLE
web: delete the artisanal, hand-curated typescript types in favor of shiny new protobuf-generated types

### DIFF
--- a/web/src/AlertPane.test.tsx
+++ b/web/src/AlertPane.test.tsx
@@ -2,9 +2,11 @@ import React from "react"
 import AlertPane from "./AlertPane"
 import renderer from "react-test-renderer"
 import { oneResourceUnrecognizedError } from "./testdata"
-import { Resource, TriggerMode } from "./types"
+import { TriggerMode } from "./types"
 import PathBuilder from "./PathBuilder"
 import { mount } from "enzyme"
+
+type Resource = Proto.webviewResource
 
 let pb = new PathBuilder("localhost", "")
 beforeEach(() => {
@@ -34,7 +36,6 @@ it("renders one container start error", () => {
     {
       log: "laa dee daa I'm not an error\nI'm serious",
       finishTime: ts,
-      error: null,
     },
   ]
   if (!resource.k8sResourceInfo) throw new Error("Missing k8s info")
@@ -101,7 +102,6 @@ it("shows that a container has restarted", () => {
     {
       log: "laa dee daa I'm not an error\nseriously",
       finishTime: ts,
-      error: null,
     },
   ]
   if (!resource.k8sResourceInfo) throw new Error("missing k8s info")
@@ -126,7 +126,6 @@ it("shows that a crash rebuild has occurred", () => {
     {
       log: "laa dee daa I'm not an error\nseriously",
       finishTime: ts,
-      error: null,
       isCrashRebuild: true,
     },
   ]
@@ -153,7 +152,6 @@ it("renders multiple lines of a crash log", () => {
     {
       log: "laa dee daa I'm not an error\nseriously",
       finishTime: ts,
-      error: null,
       isCrashRebuild: true,
     },
   ]
@@ -179,7 +177,6 @@ it("renders warnings", () => {
     {
       log: "laa dee daa I'm not an error\nseriously",
       finishTime: ts,
-      error: null,
       isCrashRebuild: true,
       warnings: ["Hi I'm a warning"],
     },
@@ -217,7 +214,6 @@ function fillResourceFields(): Resource {
     combinedLog: "",
     buildHistory: [],
     crashLog: "",
-    currentBuild: 0,
     directoriesWatched: [],
     endpoints: [],
     podID: "",

--- a/web/src/AlertPane.tsx
+++ b/web/src/AlertPane.tsx
@@ -3,10 +3,11 @@ import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark-gr
 import AnsiLine from "./AnsiLine"
 import TimeAgo from "react-timeago"
 import "./AlertPane.scss"
-import { Resource } from "./types"
 import { timeAgoFormatter } from "./timeFormatters"
 import { getResourceAlerts, hasAlert } from "./alerts"
 import PathBuilder from "./PathBuilder"
+
+type Resource = Proto.webviewResource
 
 type AlertsProps = {
   pathBuilder: PathBuilder
@@ -42,6 +43,7 @@ class AlertPane extends PureComponent<AlertsProps> {
 
     let alertResources = resources.filter(r => hasAlert(r))
     alertResources.forEach(resource => {
+      let resName = resource.name ?? ""
       getResourceAlerts(resource).forEach(alert => {
         let dismissButton = <div />
         if (alert.dismissHandler && !isSnapshot) {
@@ -55,7 +57,7 @@ class AlertPane extends PureComponent<AlertsProps> {
           )
         }
         alertElements.push(
-          <li key={alert.alertType + resource.name} className="AlertPane-item">
+          <li key={alert.alertType + resName} className="AlertPane-item">
             <header>
               <div className="AlertPane-headerDiv">
                 <h3 className="AlertPane-headerDiv-header">{alert.header}</h3>

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -1,12 +1,9 @@
-import {
-  K8sResourceInfo,
-  SocketState,
-  WebView,
-  Snapshot,
-  Resource,
-} from "./types"
+import { SocketState, Snapshot } from "./types"
 import HudState from "./HudState"
 import PathBuilder from "./PathBuilder"
+
+type Resource = Proto.webviewResource
+type K8sResourceInfo = Proto.webviewK8sResourceInfo
 
 interface HudInt {
   setAppState: <K extends keyof HudState>(state: Pick<HudState, K>) => void
@@ -54,32 +51,13 @@ class AppController {
       this.liveSocket = true
       this.tryConnectCount = 0
 
-      let data: WebView = JSON.parse(event.data)
+      let data: Proto.webviewView = JSON.parse(event.data)
 
-      data.resources = this.setDefaultResourceInfo(data.resources)
       // @ts-ignore
       this.component.setAppState({
         view: data,
         socketState: SocketState.Active,
       })
-    })
-  }
-
-  setDefaultResourceInfo(resources: Array<Resource>): Array<Resource> {
-    return resources.map(r => {
-      if (!r.k8sResourceInfo && !r.dcResourceInfo) {
-        let ri: K8sResourceInfo = {
-          podName: "",
-          podCreationTime: "",
-          podUpdateStartTime: "",
-          podStatus: "",
-          podStatusMessage: "",
-          podRestarts: 0,
-          podLog: "",
-        }
-        r.k8sResourceInfo = ri
-      }
-      return r
     })
   }
 
@@ -135,9 +113,6 @@ class AppController {
       .then(resp => resp.json())
       .then((data: Snapshot) => {
         data.view = data.view || {}
-
-        let resources = (data.view && data.view.resources) || []
-        data.view.resources = this.setDefaultResourceInfo(resources)
 
         this.component.setAppState({
           view: data.view,

--- a/web/src/FacetsPane.tsx
+++ b/web/src/FacetsPane.tsx
@@ -2,7 +2,8 @@ import React, { PureComponent } from "react"
 import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark-gray.svg"
 import AnsiLine from "./AnsiLine"
 import "./FacetsPane.scss"
-import { Resource } from "./types"
+
+type Resource = Proto.webviewResource
 
 type FacetsProps = {
   resource: Resource
@@ -41,7 +42,7 @@ class FacetsPane extends PureComponent<FacetsProps> {
               <h3>{facet.name}</h3>
             </div>
           </header>
-          <section>{logToLines(facet.value)}</section>
+          <section>{logToLines(facet.value ?? "")}</section>
         </li>
       )
     })

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -21,7 +21,6 @@ import {
   ShowFatalErrorModal,
   SnapshotHighlight,
   SocketState,
-  WebView,
 } from "./types"
 import { logLinesFromString } from "./logs"
 import HudState from "./HudState"
@@ -328,6 +327,7 @@ class HUD extends Component<HudProps, HudState> {
           .map(r => numberOfAlerts(r))
           .reduce((sum, current) => sum + current, 0)
       }
+      let isFacetsEnabled = this.getFeatures().isEnabled("facets")
       return (
         <TopBar
           logUrl={name === "" ? this.path("/") : this.path(`/r/${name}`)}
@@ -340,9 +340,7 @@ class HUD extends Component<HudProps, HudState> {
           handleOpenModal={this.handleOpenModal}
           highlight={snapshotHighlight}
           facetsUrl={
-            name !== "" &&
-            this.state.view.featureFlags &&
-            this.state.view.featureFlags["facets"]
+            name !== "" && isFacetsEnabled
               ? this.path(`/r/${name}/facets`)
               : null
           }
@@ -430,7 +428,7 @@ class HUD extends Component<HudProps, HudState> {
         if (this.state.logStore) {
           logLines = this.state.logStore.manifestLog(name)
         } else if (view) {
-          let r = view.resources.find(r => r.name === name)
+          let r = resources.find(r => r.name === name)
           if (r === undefined) {
             return <Route component={NotFound} />
           }
@@ -515,7 +513,7 @@ class HUD extends Component<HudProps, HudState> {
     )
   }
 
-  renderShareSnapshotModal(view: WebView | null) {
+  renderShareSnapshotModal(view: Proto.webviewView | null) {
     let handleClose = () =>
       this.setState({ showSnapshotModal: false, snapshotLink: "" })
     let handleSendSnapshot = () =>
@@ -543,7 +541,7 @@ class HUD extends Component<HudProps, HudState> {
     )
   }
 
-  renderFatalErrorModal(view: WebView | null) {
+  renderFatalErrorModal(view: Proto.webviewView | null) {
     let error = view && view.fatalError
     let handleClose = () =>
       this.setState({ showFatalErrorModal: ShowFatalErrorModal.Hide })

--- a/web/src/HudState.tsx
+++ b/web/src/HudState.tsx
@@ -1,13 +1,8 @@
-import {
-  WebView,
-  ShowFatalErrorModal,
-  SnapshotHighlight,
-  SocketState,
-} from "./types"
+import { ShowFatalErrorModal, SnapshotHighlight, SocketState } from "./types"
 import LogStore from "./LogStore"
 
 type HudState = {
-  view: WebView
+  view: Proto.webviewView
   isSidebarClosed: boolean
   snapshotLink: string
   showSnapshotModal: boolean

--- a/web/src/Sidebar.stories.tsx
+++ b/web/src/Sidebar.stories.tsx
@@ -4,8 +4,9 @@ import Sidebar, { SidebarItem } from "./Sidebar"
 import { oneResourceView, twoResourceView } from "./testdata"
 import PathBuilder from "./PathBuilder"
 import { MemoryRouter } from "react-router"
-import { ResourceView, TriggerMode, Resource } from "./types"
+import { ResourceView, TriggerMode } from "./types"
 
+type Resource = Proto.webviewResource
 let pathBuilder = new PathBuilder("localhost", "/")
 
 function twoItemSidebar() {

--- a/web/src/Sidebar.test.tsx
+++ b/web/src/Sidebar.test.tsx
@@ -4,8 +4,10 @@ import renderer from "react-test-renderer"
 import { MemoryRouter } from "react-router"
 import Sidebar, { SidebarItem } from "./Sidebar"
 import { oneResource, twoResourceView } from "./testdata"
-import { Resource, ResourceView, TriggerMode } from "./types"
+import { ResourceView, TriggerMode } from "./types"
 import PathBuilder from "./PathBuilder"
+
+type Resource = Proto.webviewResource
 
 let pathBuilder = new PathBuilder("localhost", "/")
 
@@ -39,7 +41,8 @@ describe("sidebar", () => {
 
   it("renders list of resources", () => {
     let items = twoResourceView().resources.map((res: Resource) => {
-      res.buildHistory[0].error = "error!"
+      let history = res.buildHistory ?? []
+      history[0].error = "error!"
       return new SidebarItem(res)
     })
     const tree = renderer

--- a/web/src/Sidebar.tsx
+++ b/web/src/Sidebar.tsx
@@ -3,13 +3,7 @@ import { ReactComponent as ChevronSvg } from "./assets/svg/chevron.svg"
 import { Link } from "react-router-dom"
 import { combinedStatus } from "./status"
 import "./Sidebar.scss"
-import {
-  ResourceView,
-  TriggerMode,
-  Build,
-  Resource,
-  ResourceStatus,
-} from "./types"
+import { ResourceView, TriggerMode, ResourceStatus } from "./types"
 import TimeAgo from "react-timeago"
 import { isZeroTime } from "./time"
 import PathBuilder from "./PathBuilder"
@@ -17,6 +11,9 @@ import { timeAgoFormatter } from "./timeFormatters"
 import SidebarIcon from "./SidebarIcon"
 import SidebarTriggerButton from "./SidebarTriggerButton"
 import { numberOfAlerts } from "./alerts"
+
+type Resource = Proto.webviewResource
+type Build = Proto.webviewBuildRecord
 
 class SidebarItem {
   name: string
@@ -36,17 +33,17 @@ class SidebarItem {
    * Create a pared down SidebarItem from a ResourceView
    */
   constructor(res: Resource) {
-    this.name = res.name
-    this.isTiltfile = res.isTiltfile
+    this.name = res.name ?? ""
+    this.isTiltfile = !!res.isTiltfile
     this.status = combinedStatus(res)
     this.hasEndpoints = (res.endpoints || []).length > 0
-    this.lastDeployTime = res.lastDeployTime
-    this.pendingBuildSince = res.pendingBuildSince
-    this.currentBuildStartTime = res.currentBuild.startTime
+    this.lastDeployTime = res.lastDeployTime ?? ""
+    this.pendingBuildSince = res.pendingBuildSince ?? ""
+    this.currentBuildStartTime = res.currentBuild?.startTime ?? ""
     this.alertCount = numberOfAlerts(res)
-    this.triggerMode = res.triggerMode
-    this.hasPendingChanges = res.hasPendingChanges
-    this.queued = res.queued
+    this.triggerMode = res.triggerMode ?? TriggerMode.TriggerModeAuto
+    this.hasPendingChanges = !!res.hasPendingChanges
+    this.queued = !!res.queued
     let buildHistory = res.buildHistory || []
     if (buildHistory.length > 0) {
       this.lastBuild = buildHistory[0]

--- a/web/src/SidebarTriggerButton.test.tsx
+++ b/web/src/SidebarTriggerButton.test.tsx
@@ -3,11 +3,13 @@ import { mount } from "enzyme"
 import SidebarTriggerButton, {
   TriggerButtonTooltip,
 } from "./SidebarTriggerButton"
-import { Resource, ResourceView, TriggerMode } from "./types"
+import { ResourceView, TriggerMode } from "./types"
 import { oneResource, twoResourceView } from "./testdata"
 import Sidebar, { SidebarItem } from "./Sidebar"
 import { MemoryRouter } from "react-router"
 import PathBuilder from "./PathBuilder"
+
+type Resource = Proto.webviewResource
 
 let pathBuilder = new PathBuilder("localhost", "/")
 
@@ -317,7 +319,7 @@ describe("SidebarTriggerButton", () => {
   it("shows a trigger button for resource that failed its initial build", () => {
     let res = oneResource()
     res.lastDeployTime = ""
-    res.currentBuild = false
+    res.currentBuild = {}
     res.hasPendingChanges = false
     res.pendingBuildSince = ""
     let items = [new SidebarItem(res)]

--- a/web/src/Statusbar.test.tsx
+++ b/web/src/Statusbar.test.tsx
@@ -4,7 +4,8 @@ import Statusbar, { StatusItem } from "./Statusbar"
 import { mount } from "enzyme"
 import { twoResourceView } from "./testdata"
 import { MemoryRouter } from "react-router"
-import { TiltBuild } from "./types"
+
+type TiltBuild = Proto.webviewTiltBuild
 
 describe("StatusBar", () => {
   let runningVersion: TiltBuild = {

--- a/web/src/Statusbar.tsx
+++ b/web/src/Statusbar.tsx
@@ -6,9 +6,12 @@ import { ReactComponent as UpdateAvailableSvg } from "./assets/svg/update-availa
 import { combinedStatus, warnings } from "./status"
 import "./Statusbar.scss"
 import { combinedStatusMessage } from "./combinedStatusMessage"
-import { Build, ResourceStatus, TiltBuild } from "./types"
+import { ResourceStatus } from "./types"
 import mostRecentBuildToDisplay from "./mostRecentBuild"
 import { Link } from "react-router-dom"
+
+type Build = Proto.webviewBuildRecord
+type TiltBuild = Proto.webviewTiltBuild
 
 class StatusItem {
   public warningCount: number = 0
@@ -47,8 +50,8 @@ class StatusItem {
 type StatusBarProps = {
   items: Array<StatusItem>
   alertsUrl: string
-  runningVersion: TiltBuild | null
-  latestVersion: TiltBuild | null
+  runningVersion: TiltBuild | null | undefined
+  latestVersion: TiltBuild | null | undefined
   checkVersion: boolean
 }
 
@@ -122,8 +125,8 @@ class Statusbar extends PureComponent<StatusBarProps> {
   }
 
   tiltPanel(
-    runningVersion: TiltBuild | null,
-    latestVersion: TiltBuild | null,
+    runningVersion: TiltBuild | null | undefined,
+    latestVersion: TiltBuild | null | undefined,
     shouldCheckVersion: boolean
   ) {
     let content: ReactElement = <LogoSvg className="Statusbar-logo" />

--- a/web/src/alerts.test.ts
+++ b/web/src/alerts.test.ts
@@ -8,7 +8,10 @@ import {
   PodStatusErrorType,
   WarningErrorType,
 } from "./alerts"
-import { Resource, K8sResourceInfo, TriggerMode } from "./types"
+import { TriggerMode } from "./types"
+
+type Resource = Proto.webviewResource
+type K8sResourceInfo = Proto.webviewK8sResourceInfo
 
 describe("getResourceAlerts", () => {
   it("K8Resource: shows that a pod status of error is an alert", () => {
@@ -83,12 +86,10 @@ describe("getResourceAlerts", () => {
       {
         log: "Hello I am a log",
         isCrashRebuild: true,
-        error: null,
       },
       {
         log: "Hello I am a log 2 ",
         isCrashRebuild: true,
-        error: null,
       },
     ]
     let rInfo = r.k8sResourceInfo
@@ -114,7 +115,6 @@ describe("getResourceAlerts", () => {
       {
         log: "Hello I'm a log",
         warnings: ["Hi i'm a warning"],
-        error: null,
         finishTime: "10:00am",
       },
       {
@@ -235,7 +235,6 @@ it("DC Resource: should show a warning alert using the first build history ", ()
     {
       log: "Hello I'm a log",
       warnings: ["Hi i'm a warning"],
-      error: null,
       finishTime: "10:00am",
     },
     {
@@ -263,7 +262,6 @@ it("DC resource: should show a warning alert using the first build history ", ()
     {
       log: "Hello I'm a log",
       warnings: ["Hi i'm a warning"],
-      error: null,
       finishTime: "10:00am",
     },
     {
@@ -365,7 +363,6 @@ function k8sResource(): Resource {
     combinedLog: "",
     buildHistory: [],
     crashLog: "",
-    currentBuild: 0,
     directoriesWatched: [],
     endpoints: [],
     podID: "podID",
@@ -401,9 +398,6 @@ function dcResource(): Resource {
     triggerMode: 0,
     buildHistory: [
       {
-        edits: null,
-        error: null,
-        warnings: null,
         startTime: "2019-08-07T11:43:32.422237-04:00",
         finishTime: "2019-08-07T11:43:37.568626-04:00",
         log: "",
@@ -411,9 +405,6 @@ function dcResource(): Resource {
       },
     ],
     currentBuild: {
-      edits: null,
-      error: null,
-      warnings: null,
       startTime: "0001-01-01T00:00:00Z",
       finishTime: "0001-01-01T00:00:00Z",
       log: "",

--- a/web/src/alerts.ts
+++ b/web/src/alerts.ts
@@ -1,5 +1,7 @@
-import { K8sResourceInfo, Resource } from "./types"
 import { podStatusIsError, podStatusIsCrash } from "./constants"
+
+type Resource = Proto.webviewResource
+type K8sResourceInfo = Proto.webviewK8sResourceInfo
 
 export type Alert = {
   alertType: string
@@ -25,7 +27,8 @@ function hasAlert(resource: Resource) {
 
 //Errors for K8s Resources
 function crashRebuild(r: Resource): boolean {
-  return r.buildHistory.length > 0 && r.buildHistory[0].isCrashRebuild
+  let history = r.buildHistory ?? []
+  return history.length > 0 && !!history[0].isCrashRebuild
 }
 
 function podStatusHasError(r: Resource) {
@@ -40,12 +43,13 @@ function podStatusHasError(r: Resource) {
 
 function podRestarted(r: Resource) {
   let rInfo = r.k8sResourceInfo as K8sResourceInfo
-  return rInfo.podRestarts > 0
+  return (rInfo.podRestarts ?? 0) > 0
 }
 
 // Errors for both DC and K8s Resources
 function buildFailed(resource: Resource) {
-  return resource.buildHistory.length > 0 && resource.buildHistory[0].error
+  let history = resource.buildHistory ?? []
+  return history.length > 0 && history[0].error
 }
 
 //This function determines what kind of alert should be made based on the functions defined
@@ -86,7 +90,7 @@ function podStatusIsErrAlert(resource: Resource): Alert {
   let podStatusMessage = rInfo.podStatusMessage
   let msg = ""
   if (podStatusIsCrash(podStatus)) {
-    msg = resource.crashLog
+    msg = resource.crashLog ?? ""
   }
   msg = msg || podStatusMessage || `Pod has status ${podStatus}`
 
@@ -94,14 +98,14 @@ function podStatusIsErrAlert(resource: Resource): Alert {
     alertType: PodStatusErrorType,
     header: "",
     msg: msg,
-    timestamp: rInfo.podCreationTime,
-    resourceName: resource.name,
+    timestamp: rInfo.podCreationTime ?? "",
+    resourceName: resource.name ?? "",
   }
 }
 function podRestartAlert(r: Resource): Alert {
   let rInfo = r.k8sResourceInfo as K8sResourceInfo
   let msg = r.crashLog || ""
-  let header = `Restarts: ${rInfo.podRestarts.toString()}`
+  let header = `Restarts: ${Number(rInfo.podRestarts).toString()}`
 
   let dismissHandler = () => {
     let url = "/api/action"
@@ -128,8 +132,8 @@ function podRestartAlert(r: Resource): Alert {
     alertType: PodRestartErrorType,
     header: header,
     msg: msg,
-    timestamp: rInfo.podCreationTime,
-    resourceName: r.name,
+    timestamp: rInfo.podCreationTime ?? "",
+    resourceName: r.name ?? "",
     dismissHandler: dismissHandler,
   }
 }
@@ -140,36 +144,38 @@ function crashRebuildAlert(r: Resource): Alert {
     alertType: CrashRebuildErrorType,
     header: "Pod crashed",
     msg: msg,
-    timestamp: rInfo.podCreationTime,
-    resourceName: r.name,
+    timestamp: rInfo.podCreationTime ?? "",
+    resourceName: r.name ?? "",
   }
 }
 function buildFailedAlert(resource: Resource): Alert {
   // both: DCResource and K8s Resource
-  let msg = resource.buildHistory[0].log || ""
+  let history = resource.buildHistory ?? []
+  let msg = history[0].log || ""
   return {
     alertType: BuildFailedErrorType,
     header: "Build error",
     msg: msg,
-    timestamp: resource.buildHistory[0].finishTime,
-    resourceName: resource.name,
+    timestamp: history[0].finishTime ?? "",
+    resourceName: resource.name ?? "",
   }
 }
 function warningsAlerts(resource: Resource): Array<Alert> {
   let warnings: Array<string> = []
   let alertArray: Array<Alert> = []
+  let history = resource.buildHistory ?? []
 
-  if (resource.buildHistory.length > 0) {
-    warnings = resource.buildHistory[0].warnings
+  if (history.length) {
+    warnings = history[0].warnings ?? []
   }
-  if ((warnings || []).length > 0) {
+  if (warnings.length > 0) {
     warnings.forEach(w => {
       alertArray.push({
         alertType: WarningErrorType,
-        header: resource.name,
+        header: resource.name ?? "",
         msg: w,
-        timestamp: resource.buildHistory[0].finishTime,
-        resourceName: resource.name,
+        timestamp: history[0].finishTime ?? "",
+        resourceName: resource.name ?? "",
       })
     })
   }

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -33,11 +33,11 @@ const podStatusErrImgPull = "ErrImagePull"
 const podStatusRunError = "RunContainerError"
 const podStatusStartError = "StartError"
 
-function podStatusIsCrash(status: string) {
+function podStatusIsCrash(status: string | undefined) {
   return status === podStatusError || status === podStatusCrashLoopBackOff
 }
 
-function podStatusIsError(status: string) {
+function podStatusIsError(status: string | undefined) {
   return (
     status === podStatusError ||
     status === podStatusCrashLoopBackOff ||

--- a/web/src/feature.ts
+++ b/web/src/feature.ts
@@ -7,9 +7,9 @@ type featureFlags = { [featureFlag: string]: boolean }
 export default class Features {
   private flags: featureFlags
 
-  constructor(flags: featureFlags | null) {
+  constructor(flags: object | null | undefined) {
     if (flags) {
-      this.flags = flags
+      this.flags = flags as featureFlags
     } else {
       this.flags = {}
     }

--- a/web/src/mostRecentBuild.test.ts
+++ b/web/src/mostRecentBuild.test.ts
@@ -11,7 +11,6 @@ it("returns null if there are no builds", () => {
 it("returns the most recent build if there are no pending builds", () => {
   let recent = {
     edits: ["main.go"],
-    error: null,
     startTime: "2019-04-24T13:08:41.017623-04:00",
     finishTime: "2019-04-24T13:08:42.926608-04:00",
     log: "",
@@ -28,7 +27,6 @@ it("returns the most recent build if there are no pending builds", () => {
     buildHistory: [
       {
         edits: ["main.go"],
-        error: null,
         startTime: "2019-04-24T13:08:39.017623-04:00",
         finishTime: "2019-04-24T13:08:40.926608-04:00",
         log: "",
@@ -48,8 +46,6 @@ it("returns the most recent build if there are no pending builds", () => {
 
 it("returns null if there are no pending builds and the most recent build has no edits", () => {
   let recent = {
-    edits: null,
-    error: null,
     startTime: "2019-04-24T13:08:41.017623-04:00",
     finishTime: "2019-04-24T13:08:42.926608-04:00",
     log: "",
@@ -65,8 +61,6 @@ it("returns null if there are no pending builds and the most recent build has no
     name: "snack",
     buildHistory: [
       {
-        edits: null,
-        error: null,
         startTime: "2019-04-24T13:08:39.017623-04:00",
         finishTime: "2019-04-24T13:08:40.926608-04:00",
         log: "",
@@ -94,8 +88,6 @@ it("returns the pending build if there is one", () => {
     name: "snack",
     buildHistory: [
       {
-        edits: null,
-        error: null,
         startTime: "2019-04-24T13:08:39.017623-04:00",
         finishTime: "2019-04-24T13:08:40.926608-04:00",
         log: "",

--- a/web/src/mostRecentBuild.ts
+++ b/web/src/mostRecentBuild.ts
@@ -1,5 +1,6 @@
-import { Build } from "./types"
 import { isZeroTime } from "./time"
+
+type Build = Proto.webviewBuildRecord
 
 export type ResourceWithBuilds = {
   name: string
@@ -29,7 +30,7 @@ type BuildTuple = {
 const makePendingBuild = (r: ResourceWithBuilds): BuildTuple => {
   return {
     name: r.name,
-    since: r.pendingBuildSince,
+    since: r.pendingBuildSince ?? "",
     edits: r.pendingBuildEdits || [],
   }
 }
@@ -37,7 +38,7 @@ const makePendingBuild = (r: ResourceWithBuilds): BuildTuple => {
 const makeBuildHistory = (r: ResourceWithBuilds, b: Build): BuildTuple => {
   return {
     name: r.name,
-    since: b.startTime,
+    since: b.startTime ?? "",
     edits: b.edits || [],
   }
 }

--- a/web/src/status.tsx
+++ b/web/src/status.tsx
@@ -1,5 +1,7 @@
 import { isZeroTime } from "./time"
-import { Resource, ResourceStatus, RuntimeStatus, TriggerMode } from "./types"
+import { ResourceStatus, RuntimeStatus, TriggerMode } from "./types"
+
+type Resource = Proto.webviewResource
 
 // A combination of runtime status and build status over a resource view.
 // 1) If there's a current or pending build, this is "pending".
@@ -40,7 +42,7 @@ function combinedStatus(res: Resource): ResourceStatus {
     case RuntimeStatus.Ok:
       return ResourceStatus.Healthy
     case RuntimeStatus.NotApplicable:
-      if (res.buildHistory.length > 0) {
+      if (res.buildHistory?.length) {
         return ResourceStatus.Healthy
       } else {
         return ResourceStatus.None

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -1,6 +1,8 @@
 import { RouteComponentProps } from "react-router-dom"
 import { UnregisterCallback, Href } from "history"
-import { Resource, TriggerMode } from "./types"
+import { TriggerMode } from "./types"
+
+type Resource = Proto.webviewResource
 
 type view = {
   resources: Array<Resource>

--- a/web/src/time.tsx
+++ b/web/src/time.tsx
@@ -1,6 +1,6 @@
 const zeroTime = "0001-01-01T00:00:00Z"
 
-function isZeroTime(time: string) {
+function isZeroTime(time: string | undefined) {
   return !time || time === zeroTime
 }
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -20,22 +20,6 @@ export enum TriggerMode {
   TriggerModeManualIncludingInitial,
 }
 
-export type Build = {
-  error: {} | string | null
-  startTime: string
-  log: string
-  finishTime: string
-  edits: Array<string> | null
-  isCrashRebuild: boolean
-  warnings: Array<string> | null
-}
-
-export type TiltBuild = {
-  version: string
-  date: string
-  dev: boolean
-}
-
 // what is the status of the resource in the cluster
 export enum RuntimeStatus {
   Ok = "ok",
@@ -54,46 +38,6 @@ export enum ResourceStatus {
   None, // e.g., a manual build that has never executed
 }
 
-export type Resource = {
-  name: string
-  combinedLog: string
-  buildHistory: Array<any>
-  crashLog: string
-  currentBuild: any
-  directoriesWatched: Array<any>
-  endpoints: Array<string>
-  podID: string
-  isTiltfile: boolean
-  lastDeployTime: string
-  pathsWatched: Array<string>
-  pendingBuildEdits: Array<string>
-  pendingBuildReason: number
-  pendingBuildSince: string
-  k8sResourceInfo?: K8sResourceInfo
-  dcResourceInfo?: DCResourceInfo
-  runtimeStatus: string
-  triggerMode: TriggerMode
-  hasPendingChanges: boolean
-  facets: Array<Facet>
-  queued: boolean
-}
-export type K8sResourceInfo = {
-  podName: string
-  podCreationTime: string
-  podUpdateStartTime: string
-  podStatus: string
-  podStatusMessage: string
-  podRestarts: number
-  podLog: string
-}
-export type DCResourceInfo = {
-  configPaths: Array<string>
-  containerStatus: string
-  containerID: string
-  log: string
-  startTime: string
-}
-
 export type SnapshotHighlight = {
   beginningLogID: string
   endingLogID: string
@@ -106,24 +50,8 @@ export enum ShowFatalErrorModal {
   Hide,
 }
 
-export type WebView = {
-  resources: Array<Resource>
-  log: string
-  needsAnalyticsNudge: boolean
-  runningTiltBuild: TiltBuild
-  latestTiltBuild: TiltBuild
-  featureFlags: { [featureFlag: string]: boolean }
-  tiltCloudUsername: string
-  tiltCloudSchemeHost: string
-  tiltCloudTeamID: string
-  fatalError: string | undefined
-  versionSettings: {
-    checkUpdates: boolean
-  }
-}
-
 export type Snapshot = {
-  view: WebView
+  view: Proto.webviewView
   isSidebarClosed: boolean
   path?: string
   snapshotHighlight?: SnapshotHighlight | null


### PR DESCRIPTION
Hello @jazzdan, @hyu,

Please review the following commits I made in branch nicks/types:

dfd5fda3fc6fb732c09e556af8d5b32015e7608b (2019-12-11 17:45:05 -0500)
web: delete the artisanal, hand-curated typescript types in favor of shiny new protobuf-generated types