### PR TITLE
web: tweak Manifest Name layout

### DIFF
--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -4,8 +4,8 @@ import AnsiLine from "./AnsiLine"
 import "./LogPane.scss"
 import ReactDOM from "react-dom"
 import { LogLine, SnapshotHighlight } from "./types"
-import { sourcePrefix } from "./logs"
 import color from "./color"
+import { SizeUnit, Width } from "./constants"
 import findLogLineID from "./findLogLine"
 import styled from "styled-components"
 
@@ -37,15 +37,20 @@ type LogLineComponentProps = {
 
 let LogLinePrefixRoot = styled.span`
   user-select: none;
-  width: 6em;
+  width: calc(
+    ${Width.tabNav}px - ${SizeUnit(0.5)}
+  ); // Match height of tab above
+  box-sizing: border-box;
   display: inline-block;
-  border-right: 1px solid ${color.grayLightest};
-  padding-right: 16px;
-  margin-right: 16px;
+  background-color: ${color.grayDark};
+  border-right: 1px dotted ${color.grayLightest};
+  color: ${color.grayLightest};
+  padding-right: ${SizeUnit(0.5)};
+  margin-right: ${SizeUnit(0.5)};
+  text-align: right;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  color: ${color.grayLight};
   flex-shrink: 0;
 
   &::selection {
@@ -54,7 +59,7 @@ let LogLinePrefixRoot = styled.span`
 `
 
 let LogLinePrefix = React.memo((props: { name: string }) => {
-  return <LogLinePrefixRoot>{props.name}</LogLinePrefixRoot>
+  return <LogLinePrefixRoot title={props.name}>{props.name}</LogLinePrefixRoot>
 })
 
 class LogLineComponent extends PureComponent<LogLineComponentProps> {

--- a/web/src/TabNav.scss
+++ b/web/src/TabNav.scss
@@ -17,7 +17,7 @@
   box-sizing: border-box;
   height: $tabnav-height;
   flex: 0 0 auto;
-  min-width: 10em;
+  width: $tabnav-width;
   color: inherit;
   text-decoration: none;
   display: flex;

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -43,6 +43,7 @@ $sidebar-collapsed-width: $sidebar-item;
 $alert-badge: $spacing-unit * 0.75;
 
 $topbar-height: $spacing-unit * 2.25;
+$tabnav-width: 160px; // Fits our current labels
 $tabnav-height: $topbar-height;
 $resourceInfo-height: $spacing-unit * 1.5;
 $analyticsNudge-height: $tabnav-height * 1.5;

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -19,6 +19,7 @@ export enum Height {
 export enum Width {
   sidebar = unit * 10,
   sidebarCollapsed = unit * 1.5,
+  tabNav = unit * 5, // Match constants.scss > $tabnav-width
 }
 
 export function SizeUnit(multiplier: number) {


### PR DESCRIPTION
- Right align the text so the ragged left edge makes it easier to distinguish manifests from each other.

- Align the manifest width with the tab width, because it was previously juuuuuust a little off.

- Show full Manifest name on hover

![Screen Shot 2019-12-13 at 5 13 52 PM](https://user-images.githubusercontent.com/20349/70835781-29338e80-1dcc-11ea-8799-195c07b54266.png)
