### PR TITLE
web: fix an off-by-one error in how we show progress logs

### DIFF
--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -180,7 +180,7 @@ describe("LogStore", () => {
     )
   })
 
-  it("handles progressLogs", () => {
+  it("handles progressLogs interleaved", () => {
     let logs = new LogStore()
     logs.append({
       spans: { "": {} },
@@ -190,7 +190,7 @@ describe("LogStore", () => {
         { text: "layer 3: Pending\n", fields: { progressID: "layer 3" } },
       ],
       fromCheckpoint: 0,
-      toCheckpoint: 2,
+      toCheckpoint: 3,
     })
 
     expect(logLinesToString(logs.allLog(), true)).toEqual(
@@ -201,12 +201,36 @@ describe("LogStore", () => {
       segments: [
         { text: "layer 2: Finished\n", fields: { progressID: "layer 2" } },
       ],
-      fromCheckpoint: 2,
-      toCheckpoint: 3,
+      fromCheckpoint: 3,
+      toCheckpoint: 4,
     })
 
     expect(logLinesToString(logs.allLog(), true)).toEqual(
       "layer 1: Pending\nlayer 2: Finished\nlayer 3: Pending"
     )
+  })
+
+  it("handles progressLogs adjacent", () => {
+    let logs = new LogStore()
+    logs.append({
+      spans: { "": {} },
+      segments: [
+        { text: "layer 1: Pending\n", fields: { progressID: "layer 1" } },
+      ],
+      fromCheckpoint: 0,
+      toCheckpoint: 1,
+    })
+
+    expect(logLinesToString(logs.allLog(), true)).toEqual("layer 1: Pending")
+
+    logs.append({
+      segments: [
+        { text: "layer 1: Finished\n", fields: { progressID: "layer 1" } },
+      ],
+      fromCheckpoint: 1,
+      toCheckpoint: 2,
+    })
+
+    expect(logLinesToString(logs.allLog(), true)).toEqual("layer 1: Finished")
   })
 })

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -191,7 +191,7 @@ class LogStore {
     }
 
     // Iterate backwards and figure out which line to overwrite.
-    for (let i = span.lastLineIndex - 1; i >= span.firstLineIndex; i--) {
+    for (let i = span.lastLineIndex; i >= span.firstLineIndex; i--) {
       let cur = this.lines[i]
       if (cur.spanId != candidate.spanId) {
         // skip lines from other spans


### PR DESCRIPTION
Hello @hyu, @maiamcc,

Please review the following commits I made in branch nicks/progress2:

7956c7eb14137b93e16ceca4dd625105687b2736 (2020-01-27 15:42:29 -0500)
web: fix an off-by-one error in how we show progress logs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics