### PR TITLE
args: fix tilt args url construction

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -43,6 +43,7 @@ type fixture struct {
 	tilt          *TiltDriver
 	activeTiltUp  *TiltUpResponse
 	tearingDown   bool
+	tiltArgs      []string
 }
 
 func newFixture(t *testing.T, dir string) *fixture {
@@ -163,7 +164,7 @@ func (f *fixture) TiltUp(name string) {
 }
 
 func (f *fixture) TiltWatch() {
-	response, err := f.tilt.Up(nil, f.LogWriter())
+	response, err := f.tilt.Up(f.tiltArgs, f.LogWriter())
 	if err != nil {
 		f.t.Fatalf("TiltWatch: %v", err)
 	}
@@ -171,7 +172,7 @@ func (f *fixture) TiltWatch() {
 }
 
 func (f *fixture) TiltWatchExec() {
-	response, err := f.tilt.Up([]string{"--update-mode=exec"}, f.LogWriter())
+	response, err := f.tilt.Up(append([]string{"--update-mode=exec"}, f.tiltArgs...), f.LogWriter())
 	if err != nil {
 		f.t.Fatalf("TiltWatchExec: %v", err)
 	}

--- a/integration/tilt.go
+++ b/integration/tilt.go
@@ -77,6 +77,11 @@ func (d *TiltDriver) Up(args []string, out io.Writer) (*TiltUpResponse, error) {
 	return response, nil
 }
 
+func (d *TiltDriver) Args(args []string, out io.Writer) error {
+	cmd := d.cmd(append([]string{"args"}, args...), out)
+	return cmd.Run()
+}
+
 type TiltUpResponse struct {
 	done chan struct{}
 	err  error

--- a/integration/tilt_args/Tiltfile
+++ b/integration/tilt_args/Tiltfile
@@ -1,0 +1,6 @@
+config.define_string_list('resources', args=True)
+cfg = config.parse()
+config.set_enabled_resources(cfg.get('resources', []))
+
+local_resource('foo', 'echo foo run')
+local_resource('bar', 'echo bar run')

--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -1,0 +1,32 @@
+//+build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTiltArgs(t *testing.T) {
+	f := newFixture(t, "tilt_args")
+	defer f.TearDown()
+
+	f.tiltArgs = []string{"foo"}
+
+	f.TiltWatch()
+
+	err := f.logs.WaitUntilContains("foo run", time.Second)
+	require.NoError(t, err)
+
+	f.logs.Reset()
+
+	err = f.tilt.Args([]string{"bar"}, f.logs)
+	require.NoError(t, err)
+
+	err = f.logs.WaitUntilContains("bar run", time.Second)
+	require.NoError(t, err)
+
+	require.NotContains(t, f.logs.String(), "foo run")
+}

--- a/internal/testutils/bufsync/bufsync.go
+++ b/internal/testutils/bufsync/bufsync.go
@@ -45,4 +45,11 @@ func (b *ThreadSafeBuffer) WaitUntilContains(expected string, timeout time.Durat
 	return fmt.Errorf("Timeout. Expected %q. Actual: %s", expected, b.String())
 }
 
+func (b *ThreadSafeBuffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.buf.Reset()
+}
+
 var _ io.Writer = &ThreadSafeBuffer{}


### PR DESCRIPTION
### Problem

`path.Join` ends up de-duping existing /'s, and `http://` isn't part of a path, so it's not appropriate to use there.

### Solution

Don't `path.Join` the scheme.