### PR TITLE
local: kill processes on shutdown

### DIFF
--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -18,6 +18,9 @@ type Controller struct {
 	procCount int
 }
 
+var _ store.Subscriber = &Controller{}
+var _ store.TearDowner = &Controller{}
+
 func NewController(execer Execer) *Controller {
 	return &Controller{
 		execer: execer,
@@ -119,6 +122,12 @@ func (c *Controller) getOrMakeProc(name model.ManifestName) *currentProcess {
 	}
 
 	return c.procs[name]
+}
+
+func (c *Controller) TearDown(ctx context.Context) {
+	for name := range c.procs {
+		c.stop(name)
+	}
 }
 
 func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore) {

--- a/internal/engine/local/controller_test.go
+++ b/internal/engine/local/controller_test.go
@@ -85,6 +85,21 @@ func TestUniqueSpanIDs(t *testing.T) {
 	require.NotEqual(t, fooStart.SpanID(), barStart.SpanID(), "different resources should have unique log span ids")
 }
 
+func TestTearDown(t *testing.T) {
+	f := newFixture(t)
+	defer f.teardown()
+
+	t1 := time.Unix(1, 0)
+	f.resource("foo", "foo.sh", t1)
+	f.resource("bar", "bar.sh", t1)
+	f.step()
+
+	f.c.TearDown(f.ctx)
+
+	f.fe.RequireNoKnownProcess(t, "foo.sh")
+	f.fe.RequireNoKnownProcess(t, "bar.sh")
+}
+
 type fixture struct {
 	t      *testing.T
 	st     *store.TestingStore


### PR DESCRIPTION
### Problem

When using `local_resource` with a `serve_cmd`, the processes are left running when you stop Tilt. When you restart Tilt, all the `serve_cmd`s will fail because the old processes still have the port.

### Solution

For now, kill `serve_cmd`s when Tilt exits.

Cons:
* inconsistent with other types of resources (k8s and DC resources are left running on exit)
* prevents us from reusing old processes if nothing's changed

Pros:
* restarting tilt when using serve_cmd isn't insanely annoying

We'll probably want to do something different in the longer run (and maybe even before we publicize this feature) but this will ease iterating on this.