### PR TITLE
web: reset autoscroll when switching views. Fixes https://github.com/windmilleng/tilt/issues/2571

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -448,6 +448,7 @@ class HUD extends Component<HudProps, HudState> {
         <LogPane
           logLines={logLines}
           showManifestPrefix={false}
+          manifestName={name}
           handleSetHighlight={this.handleSetHighlight}
           handleClearHighlight={this.handleClearHighlight}
           highlight={snapshotHighlight}
@@ -492,6 +493,7 @@ class HUD extends Component<HudProps, HudState> {
         <LogPane
           logLines={allLogs}
           showManifestPrefix={true}
+          manifestName={""}
           handleSetHighlight={this.handleSetHighlight}
           handleClearHighlight={this.handleClearHighlight}
           highlight={this.state.snapshotHighlight}

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -344,6 +344,7 @@ it("renders without crashing", () => {
   Element.prototype.scrollIntoView = jest.fn()
   ReactDOM.render(
     <LogPane
+      manifestName={""}
       logLines={logLinesFromString("hello\nworld\nfoo")}
       showManifestPrefix={false}
       message="world"
@@ -363,6 +364,7 @@ it("renders logs", () => {
   const tree = renderer
     .create(
       <LogPane
+        manifestName={""}
         logLines={logLinesFromString(log)}
         showManifestPrefix={false}
         handleSetHighlight={fakeHandleSetHighlight}
@@ -381,6 +383,7 @@ it("renders logs with leading whitespace and ANSI codes", () => {
   const tree = renderer
     .create(
       <LogPane
+        manifestName={""}
         logLines={logLinesFromString(longLog)}
         showManifestPrefix={false}
         handleSetHighlight={fakeHandleSetHighlight}
@@ -404,6 +407,7 @@ it("renders highlighted lines", () => {
   }
   let el = (
     <LogPane
+      manifestName={""}
       logLines={logLinesFromString(log)}
       showManifestPrefix={false}
       handleSetHighlight={fakeHandleSetHighlight}
@@ -432,6 +436,7 @@ it("scrolls to highlighted lines in snapshot", () => {
   }
   const wrapper = mount<LogPane>(
     <LogPane
+      manifestName={""}
       logLines={logLinesFromString(longLog)}
       showManifestPrefix={false}
       handleSetHighlight={fakeHandleSetHighlight}
@@ -462,6 +467,7 @@ it("does not scroll to highlighted lines if not snapshot", () => {
   }
   const wrapper = mount<LogPane>(
     <LogPane
+      manifestName={""}
       logLines={logLinesFromString(longLog)}
       showManifestPrefix={false}
       handleSetHighlight={fakeHandleSetHighlight}
@@ -492,6 +498,7 @@ it("doesn't set selection event handler if snapshot", () => {
   }
   const wrapper = mount<LogPane>(
     <LogPane
+      manifestName={""}
       logLines={logLinesFromString(longLog)}
       showManifestPrefix={false}
       handleSetHighlight={fakeHandleSetHighlight}

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -12,6 +12,7 @@ import styled from "styled-components"
 const WHEEL_DEBOUNCE_MS = 250
 
 type LogPaneProps = {
+  manifestName: string
   logLines: LogLine[]
   showManifestPrefix: boolean
   message?: string
@@ -155,9 +156,19 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
   }
 
   componentDidUpdate(prevProps: LogPaneProps) {
-    if (!this.state.autoscroll) {
-      return
+    if (prevProps.manifestName != this.props.manifestName) {
+      this.setState({
+        autoscroll: true,
+        lastWheelEventTimeMs: 0,
+      })
+
+      this.scrollLastElementIntoView()
+    } else if (this.state.autoscroll) {
+      this.scrollLastElementIntoView()
     }
+  }
+
+  scrollLastElementIntoView() {
     if (this.lastElement.current?.scrollIntoView) {
       this.lastElement.current.scrollIntoView()
     }


### PR DESCRIPTION
Hello @hyu, @jazzdan,

Please review the following commits I made in branch nicks/windowing:

8877b17b3ba48f851ead49610e48b93fc6118e0b (2020-01-14 19:12:26 -0500)
web: reset autoscroll when switching views. Fixes https://github.com/windmilleng/tilt/issues/2571