### PR TITLE
engine: move targetqueue into buildcontrol

### DIFF
--- a/internal/engine/buildcontrol/target_queue.go
+++ b/internal/engine/buildcontrol/target_queue.go
@@ -1,4 +1,4 @@
-package engine
+package buildcontrol
 
 import (
 	"context"
@@ -89,6 +89,10 @@ func NewImageTargetQueue(ctx context.Context, iTargets []model.ImageTarget, stat
 		needsOwnBuild: needsOwnBuild,
 		depsNeedBuild: depsNeedBuild,
 	}, nil
+}
+
+func (q *TargetQueue) Results() store.BuildResultSet {
+	return q.results
 }
 
 func (q *TargetQueue) CountDirty() int {

--- a/internal/engine/buildcontrol/target_queue_test.go
+++ b/internal/engine/buildcontrol/target_queue_test.go
@@ -1,4 +1,4 @@
-package engine
+package buildcontrol
 
 import (
 	"context"

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -67,7 +67,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	span.SetTag("target", dcTargets[0].Name)
 	defer span.Finish()
 
-	q, err := NewImageTargetQueue(ctx, iTargets, currentState, bd.icb.ib.ImageExists)
+	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, currentState, bd.icb.ib.ImageExists)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
@@ -126,7 +126,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		return store.BuildResultSet{}, err
 	}
 
-	results := q.results
+	results := q.Results()
 	results[dcTarget.ID()] = store.NewDockerComposeDeployResult(dcTarget.ID(), cid)
 	return results, nil
 }

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -125,7 +125,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		ibd.analytics.Timer("build.image", time.Since(startTime), tags)
 	}()
 
-	q, err := NewImageTargetQueue(ctx, iTargets, stateSet, ibd.ib.ImageExists)
+	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, stateSet, ibd.ib.ImageExists)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}
@@ -169,7 +169,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 
 	// (If we pass an empty list of refs here (as we will do if only deploying
 	// yaml), we just don't inject any image refs into the yaml, nbd.
-	brs, err := ibd.deploy(ctx, st, ps, iTargetMap, kTarget, q.results, anyLiveUpdate)
+	brs, err := ibd.deploy(ctx, st, ps, iTargetMap, kTarget, q.Results(), anyLiveUpdate)
 	return brs, buildcontrol.WrapDontFallBackError(err)
 }
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/targetqueue:

2dd42cec5aca64ca67d3ad5fba03a6a745b1f857 (2020-01-24 14:14:37 -0500)
engine: move targetqueue into buildcontrol

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics