### PR TITLE
engine/store: rename maxBuildSlots to maxParallelUpdates

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3493,9 +3493,9 @@ func (f *testFixture) setManifests(manifests []model.Manifest) {
 	f.cc.SetTiltfileLoaderForTesting(tfl)
 }
 
-func (f *testFixture) setMaxBuildSlots(n int) {
+func (f *testFixture) setMaxParallelUpdates(n int) {
 	state := f.store.LockMutableStateForTesting()
-	state.MaxBuildSlots = n
+	state.MaxParallelUpdates = n
 	f.store.UnlockMutableState()
 }
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -42,7 +42,7 @@ type EngineState struct {
 	// How many builds have been completed (pass or fail) since starting tilt
 	CompletedBuildCount int
 
-	MaxBuildSlots int
+	MaxParallelUpdates int
 
 	FatalError error
 	HUDEnabled bool
@@ -147,12 +147,12 @@ func (e *EngineState) BuildStatus(id model.TargetID) BuildStatus {
 
 func (e *EngineState) AvailableBuildSlots() int {
 	currentlyBuilding := len(e.CurrentlyBuilding)
-	if currentlyBuilding >= e.MaxBuildSlots {
+	if currentlyBuilding >= e.MaxParallelUpdates {
 		// this could happen if user decreases max build slots while
 		// multiple builds are in progress, no big deal
 		return 0
 	}
-	return e.MaxBuildSlots - currentlyBuilding
+	return e.MaxParallelUpdates - currentlyBuilding
 }
 
 func (e *EngineState) UpsertManifestTarget(mt *ManifestTarget) {
@@ -337,7 +337,7 @@ func NewState() *EngineState {
 	ret.VersionSettings = model.VersionSettings{
 		CheckUpdates: true,
 	}
-	ret.MaxBuildSlots = 1
+	ret.MaxParallelUpdates = 1
 	ret.CurrentlyBuilding = make(map[model.ManifestName]bool)
 	return ret
 }


### PR DESCRIPTION
i don't love the build/update naming inconsistency, but i'd rather it
be further down into the engine (e.g. when we compare currentlyBuilding vs.
maxParallelBuilds) than closer to the user (e.g. `update_settings(max_parallel_builds=x)`)