### PR TITLE
local serve: make first cleanup attempt w/ SIGINT instead of SIGKILL

### DIFF
--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -165,7 +166,7 @@ func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan s
 		}
 		statusCh <- statusAndMetadata{status: Error, spanID: spanID}
 	case <-ctx.Done():
-		err := c.Process.Kill()
+		err := c.Process.Signal(os.Interrupt)
 		if err != nil {
 			procutil.KillProcessGroup(c)
 		} else {


### PR DESCRIPTION
e.g., `docker run` will kill the underlying container if it gets a SIGINT, but doesn't get a chance if it gets a SIGKILL