### PR TITLE
web: Add new HUDLayout to Storybook in prep for new page hierarchy

### DIFF
--- a/web/src/HUDLayout.stories.tsx
+++ b/web/src/HUDLayout.stories.tsx
@@ -20,42 +20,41 @@ let Main = styled.main`
   border-right: 1px dashed ${Color.white};
   border-bottom: 1px dashed ${Color.white};
   padding: ${SizeUnit(0.5)};
-  white-space: pre;
 `
 
-
-let mainLorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-sed do eiusmod tempor incididunt ut 
-labore et dolore magna aliqua. Ut enim ad minim veniam, 
-
-quis nostrud exercitation ullamco laboris nisi ut 
-aliquip ex ea commodo consequat. Duis aute irure dolor
-in reprehenderit in voluptate velit esse cillum 
-dolore eu fugiat nulla pariatur. 
-
-Excepteur sint occaecat cupidatat non proident, 
-sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-sed do eiusmod tempor incididunt ut 
-labore et dolore magna aliqua. Ut enim ad minim veniam, 
-
-quis nostrud exercitation ullamco laboris nisi ut 
-aliquip ex ea commodo consequat. Duis aute irure dolor
-in reprehenderit in voluptate velit esse cillum 
-dolore eu fugiat nulla pariatur. 
-
-Excepteur sint occaecat cupidatat non proident, 
-sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Platea dictumst quisque sagittis purus sit amet volutpat consequat mauris. 
-Eleifend mi in nulla posuere sollicitudin aliquam. 
-Lorem dolor sed viverra ipsum. Laoreet non curabitur gravida arcu ac tortor dignissim. 
-
-Tortor dignissim convallis aenean et tortor at. 
-Aliquam sem et tortor consequat id porta nibh. 
-Arcu ac tortor dignissim convallis aenean et tortor at.
-`
+let mainLorem = <p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br />
+  sed do eiusmod tempor incididunt ut<br />
+  labore et dolore magna aliqua. Ut enim ad minim veniam,<br />
+  <br />
+  quis nostrud exercitation ullamco laboris nisi ut<br />
+  aliquip ex ea commodo consequat. Duis aute irure dolor<br />
+  in reprehenderit in voluptate velit esse cillum<br />
+  dolore eu fugiat nulla pariatur.<br />
+  <br/>
+  Excepteur sint occaecat cupidatat non proident,<br/>
+  sunt in culpa qui officia deserunt mollit anim id est laborum.<br/>
+  <br/>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br/>
+  sed do eiusmod tempor incididunt ut<br/>
+  labore et dolore magna aliqua. Ut enim ad minim veniam,<br/>
+  <br/>
+  quis nostrud exercitation ullamco laboris nisi ut<br/>
+  aliquip ex ea commodo consequat. Duis aute irure dolor<br/>
+  in reprehenderit in voluptate velit esse cillum<br/>
+  dolore eu fugiat nulla pariatur.<br/>
+  <br/>
+  Excepteur sint occaecat cupidatat non proident,<br/>
+  sunt in culpa qui officia deserunt mollit anim id est laborum.<br/>
+  <br/>
+  Platea dictumst quisque sagittis purus sit amet volutpat consequat mauris.<br/>
+  Eleifend mi in nulla posuere sollicitudin aliquam.<br/>
+  Lorem dolor sed viverra ipsum. Laoreet non curabitur gravida arcu ac tortor dignissim.<br/>
+  <br/>
+  Tortor dignissim convallis aenean et tortor at.<br/>
+  Aliquam sem et tortor consequat id porta nibh.<br/>
+  Arcu ac tortor dignissim convallis aenean et tortor at.<br/>
+</p>
 
 function layoutDefault() {
   return (

--- a/web/src/HUDLayout.stories.tsx
+++ b/web/src/HUDLayout.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { storiesOf } from "@storybook/react"
 import HUDLayout from "./HUDLayout"
 import styled from "styled-components"
-import {Color, Height, SizeUnit} from "./constants"
+import { Color, Height, SizeUnit } from "./constants"
 
 let Header = styled.header`
   border-right: 1px dashed ${Color.white};
@@ -22,39 +22,66 @@ let Main = styled.main`
   padding: ${SizeUnit(0.5)};
 `
 
-let mainLorem = <p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br />
-  sed do eiusmod tempor incididunt ut<br />
-  labore et dolore magna aliqua. Ut enim ad minim veniam,<br />
-  <br />
-  quis nostrud exercitation ullamco laboris nisi ut<br />
-  aliquip ex ea commodo consequat. Duis aute irure dolor<br />
-  in reprehenderit in voluptate velit esse cillum<br />
-  dolore eu fugiat nulla pariatur.<br />
-  <br/>
-  Excepteur sint occaecat cupidatat non proident,<br/>
-  sunt in culpa qui officia deserunt mollit anim id est laborum.<br/>
-  <br/>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br/>
-  sed do eiusmod tempor incididunt ut<br/>
-  labore et dolore magna aliqua. Ut enim ad minim veniam,<br/>
-  <br/>
-  quis nostrud exercitation ullamco laboris nisi ut<br/>
-  aliquip ex ea commodo consequat. Duis aute irure dolor<br/>
-  in reprehenderit in voluptate velit esse cillum<br/>
-  dolore eu fugiat nulla pariatur.<br/>
-  <br/>
-  Excepteur sint occaecat cupidatat non proident,<br/>
-  sunt in culpa qui officia deserunt mollit anim id est laborum.<br/>
-  <br/>
-  Platea dictumst quisque sagittis purus sit amet volutpat consequat mauris.<br/>
-  Eleifend mi in nulla posuere sollicitudin aliquam.<br/>
-  Lorem dolor sed viverra ipsum. Laoreet non curabitur gravida arcu ac tortor dignissim.<br/>
-  <br/>
-  Tortor dignissim convallis aenean et tortor at.<br/>
-  Aliquam sem et tortor consequat id porta nibh.<br/>
-  Arcu ac tortor dignissim convallis aenean et tortor at.<br/>
-</p>
+let mainLorem = (
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    <br />
+    sed do eiusmod tempor incididunt ut
+    <br />
+    labore et dolore magna aliqua. Ut enim ad minim veniam,
+    <br />
+    <br />
+    quis nostrud exercitation ullamco laboris nisi ut
+    <br />
+    aliquip ex ea commodo consequat. Duis aute irure dolor
+    <br />
+    in reprehenderit in voluptate velit esse cillum
+    <br />
+    dolore eu fugiat nulla pariatur.
+    <br />
+    <br />
+    Excepteur sint occaecat cupidatat non proident,
+    <br />
+    sunt in culpa qui officia deserunt mollit anim id est laborum.
+    <br />
+    <br />
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    <br />
+    sed do eiusmod tempor incididunt ut
+    <br />
+    labore et dolore magna aliqua. Ut enim ad minim veniam,
+    <br />
+    <br />
+    quis nostrud exercitation ullamco laboris nisi ut
+    <br />
+    aliquip ex ea commodo consequat. Duis aute irure dolor
+    <br />
+    in reprehenderit in voluptate velit esse cillum
+    <br />
+    dolore eu fugiat nulla pariatur.
+    <br />
+    <br />
+    Excepteur sint occaecat cupidatat non proident,
+    <br />
+    sunt in culpa qui officia deserunt mollit anim id est laborum.
+    <br />
+    <br />
+    Platea dictumst quisque sagittis purus sit amet volutpat consequat mauris.
+    <br />
+    Eleifend mi in nulla posuere sollicitudin aliquam.
+    <br />
+    Lorem dolor sed viverra ipsum. Laoreet non curabitur gravida arcu ac tortor
+    dignissim.
+    <br />
+    <br />
+    Tortor dignissim convallis aenean et tortor at.
+    <br />
+    Aliquam sem et tortor consequat id porta nibh.
+    <br />
+    Arcu ac tortor dignissim convallis aenean et tortor at.
+    <br />
+  </p>
+)
 
 function layoutDefault() {
   return (
@@ -83,4 +110,3 @@ function layoutWithSidebarCollapsed() {
 storiesOf("HUDLayout", module)
   .add("default", layoutDefault)
   .add("sidebar-collapsed", layoutWithSidebarCollapsed)
-

--- a/web/src/HUDLayout.stories.tsx
+++ b/web/src/HUDLayout.stories.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { storiesOf } from "@storybook/react"
+import HUDLayout from "./HUDLayout"
+import styled from "styled-components"
+import {Color, Height, SizeUnit} from "./constants"
+
+let Header = styled.header`
+  border-right: 1px dashed ${Color.white};
+  height: 100px;
+  padding: ${SizeUnit(0.5)};
+`
+
+let StickyNav = styled.nav`
+  background-color: ${Color.white};
+  color: ${Color.gray};
+  padding: ${SizeUnit(0.25)};
+`
+
+let Main = styled.main`
+  border-right: 1px dashed ${Color.white};
+  border-bottom: 1px dashed ${Color.white};
+  padding: ${SizeUnit(0.5)};
+  white-space: pre;
+`
+
+
+let mainLorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+sed do eiusmod tempor incididunt ut 
+labore et dolore magna aliqua. Ut enim ad minim veniam, 
+
+quis nostrud exercitation ullamco laboris nisi ut 
+aliquip ex ea commodo consequat. Duis aute irure dolor
+in reprehenderit in voluptate velit esse cillum 
+dolore eu fugiat nulla pariatur. 
+
+Excepteur sint occaecat cupidatat non proident, 
+sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+sed do eiusmod tempor incididunt ut 
+labore et dolore magna aliqua. Ut enim ad minim veniam, 
+
+quis nostrud exercitation ullamco laboris nisi ut 
+aliquip ex ea commodo consequat. Duis aute irure dolor
+in reprehenderit in voluptate velit esse cillum 
+dolore eu fugiat nulla pariatur. 
+
+Excepteur sint occaecat cupidatat non proident, 
+sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Platea dictumst quisque sagittis purus sit amet volutpat consequat mauris. 
+Eleifend mi in nulla posuere sollicitudin aliquam. 
+Lorem dolor sed viverra ipsum. Laoreet non curabitur gravida arcu ac tortor dignissim. 
+
+Tortor dignissim convallis aenean et tortor at. 
+Aliquam sem et tortor consequat id porta nibh. 
+Arcu ac tortor dignissim convallis aenean et tortor at.
+`
+
+function layoutDefault() {
+  return (
+    <HUDLayout
+      header={<Header>Header</Header>}
+      stickyNav={<StickyNav>Sticky Nav</StickyNav>}
+      isSidebarClosed={false}
+    >
+      <Main>{mainLorem}</Main>
+    </HUDLayout>
+  )
+}
+
+function layoutWithSidebarCollapsed() {
+  return (
+    <HUDLayout
+      header={<Header>Header</Header>}
+      stickyNav={<StickyNav>Sticky Nav</StickyNav>}
+      isSidebarClosed={true}
+    >
+      <Main>{mainLorem}</Main>
+    </HUDLayout>
+  )
+}
+
+storiesOf("HUDLayout", module)
+  .add("default", layoutDefault)
+  .add("sidebar-collapsed", layoutWithSidebarCollapsed)
+

--- a/web/src/HUDLayout.tsx
+++ b/web/src/HUDLayout.tsx
@@ -1,0 +1,96 @@
+import React from "react"
+import styled from "styled-components"
+import {AnimDuration, Height, Width, ZIndex} from "./constants"
+
+// The HUD UI looks like this:
+//
+//            +----------------------------+---------+
+//            | Header                     | Sidebar |
+//            |                            |         |
+//            +----------------------------+         |
+//  StickyNav +----------------------------+         |
+//            |                            |         |
+//            | Main                       |         |
+//            |                            |         |
+//            |                            |         |
+//            |                            |         |
+//            |                            |         |
+//            +--------------------------------------+
+//            +--------------------------------------+ Statusbar
+//
+// We need to satisfy several constraints:
+//
+// 1) Main streams logs and can grow very tall.
+//    So we expect scrolling to be a common interaction.
+//
+// 2) Sidebar abuts Main, and is collapsible.
+//    Sidebar never covers any content within HUDLayout.
+//
+// 3) StickyNav does not scroll offscreen, but sticks to the top.
+//
+// 4) Header, StickyNav, and Statusbar may temporarily cover Main content,
+//    but scrolling should make any covered content visible.
+//
+//
+// To create this layout:
+//
+//    We're avoiding the approach of making Main `overflow: auto / scroll-y`.
+//    Inner-div-scrolls can have lots of accessibility and UX issues.
+//    (Nick can tell you hours of stories about this. e.g.,
+//    https://medium.engineering/the-case-of-the-eternal-blur-ab350b9653ea)
+//
+//    HUDLayout has side padding that dynamically matches the Sidebar width,
+//    and bottom padding that matches Statusbar height. So when Sidebar
+//    and Statusbar are put in place with `position: fixed`, nothing is covered.
+//
+//    This way, scrolling anywhere on the page will scroll Main content.
+//    (Unless you scroll atop the Sidebar, which _is_ `overflow: auto` 👀)
+
+
+type HUDLayoutProps = {
+  header: React.ReactNode
+  stickyNav: React.ReactNode
+
+  // The main pane
+  children: React.ReactNode
+
+  isSidebarClosed: boolean
+}
+
+let Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-right: ${Width.sidebar}px;
+  padding-bottom: ${Height.statusbar}px;
+  transition: padding-right ${AnimDuration.default} ease;
+  
+  
+  &.is-sidebarCollapsed {
+    padding-right: ${Width.sidebarCollapsed}px;
+  }
+`
+
+let Header = styled.header`
+`
+
+let StickyNav = styled.nav`
+  position: sticky;
+  top: 0;
+`
+
+let Main = styled.main`
+`
+
+export default function HUDLayout(props: HUDLayoutProps) {
+  return (
+    <Root className={props.isSidebarClosed ? "is-sidebarCollapsed" : ""}>
+      <Header>
+        {props.header}
+      </Header>
+      <StickyNav>
+        {props.stickyNav}
+      </StickyNav>
+      <Main>{props.children}</Main>
+    </Root>
+  )
+}

--- a/web/src/HUDLayout.tsx
+++ b/web/src/HUDLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled from "styled-components"
-import {AnimDuration, Height, Width, ZIndex} from "./constants"
+import { AnimDuration, Height, Width, ZIndex } from "./constants"
 
 // The HUD UI looks like this:
 //
@@ -46,7 +46,6 @@ import {AnimDuration, Height, Width, ZIndex} from "./constants"
 //    This way, scrolling anywhere on the page will scroll Main content.
 //    (Unless you scroll atop the Sidebar, which _is_ `overflow: auto` 👀)
 
-
 type HUDLayoutProps = {
   header: React.ReactNode
   stickyNav: React.ReactNode
@@ -63,33 +62,26 @@ let Root = styled.div`
   padding-right: ${Width.sidebar}px;
   padding-bottom: ${Height.statusbar}px;
   transition: padding-right ${AnimDuration.default} ease;
-  
-  
+
   &.is-sidebarCollapsed {
     padding-right: ${Width.sidebarCollapsed}px;
   }
 `
 
-let Header = styled.header`
-`
+let Header = styled.header``
 
 let StickyNav = styled.nav`
   position: sticky;
   top: 0;
 `
 
-let Main = styled.main`
-`
+let Main = styled.main``
 
 export default function HUDLayout(props: HUDLayoutProps) {
   return (
     <Root className={props.isSidebarClosed ? "is-sidebarCollapsed" : ""}>
-      <Header>
-        {props.header}
-      </Header>
-      <StickyNav>
-        {props.stickyNav}
-      </StickyNav>
+      <Header>{props.header}</Header>
+      <StickyNav>{props.stickyNav}</StickyNav>
       <Main>{props.children}</Main>
     </Root>
   )

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -21,8 +21,17 @@ export enum Width {
   sidebarCollapsed = unit * 1.5,
 }
 
+export function SizeUnit(multiplier: number) {
+  let unit = 32
+  return `${unit * multiplier}px`
+}
+
 export enum ZIndex {
   topFrame = 500,
+}
+
+export enum AnimDuration {
+  default = "0.3s",
 }
 
 // Pod Status


### PR DESCRIPTION
I'm proposing a change to the visual hierarchy of our main page, in preparation for creating more space in our layout for helpful Log navigation tools. 

First step: Create a new HUDLayout which will eventually replace HUDGrid:

![Screen Shot 2019-12-12 at 4 56 04 PM](https://user-images.githubusercontent.com/20349/70752555-df31a680-1d00-11ea-8dbe-1629a4439689.png)
