### PR TITLE
engine: attach span ids instead of counts to build events, now that they can happen in parallel

### DIFF
--- a/internal/engine/buildcontrol/actions.go
+++ b/internal/engine/buildcontrol/actions.go
@@ -26,15 +26,17 @@ func (BuildLogAction) Action() {}
 
 type BuildCompleteAction struct {
 	ManifestName model.ManifestName
+	SpanID       logstore.SpanID
 	Result       store.BuildResultSet
 	Error        error
 }
 
 func (BuildCompleteAction) Action() {}
 
-func NewBuildCompleteAction(mn model.ManifestName, result store.BuildResultSet, err error) BuildCompleteAction {
+func NewBuildCompleteAction(mn model.ManifestName, spanID logstore.SpanID, result store.BuildResultSet, err error) BuildCompleteAction {
 	return BuildCompleteAction{
 		ManifestName: mn,
+		SpanID:       spanID,
 		Result:       result,
 		Error:        err,
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -271,7 +271,6 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		delete(engineState.CurrentlyBuilding, cb.ManifestName)
 	}()
 
-	buildCount := engineState.CompletedBuildCount
 	engineState.CompletedBuildCount++
 
 	mt, ok := engineState.ManifestTargets[cb.ManifestName]
@@ -285,7 +284,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		s := fmt.Sprintf("%s %v", p, err)
 		a := buildcontrol.BuildLogAction{
 			// TODO(nick): logger.ErrorLvl?
-			LogEvent: store.NewLogEvent(mt.Manifest.Name, SpanIDForBuildLog(buildCount), logger.InfoLvl, []byte(s)),
+			LogEvent: store.NewLogEvent(mt.Manifest.Name, cb.SpanID, logger.InfoLvl, []byte(s)),
 		}
 		handleLogAction(engineState, a)
 	}


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/buildid:

a42c508f46989bc9bf6e2e867fb45bb3a7198814 (2020-01-08 12:36:20 -0500)
engine: attach span ids instead of counts to build events, now that they can happen in parallel