### PR TITLE
web: disable smoothing and calculate autoscroll without forcing layouts

### DIFF
--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -12,8 +12,6 @@ body {
   margin: 0;
   padding: 0;
   font-family: $font-monospace;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   background-color: $color-gray-dark;
   color: $color-white;
   font-size: $font-size;


### PR DESCRIPTION
Hello @hyu, @jazzdan,

Please review the following commits I made in branch nicks/windowing2:

94a56d14f2d3da197dc0431903fa14f37280de4e (2020-01-15 09:32:16 -0500)
web: disable smoothing and calculate autoscroll without forcing layouts
These two optimizations speed up scrolling and responsiveness dramatically

4e3e57bf8c8788754188f6a9bbce44d6cc0085aa (2020-01-14 19:27:30 -0500)
web: reset autoscroll when switching views. Fixes https://github.com/windmilleng/tilt/issues/2571