### PR TITLE
engine/tests: fakeBuildAndDeployer stores/completes builds by targetIDs instead of buildIndex

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1059,9 +1059,8 @@ func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 	f.setMaxBuildSlots(3)
 
 	manifest := f.newManifest("fe")
-	manifests := []model.Manifest{manifest}
-	f.startWithInitManifests(nil, manifests, true)
-	f.completeAndCheckInitManifests(manifests)
+	f.startWithInitManifests(nil, []model.Manifest{manifest}, true)
+	f.completeAndCheckBuildsForManifests(manifest)
 	f.waitUntilNumBuildSlots(3)
 
 	// file change starts a build
@@ -1073,7 +1072,7 @@ func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 	f.waitUntilNumBuildSlots(2) // still two build slots available
 
 	// complete the first build
-	f.b.completeBuild(build1Index)
+	f.completeBuildForManifest(manifest)
 	call := f.nextCall("expect build from first pending file change (A.txt)")
 	f.assertCallIsForManifestAndFiles(call, manifest, "A.txt")
 	f.waitForCompletedBuildCount(2)
@@ -1083,7 +1082,7 @@ func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 	f.waitUntilManifestBuilding("fe")
 	f.waitUntilBuildCountAtLeast(build2Index)
 
-	f.b.completeBuild(build2Index)
+	f.completeBuildForManifest(manifest)
 	call = f.nextCall("expect build from second pending file change (B.txt)")
 	f.assertCallIsForManifestAndFiles(call, manifest, "B.txt")
 	f.waitUntilManifestNotBuilding("fe")
@@ -1102,27 +1101,24 @@ func TestBuildControllerWontBuildManifestIfNoSlotsAvailable(t *testing.T) {
 	manA := f.newDockerBuildManifestWithBuildPath("manA", f.JoinPath("a"))
 	manB := f.newDockerBuildManifestWithBuildPath("manB", f.JoinPath("b"))
 	manC := f.newDockerBuildManifestWithBuildPath("manC", f.JoinPath("c"))
-	manifests := []model.Manifest{manA, manB, manC}
-	f.startWithInitManifests(nil, manifests, true)
-	f.completeAndCheckInitManifests(manifests)
+	f.startWithInitManifests(nil, []model.Manifest{manA, manB, manC}, true)
+	f.completeAndCheckBuildsForManifests(manA, manB, manC)
 
 	// start builds for all manifests (we only have 2 build slots)
-	indexA := f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
-	indexB := f.editFileAndWaitForManifestBuilding("manB", "b/main.go")
+	f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
+	f.editFileAndWaitForManifestBuilding("manB", "b/main.go")
 	f.editFileAndAssertManifestNotBuilding("manC", "c/main.go")
 
 	// Complete one build...
-	f.b.completeBuild(indexA)
+	f.completeBuildForManifest(manA)
 	call := f.nextCall("expect manA build complete")
 	f.assertCallIsForManifestAndFiles(call, manA, "a/main.go")
 
 	// ...and now there's a free build slot for 'manC'
-	indexC := indexB + 1
 	f.waitUntilManifestBuilding("manC")
-	f.waitUntilBuildCountAtLeast(indexC)
 
 	// complete the rest (can't guarantee order)
-	f.completeAndCheckBuildsForManifests([]int{indexB, indexC}, []model.Manifest{manB, manC})
+	f.completeAndCheckBuildsForManifests(manB, manC)
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -1138,14 +1134,13 @@ func TestCurrentlyBuildingMayExceedMaxBuildCount(t *testing.T) {
 	manA := f.newDockerBuildManifestWithBuildPath("manA", f.JoinPath("a"))
 	manB := f.newDockerBuildManifestWithBuildPath("manB", f.JoinPath("b"))
 	manC := f.newDockerBuildManifestWithBuildPath("manC", f.JoinPath("c"))
-	manifests := []model.Manifest{manA, manB, manC}
-	f.startWithInitManifests(nil, manifests, true)
-	f.completeAndCheckInitManifests(manifests)
+	f.startWithInitManifests(nil, []model.Manifest{manA, manB, manC}, true)
+	f.completeAndCheckBuildsForManifests(manA, manB, manC)
 
 	// start builds for all manifests
-	manABuild1Index := f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
-	manBBuild1Index := f.editFileAndWaitForManifestBuilding("manB", "b/main.go")
-	manCBuild1Index := f.editFileAndWaitForManifestBuilding("manC", "c/main.go")
+	f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
+	f.editFileAndWaitForManifestBuilding("manB", "b/main.go")
+	f.editFileAndWaitForManifestBuilding("manC", "c/main.go")
 	f.waitUntilNumBuildSlots(0)
 
 	// decrease max build slots (now less than the number of current builds, but this is okay)
@@ -1155,7 +1150,7 @@ func TestCurrentlyBuildingMayExceedMaxBuildCount(t *testing.T) {
 	// another file change for manB -- will try to start another build as soon as possible
 	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("b/other.go"))
 
-	f.b.completeBuild(manBBuild1Index)
+	f.completeBuildForManifest(manB)
 	call := f.nextCall("expect manB build complete")
 	f.assertCallIsForManifestAndFiles(call, manB, "b/main.go")
 
@@ -1165,20 +1160,18 @@ func TestCurrentlyBuildingMayExceedMaxBuildCount(t *testing.T) {
 	f.waitUntilManifestNotBuilding("manB")
 
 	// complete another build...
-	f.b.completeBuild(manABuild1Index)
+	f.completeBuildForManifest(manA)
 	call = f.nextCall("expect manA build complete")
 	f.assertCallIsForManifestAndFiles(call, manA, "a/main.go")
 
 	// ...now that we have an available slots again, manB will rebuild
-	manBBuild2Index := f.b.buildCount + 1
 	f.waitUntilManifestBuilding("manB")
-	f.waitUntilBuildCountAtLeast(manBBuild1Index)
 
-	f.b.completeBuild(manBBuild2Index)
+	f.completeBuildForManifest(manB)
 	call = f.nextCall("expect manB build complete (second build)")
 	f.assertCallIsForManifestAndFiles(call, manB, "b/other.go")
 
-	f.b.completeBuild(manCBuild1Index)
+	f.completeBuildForManifest(manC)
 	call = f.nextCall("expect manC build complete")
 	f.assertCallIsForManifestAndFiles(call, manC, "c/main.go")
 
@@ -1196,11 +1189,10 @@ func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
 
 	manA := f.newDockerBuildManifestWithBuildPath("manA", f.JoinPath("a"))
 	manB := f.newDockerBuildManifestWithBuildPath("manB", f.JoinPath("b"))
-	manifests := []model.Manifest{manA, manB}
-	f.startWithInitManifests(nil, manifests, true)
-	f.completeAndCheckInitManifests(manifests)
+	f.startWithInitManifests(nil, []model.Manifest{manA, manB}, true)
+	f.completeAndCheckBuildsForManifests(manA, manB)
 
-	indexA := f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
+	f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
 
 	// deliberately de-sync engine state and build controller
 	st := f.store.LockMutableStateForTesting()
@@ -1209,7 +1201,6 @@ func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
 
 	// this build won't start while state and build controller are out of sync
 	f.editFileAndAssertManifestNotBuilding("manB", "b/main.go")
-	indexB := f.b.buildCount + 1
 
 	// resync the two counts...
 	st = f.store.LockMutableStateForTesting()
@@ -1218,10 +1209,9 @@ func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
 
 	// ...and manB build will start as expected
 	f.waitUntilManifestBuilding("manB")
-	f.waitUntilBuildCountAtLeast(indexB)
 
 	// complete all builds (can't guarantee order)
-	f.completeAndCheckBuildsForManifests([]int{indexA, indexB}, manifests)
+	f.completeAndCheckBuildsForManifests(manA, manB)
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -1240,20 +1230,18 @@ func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
 	manA := f.newDockerBuildManifestWithBuildPath("manA", f.JoinPath("a"))
 	manB := f.newDockerBuildManifestWithBuildPath("manB", f.JoinPath("b"))
 	manC := f.newDockerBuildManifestWithBuildPath("manC", f.JoinPath("c"))
-	manifests := []model.Manifest{manA, manB, manC}
-	f.startWithInitManifests(nil, manifests, true)
-	f.completeAndCheckInitManifests(manifests)
+	f.startWithInitManifests(nil, []model.Manifest{manA, manB, manC}, true)
+	f.completeAndCheckBuildsForManifests(manA, manB, manC)
 
 	// start builds for all manifests (we only have 2 build slots)
 	f.SetNextBuildFailure(errA)
-	indexA := f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
+	f.editFileAndWaitForManifestBuilding("manA", "a/main.go")
 	f.SetNextBuildFailure(errB)
-	indexB := f.editFileAndWaitForManifestBuilding("manB", "b/main.go")
+	f.editFileAndWaitForManifestBuilding("manB", "b/main.go")
 	f.editFileAndAssertManifestNotBuilding("manC", "c/main.go")
-	indexC := f.b.buildCount + 1
 
 	// Complete one build...
-	f.b.completeBuild(indexA)
+	f.completeBuildForManifest(manA)
 	call := f.nextCall("expect manA build complete")
 	f.assertCallIsForManifestAndFiles(call, manA, "a/main.go")
 	f.WaitUntilManifestState("last manA build reflects expected error", "manA", func(ms store.ManifestState) bool {
@@ -1262,10 +1250,9 @@ func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
 
 	// ...'manC' should start building, even though the manA build ended with an error
 	f.waitUntilManifestBuilding("manC")
-	f.waitUntilBuildCountAtLeast(indexC)
 
 	// complete the rest
-	f.completeAndCheckBuildsForManifests([]int{indexB, indexC}, []model.Manifest{manB, manC})
+	f.completeAndCheckBuildsForManifests(manB, manC)
 	f.WaitUntilManifestState("last manB build reflects expected error", "manB", func(ms store.ManifestState) bool {
 		return ms.LastBuild().Error == errB
 	})
@@ -1348,13 +1335,9 @@ func (f *testFixture) assertCallIsForManifestAndFiles(call buildAndDeployCall, m
 	assert.Equal(f.t, f.JoinPaths(files), call.oneState().FilesChanged())
 }
 
-func (f *testFixture) completeAndCheckBuildsForManifests(indexes []int, manifests []model.Manifest) {
-	if len(indexes) != len(manifests) {
-		f.t.Fatalf("can only complete + check builds for manifests when passed an equal number of indexes and manifests")
-	}
-
-	for _, i := range indexes {
-		f.b.completeBuild(i)
+func (f *testFixture) completeAndCheckBuildsForManifests(manifests ...model.Manifest) {
+	for _, m := range manifests {
+		f.completeBuildForManifest(m)
 	}
 
 	expectedImageTargets := make([][]model.ImageTarget, len(manifests))
@@ -1370,26 +1353,4 @@ func (f *testFixture) completeAndCheckBuildsForManifests(indexes []int, manifest
 	for _, m := range manifests {
 		f.waitUntilManifestNotBuilding(m.Name)
 	}
-}
-
-func (f *testFixture) completeAndCheckInitManifests(manifests []model.Manifest) {
-	st := f.store.RLockState()
-	completedCount := st.CompletedBuildCount
-	f.store.RUnlockState()
-
-	if completedCount != 0 {
-		f.t.Fatalf("can only call `completeAndCheckInitManifests` when no builds have yet completed "+
-			"(found %d completed builds)", completedCount)
-	}
-
-	if !f.b.completeBuildsManually {
-		f.t.Fatalf("can only call `completeAndCheckInitManifests` when fakeBaD.completeBuildsManually is enabled")
-	}
-
-	indexes := make([]int, len(manifests))
-	for i := 0; i < len(manifests); i++ {
-		indexes[i] = i + 1
-	}
-
-	f.completeAndCheckBuildsForManifests(indexes, manifests)
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3909,6 +3909,10 @@ func (f *testFixture) registerDeployedPodTemplateSpecHashToManifest(name model.M
 	f.store.UnlockMutableState()
 }
 
+func (f *testFixture) completeBuildForManifest(m model.Manifest) {
+	f.b.completeBuild(targetIDStringForManifest(m))
+}
+
 func podTemplateSpecHashesForTarg(t *testing.T, targ model.K8sTarget) []k8s.PodTemplateSpecHash {
 	entities, err := k8s.ParseYAMLFromString(targ.YAML)
 	require.NoError(t, err)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -160,7 +161,8 @@ type fakeBuildAndDeployer struct {
 	calls chan buildAndDeployCall
 
 	completeBuildsManually bool
-	buildCompletionChans   sync.Map // map[int]buildCompletionChannel; close channel at buildCompletionChans[n] to complete build #n
+	buildCompletionChans   sync.Map // map[string]buildCompletionChannel; close channel at buildCompletionChans[k(targs)] to
+	// complete the build started for targs (where k(targs) generates a unique string key for the set of targets)
 
 	buildCount int
 
@@ -202,16 +204,16 @@ func (b *fakeBuildAndDeployer) nextBuildResult(iTarget model.ImageTarget, deploy
 func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, state store.BuildStateSet) (brs store.BuildResultSet, err error) {
 	b.mu.Lock()
 	b.buildCount++
-	index := b.buildCount
-	b.registerBuild(index)
+	buildKey := stringifyTargetIDs(specs)
+	b.registerBuild(buildKey)
 
 	if !b.completeBuildsManually {
 		// i.e. we should complete builds automatically: mark the build for completion now,
 		// so we return immediately at the end of BuildAndDeploy.
-		b.completeBuild(index)
+		b.completeBuild(buildKey)
 	}
 
-	call := buildAndDeployCall{count: index, specs: specs, state: state}
+	call := buildAndDeployCall{count: b.buildCount, specs: specs, state: state}
 	if call.dc().Empty() && call.k8s().Empty() && call.local().Empty() {
 		b.t.Fatalf("Invalid call: %+v", call)
 	}
@@ -290,13 +292,13 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 	b.mu.Unlock()
 
 	// block until we know we're supposed to resolve this build
-	b.waitUntilBuildCompleted(ctx, index)
+	b.waitUntilBuildCompleted(ctx, buildKey)
 
 	return result, err
 }
-func (b *fakeBuildAndDeployer) getOrCreateBuildCompletionChannel(index int) buildCompletionChannel {
+func (b *fakeBuildAndDeployer) getOrCreateBuildCompletionChannel(key string) buildCompletionChannel {
 	ch := make(buildCompletionChannel)
-	val, _ := b.buildCompletionChans.LoadOrStore(index, ch)
+	val, _ := b.buildCompletionChans.LoadOrStore(key, ch)
 
 	var ok bool
 	ch, ok = val.(buildCompletionChannel)
@@ -307,12 +309,12 @@ func (b *fakeBuildAndDeployer) getOrCreateBuildCompletionChannel(index int) buil
 	return ch
 }
 
-func (b *fakeBuildAndDeployer) registerBuild(index int) {
-	b.getOrCreateBuildCompletionChannel(index)
+func (b *fakeBuildAndDeployer) registerBuild(key string) {
+	b.getOrCreateBuildCompletionChannel(key)
 }
 
-func (b *fakeBuildAndDeployer) waitUntilBuildCompleted(ctx context.Context, index int) {
-	ch := b.getOrCreateBuildCompletionChannel(index)
+func (b *fakeBuildAndDeployer) waitUntilBuildCompleted(ctx context.Context, key string) {
+	ch := b.getOrCreateBuildCompletionChannel(key)
 
 	// wait until channel for this build is closed, or context is canceled/finishes.
 	select {
@@ -320,7 +322,7 @@ func (b *fakeBuildAndDeployer) waitUntilBuildCompleted(ctx context.Context, inde
 	case <-ctx.Done():
 	}
 
-	b.buildCompletionChans.Delete(index)
+	b.buildCompletionChans.Delete(key)
 }
 
 func newFakeBuildAndDeployer(t *testing.T) *fakeBuildAndDeployer {
@@ -332,8 +334,8 @@ func newFakeBuildAndDeployer(t *testing.T) *fakeBuildAndDeployer {
 	}
 }
 
-func (b *fakeBuildAndDeployer) completeBuild(index int) {
-	ch := b.getOrCreateBuildCompletionChannel(index)
+func (b *fakeBuildAndDeployer) completeBuild(key string) {
+	ch := b.getOrCreateBuildCompletionChannel(key)
 	close(ch)
 }
 
@@ -4015,4 +4017,19 @@ func (f *fakeSnapshotUploader) Upload(token token.Token, teamID string, snapshot
 
 func (f *fakeSnapshotUploader) IDToSnapshotURL(id cloud.SnapshotID) string {
 	panic("not implemented")
+}
+
+// stringifyTargetIDs attempts to make a unique string to identify any set of targets
+// (order-agnostic) by sorting and then concatenating the target IDs.
+func stringifyTargetIDs(targets []model.TargetSpec) string {
+	ids := make([]string, len(targets))
+	for i, t := range targets {
+		ids[i] = t.ID().String()
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, "::")
+}
+
+func targetIDStringForManifest(m model.Manifest) string {
+	return stringifyTargetIDs(m.TargetSpecs())
 }


### PR DESCRIPTION
this should make the parallel build tests less janky