### PR TITLE
tiltfile: add network argument to docker_buld

### DIFF
--- a/internal/build/options.go
+++ b/internal/build/options.go
@@ -16,6 +16,7 @@ func Options(archive io.Reader, db model.DockerBuild) docker.BuildOptions {
 		BuildArgs:  manifestBuildArgsToDockerBuildArgs(db.BuildArgs),
 		Target:     string(db.TargetStage),
 		SSHSpecs:   db.SSHSpecs,
+		Network:    db.Network,
 	}
 }
 

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -474,6 +474,7 @@ func (c *Cli) ImageBuild(ctx context.Context, buildContext io.Reader, options Bu
 	opts.Dockerfile = options.Dockerfile
 	opts.Tags = options.Tags
 	opts.Target = options.Target
+	opts.NetworkMode = options.Network
 
 	opts.Labels = BuiltByTiltLabel // label all images as built by us
 

--- a/internal/docker/options.go
+++ b/internal/docker/options.go
@@ -10,4 +10,5 @@ type BuildOptions struct {
 	Tags       []string
 	Target     string
 	SSHSpecs   []string
+	Network    string
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1087,6 +1087,7 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 				LiveUpdate:  lu,
 				TargetStage: model.DockerBuildTarget(image.targetStage),
 				SSHSpecs:    image.sshSpecs,
+				Network:     image.network,
 			})
 		case CustomBuild:
 			r := model.CustomBuild{

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -202,6 +202,8 @@ type DockerBuild struct {
 	// Pass SSH secrets to docker so it can clone private repos.
 	// https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds
 	SSHSpecs []string
+
+	Network string
 }
 
 func (DockerBuild) buildDetails() {}


### PR DESCRIPTION
- Adds a network argument to the docker_build command
- Plumbs the network argument in docker_build through to the underlying docker build

Fixes: #2483 