### PR TITLE
engine test: fakeBuildAndDeployer can now resolve builds manually

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -70,6 +70,8 @@ import (
 
 var originalWD string
 
+type buildCompletionChannel chan bool
+
 func init() {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -156,9 +158,8 @@ type fakeBuildAndDeployer struct {
 	t     *testing.T
 	calls chan buildAndDeployCall
 
-	resolveBuildsManually    bool
-	buildsAwaitingResolution map[int]bool
-	resolveBuildsMu          sync.Mutex
+	completeBuildsManually bool
+	buildCompletionChans   sync.Map // map[int]buildCompletionChannel; close channel at buildCompletionChans[n] to complete build #n
 
 	buildCount int
 
@@ -199,15 +200,16 @@ func (b *fakeBuildAndDeployer) nextBuildResult(iTarget model.ImageTarget, deploy
 
 func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, state store.BuildStateSet) (brs store.BuildResultSet, err error) {
 	b.buildCount++
-	count := b.buildCount
+	index := b.buildCount
+	b.registerBuild(index)
 
-	if !b.resolveBuildsManually {
+	if !b.completeBuildsManually {
 		// resolve builds automatically: mark the build for resolution now,,
 		// so we complete the build as soon as we start it
-		b.resolveBuildAtIndex(count)
+		b.resolveBuild(index)
 	}
 
-	call := buildAndDeployCall{count: count, specs: specs, state: state}
+	call := buildAndDeployCall{count: index, specs: specs, state: state}
 	if call.dc().Empty() && call.k8s().Empty() && call.local().Empty() {
 		b.t.Fatalf("Invalid call: %+v", call)
 	}
@@ -284,40 +286,64 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 	}
 
 	// block until we know we're supposed to resolve this build
-	for {
-		if _, ok := b.buildsAwaitingResolution[count]; ok {
-			delete(b.buildsAwaitingResolution, count)
-			break
-		}
-
-		select {
-		case <-ctx.Done():
-			break
-		case <-time.After(time.Millisecond * 5):
-		}
-	}
+	b.waitUntilBuildCompleted(ctx, index)
 
 	return result, err
 }
+func (b *fakeBuildAndDeployer) getBuildCompletionChan(index int) (buildCompletionChannel, bool) {
+	var ch buildCompletionChannel
+	val, ok := b.buildCompletionChans.Load(index)
+	if ok {
+		var chanOk bool
+		ch, chanOk = val.(buildCompletionChannel)
+		if !chanOk {
+			panic(fmt.Sprintf("exected map value of type: buildCompletionChannel, got %T", val))
+		}
+	}
 
+	return ch, ok
+}
+
+func (b *fakeBuildAndDeployer) registerBuild(index int) {
+	if _, ok := b.getBuildCompletionChan(index); ok {
+		b.t.Fatalf("Tried to register build #%d, but it's already registered (i.e. completion chan already exists)", index)
+	}
+	ch := make(buildCompletionChannel)
+	b.buildCompletionChans.Store(index, ch)
+}
+
+func (b *fakeBuildAndDeployer) waitUntilBuildCompleted(ctx context.Context, index int) {
+	ch, ok := b.getBuildCompletionChan(index)
+	if !ok {
+		panic(fmt.Sprintf("no completion channel for build #%d (b.registerBuild should already have been called)", index))
+	}
+
+	// wait until channel for this build is closed, or context is canceled/finishes.
+	select {
+	case <-ch:
+	case <-ctx.Done():
+	}
+
+	b.buildCompletionChans.Delete(index)
+}
 func newFakeBuildAndDeployer(t *testing.T) *fakeBuildAndDeployer {
 	return &fakeBuildAndDeployer{
-		t:                        t,
-		calls:                    make(chan buildAndDeployCall, 20),
-		buildsAwaitingResolution: make(map[int]bool),
-		buildLogOutput:           make(map[model.TargetID]string),
-		resultsByID:              store.BuildResultSet{},
+		t:              t,
+		calls:          make(chan buildAndDeployCall, 20),
+		buildLogOutput: make(map[model.TargetID]string),
+		resultsByID:    store.BuildResultSet{},
 	}
 }
 
-func (b *fakeBuildAndDeployer) resolveBuildAtIndex(i int) {
-	b.resolveBuildsMu.Lock()
-	defer b.resolveBuildsMu.Unlock()
-
-	if _, ok := b.buildsAwaitingResolution[i]; ok {
-		b.t.Fatalf("Tried to mark build #%d for resolution, but build already marked", i)
+func (b *fakeBuildAndDeployer) resolveBuild(index int) {
+	ch, ok := b.getBuildCompletionChan(index)
+	if !ok {
+		// TODO(maia): maybe this should just create and close a channel for this key
+		b.t.Fatalf("tried to mark build #%d for for completion, but no completion channel registered (b.registerBuild(index) "+
+			"should already have been called--probably by b.BuildAndDeploy)", index)
 	}
-	b.buildsAwaitingResolution[i] = true
+
+	close(ch)
 }
 
 func TestUpper_Up(t *testing.T) {
@@ -3711,6 +3737,12 @@ func (f *testFixture) TearDown() {
 	f.kClient.TearDown()
 	close(f.fsWatcher.events)
 	close(f.fsWatcher.errors)
+	f.b.buildCompletionChans.Range(func(key, value interface{}) bool {
+		if ch, ok := value.(buildCompletionChannel); ok {
+			close(ch)
+		}
+		return true
+	})
 	f.cancel()
 }
 


### PR DESCRIPTION
this PR doesn't change any behavior right now, but sets me up
to better test parallel builds--can now start builds A, B, and C,
and complete just build C