### PR TITLE
local: remove stoppedCh and use procNum to filter out old events

### DIFF
--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"os/exec"
 	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -94,6 +97,15 @@ func fakeRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan stat
 		// even an exit code of 0 is an error, because services aren't supposed to exit!
 		statusCh <- Error
 	}
+}
+
+func (fe *FakeExecer) RequireNoKnownProcess(t *testing.T, cmd string) {
+	fe.mu.Lock()
+	defer fe.mu.Unlock()
+
+	_, ok := fe.processes[cmd]
+
+	require.False(t, ok, "%T should not be tracking any process with cmd %q, but it is", FakeExecer{}, cmd)
 }
 
 func ProvideExecer() Execer {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3269,9 +3269,7 @@ func TestLocalResourceServeChangeCmd(t *testing.T) {
 		return strings.Contains(state.LogStore.ManifestLog("foo"), "Starting cmd false")
 	})
 
-	f.withState(func(state store.EngineState) {
-		require.Contains(t, state.LogStore.ManifestLog("foo"), "cmd true canceled")
-	})
+	f.fe.RequireNoKnownProcess(t, "true")
 
 	err := f.Stop()
 	require.NoError(t, err)


### PR DESCRIPTION
### Problem

When we kill an old process because we're replacing it with a new one, we log the error generated by killing it. This is unlikely to be useful to the user.

### Solution

Filter out any events generated by a process that is no longer current, per procNum.
This also obsolesces stoppedCh, which reduces opportunity for dumb channel bugs.