### PR TITLE
web: default span ids to _. Fixes firestore issues with empty map keys

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -299,13 +299,13 @@ it("loads logs incrementally", async () => {
   let snapshot = hud.snapshotFromState(hud.state)
   expect(snapshot.view?.logList).toEqual({
     spans: {
-      "": { manifestName: "" },
+      _: { manifestName: "" },
     },
     segments: [
-      { text: "line1\n", time: now, level: "INFO", spanId: "" },
-      { text: "line2\n", time: now, level: "INFO", spanId: "" },
-      { text: "line3\n", time: now, level: "INFO", spanId: "" },
-      { text: "line4\n", time: now, level: "INFO", spanId: "" },
+      { text: "line1\n", time: now, level: "INFO", spanId: "_" },
+      { text: "line2\n", time: now, level: "INFO", spanId: "_" },
+      { text: "line3\n", time: now, level: "INFO", spanId: "_" },
+      { text: "line4\n", time: now, level: "INFO", spanId: "_" },
     ],
   })
 })


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch4132/firestore:

2162402d2520fa86f0fad7de897a405170655bab (2019-12-18 14:33:44 -0500)
web: default span ids to _. Fixes firestore issues with empty map keys