### PR TITLE
logstore: incremental log loading

### DIFF
--- a/internal/cloud/snapshot_uploader.go
+++ b/internal/cloud/snapshot_uploader.go
@@ -54,7 +54,7 @@ type snapshotIDResponse struct {
 }
 
 func (s snapshotUploader) TakeAndUpload(state store.EngineState) (SnapshotID, error) {
-	view, err := webview.StateToProtoView(state)
+	view, err := webview.StateToProtoView(state, 0)
 	if err != nil {
 		return "", err
 	}

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -115,7 +115,7 @@ func (s *HeadsUpServer) Router() http.Handler {
 
 func (s *HeadsUpServer) ViewJSON(w http.ResponseWriter, req *http.Request) {
 	state := s.store.RLockState()
-	view, err := webview.StateToProtoView(state)
+	view, err := webview.StateToProtoView(state, 0)
 	s.store.RUnlockState()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error converting view to proto: %v", err), http.StatusInternalServerError)
@@ -145,7 +145,7 @@ func (s *HeadsUpServer) DumpEngineJSON(w http.ResponseWriter, req *http.Request)
 
 func (s *HeadsUpServer) SnapshotJSON(w http.ResponseWriter, req *http.Request) {
 	state := s.store.RLockState()
-	view, err := webview.StateToProtoView(state)
+	view, err := webview.StateToProtoView(state, 0)
 	s.store.RUnlockState()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error converting view to proto: %v", err), http.StatusInternalServerError)

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -12,11 +12,12 @@ import (
 	"github.com/windmilleng/tilt/internal/ospath"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
 
 	proto_webview "github.com/windmilleng/tilt/pkg/webview"
 )
 
-func StateToProtoView(s store.EngineState) (*proto_webview.View, error) {
+func StateToProtoView(s store.EngineState, logCheckpoint logstore.Checkpoint) (*proto_webview.View, error) {
 	ret := &proto_webview.View{}
 
 	rpv, err := tiltfileResourceProtoView(s)
@@ -128,7 +129,7 @@ func StateToProtoView(s store.EngineState) (*proto_webview.View, error) {
 		ret.Resources = append(ret.Resources, r)
 	}
 
-	logList, err := s.LogStore.ToLogList()
+	logList, err := s.LogStore.ToLogList(logCheckpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -161,6 +162,12 @@ func StateToProtoView(s store.EngineState) (*proto_webview.View, error) {
 	ret.VersionSettings = &proto_webview.VersionSettings{
 		CheckUpdates: s.VersionSettings.CheckUpdates,
 	}
+
+	start, err := timeToProto(s.TiltStartTime)
+	if err != nil {
+		return nil, err
+	}
+	ret.TiltStartTime = start
 
 	return ret, nil
 }

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -22,7 +22,7 @@ import (
 var fooManifest = model.Manifest{Name: "foo"}.WithDeployTarget(model.K8sTarget{})
 
 func stateToProtoView(t *testing.T, s store.EngineState) *proto_webview.View {
-	v, err := StateToProtoView(s)
+	v, err := StateToProtoView(s, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -225,3 +225,34 @@ func TestManifestLogContinuation(t *testing.T) {
 	assert.Equal(t, "ab", l.ManifestLog("back"))
 	assert.Equal(t, "1\n2\nfe          ┊ 3478\n5\n6\nback        ┊ ab\n5\n6\n", l.String())
 }
+
+func TestLogIncremental(t *testing.T) {
+	l := NewLogStore()
+	l.Append(newGlobalTestLogEvent("line1\n"), nil)
+	l.Append(newGlobalTestLogEvent("line2\n"), nil)
+	l.Append(newGlobalTestLogEvent("line3\n"), nil)
+
+	list, err := l.ToLogList(0)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(list.Segments))
+	assert.Equal(t, int32(0), list.FromCheckpoint)
+	assert.Equal(t, int32(3), list.ToCheckpoint)
+
+	list, err = l.ToLogList(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(list.Segments))
+	assert.Equal(t, int32(1), list.FromCheckpoint)
+	assert.Equal(t, int32(3), list.ToCheckpoint)
+
+	list, err = l.ToLogList(3)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(list.Segments))
+	assert.Equal(t, int32(-1), list.FromCheckpoint)
+	assert.Equal(t, int32(-1), list.ToCheckpoint)
+
+	list, err = l.ToLogList(10)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(list.Segments))
+	assert.Equal(t, int32(-1), list.FromCheckpoint)
+	assert.Equal(t, int32(-1), list.ToCheckpoint)
+}

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -43,6 +43,8 @@ class AppController {
   createNewSocket() {
     this.tryConnectCount++
     this.socket = new WebSocket(this.url)
+    let socket = this.socket
+
     this.socket.addEventListener("close", this.onSocketClose.bind(this))
     this.socket.addEventListener("message", event => {
       if (!this.liveSocket) {
@@ -52,6 +54,15 @@ class AppController {
       this.tryConnectCount = 0
 
       let data: Proto.webviewView = JSON.parse(event.data)
+      let toCheckpoint = data.logList?.toCheckpoint
+      if (toCheckpoint && toCheckpoint > 0) {
+        let tiltStartTime = data.tiltStartTime
+        let response: Proto.webviewAckWebsocketRequest = {
+          toCheckpoint,
+          tiltStartTime,
+        }
+        socket.send(JSON.stringify(response))
+      }
 
       // @ts-ignore
       this.component.setAppState({

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -124,12 +124,18 @@ class HUD extends Component<HudProps, HudState> {
   setAppState<K extends keyof HudState>(state: Pick<HudState, K>) {
     this.setState(prevState => {
       let newState = _.clone(state) as any
+      newState.logStore = prevState.logStore ?? new LogStore()
+
       let newLogList = newState.view?.logList
       if (newLogList) {
-        // For now, just create a brand new log store.
-        // In the future, we'll do more complex merging.
-        newState.logStore = new LogStore()
-        newState.logStore.append(newLogList)
+        let fromCheckpoint = newLogList.fromCheckpoint ?? 0
+        if (fromCheckpoint > 0) {
+          newState.logStore.append(newLogList)
+        } else if (fromCheckpoint === 0) {
+          // if the fromCheckpoint is 0 or undefined, create a brand new log store.
+          newState.logStore = new LogStore()
+          newState.logStore.append(newLogList)
+        }
       }
       return newState
     })

--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -126,4 +126,33 @@ describe("LogStore", () => {
     )
     expect(logLinesToString(logs.spanLog(["pod-c"]), false)).toEqual("")
   })
+
+  it("handles incremental logs", () => {
+    let logs = new LogStore()
+    logs.append({
+      spans: { "": {} },
+      segments: [newGlobalSegment("line1\n"), newGlobalSegment("line2\n")],
+      fromCheckpoint: 0,
+      toCheckpoint: 2,
+    })
+    logs.append({
+      spans: { "": {} },
+      segments: [newGlobalSegment("line3\n"), newGlobalSegment("line4\n")],
+      fromCheckpoint: 2,
+      toCheckpoint: 4,
+    })
+    logs.append({
+      spans: { "": {} },
+      segments: [
+        newGlobalSegment("line4\n"),
+        newGlobalSegment("line4\n"),
+        newGlobalSegment("line5\n"),
+      ],
+      fromCheckpoint: 2,
+      toCheckpoint: 5,
+    })
+    expect(logLinesToString(logs.allLog(), true)).toEqual(
+      "line1\nline2\nline3\nline4\nline5"
+    )
+  })
 })


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/ch4095/logs:

cdb8b67a150ed3850a4c3a08b3ed776a274174e7 (2019-12-13 16:19:01 -0500)
logstore: incremental log loading
Now, we only push down the logs that have changed, rather than pushing
down all the logs on every websocket message

89bf4760d2a532c89df5e7033a88838732f49492 (2019-12-13 15:30:10 -0500)
webview proto: define incremental log-loading protocol