### PR TITLE
tiltfile: required arg test for max_parallel_updates (for now)

### DIFF
--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4362,6 +4362,14 @@ func TestMaxParallelUpdates(t *testing.T) {
 			tiltfile:            "update_settings(max_parallel_updates=-1)",
 			expectErrorContains: "must be >= 1",
 		},
+		{
+			// as more settings are configurable from this func, max_parallel_updates
+			// won't be a required arg and instead we should test that it gets
+			// set to the approprirate default; but for now, it IS required.
+			name:                "max_parallel_updates is required arg",
+			tiltfile:            "update_settings()",
+			expectErrorContains: "missing argument for max_parallel_updates",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFixture(t)


### PR DESCRIPTION
Hello @nicks, @hyu,

Please review the following commits I made in branch maiamcc/update-settings-required-arg:

62dbd3888332109d4fd3746c4c21749dca6e7183 (2020-01-09 17:28:25 -0500)
tiltfile: required arg test for max_parallel_updates (for now)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics