### PR TITLE
web: remove trailing newline from logline serialization

### DIFF
--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -29,7 +29,7 @@ describe("LogStore", () => {
       segments: [newGlobalSegment("foo"), newGlobalSegment("bar")],
     })
 
-    expect(logLinesToString(logs.allLog(), true)).toEqual("foobar\n")
+    expect(logLinesToString(logs.allLog(), true)).toEqual("foobar")
   })
 
   it("handles changing levels", () => {
@@ -43,7 +43,7 @@ describe("LogStore", () => {
       ],
     })
 
-    expect(logLinesToString(logs.allLog(), true)).toEqual("foo\nbar\nbaz\n")
+    expect(logLinesToString(logs.allLog(), true)).toEqual("foo\nbar\nbaz")
   })
 
   it("handles prefixes in all logs", () => {
@@ -58,7 +58,7 @@ describe("LogStore", () => {
     })
 
     expect(logLinesToString(logs.allLog(), true)).toEqual(
-      "line1\nfe          ┊ line2\nline3\n"
+      "line1\nfe          ┊ line2\nline3"
     )
   })
 
@@ -77,7 +77,7 @@ describe("LogStore", () => {
     })
 
     expect(logLinesToString(logs.allLog(), true)).toEqual(
-      "line1\ncockroachdb…┊ line2\nline3\n"
+      "line1\ncockroachdb…┊ line2\nline3"
     )
   })
 
@@ -92,7 +92,7 @@ describe("LogStore", () => {
       ],
     })
 
-    expect(logLinesToString(logs.manifestLog("fe"), false)).toEqual("line2\n")
+    expect(logLinesToString(logs.manifestLog("fe"), false)).toEqual("line2")
   })
 
   it("handles multi-span manifest logs", () => {
@@ -110,19 +110,19 @@ describe("LogStore", () => {
     })
 
     expect(logLinesToString(logs.manifestLog("fe"), false)).toEqual(
-      "pod-a: line1\npod-b: line2\npod-a: line3\n"
+      "pod-a: line1\npod-b: line2\npod-a: line3"
     )
     expect(logLinesToString(logs.spanLog(["pod-a", "pod-b"]), false)).toEqual(
-      "pod-a: line1\npod-b: line2\npod-a: line3\n"
+      "pod-a: line1\npod-b: line2\npod-a: line3"
     )
     expect(logLinesToString(logs.spanLog(["pod-a"]), false)).toEqual(
-      "pod-a: line1\npod-a: line3\n"
+      "pod-a: line1\npod-a: line3"
     )
     expect(logLinesToString(logs.spanLog(["pod-b"]), false)).toEqual(
-      "pod-b: line2\n"
+      "pod-b: line2"
     )
     expect(logLinesToString(logs.spanLog(["pod-b"]), false)).toEqual(
-      "pod-b: line2\n"
+      "pod-b: line2"
     )
     expect(logLinesToString(logs.spanLog(["pod-c"]), false)).toEqual("")
   })

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -21,13 +21,13 @@ export function logLinesToString(
 ): string {
   return lines
     .map(line => {
-      let text = line.text + "\n"
+      let text = line.text
       if (showManifestPrefix) {
         text = sourcePrefix(line.manifestName) + text
       }
       return text
     })
-    .join("")
+    .join("\n")
 }
 
 export function sourcePrefix(n: string) {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/newlines:

8e78fadd1068a4691b4d8f394d43ce2e9b962e94 (2019-12-12 16:28:33 -0500)
web: remove trailing newline from logline serialization
this only affects tests (and is for making some test diffs in a future pr easier to follow)