### PR TITLE
web: standardize on T[] instead of Array<T>

### DIFF
--- a/web/src/alerts.test.ts
+++ b/web/src/alerts.test.ts
@@ -21,7 +21,7 @@ describe("getResourceAlerts", () => {
     rInfo.podStatusMessage = "I'm a pod in Error"
 
     let actual = getResourceAlerts(r)
-    let expectedAlerts: Array<Alert> = [
+    let expectedAlerts: Alert[] = [
       {
         alertType: PodStatusErrorType,
         msg: "I'm a pod in Error",
@@ -42,7 +42,7 @@ describe("getResourceAlerts", () => {
       delete a.dismissHandler
       return a
     })
-    let expectedAlerts: Array<Alert> = [
+    let expectedAlerts: Alert[] = [
       {
         alertType: PodRestartErrorType,
         msg: "",
@@ -67,7 +67,7 @@ describe("getResourceAlerts", () => {
       },
     ]
     let actual = getResourceAlerts(r)
-    let expectedAlerts: Array<Alert> = [
+    let expectedAlerts: Alert[] = [
       {
         alertType: BuildFailedErrorType,
         msg: "Build error log",
@@ -97,7 +97,7 @@ describe("getResourceAlerts", () => {
     rInfo.podCreationTime = "10:00AM"
 
     let actual = getResourceAlerts(r)
-    let expectedAlerts: Array<Alert> = [
+    let expectedAlerts: Alert[] = [
       {
         alertType: CrashRebuildErrorType,
         msg: "Hello I am a crash log",
@@ -123,7 +123,7 @@ describe("getResourceAlerts", () => {
       },
     ]
     let actual = getResourceAlerts(r)
-    let expectedAlerts: Array<Alert> = [
+    let expectedAlerts: Alert[] = [
       {
         alertType: WarningErrorType,
         msg: "Hi i'm a warning",
@@ -158,7 +158,7 @@ describe("getResourceAlerts", () => {
       delete a.dismissHandler
       return a
     })
-    let expectedAlerts: Array<Alert> = [
+    let expectedAlerts: Alert[] = [
       {
         alertType: PodRestartErrorType,
         msg: "I'm a pod that crashed",
@@ -190,7 +190,7 @@ describe("getResourceAlerts", () => {
       },
     ]
     let actual = getResourceAlerts(r)
-    let expectedAlerts: Array<Alert> = [
+    let expectedAlerts: Alert[] = [
       {
         alertType: CrashRebuildErrorType,
         msg: "Hello I am a crash log",
@@ -243,7 +243,7 @@ it("DC Resource: should show a warning alert using the first build history ", ()
     },
   ]
   let actual = getResourceAlerts(r)
-  let expectedAlerts: Array<Alert> = [
+  let expectedAlerts: Alert[] = [
     {
       alertType: WarningErrorType,
       msg: "Hi i'm a warning",
@@ -270,7 +270,7 @@ it("DC resource: should show a warning alert using the first build history ", ()
     },
   ]
   let actual = getResourceAlerts(r)
-  let expectedAlerts: Array<Alert> = [
+  let expectedAlerts: Alert[] = [
     {
       alertType: WarningErrorType,
       msg: "Hi i'm a warning",
@@ -296,7 +296,7 @@ it("DC Resource has build failed alert using first build history info ", () => {
     },
   ]
   let actual = getResourceAlerts(r)
-  let expectedAlerts: Array<Alert> = [
+  let expectedAlerts: Alert[] = [
     {
       alertType: BuildFailedErrorType,
       msg: "Hi you're build failed :'(",
@@ -338,7 +338,7 @@ it("renders a build error for both a K8s resource and DC resource ", () => {
   let k8sAlerts = getResourceAlerts(k8sresource)
 
   let actual = dcAlerts.concat(k8sAlerts)
-  let expectedAlerts: Array<Alert> = [
+  let expectedAlerts: Alert[] = [
     {
       alertType: BuildFailedErrorType,
       msg: "Hi your build failed :'(",

--- a/web/src/alerts.ts
+++ b/web/src/alerts.ts
@@ -54,8 +54,8 @@ function buildFailed(resource: Resource) {
 
 //This function determines what kind of alert should be made based on the functions defined
 //above
-function getResourceAlerts(r: Resource): Array<Alert> {
-  let result: Array<Alert> = []
+function getResourceAlerts(r: Resource): Alert[] {
+  let result: Alert[] = []
 
   if (r.k8sResourceInfo) {
     // K8s alerts
@@ -160,9 +160,9 @@ function buildFailedAlert(resource: Resource): Alert {
     resourceName: resource.name ?? "",
   }
 }
-function warningsAlerts(resource: Resource): Array<Alert> {
-  let warnings: Array<string> = []
-  let alertArray: Array<Alert> = []
+function warningsAlerts(resource: Resource): Alert[] {
+  let warnings: string[] = []
+  let alertArray: Alert[] = []
   let history = resource.buildHistory ?? []
 
   if (history.length) {

--- a/web/src/combinedStatusMessage.ts
+++ b/web/src/combinedStatusMessage.ts
@@ -2,7 +2,7 @@ import { isZeroTime } from "./time"
 import { StatusItem } from "./Statusbar"
 import { podStatusIsCrash, podStatusIsError } from "./constants"
 
-const combinedStatusMessage = (resources: Array<StatusItem>): string => {
+const combinedStatusMessage = (resources: StatusItem[]): string => {
   let buildingResources = resources.filter(
     r => !isZeroTime(r.currentBuild.startTime)
   )

--- a/web/src/mostRecentBuild.test.ts
+++ b/web/src/mostRecentBuild.test.ts
@@ -2,7 +2,7 @@ import mostRecentBuildToDisplay, { ResourceWithBuilds } from "./mostRecentBuild"
 import { zeroTime } from "./time"
 
 it("returns null if there are no builds", () => {
-  const resources: Array<ResourceWithBuilds> = []
+  const resources: ResourceWithBuilds[] = []
 
   let actual = mostRecentBuildToDisplay(resources)
   expect(actual).toBeNull()
@@ -38,7 +38,7 @@ it("returns the most recent build if there are no pending builds", () => {
     pendingBuildEdits: null,
     pendingBuildSince: zeroTime,
   }
-  const resources: Array<ResourceWithBuilds> = [resource]
+  const resources: ResourceWithBuilds[] = [resource]
 
   let actual = mostRecentBuildToDisplay(resources)
   expect(actual).toEqual(expectedTuple)
@@ -72,7 +72,7 @@ it("returns null if there are no pending builds and the most recent build has no
     pendingBuildEdits: null,
     pendingBuildSince: zeroTime,
   }
-  const resources: Array<ResourceWithBuilds> = [resource]
+  const resources: ResourceWithBuilds[] = [resource]
 
   let actual = mostRecentBuildToDisplay(resources)
   expect(actual).toBeNull()

--- a/web/src/mostRecentBuild.ts
+++ b/web/src/mostRecentBuild.ts
@@ -4,9 +4,9 @@ type Build = Proto.webviewBuildRecord
 
 export type ResourceWithBuilds = {
   name: string
-  buildHistory: Array<Build>
+  buildHistory: Build[]
   pendingBuildSince: string
-  pendingBuildEdits: Array<string> | null
+  pendingBuildEdits: string[] | null
 }
 
 const buildByDate = (b1: BuildTuple, b2: BuildTuple) => {
@@ -24,7 +24,7 @@ const buildByDate = (b1: BuildTuple, b2: BuildTuple) => {
 type BuildTuple = {
   name: string
   since: string
-  edits: Array<string>
+  edits: string[]
 }
 
 const makePendingBuild = (r: ResourceWithBuilds): BuildTuple => {
@@ -44,7 +44,7 @@ const makeBuildHistory = (r: ResourceWithBuilds, b: Build): BuildTuple => {
 }
 
 const mostRecentBuildToDisplay = (
-  resources: Array<ResourceWithBuilds>
+  resources: ResourceWithBuilds[]
 ): BuildTuple | null => {
   let r = null
   let pendingBuildsSorted = resources


### PR DESCRIPTION
I thought we should standardize on one way of notating arrays, and this way uses fewer characters
and more closely aligns with how slices are annotated in Go.

I ran:

```
jscodeshift -t ~/development/typescript-generic-array-to-square-brackets/transform.js --extensions=ts --parser=ts src/
```

The code for the jscodeshift transformer lives [here](https://github.com/jazzdan/typescript-generic-array-to-square-brackets).