### PR TITLE
logger: fix level filtering

### DIFF
--- a/internal/store/logger.go
+++ b/internal/store/logger.go
@@ -9,9 +9,7 @@ import (
 func NewLogActionLogger(ctx context.Context, dispatch func(action Action)) logger.Logger {
 	l := logger.Get(ctx)
 	return logger.NewFuncLogger(l.SupportsColor(), l.Level(), func(level logger.Level, b []byte) error {
-		if l.Level().ShouldDisplay(level) {
-			dispatch(NewGlobalLogEvent(level, b))
-		}
+		dispatch(NewGlobalLogEvent(level, b))
 		return nil
 	})
 }

--- a/pkg/logger/func_logger.go
+++ b/pkg/logger/func_logger.go
@@ -39,11 +39,15 @@ func (l funcLogger) Debugf(format string, a ...interface{}) {
 }
 
 func (l funcLogger) Write(level Level, bytes []byte) {
-	_ = l.write(level, bytes)
+	if l.level.ShouldDisplay(level) {
+		_ = l.write(level, bytes)
+	}
 }
 
 func (l funcLogger) WriteString(level Level, s string) {
-	_ = l.write(level, []byte(s))
+	if l.level.ShouldDisplay(level) {
+		_ = l.write(level, []byte(s))
+	}
 }
 
 type FuncLoggerWriter struct {

--- a/pkg/logger/func_logger_test.go
+++ b/pkg/logger/func_logger_test.go
@@ -1,0 +1,23 @@
+package logger
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuncLogger_Level(t *testing.T) {
+	out := &bytes.Buffer{}
+	fl := NewFuncLogger(true, InfoLvl, func(level Level, b []byte) error {
+		_, err := out.Write(b)
+		return err
+	})
+
+	fl.Infof("info")
+	fl.Debugf("debug")
+
+	s := out.String()
+	require.Contains(t, s, "info")
+	require.NotContains(t, s, "debug")
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -100,11 +100,8 @@ func NewLogger(minLevel Level, writer io.Writer) Logger {
 		}
 	}
 	return NewFuncLogger(supportsColor, minLevel, func(level Level, bytes []byte) error {
-		if minLevel.ShouldDisplay(level) {
-			_, err := writer.Write(bytes)
-			return err
-		}
-		return nil
+		_, err := writer.Write(bytes)
+		return err
 	})
 }
 


### PR DESCRIPTION
### Problem

Messages logged on the debug level show up even if you aren't running with `--debug` (and same for verbose).

Some uses of `FuncLogger` do level filtering themselves, and some rely on `FuncLogger` to do the filtering for them. It turns out `FuncLogger` does not do any level filtering itself.

### Solution

Move all `FuncLogger`-related level filtering into `FuncLogger` itself.
(really only the `FuncLogger` change is needed to fix the problem, and the other changes are cleaning up what is not redundant level filtering)