### PR TITLE
web: Add a method for getting a single pod's logs

### DIFF
--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -74,4 +74,36 @@ describe("LogStore", () => {
 
     expect(logLinesToString(logs.manifestLog("fe"), false)).toEqual("line2\n")
   })
+
+  it("handles multi-span manifest logs", () => {
+    let logs = new LogStore()
+    logs.append({
+      spans: {
+        "pod-a": { manifestName: "fe" },
+        "pod-b": { manifestName: "fe" },
+      },
+      segments: [
+        { spanId: "pod-a", text: "pod-a: line1\n", time: now() },
+        { spanId: "pod-b", text: "pod-b: line2\n", time: now() },
+        { spanId: "pod-a", text: "pod-a: line3\n", time: now() },
+      ],
+    })
+
+    expect(logLinesToString(logs.manifestLog("fe"), false)).toEqual(
+      "pod-a: line1\npod-b: line2\npod-a: line3\n"
+    )
+    expect(logLinesToString(logs.spanLog(["pod-a", "pod-b"]), false)).toEqual(
+      "pod-a: line1\npod-b: line2\npod-a: line3\n"
+    )
+    expect(logLinesToString(logs.spanLog(["pod-a"]), false)).toEqual(
+      "pod-a: line1\npod-a: line3\n"
+    )
+    expect(logLinesToString(logs.spanLog(["pod-b"]), false)).toEqual(
+      "pod-b: line2\n"
+    )
+    expect(logLinesToString(logs.spanLog(["pod-b"]), false)).toEqual(
+      "pod-b: line2\n"
+    )
+    expect(logLinesToString(logs.spanLog(["pod-c"]), false)).toEqual("")
+  })
 })

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -84,7 +84,19 @@ class LogStore {
   }
 
   allLog(): LogLine[] {
-    return this.manifestLog("")
+    return this.logHelper(this.spans)
+  }
+
+  spanLog(spanIds: string[]): LogLine[] {
+    let spans: { [key: string]: LogSpan } = {}
+    spanIds.forEach(spanId => {
+      let span = this.spans[spanId]
+      if (span) {
+        spans[spanId] = span
+      }
+    })
+
+    return this.logHelper(spans)
   }
 
   spansForManifest(mn: string): { [key: string]: LogSpan } {
@@ -99,10 +111,13 @@ class LogStore {
   }
 
   manifestLog(mn: string): LogLine[] {
+    let spans = this.spansForManifest(mn)
+    return this.logHelper(spans)
+  }
+
+  logHelper(spansToLog: { [key: string]: LogSpan }): LogLine[] {
     let result: LogLine[] = []
     let lastLineCompleted = false
-    let allLogs = mn === ""
-    let filteredLogs = mn !== ""
 
     // We want to print the log line-by-line, but we don't actually store the logs
     // line-by-line. We store them as segments.
@@ -118,12 +133,13 @@ class LogStore {
     // for normal inputs should be fine.
     let startIndex = 0
     let lastIndex = this.segments.length - 1
-    if (filteredLogs) {
-      let spans = this.spansForManifest(mn)
+    let isFilteredLog =
+      Object.keys(spansToLog).length != Object.keys(this.spans).length
+    if (isFilteredLog) {
       let earliestStartIndex = -1
       let latestEndIndex = -1
-      for (let spanId in spans) {
-        let span = spans[spanId]
+      for (let spanId in spansToLog) {
+        let span = spansToLog[spanId]
         if (
           earliestStartIndex == -1 ||
           span.firstSegmentIndex < earliestStartIndex
@@ -152,13 +168,8 @@ class LogStore {
       }
 
       let spanId = segment.spanId
-      let span = this.spans[spanId]
+      let span = spansToLog[spanId]
       if (!span) {
-        // Something has gone terribly wrong
-        continue
-      }
-
-      if (filteredLogs && mn != span.manifestName) {
         continue
       }
 


### PR DESCRIPTION
Hello @jazzdan, @hyu,

Please review the following commits I made in branch nicks/spanlog:

246d800b26cf402d71f40f4c79472ed246bc736d (2019-12-12 10:57:59 -0500)
web: Add a method for getting a single pod's logs