### PR TITLE
local serve: correctly separate resource logs

### DIFF
--- a/internal/engine/local/actions.go
+++ b/internal/engine/local/actions.go
@@ -6,7 +6,6 @@ import (
 
 type LocalServeStatusAction struct {
 	ManifestName model.ManifestName
-	SequenceNum  int
 	Status       model.RuntimeStatus
 }
 


### PR DESCRIPTION
### Problem

When we have multiple local resources, a resource's logs often end up in the wrong resource.

This is because the span IDs are keyed off of the sequenceCount, but we have duplicate sequenceCounts across resources because it's just 0, 1, 2, ... Since we're logging with identical spanIDs, the LogStore combines these. (even though they have different manifest names! that's probably a bug we should fix, but it seems good to have unique span IDs whether we fix that or not)

### Solution

Instead of having each process go through sequenceNums of 0, 1, 2..., use a global monotonically increasing number as the tilt process ID, so that each process still has an increasing sequenceNum, but it's also globally unique.