### PR TITLE
k8s: oops! I accidentally turned the watch timeout too low

### DIFF
--- a/scripts/patch/cache/reflector.go.patch
+++ b/scripts/patch/cache/reflector.go.patch
@@ -90,7 +90,7 @@ func createDefaultDropWatchHandler(name string) DropWatchHandler {
 var (
 	// We try to spread the load on apiserver by setting timeouts for
 	// watch requests - it is random in [minWatchTimeout, 2*minWatchTimeout].
-	minWatchTimeout = 10 * time.Second
+	minWatchTimeout = time.Minute
 )
 
 // NewNamespaceKeyedIndexerAndReflector creates an Indexer and a Reflector

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -90,7 +90,7 @@ func createDefaultDropWatchHandler(name string) DropWatchHandler {
 var (
 	// We try to spread the load on apiserver by setting timeouts for
 	// watch requests - it is random in [minWatchTimeout, 2*minWatchTimeout].
-	minWatchTimeout = 10 * time.Second
+	minWatchTimeout = time.Minute
 )
 
 // NewNamespaceKeyedIndexerAndReflector creates an Indexer and a Reflector


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/duration:

41937f0b338e70a1941df845d22d191bcbb343d8 (2020-01-16 21:54:00 -0500)
k8s: oops! I accidentally turned the watch timeout too low
This is the length of time that a watch waits before
it notices that it's lost access credentials. It was originally
at 5 minutes. I turned it down to 10sec for testing.
Let's turn it down to 1 minute.