### PR TITLE
integration: bump timeout and reenable local_resource test

### DIFF
--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -15,7 +15,6 @@ import (
 const cleanupTxt = "cleanup.txt"
 
 func TestLocalResourceCleanup(t *testing.T) {
-	t.Skip("failing in CI")
 	f := newFixture(t, "local_resource")
 	defer f.TearDown()
 
@@ -25,8 +24,8 @@ func TestLocalResourceCleanup(t *testing.T) {
 
 	f.TiltWatch()
 
-	require.NoError(t, f.logs.WaitUntilContains("hello! foo #1", time.Second))
-	require.NoError(t, f.logs.WaitUntilContains("hello! bar #1", time.Second))
+	require.NoError(t, f.logs.WaitUntilContains("hello! foo #1", 5*time.Second))
+	require.NoError(t, f.logs.WaitUntilContains("hello! bar #1", 5*time.Second))
 
 	// send a SIGTERM and make sure Tilt propagates it to its local_resource processes
 


### PR DESCRIPTION
this passed 600x in circleci, so hopefully we're good now...