### PR TITLE
local execer: start serve commands in process groups and clean them up

### DIFF
--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -117,10 +117,6 @@ func (e *processExecer) Start(ctx context.Context, cmd model.Cmd, w io.Writer, s
 	return doneCh
 }
 
-func killPG(c *exec.Cmd) error {
-	return syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
-}
-
 func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan status, doneCh chan struct{}) {
 	defer close(doneCh)
 	defer close(statusCh)
@@ -150,7 +146,7 @@ func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan s
 		}
 		statusCh <- Error
 	case <-ctx.Done():
-		err := syscall.Kill(c.Process.Pid, syscall.SIGINT)
+		err := c.Process.Kill()
 		if err != nil {
 			procutil.KillProcessGroup(c)
 		} else {

--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os/exec"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -114,35 +116,48 @@ func (e *processExecer) Start(ctx context.Context, cmd model.Cmd, w io.Writer, s
 	return doneCh
 }
 
+func killPG(c *exec.Cmd) error {
+	return syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+}
+
 func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan status, doneCh chan struct{}) {
 	defer close(doneCh)
 	defer close(statusCh)
 
-	c := exec.CommandContext(ctx, cmd.Argv[0], cmd.Argv[1:]...)
+	c := exec.Command(cmd.Argv[0], cmd.Argv[1:]...)
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	c.Stderr = w
 	c.Stdout = w
 
-	err := c.Start()
-	if err != nil {
-		// TODO(dmiller): should this be different status than when the command fails? Unknown?
-		statusCh <- Error
-		return
-	}
+	errCh := make(chan error)
 
-	statusCh <- Running
+	go func() {
+		statusCh <- Running
+		errCh <- c.Run()
+	}()
 
-	err = c.Wait()
-	if err != nil {
-		// TODO(matt) don't log error if it was killed by tilt
-		// TODO(matt) how do we get this to show up as an error in the web UI?
-		_, err = fmt.Fprintf(w, "Error execing %s: %v", cmd.String(), err)
-		if err != nil {
-			logger.Get(ctx).Infof("Unable to print exec output to writer: %v", err)
+	select {
+	case err := <-errCh:
+		if err == nil {
+			logger.Get(ctx).Infof("%s exited with exit code 0", cmd.String())
+		} else if ee, ok := err.(*exec.ExitError); ok {
+			logger.Get(ctx).Infof("%s exited with exit code %d", cmd.String(), ee.ExitCode())
+		} else {
+			logger.Get(ctx).Infof("error execing %s: %v", cmd.String(), err)
 		}
 		statusCh <- Error
-		return
+	case <-ctx.Done():
+		err := syscall.Kill(c.Process.Pid, syscall.SIGINT)
+		if err != nil {
+			_ = killPG(c)
+		} else {
+			// wait and then send SIGKILL to the process group, unless the command finished
+			select {
+			case <-time.After(50 * time.Millisecond):
+				_ = killPG(c)
+			case <-doneCh:
+			}
+		}
+		statusCh <- Done
 	}
-
-	// TODO(matt) if the process exits w/ exit code 0, Tilt shows it as green - should it be red?
-	statusCh <- Done
 }

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -6,13 +6,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/bufsync"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
 func TestTrue(t *testing.T) {
 	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
 	f.start("true")
 
 	f.assertCmdSucceeds()
@@ -20,6 +24,8 @@ func TestTrue(t *testing.T) {
 
 func TestSleep(t *testing.T) {
 	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
 	f.start("sleep 5")
 
 	f.waitForStatusAndNoError(Running)
@@ -31,40 +37,76 @@ func TestSleep(t *testing.T) {
 
 func TestPrintsLogs(t *testing.T) {
 	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
 	f.start("echo testing123456")
 	f.assertCmdSucceeds()
 	f.assertLogContains("testing123456")
 }
 
-func TestHandlesFailures(t *testing.T) {
+func TestHandlesExits(t *testing.T) {
 	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
 	f.start("false")
 
 	f.waitForError()
-	f.assertLogContains("Error execing ")
+	f.assertLogContains("exited with exit code 1")
+}
+
+func TestStopsGrandchildren(t *testing.T) {
+	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
+	f.start("bash -c '(for i in $(seq 1 20); do echo loop$i; sleep 1; done)'")
+	f.waitForStatusAndNoError(Running)
+
+	// wait until there's log output
+	timeout := time.After(time.Second)
+	for {
+		if strings.Contains(f.testWriter.String(), "loop1") {
+			break
+		}
+		select {
+		case <-timeout:
+			t.Fatal("never saw any process output")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	// cancel the context
+	f.cancel()
+	f.waitForStatusAndNoError(Done)
 }
 
 type processExecFixture struct {
 	t          *testing.T
 	ctx        context.Context
+	cancel     context.CancelFunc
 	execer     *processExecer
-	testWriter *strings.Builder
+	testWriter *bufsync.ThreadSafeBuffer
 	statusCh   chan status
 }
 
 func newProcessExecFixture(t *testing.T) *processExecFixture {
 	execer := NewProcessExecer()
-	ctx := context.Background()
-	testWriter := &strings.Builder{}
+	testWriter := bufsync.NewThreadSafeBuffer()
+	ctx, _, _ := testutils.ForkedCtxAndAnalyticsForTest(testWriter)
+	ctx, cancel := context.WithCancel(ctx)
 	statusCh := make(chan status)
 
 	return &processExecFixture{
 		t:          t,
 		ctx:        ctx,
+		cancel:     cancel,
 		execer:     execer,
 		testWriter: testWriter,
 		statusCh:   statusCh,
 	}
+}
+
+func (f *processExecFixture) tearDown() {
+	f.cancel()
 }
 
 func (f *processExecFixture) start(cmd string) {
@@ -73,13 +115,17 @@ func (f *processExecFixture) start(cmd string) {
 }
 
 func (f *processExecFixture) assertCmdSucceeds() {
-	f.waitForStatusAndNoError(Done)
+	f.waitForError()
+	f.assertLogContains("exited with exit code 0")
 }
 
 func (f *processExecFixture) waitForStatusAndNoError(expectedStatus status) {
 	for {
 		select {
-		case status := <-f.statusCh:
+		case status, ok := <-f.statusCh:
+			if !ok {
+				f.t.Fatal("statusCh closed")
+			}
 			if expectedStatus == status {
 				return
 			}
@@ -94,7 +140,7 @@ func (f *processExecFixture) waitForStatusAndNoError(expectedStatus status) {
 }
 
 func (f *processExecFixture) assertLogContains(s string) {
-	assert.Contains(f.t, f.testWriter.String(), s)
+	require.Contains(f.t, f.testWriter.String(), s)
 }
 
 func (f *processExecFixture) waitForError() {

--- a/pkg/assets/dev.go
+++ b/pkg/assets/dev.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windmilleng/tilt/internal/network"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/procutil"
 )
 
 const errorBodyStyle = `
@@ -86,7 +87,7 @@ func (s *devServer) TearDown(ctx context.Context) {
 	defer s.mu.Unlock()
 
 	cmd := s.cmd
-	killProcessGroup(cmd)
+	procutil.KillProcessGroup(cmd)
 	s.disposed = true
 }
 
@@ -114,7 +115,7 @@ func (s *devServer) start(ctx context.Context, stdout, stderr io.Writer) (*exec.
 
 	// yarn will spawn the dev server as a subprocess, so set
 	// a process group id so we can murder them all.
-	setOptNewProcessGroup(attrs)
+	procutil.SetOptNewProcessGroup(attrs)
 
 	cmd.SysProcAttr = attrs
 

--- a/pkg/procutil/procutil_unix.go
+++ b/pkg/procutil/procutil_unix.go
@@ -1,17 +1,17 @@
 // +build !windows
 
-package assets
+package procutil
 
 import (
 	"os/exec"
 	"syscall"
 )
 
-func setOptNewProcessGroup(attrs *syscall.SysProcAttr) {
+func SetOptNewProcessGroup(attrs *syscall.SysProcAttr) {
 	attrs.Setpgid = true
 }
 
-func killProcessGroup(cmd *exec.Cmd) {
+func KillProcessGroup(cmd *exec.Cmd) {
 	if cmd != nil && cmd.Process != nil {
 		// Kill the entire process group.
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)

--- a/pkg/procutil/procutil_windows.go
+++ b/pkg/procutil/procutil_windows.go
@@ -1,17 +1,15 @@
 // +build windows
 
-package assets
+package procutil
 
 import (
 	"os/exec"
 	"syscall"
 )
 
-const createNewProcessGroupFlag = 0x00000200
-
 // https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 func setOptNewProcessGroup(attrs *syscall.SysProcAttr) {
-	attrs.CreationFlags = createNewProcessGroupFlag
+	attrs.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
 }
 
 func killProcessGroup(cmd *exec.Cmd) {

--- a/pkg/procutil/procutil_windows.go
+++ b/pkg/procutil/procutil_windows.go
@@ -8,11 +8,11 @@ import (
 )
 
 // https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
-func setOptNewProcessGroup(attrs *syscall.SysProcAttr) {
+func SetOptNewProcessGroup(attrs *syscall.SysProcAttr) {
 	attrs.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
 }
 
-func killProcessGroup(cmd *exec.Cmd) {
+func KillProcessGroup(cmd *exec.Cmd) {
 	if cmd != nil && cmd.Process != nil {
 		cmd.Process.Kill()
 	}


### PR DESCRIPTION
### Problem

We run local resource's serve_cmd as a child process. When that child process spawns a grandchild process, then our mechanism of canceling the Context does not work to kill the grandchild process or cause cmd.Wait to return, so tilt effectively hangs when trying to stop the process.

### Solution

Don't rely on canceling the context to kill the child process, and instead spawn the child process in a process group and kill the whole process group. Code lifted wholesale from Mish (https://github.com/windmilleng/mish/blob/master/mish/shmill/shmill.go#L170)

While I was here, I also made it so that we consider it an error even when a process exits with exit code 0.