### PR TITLE
engine: remove logs from the runtime data model and load them from the logstore

### DIFF
--- a/internal/dockercompose/state.go
+++ b/internal/dockercompose/state.go
@@ -55,9 +55,6 @@ type State struct {
 	Status      Status
 	ContainerID container.ID
 
-	// TODO(nick): Delete this and use SpanID to look up the log.
-	CurrentLog model.Log
-
 	StartTime     time.Time
 	IsStopping    bool
 	LastReadyTime time.Time
@@ -66,15 +63,6 @@ type State struct {
 }
 
 func (State) RuntimeState() {}
-
-func (s State) Log() model.Log {
-	return s.CurrentLog
-}
-
-func (s State) WithCurrentLog(l model.Log) State {
-	s.CurrentLog = l
-	return s
-}
 
 func (s State) WithSpanID(spanID model.LogSpanID) State {
 	s.SpanID = spanID

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -133,10 +133,6 @@ type Pod struct {
 
 	HasSynclet bool
 
-	// The log for the currently active pod, if any
-	// TODO(nick): Delete this and use SpanID to look up the log.
-	CurrentLog model.Log `testdiff:"ignore"`
-
 	Containers []Container
 
 	// We want to show the user # of restarts since some baseline time
@@ -171,10 +167,6 @@ func (p Pod) isAfter(p2 Pod) bool {
 		return false
 	}
 	return p.PodID > p2.PodID
-}
-
-func (p Pod) Log() model.Log {
-	return p.CurrentLog
 }
 
 func (p Pod) AllContainerPorts() []int32 {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/runtimelog:

4cca650332357d0bced0b1f08b9aff5c560f5f07 (2019-12-20 17:21:13 -0500)
engine: remove logs from the runtime data model and load them from the logstore
Note that this changes functionality slightly. Before this PR,
we would clear the pod logs every time the pod crashed. In the LogStore,
there's a single span ID for a pod's logs, no matter how many times it crashed.

I don't *think* that changing this behavior will have any bad side-effects
but @maiamcc might be able to think of problems that I don't remember right now.

Long-term, I think we should move towards a system where every container ID
has its own log span ID, and that span ID has a parent span ID for the whole
pod's logs (similar to how spans work in opentracing)