### PR TITLE
goreleaser: fix some deprecation notices

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,8 +13,8 @@ builds:
   - windows
   goarch:
   - amd64
-archive:
-  name_template: "{{ .ProjectName }}.{{ .Version }}.{{ .Os }}.{{ .Arch }}"
+archives:
+- name_template: "{{ .ProjectName }}.{{ .Version }}.{{ .Os }}.{{ .Arch }}"
   replacements:
     windows: windows_ALPHA
     darwin: mac
@@ -31,8 +31,8 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-brew:
-  github:
+brews:
+- github:
     owner: windmilleng
     name: homebrew-tap
   commit_author:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/goreleaser:

e2fce573d5723f14fdd1f8bd29527da7d1860be6 (2020-01-06 17:24:40 -0500)
goreleaser: fix some deprecation notices