### PR TITLE
cloud: no longer any reason to clear feature flags on upload

### DIFF
--- a/internal/cloud/snapshot_uploader.go
+++ b/internal/cloud/snapshot_uploader.go
@@ -61,14 +61,7 @@ func (s snapshotUploader) TakeAndUpload(state store.EngineState) (SnapshotID, er
 	return s.Upload(state.Token, state.TeamName, &proto_webview.Snapshot{View: view})
 }
 
-func cleanSnapshot(snapshot *proto_webview.Snapshot) *proto_webview.Snapshot {
-	snapshot.View.FeatureFlags = nil
-	return snapshot
-}
-
 func (s snapshotUploader) Upload(token token.Token, teamID string, snapshot *proto_webview.Snapshot) (SnapshotID, error) {
-	snapshot = cleanSnapshot(snapshot)
-
 	b := &bytes.Buffer{}
 	jsEncoder := &runtime.JSONPb{OrigName: false, EmitDefaults: true}
 	err := jsEncoder.NewEncoder(b).Encode(snapshot)


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/ch4136/facets:

92ae7159ced87335ef8078c3ad83c1b78f891ebe (2020-01-02 18:12:27 -0500)
cloud: no longer any reason to clear feature flags on upload