### PR TITLE
logger: add arbitrary fields to log events

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -166,8 +166,8 @@ type BuildLogActionWriter struct {
 	spanID       logstore.SpanID
 }
 
-func (w BuildLogActionWriter) Write(level logger.Level, p []byte) error {
-	w.store.Dispatch(store.NewLogAction(w.manifestName, w.spanID, level, p))
+func (w BuildLogActionWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
+	w.store.Dispatch(store.NewLogAction(w.manifestName, w.spanID, level, fields, p))
 	return nil
 }
 

--- a/internal/engine/configs/tiltfile_log_writer.go
+++ b/internal/engine/configs/tiltfile_log_writer.go
@@ -18,8 +18,8 @@ func NewTiltfileLogWriter(s store.RStore, loadCount int) *tiltfileLogWriter {
 	return &tiltfileLogWriter{s, loadCount}
 }
 
-func (w *tiltfileLogWriter) Write(level logger.Level, p []byte) error {
-	w.store.Dispatch(store.NewLogAction(model.TiltfileManifestName, SpanIDForLoadCount(w.loadCount), level, p))
+func (w *tiltfileLogWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
+	w.store.Dispatch(store.NewLogAction(model.TiltfileManifestName, SpanIDForLoadCount(w.loadCount), level, fields, p))
 	return nil
 }
 

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -224,12 +224,12 @@ type LocalServeLogActionWriter struct {
 	procNum             int
 }
 
-func (w LocalServeLogActionWriter) Write(level logger.Level, p []byte) error {
+func (w LocalServeLogActionWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
 	if !w.stillHasSameProcNum() {
 		return nil
 	}
 
-	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForServeLog(w.procNum), level, p))
+	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForServeLog(w.procNum), level, fields, p))
 	return nil
 }
 

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -257,7 +257,7 @@ func checkForContainerCrash(ctx context.Context, state *store.EngineState, mt *s
 	ms.NeedsRebuildFromCrash = true
 	ms.LiveUpdatedContainerIDs = container.NewIDSet()
 	msg := fmt.Sprintf("Detected a container change for %s. We could be running stale code. Rebuilding and deploying a new image.", ms.Name)
-	le := store.NewLogAction(ms.Name, ms.LastBuild().SpanID, logger.WarnLvl, []byte(msg+"\n"))
+	le := store.NewLogAction(ms.Name, ms.LastBuild().SpanID, logger.WarnLvl, nil, []byte(msg+"\n"))
 	handleLogAction(state, le)
 }
 

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -186,7 +186,7 @@ func (w *DockerComposeLogActionWriter) Write(p []byte) (n int, err error) {
 	// If the last line is empty, then we're starting a newline.
 	w.isStartingNewLine = len(lines[len(lines)-1]) == 0
 	newText := bytes.Join(lines, newlineAsBytes)
-	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForDCService(w.manifestName), logger.InfoLvl, newText))
+	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForDCService(w.manifestName), logger.InfoLvl, nil, newText))
 	return len(p), nil
 }
 

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -216,7 +216,7 @@ type PodLogActionWriter struct {
 }
 
 func (w PodLogActionWriter) Write(p []byte) (n int, err error) {
-	w.Store.Dispatch(store.NewLogAction(w.ManifestName, SpanIDForPod(w.PodID), logger.InfoLvl, p))
+	w.Store.Dispatch(store.NewLogAction(w.ManifestName, SpanIDForPod(w.PodID), logger.InfoLvl, nil, p))
 	return len(p), nil
 }
 

--- a/internal/engine/telemetry/controller.go
+++ b/internal/engine/telemetry/controller.go
@@ -72,5 +72,5 @@ func (t *Controller) OnChange(ctx context.Context, st store.RStore) {
 
 func (t *Controller) logError(st store.RStore, err error) {
 	spanID := logstore.SpanID(fmt.Sprintf("telemetry:%s", string(t.runCounter)))
-	st.Dispatch(store.NewLogAction(model.TiltfileManifestName, spanID, logger.InfoLvl, []byte(err.Error())))
+	st.Dispatch(store.NewLogAction(model.TiltfileManifestName, spanID, logger.InfoLvl, nil, []byte(err.Error())))
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -274,7 +274,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	err := cb.Error
 	if err != nil {
 		s := fmt.Sprintf("Build Failed: %v", err)
-		handleLogAction(engineState, store.NewLogAction(mt.Manifest.Name, cb.SpanID, logger.ErrorLvl, []byte(s)))
+		handleLogAction(engineState, store.NewLogAction(mt.Manifest.Name, cb.SpanID, logger.ErrorLvl, nil, []byte(s)))
 	}
 
 	ms := mt.State

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1322,7 +1322,7 @@ func TestPodEventOrdering(t *testing.T) {
 			}
 
 			f.upper.store.Dispatch(
-				store.NewLogAction("fe", runtimelog.SpanIDForPod(podBNow.PodID()), logger.InfoLvl, []byte("pod b log\n")))
+				store.NewLogAction("fe", runtimelog.SpanIDForPod(podBNow.PodID()), logger.InfoLvl, nil, []byte("pod b log\n")))
 
 			f.WaitUntil("pod log seen", func(state store.EngineState) bool {
 				ms, _ := state.ManifestState("fe")
@@ -2864,7 +2864,7 @@ func TestBuildLogAction(t *testing.T) {
 		SpanID:       SpanIDForBuildLog(1),
 	})
 
-	f.store.Dispatch(store.NewLogAction(manifest.Name, SpanIDForBuildLog(1), logger.InfoLvl, []byte(`a
+	f.store.Dispatch(store.NewLogAction(manifest.Name, SpanIDForBuildLog(1), logger.InfoLvl, nil, []byte(`a
 bc
 def
 ghij`)))
@@ -3218,7 +3218,7 @@ func TestTelemetryLogAction(t *testing.T) {
 
 	f.Start([]model.Manifest{}, true)
 
-	f.store.Dispatch(store.NewLogAction(model.TiltfileManifestName, "0", logger.InfoLvl, []byte("testing")))
+	f.store.Dispatch(store.NewLogAction(model.TiltfileManifestName, "0", logger.InfoLvl, nil, []byte("testing")))
 
 	f.WaitUntil("log is stored", func(state store.EngineState) bool {
 		l := state.LogStore.ManifestLog(store.TiltfileManifestName)
@@ -3785,7 +3785,7 @@ func (f *testFixture) startPod(pod *v1.Pod, manifestName model.ManifestName) {
 
 func (f *testFixture) podLog(pod *v1.Pod, manifestName model.ManifestName, s string) {
 	podID := k8s.PodID(pod.Name)
-	f.upper.store.Dispatch(store.NewLogAction(manifestName, runtimelog.SpanIDForPod(podID), logger.InfoLvl, []byte(s+"\n")))
+	f.upper.store.Dispatch(store.NewLogAction(manifestName, runtimelog.SpanIDForPod(podID), logger.InfoLvl, nil, []byte(s+"\n")))
 
 	f.WaitUntil("pod log seen", func(es store.EngineState) bool {
 		ms, _ := es.ManifestState(manifestName)

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -92,7 +92,7 @@ func TestStateToViewTiltfileLog(t *testing.T) {
 	es := newState([]model.Manifest{})
 	spanID := configs.SpanIDForLoadCount(1)
 	es.LogStore.Append(
-		store.NewLogAction(store.TiltfileManifestName, spanID, logger.InfoLvl, []byte("hello")),
+		store.NewLogAction(store.TiltfileManifestName, spanID, logger.InfoLvl, nil, []byte("hello")),
 		nil)
 	v := stateToProtoView(t, *es)
 	r, ok := findResource("(Tiltfile)", v)

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -27,6 +27,7 @@ type LogAction struct {
 	mn        model.ManifestName
 	spanID    logstore.SpanID
 	timestamp time.Time
+	fields    logger.Fields
 	msg       []byte
 	level     logger.Level
 }
@@ -45,6 +46,10 @@ func (le LogAction) Time() time.Time {
 	return le.timestamp
 }
 
+func (le LogAction) Fields() logger.Fields {
+	return le.fields
+}
+
 func (le LogAction) Message() []byte {
 	return le.msg
 }
@@ -57,13 +62,14 @@ func (le LogAction) String() string {
 	return fmt.Sprintf("manifest: %s, spanID: %s, msg: %q", le.mn, le.spanID, le.msg)
 }
 
-func NewLogAction(mn model.ManifestName, spanID logstore.SpanID, level logger.Level, b []byte) LogAction {
+func NewLogAction(mn model.ManifestName, spanID logstore.SpanID, level logger.Level, fields logger.Fields, b []byte) LogAction {
 	return LogAction{
 		mn:        mn,
 		spanID:    spanID,
 		level:     level,
 		timestamp: time.Now(),
 		msg:       append([]byte{}, b...),
+		fields:    fields,
 	}
 }
 

--- a/internal/store/logger.go
+++ b/internal/store/logger.go
@@ -8,7 +8,7 @@ import (
 
 func NewLogActionLogger(ctx context.Context, dispatch func(action Action)) logger.Logger {
 	l := logger.Get(ctx)
-	return logger.NewFuncLogger(l.SupportsColor(), l.Level(), func(level logger.Level, b []byte) error {
+	return logger.NewFuncLogger(l.SupportsColor(), l.Level(), func(level logger.Level, fields logger.Fields, b []byte) error {
 		dispatch(NewGlobalLogAction(level, b))
 		return nil
 	})

--- a/internal/synclet/log_style.go
+++ b/internal/synclet/log_style.go
@@ -50,7 +50,7 @@ func newLogStyle(ctx context.Context) (*proto.LogStyle, error) {
 }
 
 func makeContext(ctx context.Context, logStyle *proto.LogStyle, f func(m *proto.LogMessage) error) (context.Context, error) {
-	writeLog := func(level logger.Level, bytes []byte) error {
+	writeLog := func(level logger.Level, fields logger.Fields, bytes []byte) error {
 		protoLevel, err := logLevelToProto(level)
 		if err != nil {
 			return err

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4440,7 +4440,7 @@ func newFixture(t *testing.T) *fixture {
 	}
 
 	// Collect the warnings
-	l := logger.NewFuncLogger(false, logger.DebugLvl, func(level logger.Level, msg []byte) error {
+	l := logger.NewFuncLogger(false, logger.DebugLvl, func(level logger.Level, fields logger.Fields, msg []byte) error {
 		if level == logger.WarnLvl {
 			r.warnings = append(r.warnings, string(msg))
 		}

--- a/pkg/logger/deferred.go
+++ b/pkg/logger/deferred.go
@@ -17,7 +17,7 @@ type DeferredLogger struct {
 func NewDeferredLogger(ctx context.Context) *DeferredLogger {
 	original := Get(ctx)
 	dLogger := &DeferredLogger{original: original}
-	fLogger := NewFuncLogger(original.SupportsColor(), original.Level(), func(level Level, b []byte) error {
+	fLogger := NewFuncLogger(original.SupportsColor(), original.Level(), func(level Level, fields Fields, b []byte) error {
 		dLogger.mu.Lock()
 		defer dLogger.mu.Unlock()
 		if dLogger.output != nil {

--- a/pkg/logger/func_logger_test.go
+++ b/pkg/logger/func_logger_test.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,7 +10,7 @@ import (
 
 func TestFuncLogger_Level(t *testing.T) {
 	out := &bytes.Buffer{}
-	fl := NewFuncLogger(true, InfoLvl, func(level Level, b []byte) error {
+	fl := NewFuncLogger(true, InfoLvl, func(level Level, fields Fields, b []byte) error {
 		_, err := out.Write(b)
 		return err
 	})
@@ -20,4 +21,30 @@ func TestFuncLogger_Level(t *testing.T) {
 	s := out.String()
 	require.Contains(t, s, "info")
 	require.NotContains(t, s, "debug")
+}
+
+func TestOneField(t *testing.T) {
+	out := &bytes.Buffer{}
+	fl := NewFuncLogger(true, InfoLvl, func(level Level, fields Fields, b []byte) error {
+		_, err := fmt.Fprintf(out, "[%v]: %s", fields, string(b))
+		return err
+	})
+
+	fl.WithFields(Fields{"a": "1"}).Infof("info")
+	s := out.String()
+	require.Equal(t, s, "[map[a:1]]: info\n")
+}
+
+func TestFieldLayering(t *testing.T) {
+	out := &bytes.Buffer{}
+	fl := NewFuncLogger(true, InfoLvl, func(level Level, fields Fields, b []byte) error {
+		_, err := fmt.Fprintf(out, "[%v]: %s", fields, string(b))
+		return err
+	})
+
+	l1 := fl.WithFields(Fields{"a": "1"})
+	l1.WithFields(Fields{"b": "2"}).Infof("line1")
+	l1.WithFields(Fields{"c": "3"}).Infof("line2")
+	s := out.String()
+	require.Equal(t, s, "[map[a:1 b:2]]: line1\n[map[a:1 c:3]]: line2\n")
 }


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/fields:

317b614692458b0be3ece62f9a6d5874a3208b38 (2020-01-17 16:59:20 -0500)
logger: add arbitrary fields to log events

e886ec3446bc34583c3362efb588752c069d135e (2020-01-17 16:42:20 -0500)
engine: remove some dead wrapper objects