### PR TITLE
huud: shorted default log truncation a lot. makes hud rendering much faster

### DIFF
--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -15,6 +15,8 @@ import (
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
+const defaultLogPaneHeight = 8
+
 type Renderer struct {
 	rty    rty.RTY
 	screen tcell.Screen
@@ -133,7 +135,7 @@ func (r *Renderer) renderLogPane(v view.View, vs view.ViewState) rty.Component {
 	var height int
 	switch vs.TiltLogState {
 	case view.TiltLogShort:
-		height = 8
+		height = defaultLogPaneHeight
 	case view.TiltLogHalfScreen:
 		height = rty.GROW
 	case view.TiltLogFullScreen:

--- a/internal/hud/tabview.go
+++ b/internal/hud/tabview.go
@@ -37,6 +37,11 @@ func (v *TabView) Build() rty.Component {
 }
 
 func (v *TabView) log() string {
+	var numLinesNeeded = logLineCount
+	if v.viewState.TiltLogState == view.TiltLogShort {
+		numLinesNeeded = defaultLogPaneHeight
+	}
+
 	var ret model.Log
 	var reader logstore.Reader
 	switch v.tabState {
@@ -57,9 +62,9 @@ func (v *TabView) log() string {
 	}
 
 	if !ret.Empty() {
-		return ret.Tail(logLineCount).String()
+		return ret.Tail(numLinesNeeded).String()
 	} else if !reader.Empty() {
-		return reader.String()
+		return reader.Tail(numLinesNeeded)
 	} else {
 		return "(no logs received)"
 	}


### PR DESCRIPTION
Hello @hyu, @jazzdan,

Please review the following commits I made in branch nicks/ch4131/perf:

ea2de2ddd940dd71d5f26cc84b6b8d98bf25e2cf (2019-12-18 13:11:36 -0500)
hud: shorten default log truncation a lot. makes hud rendering much faster