### PR TITLE
max number of parallel updates is 3 by default [ch4065]

### DIFF
--- a/pkg/model/update_settings.go
+++ b/pkg/model/update_settings.go
@@ -1,9 +1,9 @@
 package model
 
-var DefaultMaxParallelUpdates = 1
+var DefaultMaxParallelUpdates = 3
 
 type UpdateSettings struct {
-	MaxParallelUpdates int // max number of builds to run concurrently
+	MaxParallelUpdates int // max number of updates to run concurrently
 }
 
 func (us UpdateSettings) MaxParallelUpdatesMinOne() int {


### PR DESCRIPTION
here's the PR that will turn on parallel updates by default; merge it
whenever you like!