### PR TITLE
bump version to v0.11.3

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.11.1"
+const devVersion = "0.11.3"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.11.1"
+VERSION="0.11.3"
 BREW=$(which brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/bump:

323b2b2da5143dc8520a4baf003f58a8585c1b0b (2020-01-24 17:54:40 -0500)
bump version to v0.11.3

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics