### PR TITLE
tiltfile: default port-forward hosts to the host set on the command-line

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -77,7 +77,7 @@ In that case, see https://tilt.dev/user_config.html and/or comments in your Tilt
 	cmd.Flags().BoolVar(&c.hud, "hud", true, "If true, tilt will open in HUD mode.")
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
 	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server. Set to 0 to disable.")
-	cmd.Flags().StringVar(&webHost, "host", DefaultWebHost, "Host for the Tilt HTTP server. Set to 0.0.0.0 to listen on all interfaces.")
+	cmd.Flags().StringVar(&webHost, "host", DefaultWebHost, "Host for the Tilt HTTP server and default host for any port-forwards. Set to 0.0.0.0 to listen on all interfaces.")
 	cmd.Flags().IntVar(&webDevPort, "webdev-port", DefaultWebDevPort, "Port for the Tilt Dev Webpack server. Only applies when using --web-mode=local")
 	cmd.Flags().Lookup("logactions").Hidden = true
 	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -85,8 +85,9 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics) (
 	switchCli := docker.ProvideSwitchCli(clusterClient, localClient)
 	extension := k8scontext.NewExtension(kubeContext, env)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
+	modelWebHost := provideWebHost()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, dockerComposeClient, defaults)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, dockerComposeClient, modelWebHost, defaults)
 	cliDpDeps := newDPDeps(switchCli, tiltfileLoader)
 	return cliDpDeps, nil
 }
@@ -194,7 +195,7 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
 	extension := k8scontext.NewExtension(kubeContext, env)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, dockerComposeClient, defaults)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, dockerComposeClient, modelWebHost, defaults)
 	configsController := configs.NewConfigsController(tiltfileLoader, switchCli)
 	dockerComposeEventWatcher := engine.NewDockerComposeEventWatcher(dockerComposeClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
@@ -425,8 +426,9 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 		return DownDeps{}, err
 	}
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
+	modelWebHost := provideWebHost()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, client, extension, dockerComposeClient, defaults)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, client, extension, dockerComposeClient, modelWebHost, defaults)
 	downDeps := ProvideDownDeps(tiltfileLoader, dockerComposeClient, client)
 	return downDeps, nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3277,7 +3277,7 @@ func newTestFixtureWithHud(t *testing.T, h hud.HeadsUpDisplay) *testFixture {
 	ar := engineanalytics.ProvideAnalyticsReporter(ta, st)
 	fakeDcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	k8sContextExt := k8scontext.NewExtension("fake-context", k8s.EnvDockerDesktop)
-	tfl := tiltfile.ProvideTiltfileLoader(ta, kCli, k8sContextExt, fakeDcc, feature.MainDefaults)
+	tfl := tiltfile.ProvideTiltfileLoader(ta, kCli, k8sContextExt, fakeDcc, "localhost", feature.MainDefaults)
 	cc := configs.NewConfigsController(tfl, dockerClient)
 	dcw := NewDockerComposeEventWatcher(fakeDcc)
 	dclm := runtimelog.NewDockerComposeLogManager(fakeDcc)

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -538,7 +538,11 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []string) {
 	portForwards := mt.Manifest.K8sTarget().PortForwards
 	if len(portForwards) > 0 {
 		for _, pf := range portForwards {
-			endpoints = append(endpoints, fmt.Sprintf("http://localhost:%d/", pf.LocalPort))
+			host := pf.Host
+			if host == "" {
+				host = "localhost"
+			}
+			endpoints = append(endpoints, fmt.Sprintf("http://%s:%d/", host, pf.LocalPort))
 		}
 		return endpoints
 	}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -92,12 +92,14 @@ func ProvideTiltfileLoader(
 	kCli k8s.Client,
 	k8sContextExt k8scontext.Extension,
 	dcCli dockercompose.DockerComposeClient,
+	webHost model.WebHost,
 	fDefaults feature.Defaults) TiltfileLoader {
 	return tiltfileLoader{
 		analytics:     analytics,
 		kCli:          kCli,
 		k8sContextExt: k8sContextExt,
 		dcCli:         dcCli,
+		webHost:       webHost,
 		fDefaults:     fDefaults,
 	}
 }
@@ -106,6 +108,7 @@ type tiltfileLoader struct {
 	analytics *analytics.TiltAnalytics
 	kCli      k8s.Client
 	dcCli     dockercompose.DockerComposeClient
+	webHost   model.WebHost
 
 	k8sContextExt k8scontext.Extension
 	fDefaults     feature.Defaults
@@ -147,7 +150,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 	tlr.TiltIgnoreContents = string(tiltIgnoreContents)
 
 	privateRegistry := tfl.kCli.PrivateRegistry(ctx)
-	s := newTiltfileState(ctx, tfl.dcCli, tfl.k8sContextExt, privateRegistry, feature.FromDefaults(tfl.fDefaults))
+	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.k8sContextExt, privateRegistry, feature.FromDefaults(tfl.fDefaults))
 
 	manifests, result, err := s.loadManifests(absFilename, userConfigState)
 


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/issue2707/host:

2e0ffaafa988795fd15f6581d81a53fab54a3ed8 (2020-01-02 19:42:37 -0500)
tiltfile: default port-forward hosts to the host set on the command-line
Fixes https://github.com/windmilleng/tilt/issues/2707