### PR TITLE
engine: more info in BuildCompleteAction, store CurrentlyBuilding as set (prework for parallel build) [ch4065]

### DIFF
--- a/internal/engine/buildcontrol/actions.go
+++ b/internal/engine/buildcontrol/actions.go
@@ -25,15 +25,17 @@ type BuildLogAction struct {
 func (BuildLogAction) Action() {}
 
 type BuildCompleteAction struct {
-	Result store.BuildResultSet
-	Error  error
+	ManifestName model.ManifestName
+	Result       store.BuildResultSet
+	Error        error
 }
 
 func (BuildCompleteAction) Action() {}
 
-func NewBuildCompleteAction(result store.BuildResultSet, err error) BuildCompleteAction {
+func NewBuildCompleteAction(mn model.ManifestName, result store.BuildResultSet, err error) BuildCompleteAction {
 	return BuildCompleteAction{
-		Result: result,
-		Error:  err,
+		ManifestName: mn,
+		Result:       result,
+		Error:        err,
 	}
 }

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -105,7 +105,7 @@ func (c *BuildController) OnChange(ctx context.Context, st store.RStore) {
 		c.logBuildEntry(ctx, entry)
 
 		result, err := c.buildAndDeploy(ctx, st, entry)
-		st.Dispatch(buildcontrol.NewBuildCompleteAction(result, err))
+		st.Dispatch(buildcontrol.NewBuildCompleteAction(entry.name, result, err))
 	}()
 }
 

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -68,7 +68,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 
 	state := st.RLockState()
 	settings := state.DockerPruneSettings
-	inProgBuild := state.CurrentlyBuilding
+	buildInProg := len(state.CurrentlyBuilding) > 0
 	curBuildCount := state.CompletedBuildCount
 	hasDockerBuild := state.HasDockerBuild()
 	nextToBuild := buildcontrol.NextManifestNameToBuild(state)
@@ -85,7 +85,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 	}
 
 	// Don't prune while we're building or about to build something, in case of weird side-effects.
-	if inProgBuild != "" || nextToBuild != "" {
+	if buildInProg || nextToBuild != "" {
 		return
 	}
 

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -407,7 +407,7 @@ func (dpf *dockerPruneFixture) withBuildCount(count int) {
 
 func (dpf *dockerPruneFixture) withCurrentlyBuilding(mn model.ManifestName) {
 	store := dpf.st.LockMutableStateForTesting()
-	store.CurrentlyBuilding = mn
+	store.CurrentlyBuilding[mn] = true
 	dpf.st.UnlockMutableState()
 }
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -260,20 +260,20 @@ func handleBuildStarted(ctx context.Context, state *store.EngineState, action bu
 		ms.CrashLog = model.Log{}
 	}
 
-	state.CurrentlyBuilding = mn
+	state.CurrentlyBuilding[mn] = true
 	removeFromTriggerQueue(state, mn)
 }
 
 func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, cb buildcontrol.BuildCompleteAction) error {
 	defer func() {
-		engineState.CurrentlyBuilding = ""
+		delete(engineState.CurrentlyBuilding, cb.ManifestName)
 	}()
 
 	buildCount := engineState.BuildControllerActionCount
 	engineState.CompletedBuildCount++
 	engineState.BuildControllerActionCount++
 
-	mt, ok := engineState.ManifestTargets[engineState.CurrentlyBuilding]
+	mt, ok := engineState.ManifestTargets[cb.ManifestName]
 	if !ok {
 		return nil
 	}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -32,7 +32,7 @@ type EngineState struct {
 	// TODO(nick): This will eventually be a general Target index.
 	ManifestTargets map[model.ManifestName]*ManifestTarget
 
-	CurrentlyBuilding model.ManifestName
+	CurrentlyBuilding map[model.ManifestName]bool
 	WatchFiles        bool
 
 	// How many builds have been completed (pass or fail) since starting tilt
@@ -127,6 +127,10 @@ func (e *EngineState) ManifestNamesForTargetID(id model.TargetID) []model.Manife
 		}
 	}
 	return result
+}
+
+func (e *EngineState) IsCurrentlyBuilding(name model.ManifestName) bool {
+	return e.CurrentlyBuilding[name]
 }
 
 func (e *EngineState) BuildStatus(id model.TargetID) BuildStatus {
@@ -323,6 +327,7 @@ func NewState() *EngineState {
 	ret.VersionSettings = model.VersionSettings{
 		CheckUpdates: true,
 	}
+	ret.CurrentlyBuilding = make(map[model.ManifestName]bool)
 	return ret
 }
 
@@ -389,6 +394,10 @@ func (ms *ManifestState) IsK8s() bool {
 
 func (ms *ManifestState) ActiveBuild() model.BuildRecord {
 	return ms.CurrentBuild
+}
+
+func (ms *ManifestState) IsBuilding() bool {
+	return !ms.CurrentBuild.Empty()
 }
 
 func (ms *ManifestState) LastBuild() model.BuildRecord {


### PR DESCRIPTION
Hello @,

Please review the following commits I made in branch maiamcc/prework-parallel-build:

9cc74255466f9a1d7d8a38884717b1e6e9251ea6 (2020-01-06 11:48:49 -0500)
engine: more info in BuildCompleteAction, store CurrentlyBuilding as set (pre-work for parallel builds) [ch4065]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics