### PR TITLE
integration: when compiling Tilt, use vendor deps

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -76,7 +76,7 @@ func newFixture(t *testing.T, dir string) *fixture {
 }
 
 func (f *fixture) installTilt() {
-	cmd := exec.CommandContext(f.ctx, "go", "install", "github.com/windmilleng/tilt/cmd/tilt")
+	cmd := exec.CommandContext(f.ctx, "go", "install", "-mod", "vendor", "github.com/windmilleng/tilt/cmd/tilt")
 	f.runOrFail(cmd, "Building tilt")
 }
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/integration3:

7e73f85785e5fba3867587a58f7dc1d3b05775b0 (2020-01-08 14:01:57 -0500)
integration: when compiling Tilt, use vendor deps