### PR TITLE
procutil: don't send signals to nil process

### DIFF
--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -141,16 +141,16 @@ func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan s
 	c.Stderr = w
 	c.Stdout = w
 
-	errCh := make(chan error)
+	err := c.Start()
+	if err != nil {
+		return
+	}
 
+	statusCh <- statusAndMetadata{status: Running, pid: c.Process.Pid, spanID: spanID}
+
+	// This is to prevent this goroutine from blocking, since we know there's only going to be one result
+	errCh := make(chan error, 1)
 	go func() {
-		err := c.Start()
-		if err != nil {
-			errCh <- err
-			return
-		}
-
-		statusCh <- statusAndMetadata{status: Running, pid: c.Process.Pid, spanID: spanID}
 		errCh <- c.Wait()
 	}()
 

--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -143,6 +143,8 @@ func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan s
 
 	err := c.Start()
 	if err != nil {
+		logger.Get(ctx).Errorf("%s failed to start: %v", cmd.String(), err)
+		statusCh <- statusAndMetadata{status: Error, spanID: spanID}
 		return
 	}
 

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -79,6 +79,15 @@ func TestStopsGrandchildren(t *testing.T) {
 	f.waitForStatusAndNoError(Done)
 }
 
+func TestHandlesProcessThatFailsToStart(t *testing.T) {
+	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
+	f.startMalformedCommand()
+	f.waitForError()
+	f.assertLogContains("failed to start: ")
+}
+
 type processExecFixture struct {
 	t          *testing.T
 	ctx        context.Context
@@ -107,6 +116,11 @@ func newProcessExecFixture(t *testing.T) *processExecFixture {
 
 func (f *processExecFixture) tearDown() {
 	f.cancel()
+}
+
+func (f *processExecFixture) startMalformedCommand() {
+	c := model.Cmd{Argv: []string{"\""}}
+	f.execer.Start(f.ctx, c, f.testWriter, f.statusCh, model.LogSpanID("rt1"))
 }
 
 func (f *processExecFixture) start(cmd string) {

--- a/pkg/procutil/procutil_unix.go
+++ b/pkg/procutil/procutil_unix.go
@@ -20,5 +20,9 @@ func KillProcessGroup(cmd *exec.Cmd) {
 }
 
 func GracefullyShutdownProcess(p *os.Process) error {
+	if p == nil {
+		return nil
+	}
+
 	return syscall.Kill(-p.Pid, syscall.SIGTERM)
 }

--- a/pkg/procutil/procutil_unix.go
+++ b/pkg/procutil/procutil_unix.go
@@ -13,10 +13,12 @@ func SetOptNewProcessGroup(attrs *syscall.SysProcAttr) {
 }
 
 func KillProcessGroup(cmd *exec.Cmd) {
-	if cmd != nil && cmd.Process != nil {
-		// Kill the entire process group.
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	if cmd == nil || cmd.Process == nil {
+		return
 	}
+
+	// Kill the entire process group.
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }
 
 func GracefullyShutdownProcess(p *os.Process) error {


### PR DESCRIPTION
Before: 

If you `tilt up` this branch Tilt would segfault
https://github.com/windmilleng/enhance/compare/dmiller/crash-tilt?expand=1

After:
It starts up fine and doesn't segfault