### PR TITLE
tilt: add args subcommand

### DIFF
--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type argsCmd struct {
+	webPort int
+	clear   bool
+	post    httpPoster
+}
+
+func newArgsCmd() *argsCmd {
+	return &argsCmd{post: http.Post}
+}
+
+func (c *argsCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "args [<tiltfile args>]",
+		Short: "Changes the Tiltfile args in use by a running Tilt",
+		Long: `Changes the Tiltfile args in use by a running Tilt.
+
+Note that this does not affect built-in Tilt args (e.g. --hud, --host), but rather the extra args that come after,
+i.e., those specifying which resources to run and/or handled by a Tiltfile calling config.parse.
+
+To provide args starting with --, insert a standalone --, e.g.:
+
+tilt args -- --foo=bar frontend backend
+`,
+	}
+
+	cmd.Flags().IntVar(&c.webPort, "port", DefaultWebPort, "Web port for the Tilt whose args should change")
+	cmd.Flags().BoolVar(&c.clear, "clear", false, "Clear the Tiltfile args, as if you'd run tilt with no args")
+
+	return cmd
+}
+
+type httpPoster func(url string, contentType string, body io.Reader) (*http.Response, error)
+
+func (c *argsCmd) run(ctx context.Context, args []string) error {
+	// require --clear instead of an empty args list to ensure an experimental `tilt flags` doesn't unintentionally wipe state
+	if len(args) == 0 {
+		if !c.clear {
+			return errors.New("no args specified. If your intent is to empty the args, run `tilt args --clear`.")
+		}
+	} else {
+		if c.clear {
+			return errors.New("--clear cannot be specified with other values. either use --clear to clear the args or specify args to replace the args with a new (non-empty) value")
+		}
+	}
+	url := fmt.Sprintf("http://localhost:%d/api/set_tiltfile_args", c.webPort)
+	body := &bytes.Buffer{}
+	err := json.NewEncoder(body).Encode(args)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode args as json")
+	}
+	res, err := c.post(url, "application/json", body)
+	if err != nil {
+		return errors.Wrapf(err, "could not connect to Tilt at %s", url)
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("error connecting to Tilt at %s: %d", url, res.StatusCode)
+	}
+
+	fmt.Printf("changed config args for Tilt running on port %d to %v\n", webPort, args)
+
+	return nil
+}

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArgsClear(t *testing.T) {
+	f := newArgsFixture()
+	f.cmd.clear = true
+	err := f.cmd.run(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, "null\n", f.fakeHttpPoster.lastRequestBody)
+}
+
+func TestArgsNewValue(t *testing.T) {
+	f := newArgsFixture()
+	err := f.cmd.run(context.Background(), []string{"--foo", "bar"})
+	require.NoError(t, err)
+	require.Equal(t, "[\"--foo\",\"bar\"]\n", f.fakeHttpPoster.lastRequestBody)
+}
+
+func TestArgsClearAndNewValue(t *testing.T) {
+	f := newArgsFixture()
+	f.cmd.clear = true
+	err := f.cmd.run(context.Background(), []string{"--foo", "bar"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--clear cannot be specified with other values")
+}
+
+func TestArgsEmptyNewValueNoClear(t *testing.T) {
+	f := newArgsFixture()
+	err := f.cmd.run(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no args specified.")
+	require.Contains(t, err.Error(), "run `tilt args --clear`")
+}
+
+type fakeHttpPoster struct {
+	lastRequestBody string
+}
+
+var _ httpPoster = (&fakeHttpPoster{}).Post
+
+func (fp *fakeHttpPoster) Post(url string, contentType string, body io.Reader) (*http.Response, error) {
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+
+	fp.lastRequestBody = string(b)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(strings.NewReader("fake http response")),
+	}, nil
+}
+
+type argsFixture struct {
+	cmd            argsCmd
+	fakeHttpPoster *fakeHttpPoster
+}
+
+func newArgsFixture() *argsFixture {
+	fp := &fakeHttpPoster{}
+	return &argsFixture{cmd: argsCmd{post: fp.Post}, fakeHttpPoster: fp}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -51,6 +51,7 @@ func Execute() {
 	addCommand(rootCmd, &downCmd{}, a)
 	addCommand(rootCmd, &versionCmd{}, a)
 	addCommand(rootCmd, &dockerPruneCmd{}, a)
+	addCommand(rootCmd, newArgsCmd(), a)
 
 	rootCmd.AddCommand(newKubectlCmd())
 	rootCmd.AddCommand(newDumpCmd())

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -50,8 +50,18 @@ type upCmd struct {
 
 func (c *upCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "up [<resource_name1>] [<resource_name2>] [...]",
-		Short: "stand up one or more resources (if no resource names specified, stand up all known resources specified in Tiltfile)",
+		Use:   "up [<Tiltfile args>]",
+		Short: "start Tilt with the given Tiltfile args",
+		Long: `
+Starts Tilt and runs services defined in the Tiltfile.
+
+By default:
+1) Tiltfile args are interpreted as the list of services to start, e.g. tilt up frontend backend.
+2) Running with no args starts all services defined in the Tiltfile
+
+This default behavior does not apply if the Tiltfile uses config.parse or config.set_enabled_resources.
+In that case, see (hopefully) comments in your Tiltfile and/or https://tilt.dev/user_config.html
+`,
 	}
 
 	cmd.Flags().BoolVar(&c.watch, "watch", true, "If true, services will be automatically rebuilt and redeployed when files change. Otherwise, each service will be started once.")

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -207,6 +207,8 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleUserStartedTiltCloudRegistrationAction(state)
 	case store.PanicAction:
 		handlePanicAction(state, action)
+	case server.SetTiltfileArgsAction:
+		handleSetTiltfileArgsAction(state, action)
 	case store.LogEvent:
 		// handled as a LogAction, do nothing
 
@@ -656,6 +658,10 @@ func handleExitAction(state *store.EngineState, action hud.ExitAction) {
 
 func handlePanicAction(state *store.EngineState, action store.PanicAction) {
 	state.PanicExited = action.Err
+}
+
+func handleSetTiltfileArgsAction(state *store.EngineState, action server.SetTiltfileArgsAction) {
+	state.UserConfigState = state.UserConfigState.WithArgs(action.Args)
 }
 
 func handleDockerComposeEvent(ctx context.Context, engineState *store.EngineState, action DockerComposeEventAction) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3106,6 +3106,41 @@ func TestVersionSettingsStoredOnState(t *testing.T) {
 	})
 }
 
+func TestConfigArgsChangeCausesTiltfileRerun(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	f.WriteFile("Tiltfile", `
+print('hello')
+config.define_string_list('foo')
+cfg = config.parse()
+print('foo=', cfg['foo'])`)
+
+	opt := func(ia InitAction) InitAction {
+		ia.UserArgs = []string{"--foo", "bar"}
+		return ia
+	}
+
+	f.loadAndStart(opt)
+
+	f.WaitUntil("first tiltfile build finishes", func(state store.EngineState) bool {
+		return len(state.TiltfileState.BuildHistory) == 1
+	})
+
+	f.withState(func(state store.EngineState) {
+		require.Contains(t, state.TiltfileState.LastBuild().Log.String(), `foo= ["bar"]`)
+	})
+	f.store.Dispatch(server.SetTiltfileArgsAction{Args: []string{"--foo", "baz", "--foo", "quu"}})
+
+	f.WaitUntil("second tiltfile build finishes", func(state store.EngineState) bool {
+		return len(state.TiltfileState.BuildHistory) == 2
+	})
+
+	f.withState(func(state store.EngineState) {
+		require.Contains(t, state.TiltfileState.LastBuild().Log.String(), `foo= ["baz", "quu"]`)
+	})
+}
+
 type fakeTimerMaker struct {
 	restTimerLock *sync.Mutex
 	maxTimerLock  *sync.Mutex
@@ -3666,11 +3701,14 @@ func (f *testFixture) assertAllBuildsConsumed() {
 	}
 }
 
-func (f *testFixture) loadAndStart() {
+func (f *testFixture) loadAndStart(initOptions ...initOption) {
 	ia := InitAction{
 		WatchFiles:   true,
 		TiltfilePath: f.JoinPath("Tiltfile"),
 		HUDEnabled:   true,
+	}
+	for _, opt := range initOptions {
+		ia = opt(ia)
 	}
 	f.Init(ia)
 }

--- a/internal/hud/server/actions.go
+++ b/internal/hud/server/actions.go
@@ -7,3 +7,9 @@ type AppendToTriggerQueueAction struct {
 }
 
 func (AppendToTriggerQueueAction) Action() {}
+
+type SetTiltfileArgsAction struct {
+	Args []string
+}
+
+func (SetTiltfileArgsAction) Action() {}

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -85,6 +85,7 @@ func ProvideHeadsUpServer(
 	r.HandleFunc("/api/snapshot/{snapshot_id}", s.SnapshotJSON)
 	r.HandleFunc("/ws/view", s.ViewWebsocket)
 	r.HandleFunc("/api/user_started_tilt_cloud_registration", s.userStartedTiltCloudRegistration)
+	r.HandleFunc("/api/set_tiltfile_args", s.HandleSetTiltfileArgs).Methods("POST")
 
 	r.PathPrefix("/").Handler(s.cookieWrapper(assetServer))
 
@@ -211,6 +212,16 @@ func (s *HeadsUpServer) HandleAnalytics(w http.ResponseWriter, req *http.Request
 
 		s.a.Incr(p.Name, p.Tags)
 	}
+}
+
+func (s *HeadsUpServer) HandleSetTiltfileArgs(w http.ResponseWriter, req *http.Request) {
+	var args []string
+	err := jsoniter.NewDecoder(req.Body).Decode(&args)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error parsing JSON payload: %v", err), http.StatusBadRequest)
+	}
+
+	s.store.Dispatch(SetTiltfileArgsAction{args})
 }
 
 func (s *HeadsUpServer) DispatchAction(w http.ResponseWriter, req *http.Request) {

--- a/pkg/model/user_config_state.go
+++ b/pkg/model/user_config_state.go
@@ -1,9 +1,18 @@
 package model
 
+import "time"
+
 type UserConfigState struct {
-	Args []string
+	ArgsChangeTime time.Time
+	Args           []string
 }
 
 func NewUserConfigState(args []string) UserConfigState {
 	return UserConfigState{Args: args}
+}
+
+func (ucs UserConfigState) WithArgs(args []string) UserConfigState {
+	ucs.Args = args
+	ucs.ArgsChangeTime = time.Now()
+	return ucs
 }


### PR DESCRIPTION
This also works on tilt instances that are not using `config` at all.

I've found the help kind of awkward to write and am super interested in advice on making it less awkward. I wrote up some of my thinking on naming issues [here](https://docs.google.com/document/d/1JXoIR2UN4zKMBdcSZiPd7AzdQM7CVOiEL453BQtI8a0/edit?usp=sharing). 