### PR TITLE
web: rewrite internal implementation of LogStore

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -302,10 +302,10 @@ it("loads logs incrementally", async () => {
       _: { manifestName: "" },
     },
     segments: [
-      { text: "line1\n", time: now, level: "INFO", spanId: "_" },
-      { text: "line2\n", time: now, level: "INFO", spanId: "_" },
-      { text: "line3\n", time: now, level: "INFO", spanId: "_" },
-      { text: "line4\n", time: now, level: "INFO", spanId: "_" },
+      { text: "line1\n", time: now, spanId: "_" },
+      { text: "line2\n", time: now, spanId: "_" },
+      { text: "line3\n", time: now, spanId: "_" },
+      { text: "line4\n", time: now, spanId: "_" },
     ],
   })
 })

--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -42,7 +42,7 @@ describe("LogStore", () => {
     })
 
     expect(logLinesToString(logs.allLog(), true)).toEqual("foo")
-    expect(logs.lineCache.length).toEqual(1)
+    expect(logs.lineCache[0].text).toEqual("foo")
     expect(logs.allLog()[0]).toStrictEqual(logs.allLog()[0])
 
     logs.append({
@@ -53,7 +53,7 @@ describe("LogStore", () => {
     })
 
     expect(logLinesToString(logs.allLog(), true)).toEqual("foobar")
-    expect(logs.lineCache.length).toEqual(1)
+    expect(logs.lineCache[0].text).toEqual("foobar")
   })
 
   it("handles changing levels", () => {


### PR DESCRIPTION
Hello @hyu, @jazzdan,

Please review the following commits I made in branch nicks/logstore:

899bed4e6ed60c777097dd7e6c7d4b266c3845d9 (2020-01-22 13:55:09 -0500)
web: rewrite internal implementation of LogStore
The web UI doesn't need the complex log-streaming stuff that the server
needs. This should be a lot simpler and easier to reason about.