### PR TITLE
scripts: bump current version

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.10.26"
+const devVersion = "0.11.0"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.10.26"
+VERSION="0.11.0"
 BREW=$(which brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/version:

dbda089f2b27762d1217a6ec0637f31f28fa60c3 (2020-01-13 18:59:20 -0500)
scripts: bump current version