### PR TITLE
cli: analytics failures should be debug logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa
 	github.com/windmilleng/fsevents v0.0.0-20190206153914-2ad75e5ddeed
 	github.com/windmilleng/fsnotify v1.4.7
-	github.com/windmilleng/wmclient v0.0.0-20191029142206-4d42565d7ef1
+	github.com/windmilleng/wmclient v0.0.0-20200124175229-a66bcbc48340
 	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
 	go.opencensus.io v0.22.2 // indirect
 	go.opentelemetry.io/otel v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -833,6 +833,8 @@ github.com/windmilleng/fsnotify v1.4.7 h1:9PUoTe3ZaKO9JLtuHQzM8BaCcrDz8rQ7PmEGo6
 github.com/windmilleng/fsnotify v1.4.7/go.mod h1:h3pBNCM04c2q++yj67m77Mof0ZG/mzQMh+OM7J+Umc0=
 github.com/windmilleng/wmclient v0.0.0-20191029142206-4d42565d7ef1 h1:83lkkQIOYfCB0O+pGZwZ+1f3fp0TVSm+DdPclkEuSgs=
 github.com/windmilleng/wmclient v0.0.0-20191029142206-4d42565d7ef1/go.mod h1:KiOUkuhrzEiLKaErC33BRLfxAIE4MGjRGi7G+R3sm7o=
+github.com/windmilleng/wmclient v0.0.0-20200124175229-a66bcbc48340 h1:QFeGATPnLyIvTdf75OuKIFzX0CRgRt5a/lK1M6k16GI=
+github.com/windmilleng/wmclient v0.0.0-20200124175229-a66bcbc48340/go.mod h1:KiOUkuhrzEiLKaErC33BRLfxAIE4MGjRGi7G+R3sm7o=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,13 +3,14 @@ package cli
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/windmilleng/tilt/internal/analytics"
+	"github.com/windmilleng/wmclient/pkg/analytics"
+
+	tiltanalytics "github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/output"
 	"github.com/windmilleng/tilt/internal/tracer"
 
@@ -39,20 +40,15 @@ func Execute() {
 		Short: "tilt creates Kubernetes Live Deploys that reflect changes seconds after they’re made",
 	}
 
-	a, err := initAnalytics(rootCmd)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	addCommand(rootCmd, &upCmd{})
+	addCommand(rootCmd, &dockerCmd{})
+	addCommand(rootCmd, &doctorCmd{})
+	addCommand(rootCmd, &downCmd{})
+	addCommand(rootCmd, &versionCmd{})
+	addCommand(rootCmd, &dockerPruneCmd{})
+	addCommand(rootCmd, newArgsCmd())
 
-	addCommand(rootCmd, &upCmd{}, a)
-	addCommand(rootCmd, &dockerCmd{}, a)
-	addCommand(rootCmd, &doctorCmd{}, a)
-	addCommand(rootCmd, &downCmd{}, a)
-	addCommand(rootCmd, &versionCmd{}, a)
-	addCommand(rootCmd, &dockerPruneCmd{}, a)
-	addCommand(rootCmd, newArgsCmd(), a)
-
+	rootCmd.AddCommand(analytics.NewCommand())
 	rootCmd.AddCommand(newKubectlCmd())
 	rootCmd.AddCommand(newDumpCmd())
 
@@ -80,22 +76,29 @@ type tiltCmd interface {
 	run(ctx context.Context, args []string) error
 }
 
-func preCommand(ctx context.Context, a *analytics.TiltAnalytics) (context.Context, func() error) {
+func preCommand(ctx context.Context) (context.Context, func() error) {
 	cleanup := func() error { return nil }
 	l := logger.NewLogger(logLevel(verbose, debug), os.Stdout)
 	ctx = logger.WithLogger(ctx, l)
-	ctx = analytics.WithAnalytics(ctx, a)
+
+	a, err := newAnalytics(l)
+	if err != nil {
+		l.Errorf("Fatal error initializing analytics: %v", err)
+		os.Exit(1)
+	}
+
+	ctx = tiltanalytics.WithAnalytics(ctx, a)
 
 	initKlog(l.Writer(logger.InfoLvl))
 
 	if trace {
 		backend, err := tracer.StringToTracerBackend(traceType)
 		if err != nil {
-			log.Printf("Warning: invalid tracer backend: %v", err)
+			l.Warnf("invalid tracer backend: %v", err)
 		}
 		cleanup, err = tracer.Init(ctx, backend)
 		if err != nil {
-			log.Printf("Warning: unable to initialize tracer: %s", err)
+			l.Warnf("unable to initialize tracer: %s", err)
 		}
 	}
 
@@ -123,10 +126,10 @@ func preCommand(ctx context.Context, a *analytics.TiltAnalytics) (context.Contex
 	return ctx, cleanup
 }
 
-func addCommand(parent *cobra.Command, child tiltCmd, a *analytics.TiltAnalytics) {
+func addCommand(parent *cobra.Command, child tiltCmd) {
 	cobraChild := child.register()
 	cobraChild.Run = func(_ *cobra.Command, args []string) {
-		ctx, cleanup := preCommand(context.Background(), a)
+		ctx, cleanup := preCommand(context.Background())
 
 		err := child.run(ctx, args)
 

--- a/vendor/github.com/windmilleng/wmclient/pkg/analytics/analytics.go
+++ b/vendor/github.com/windmilleng/wmclient/pkg/analytics/analytics.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/denisbrodbeck/machineid"
-	"github.com/spf13/cobra"
 )
 
 const statsEndpt = "https://events.windmill.build/report"
@@ -43,20 +42,6 @@ type stdLogger struct{}
 
 func (stdLogger) Printf(format string, v ...interface{}) {
 	log.Printf("[analytics] %s", fmt.Sprintf(format, v...))
-}
-
-func Init(appName string, options ...Option) (Analytics, *cobra.Command, error) {
-	a, err := NewRemoteAnalytics(appName, options...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	c, err := initCLI()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return a, c, nil
 }
 
 type Analytics interface {

--- a/vendor/github.com/windmilleng/wmclient/pkg/analytics/cli.go
+++ b/vendor/github.com/windmilleng/wmclient/pkg/analytics/cli.go
@@ -48,7 +48,7 @@ func analyticsOpt(_ *cobra.Command, args []string) (outerErr error) {
 
 const choiceFile = "analytics/user/choice.txt"
 
-func initCLI() (*cobra.Command, error) {
+func NewCommand() *cobra.Command {
 	analytics := &cobra.Command{
 		Use:   "analytics",
 		Short: "info and status about windmill analytics",
@@ -61,6 +61,5 @@ func initCLI() (*cobra.Command, error) {
 		RunE:  analyticsOpt,
 	}
 	analytics.AddCommand(opt)
-
-	return analytics, nil
+	return analytics
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -470,7 +470,7 @@ github.com/whilp/git-urls
 github.com/windmilleng/fsevents
 # github.com/windmilleng/fsnotify v1.4.7
 github.com/windmilleng/fsnotify
-# github.com/windmilleng/wmclient v0.0.0-20191029142206-4d42565d7ef1
+# github.com/windmilleng/wmclient v0.0.0-20200124175229-a66bcbc48340
 github.com/windmilleng/wmclient/pkg/analytics
 github.com/windmilleng/wmclient/pkg/dirs
 github.com/windmilleng/wmclient/pkg/env


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/ch4338/spam:

52f4bd47b05a549b4c120a7aec9bb0a4efffeddf (2020-01-24 13:16:08 -0500)
cli: analytics failures should be debug logs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics