### PR TITLE
tiltfile: ability to specify serve commands in tiltfile

### DIFF
--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -41,7 +41,7 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		"resource_deps?", &resourceDepsVal,
 		"ignore?", &ignoresVal,
 		"auto_init?", &autoInit,
-		"serveCmd?", &serveCmdStr,
+		"serve_cmd?", &serveCmdStr,
 	); err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	serveCmd := model.ToShellCmd(serveCmdStr)
 
 	if updateCmd.Empty() && serveCmd.Empty() {
-		return nil, fmt.Errorf("local_resource must have an updateCmd and/or a serveCmd, but both were empty")
+		return nil, fmt.Errorf("local_resource must have a cmd and/or a serve_cmd, but both were empty")
 	}
 
 	res := localResource{

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -35,13 +35,13 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
-		"updateCmd?", &updateCmdStr,
-		"serveCmd?", &serveCmdStr,
+		"cmd?", &updateCmdStr,
 		"deps?", &deps,
 		"trigger_mode?", &triggerMode,
 		"resource_deps?", &resourceDepsVal,
 		"ignore?", &ignoresVal,
 		"auto_init?", &autoInit,
+		"serveCmd?", &serveCmdStr,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -72,13 +72,13 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	serveCmd := model.ToShellCmd(serveCmdStr)
 
 	if updateCmd.Empty() && serveCmd.Empty() {
-		return nil, fmt.Errorf("local_resource must have an updateCmd or a serveCmd, but both were empty")
+		return nil, fmt.Errorf("local_resource must have an updateCmd and/or a serveCmd, but both were empty")
 	}
 
 	res := localResource{
 		name:         name,
-		updateCmd:    model.ToShellCmd(updateCmdStr),
-		serveCmd:     model.ToShellCmd(serveCmdStr),
+		updateCmd:    updateCmd,
+		serveCmd:     serveCmd,
 		workdir:      filepath.Dir(starkit.CurrentExecPath(thread)),
 		deps:         depsStrings,
 		triggerMode:  triggerMode,

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -14,7 +14,8 @@ import (
 
 type localResource struct {
 	name         string
-	cmd          model.Cmd
+	updateCmd    model.Cmd
+	serveCmd     model.Cmd
 	workdir      string
 	deps         []string
 	triggerMode  triggerMode
@@ -25,7 +26,7 @@ type localResource struct {
 }
 
 func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var name, cmd string
+	var name, updateCmdStr, serveCmdStr string
 	var triggerMode triggerMode
 	var deps starlark.Value
 	var resourceDepsVal starlark.Sequence
@@ -34,7 +35,8 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
-		"cmd", &cmd,
+		"updateCmd?", &updateCmdStr,
+		"serveCmd?", &serveCmdStr,
 		"deps?", &deps,
 		"trigger_mode?", &triggerMode,
 		"resource_deps?", &resourceDepsVal,
@@ -66,9 +68,17 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
+	updateCmd := model.ToShellCmd(updateCmdStr)
+	serveCmd := model.ToShellCmd(serveCmdStr)
+
+	if updateCmd.Empty() && serveCmd.Empty() {
+		return nil, fmt.Errorf("local_resource must have an updateCmd or a serveCmd, but both were empty")
+	}
+
 	res := localResource{
 		name:         name,
-		cmd:          model.ToShellCmd(cmd),
+		updateCmd:    model.ToShellCmd(updateCmdStr),
+		serveCmd:     model.ToShellCmd(serveCmdStr),
 		workdir:      filepath.Dir(starkit.CurrentExecPath(thread)),
 		deps:         depsStrings,
 		triggerMode:  triggerMode,

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1285,7 +1285,7 @@ func (s *tiltfileState) translateLocal() ([]model.Manifest, error) {
 			ignores = append(ignores, model.Dockerignore{Contents: ignoreContents, LocalPath: r.workdir})
 		}
 
-		lt := model.NewLocalTarget(model.TargetName(r.name), r.cmd, model.Cmd{}, r.deps, r.workdir).
+		lt := model.NewLocalTarget(model.TargetName(r.name), r.updateCmd, r.serveCmd, r.deps, r.workdir).
 			WithRepos(reposForPaths(paths)).
 			WithIgnores(ignores)
 		var mds []model.ManifestName

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4794,7 +4794,7 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 					deps := f.JoinPaths(matcher.deps)
 					assert.ElementsMatch(f.t, deps, lt.Dependencies())
 				default:
-					f.t.Fatal(fmt.Sprintf("unknown matcher for local target %T", matcher))
+					f.t.Fatalf("unknown matcher for local target %T", matcher)
 				}
 			}
 		default:

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3906,7 +3906,7 @@ local_resource("test", updateCmd="echo hi", deps=["foo/bar", "foo/a.txt"])
 	f.assertNumManifests(1)
 	path1 := "foo/bar"
 	path2 := "foo/a.txt"
-	m := f.assertNextManifest("test", lt(updateCmd("echo hi"), deps(path1, path2)), fileChangeMatches("foo/a.txt"))
+	m := f.assertNextManifest("test", localTarget(updateCmd("echo hi"), deps(path1, path2)), fileChangeMatches("foo/a.txt"))
 
 	lt := m.LocalTarget()
 	f.assertRepos([]string{f.Path()}, lt.LocalRepos())
@@ -3925,7 +3925,7 @@ local_resource("test", serveCmd="sleep 1000")
 	f.load()
 
 	f.assertNumManifests(1)
-	f.assertNextManifest("test", lt(serveCmd("sleep 1000")))
+	f.assertNextManifest("test", localTarget(serveCmd("sleep 1000")))
 
 	f.assertConfigFiles("Tiltfile", ".tiltignore")
 }
@@ -3941,7 +3941,7 @@ local_resource("test", updateCmd="echo hi", serveCmd="sleep 1000")
 	f.load()
 
 	f.assertNumManifests(1)
-	f.assertNextManifest("test", lt(updateCmd("echo hi"), serveCmd("sleep 1000")))
+	f.assertNextManifest("test", localTarget(updateCmd("echo hi"), serveCmd("sleep 1000")))
 
 	f.assertConfigFiles("Tiltfile", ".tiltignore")
 }
@@ -3977,7 +3977,7 @@ local_resource("toplvl-local", updateCmd="echo hello world", deps=["foo/baz", "f
 	f.load()
 
 	f.assertNumManifests(2)
-	mNested := f.assertNextManifest("nested-local", lt(updateCmd("echo nested"), deps("nested/foo/bar", "nested/more_nested/repo")))
+	mNested := f.assertNextManifest("nested-local", localTarget(updateCmd("echo nested"), deps("nested/foo/bar", "nested/more_nested/repo")))
 
 	ltNested := mNested.LocalTarget()
 	f.assertRepos([]string{
@@ -3985,7 +3985,7 @@ local_resource("toplvl-local", updateCmd="echo hello world", deps=["foo/baz", "f
 		f.JoinPath("nested/more_nested/repo"),
 	}, ltNested.LocalRepos())
 
-	mTop := f.assertNextManifest("toplvl-local", lt(updateCmd("echo hello world"), deps("foo/baz", "foo/a.txt")))
+	mTop := f.assertNextManifest("toplvl-local", localTarget(updateCmd("echo hello world"), deps("foo/baz", "foo/a.txt")))
 	ltTop := mTop.LocalTarget()
 	f.assertRepos([]string{
 		f.JoinPath("foo/baz"),
@@ -5184,7 +5184,7 @@ type localTargetHelper struct {
 	matchers []interface{}
 }
 
-func lt(opts ...interface{}) localTargetHelper {
+func localTarget(opts ...interface{}) localTargetHelper {
 	return localTargetHelper{matchers: opts}
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3919,7 +3919,7 @@ func TestLocalResourceOnlyServeCmd(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-local_resource("test", serveCmd="sleep 1000")
+local_resource("test", serve_cmd="sleep 1000")
 `)
 
 	f.load()
@@ -3935,7 +3935,7 @@ func TestLocalResourceUpdateAndServeCmd(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-local_resource("test", cmd="echo hi", serveCmd="sleep 1000")
+local_resource("test", cmd="echo hi", serve_cmd="sleep 1000")
 `)
 
 	f.load()
@@ -3954,7 +3954,7 @@ func TestLocalResourceNeitherUpdateOrServeCmd(t *testing.T) {
 local_resource("test")
 `)
 
-	f.loadErrString("local_resource must have an updateCmd and/or a serveCmd, but both were empty")
+	f.loadErrString("local_resource must have a cmd and/or a serve_cmd, but both were empty")
 }
 
 func TestLocalResourceWorkdir(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3954,7 +3954,7 @@ func TestLocalResourceNeitherUpdateOrServeCmd(t *testing.T) {
 local_resource("test")
 `)
 
-	f.loadErrString("local_resource must have an updateCmd or a serveCmd, but both were empty")
+	f.loadErrString("local_resource must have an updateCmd and/or a serveCmd, but both were empty")
 }
 
 func TestLocalResourceWorkdir(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3896,7 +3896,7 @@ func TestLocalResourceOnlyUpdateCmd(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-local_resource("test", updateCmd="echo hi", deps=["foo/bar", "foo/a.txt"])
+local_resource("test", "echo hi", deps=["foo/bar", "foo/a.txt"])
 `)
 
 	f.setupFoo()
@@ -3935,7 +3935,7 @@ func TestLocalResourceUpdateAndServeCmd(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-local_resource("test", updateCmd="echo hi", serveCmd="sleep 1000")
+local_resource("test", cmd="echo hi", serveCmd="sleep 1000")
 `)
 
 	f.load()
@@ -3962,11 +3962,11 @@ func TestLocalResourceWorkdir(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("nested/Tiltfile", `
-local_resource("nested-local", updateCmd="echo nested", deps=["foo/bar", "more_nested/repo"])
+local_resource("nested-local", "echo nested", deps=["foo/bar", "more_nested/repo"])
 `)
 	f.file("Tiltfile", `
 include('nested/Tiltfile')
-local_resource("toplvl-local", updateCmd="echo hello world", deps=["foo/baz", "foo/a.txt"])
+local_resource("toplvl-local", "echo hello world", deps=["foo/baz", "foo/a.txt"])
 `)
 
 	f.setupFoo()


### PR DESCRIPTION
Note: this is backwards incompatible because I made a formerly required field optional. It would be possible to do this in other ways. For example, we could leave updateCmd as required and just let people who only want to do serve cmds leave it empty:

```python
local_resource("foo", "", serveCmd="rails s")
```

Or we could make it a boolean parameter, like so:

```python
local_resource("build_foo", "go install .")
local_resource("serve_foo", "./main", serve=True)
```

Or make it an entirely different function.