### PR TITLE
bump version to v0.10.26

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.10.25"
+const devVersion = "0.10.26"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.10.25"
+VERSION="0.10.26"
 BREW=$(which brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/bump:

6575dbcb91b9d082826edb8afae4ffac7039bdff (2020-01-06 17:18:45 -0500)
bump version to v0.10.26