### PR TITLE
tiltfile: set max build slots from tiltfile [ch4065]

### DIFF
--- a/internal/engine/configs/actions.go
+++ b/internal/engine/configs/actions.go
@@ -33,6 +33,7 @@ type ConfigsReloadedAction struct {
 	DockerPruneSettings  model.DockerPruneSettings
 	AnalyticsTiltfileOpt analytics.Opt
 	VersionSettings      model.VersionSettings
+	UpdateSettings       model.UpdateSettings
 
 	// A checkpoint into the logstore when Tiltfile execution started.
 	// Useful for knowing how far back in time we have to scrub secrets.

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -139,6 +139,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore,
 		DockerPruneSettings:   tlr.DockerPruneSettings,
 		CheckpointAtExecStart: checkpointAtExecStart,
 		VersionSettings:       tlr.VersionSettings,
+		UpdateSettings:        tlr.UpdateSettings,
 	})
 }
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -587,7 +587,7 @@ func handleConfigsReloaded(
 	state.TelemetrySettings = event.TelemetrySettings
 	state.VersionSettings = event.VersionSettings
 
-	state.MaxBuildSlots = event.UpdateSettings.MaxBuildSlotsMinOne()
+	state.MaxBuildSlots = event.UpdateSettings.MaxParallelUpdatesMinOne()
 
 	// Remove pending file changes that were consumed by this build.
 	for file, modTime := range state.PendingConfigFileChanges {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -585,8 +585,9 @@ func handleConfigsReloaded(
 	state.Features = event.Features
 	state.TeamName = event.TeamName
 	state.TelemetrySettings = event.TelemetrySettings
-
 	state.VersionSettings = event.VersionSettings
+
+	state.MaxBuildSlots = event.UpdateSettings.MaxBuildSlots
 
 	// Remove pending file changes that were consumed by this build.
 	for file, modTime := range state.PendingConfigFileChanges {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -587,7 +587,7 @@ func handleConfigsReloaded(
 	state.TelemetrySettings = event.TelemetrySettings
 	state.VersionSettings = event.VersionSettings
 
-	state.MaxBuildSlots = event.UpdateSettings.MaxBuildSlots
+	state.MaxBuildSlots = event.UpdateSettings.MaxBuildSlotsMinOne()
 
 	// Remove pending file changes that were consumed by this build.
 	for file, modTime := range state.PendingConfigFileChanges {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -587,7 +587,7 @@ func handleConfigsReloaded(
 	state.TelemetrySettings = event.TelemetrySettings
 	state.VersionSettings = event.VersionSettings
 
-	state.MaxBuildSlots = event.UpdateSettings.MaxParallelUpdatesMinOne()
+	state.MaxParallelUpdates = event.UpdateSettings.MaxParallelUpdatesMinOne()
 
 	// Remove pending file changes that were consumed by this build.
 	for file, modTime := range state.PendingConfigFileChanges {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3292,7 +3292,7 @@ func TestDefaultMaxBuildSlots(t *testing.T) {
 		return len(state.TiltfileState.BuildHistory) == 1
 	})
 	f.withState(func(state store.EngineState) {
-		assert.Equal(t, model.DefaultMaxBuildSlots, state.MaxParallelUpdates)
+		assert.Equal(t, model.DefaultMaxParallelUpdates, state.MaxParallelUpdates)
 	})
 }
 
@@ -3304,7 +3304,7 @@ func TestSetMaxBuildSlots(t *testing.T) {
 	f.WriteFile("snack.yaml", simpleYAML)
 
 	f.WriteFile("Tiltfile", `
-max_parallel_updates(123)
+update_settings(max_parallel_updates=123)
 `+simpleTiltfile)
 	f.loadAndStart()
 

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -13,6 +13,8 @@ import (
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 
+	"github.com/windmilleng/tilt/internal/tiltfile/updatesettings"
+
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/dockercompose"
 	"github.com/windmilleng/tilt/internal/feature"
@@ -50,6 +52,7 @@ type TiltfileLoadResult struct {
 	DockerPruneSettings model.DockerPruneSettings
 	AnalyticsOpt        wmanalytics.Opt
 	VersionSettings     model.VersionSettings
+	UpdateSettings      model.UpdateSettings
 }
 
 func (r TiltfileLoadResult) Orchestrator() model.Orchestrator {
@@ -174,6 +177,9 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 
 	telemetrySettings, _ := telemetry.GetState(result)
 	tlr.TelemetrySettings = telemetrySettings
+
+	us, _ := updatesettings.GetState(result)
+	tlr.UpdateSettings = us
 
 	duration := time.Since(start)
 	s.logger.Infof("Successfully loaded Tiltfile (%s)", duration)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/windmilleng/tilt/internal/tiltfile/starlarkstruct"
 	"github.com/windmilleng/tilt/internal/tiltfile/telemetry"
+	"github.com/windmilleng/tilt/internal/tiltfile/updatesettings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/looplab/tarjan"
@@ -166,6 +167,7 @@ func (s *tiltfileState) loadManifests(absFilename string, userConfigState model.
 		config.NewExtension(userConfigState),
 		starlarkstruct.NewExtension(),
 		telemetry.NewExtension(),
+		updatesettings.NewExtension(),
 	)
 	if err != nil {
 		return nil, result, starkit.UnpackBacktrace(err)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4345,21 +4345,21 @@ func TestMaxParallelUpdates(t *testing.T) {
 		{
 			name:                  "default max parallel updates",
 			tiltfile:              "print('hello world')",
-			expectedMaxBuildSlots: model.DefaultMaxBuildSlots,
+			expectedMaxBuildSlots: model.DefaultMaxParallelUpdates,
 		},
 		{
 			name:                  "set max parallel updates",
-			tiltfile:              "max_parallel_updates(42)",
+			tiltfile:              "update_settings(max_parallel_updates=42)",
 			expectedMaxBuildSlots: 42,
 		},
 		{
 			name:                "NaN error",
-			tiltfile:            "max_parallel_updates('boop')",
+			tiltfile:            "update_settings(max_parallel_updates='boop')",
 			expectErrorContains: "got string, want int",
 		},
 		{
 			name:                "must be positive int",
-			tiltfile:            "max_parallel_updates(-1)",
+			tiltfile:            "update_settings(max_parallel_updates=-1)",
 			expectErrorContains: "must be >= 1",
 		},
 	} {
@@ -4375,8 +4375,8 @@ func TestMaxParallelUpdates(t *testing.T) {
 			}
 
 			f.load()
-			actualBuildSlots := f.loadResult.UpdateSettings.MaxBuildSlots
-			assert.Equal(t, tc.expectedMaxBuildSlots, actualBuildSlots, "expected vs. actual MaxBuildSlots")
+			actualBuildSlots := f.loadResult.UpdateSettings.MaxParallelUpdates
+			assert.Equal(t, tc.expectedMaxBuildSlots, actualBuildSlots, "expected vs. actual MaxParallelUpdates")
 		})
 	}
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4335,6 +4335,52 @@ local_resource('e', 'echo e')
 	}
 }
 
+func TestMaxParallelUpdates(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		tiltfile              string
+		expectErrorContains   string
+		expectedMaxBuildSlots int
+	}{
+		{
+			name:                  "default max parallel updates",
+			tiltfile:              "print('hello world')",
+			expectedMaxBuildSlots: model.DefaultMaxBuildSlots,
+		},
+		{
+			name:                  "set max parallel updates",
+			tiltfile:              "max_parallel_updates(42)",
+			expectedMaxBuildSlots: 42,
+		},
+		{
+			name:                "NaN error",
+			tiltfile:            "max_parallel_updates('boop')",
+			expectErrorContains: "got string, want int",
+		},
+		{
+			name:                "must be positive int",
+			tiltfile:            "max_parallel_updates(-1)",
+			expectErrorContains: "must be >= 1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			defer f.TearDown()
+
+			f.file("Tiltfile", tc.tiltfile)
+
+			if tc.expectErrorContains != "" {
+				f.loadErrString(tc.expectErrorContains)
+				return
+			}
+
+			f.load()
+			actualBuildSlots := f.loadResult.UpdateSettings.MaxBuildSlots
+			assert.Equal(t, tc.expectedMaxBuildSlots, actualBuildSlots, "expected vs. actual MaxBuildSlots")
+		})
+	}
+}
+
 type fixture struct {
 	ctx context.Context
 	out *bytes.Buffer

--- a/internal/tiltfile/updatesettings/update_settings.go
+++ b/internal/tiltfile/updatesettings/update_settings.go
@@ -10,7 +10,7 @@ import (
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
 )
 
-// Implements functions for dealing with Docker Prune settings.
+// Implements functions for dealing with update settings.
 type Extension struct {
 }
 
@@ -23,22 +23,23 @@ func (e Extension) NewState() interface{} {
 }
 
 func (e Extension) OnStart(env *starkit.Environment) error {
-	return env.AddBuiltin("max_parallel_updates", e.maxParallelUpdates)
+	return env.AddBuiltin("update_settings", e.updateSettings)
 }
 
-func (e Extension) maxParallelUpdates(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var n int
+func (e Extension) updateSettings(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var maxParallelUpdates int
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
-		"n?", &n); err != nil {
+		"max_parallel_updates", &maxParallelUpdates); err != nil {
 		return nil, err
 	}
 
-	if n < 1 {
-		return nil, fmt.Errorf("max number of parallel updates must be >= 1(got: %d)", n)
+	if maxParallelUpdates < 1 {
+		return nil, fmt.Errorf("max number of parallel updates must be >= 1(got: %d)",
+			maxParallelUpdates)
 	}
 
 	err := starkit.SetState(thread, func(settings model.UpdateSettings) model.UpdateSettings {
-		settings.MaxBuildSlots = n
+		settings.MaxParallelUpdates = maxParallelUpdates
 		return settings
 	})
 

--- a/internal/tiltfile/updatesettings/update_settings.go
+++ b/internal/tiltfile/updatesettings/update_settings.go
@@ -1,0 +1,62 @@
+package updatesettings
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/windmilleng/tilt/pkg/model"
+
+	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+)
+
+// Implements functions for dealing with Docker Prune settings.
+type Extension struct {
+}
+
+func NewExtension() Extension {
+	return Extension{}
+}
+
+func (e Extension) NewState() interface{} {
+	return model.DefaultUpdateSettings()
+}
+
+func (e Extension) OnStart(env *starkit.Environment) error {
+	return env.AddBuiltin("max_parallel_updates", e.maxParallelUpdates)
+}
+
+func (e Extension) maxParallelUpdates(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var n int
+	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
+		"n?", &n); err != nil {
+		return nil, err
+	}
+
+	if n < 1 {
+		return nil, fmt.Errorf("max number of parallel updates must be >= 1(got: %d)", n)
+	}
+
+	err := starkit.SetState(thread, func(settings model.UpdateSettings) model.UpdateSettings {
+		settings.MaxBuildSlots = n
+		return settings
+	})
+
+	return starlark.None, err
+}
+
+var _ starkit.StatefulExtension = Extension{}
+
+func MustState(model starkit.Model) model.UpdateSettings {
+	state, err := GetState(model)
+	if err != nil {
+		panic(err)
+	}
+	return state
+}
+
+func GetState(m starkit.Model) (model.UpdateSettings, error) {
+	var state model.UpdateSettings
+	err := m.Load(&state)
+	return state, err
+}

--- a/pkg/model/build_settings.go
+++ b/pkg/model/build_settings.go
@@ -6,6 +6,13 @@ type UpdateSettings struct {
 	MaxBuildSlots int // max number of builds to run concurrently
 }
 
+func (us UpdateSettings) MaxBuildSlotsMinOne() int {
+	if us.MaxBuildSlots < 1 {
+		return 1
+	}
+	return us.MaxBuildSlots
+}
+
 func DefaultUpdateSettings() UpdateSettings {
 	return UpdateSettings{MaxBuildSlots: DefaultMaxBuildSlots}
 }

--- a/pkg/model/build_settings.go
+++ b/pkg/model/build_settings.go
@@ -1,18 +1,18 @@
 package model
 
-var DefaultMaxBuildSlots = 1
+var DefaultMaxParallelUpdates = 1
 
 type UpdateSettings struct {
-	MaxBuildSlots int // max number of builds to run concurrently
+	MaxParallelUpdates int // max number of builds to run concurrently
 }
 
-func (us UpdateSettings) MaxBuildSlotsMinOne() int {
-	if us.MaxBuildSlots < 1 {
+func (us UpdateSettings) MaxParallelUpdatesMinOne() int {
+	if us.MaxParallelUpdates < 1 {
 		return 1
 	}
-	return us.MaxBuildSlots
+	return us.MaxParallelUpdates
 }
 
 func DefaultUpdateSettings() UpdateSettings {
-	return UpdateSettings{MaxBuildSlots: DefaultMaxBuildSlots}
+	return UpdateSettings{MaxParallelUpdates: DefaultMaxParallelUpdates}
 }

--- a/pkg/model/build_settings.go
+++ b/pkg/model/build_settings.go
@@ -1,0 +1,11 @@
+package model
+
+var DefaultMaxBuildSlots = 1
+
+type UpdateSettings struct {
+	MaxBuildSlots int // max number of builds to run concurrently
+}
+
+func DefaultUpdateSettings() UpdateSettings {
+	return UpdateSettings{MaxBuildSlots: DefaultMaxBuildSlots}
+}


### PR DESCRIPTION
by all rights, `state.MaxBuildSlots` should be `engine.MaxUpdateSlots` or something,
b/c I think we've been trying to move away from "build" and towards "update"--
I tried to keep the user-facing language consistent with "update", and am happy
to change backend language in a separate PR