### PR TITLE
docker: fix a bug where we were leaving buildkit sessions open

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -457,7 +457,8 @@ func (c *Cli) ImageBuild(ctx context.Context, buildContext io.Reader, options Bu
 				fmt.Errorf("Docker SSH secrets only work on Buildkit, but Buildkit has been disabled")
 		}
 
-		oneTimeSession, err := c.startBuildkitSession(ctx, identity.NewID(), options.SSHSpecs)
+		var err error
+		oneTimeSession, err = c.startBuildkitSession(ctx, identity.NewID(), options.SSHSpecs)
 		if err != nil {
 			return types.ImageBuildResponse{}, errors.Wrapf(err, "ImageBuild")
 		}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/buildkitsession:

a4ee99f4fefa2f707b291129e060b3fecc58ccf5 (2020-01-24 18:28:07 -0500)
docker: fix a bug where we were leaving buildkit sessions open

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics