### PR TITLE
local resource: fix spanid in view

### DIFF
--- a/internal/hud/view/view.go
+++ b/internal/hud/view/view.go
@@ -75,7 +75,7 @@ type LocalResourceInfo struct {
 }
 
 func NewLocalResourceInfo(status model.RuntimeStatus, pid int, spanID model.LogSpanID) LocalResourceInfo {
-	return LocalResourceInfo{status: status}
+	return LocalResourceInfo{status: status, pid: pid, spanID: spanID}
 }
 
 var _ ResourceInfoView = LocalResourceInfo{}


### PR DESCRIPTION
with this last line, now local resource runtime logs work in the TUI