### PR TITLE
cloud: lookup errors should be debug logs

### DIFF
--- a/internal/cloud/cloud_username_manager.go
+++ b/internal/cloud/cloud_username_manager.go
@@ -79,7 +79,7 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		logger.Get(ctx).Infof("error making whoami request: %v", err)
+		logger.Get(ctx).Debugf("error making whoami request: %v", err)
 		c.error()
 		return
 	}
@@ -87,7 +87,7 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := c.client.Do(req)
 	if err != nil {
-		logger.Get(ctx).Infof("error checking tilt cloud status: %v", err)
+		logger.Get(ctx).Debugf("error checking tilt cloud status: %v", err)
 		c.error()
 		return
 	}
@@ -95,25 +95,25 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 	if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			logger.Get(ctx).Infof("tilt cloud status request failed with status %d. error reading response body: %v", resp.StatusCode, err)
+			logger.Get(ctx).Debugf("tilt cloud status request failed with status %d. error reading response body: %v", resp.StatusCode, err)
 			c.error()
 			return
 		}
-		logger.Get(ctx).Infof("error checking tilt cloud status: code: %d, message: %s", resp.StatusCode, string(body))
+		logger.Get(ctx).Debugf("error checking tilt cloud status: code: %d, message: %s", resp.StatusCode, string(body))
 		c.error()
 		return
 	}
 
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		logger.Get(ctx).Infof("error reading response body: %v", err)
+		logger.Get(ctx).Debugf("error reading response body: %v", err)
 		c.error()
 		return
 	}
 	r := whoAmIResponse{}
 	err = json.NewDecoder(bytes.NewReader(responseBody)).Decode(&r)
 	if err != nil {
-		logger.Get(ctx).Infof("error decoding tilt whoami response '%s': %v", string(responseBody), err)
+		logger.Get(ctx).Debugf("error decoding tilt whoami response '%s': %v", string(responseBody), err)
 		c.error()
 		return
 	}


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/ch4339/spam:

88634c7dff7f38ef8cb615b3fc5033b05b68feab (2020-01-24 13:19:26 -0500)
cloud: lookup errors should be debug logs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics