### PR TITLE
build: use progress ids to print buildkit output more effectively

### DIFF
--- a/internal/build/testdata/TestBuildkitPrinter/echo-hi-success-verbose.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/echo-hi-success-verbose.master.txt
@@ -1,6 +1,8 @@
 [1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9
-[1/2] done | 702ms
+[1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9 [done: 2ms]
+[1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9 [done: 702ms]
 [2/2] RUN echo hi
   → hi
-[2/2] done | 1.365s
+[2/2] RUN echo hi [done: 1.365s]
 exporting to image
+exporting to image [done: 66ms]

--- a/internal/build/testdata/TestBuildkitPrinter/echo-hi-success.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/echo-hi-success.master.txt
@@ -1,6 +1,8 @@
 [1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9
-[1/2] done | 702ms
+[1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9 [done: 2ms]
+[1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9 [done: 702ms]
 [2/2] RUN echo hi
   → hi
-[2/2] done | 1.365s
+[2/2] RUN echo hi [done: 1.365s]
 exporting to image
+exporting to image [done: 66ms]

--- a/internal/build/testdata/TestBuildkitPrinter/multistage-fail-copy.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/multistage-fail-copy.master.txt
@@ -1,6 +1,6 @@
 [stage-1 1/3] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9
 [builder 2/2] RUN echo hi > hi.txt
-[builder 2/2] done | 1.16s
+[builder 2/2] RUN echo hi > hi.txt [done: 1.16s]
 [stage-1 2/3] COPY --from=builder /dest/hi.txt /src/hi.txt
 
 ERROR IN: [stage-1 2/3] COPY --from=builder /dest/hi.txt /src/hi.txt

--- a/internal/build/testdata/TestBuildkitPrinter/multistage-fail-run.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/multistage-fail-run.master.txt
@@ -1,8 +1,8 @@
-[cached] [stage-1 1/3] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9
+[stage-1 1/3] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9 [cached]
 [builder 2/2] RUN echo hi > hi.txt
-[builder 2/2] done | 1.318s
+[builder 2/2] RUN echo hi > hi.txt [done: 1.318s]
 [stage-1 2/3] COPY --from=builder /src/hi.txt /dest/hi.txt
-[stage-1 2/3] done | 1.128s
+[stage-1 2/3] COPY --from=builder /src/hi.txt /dest/hi.txt [done: 1.128s]
 [stage-1 3/3] RUN cat hi.txt && exit 1
   → hi
 

--- a/internal/build/testdata/TestBuildkitPrinter/multistage-success.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/multistage-success.master.txt
@@ -1,9 +1,10 @@
 [stage-1 1/3] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9
 [builder 2/2] RUN echo hi > hi.txt
-[builder 2/2] done | 1.203s
+[builder 2/2] RUN echo hi > hi.txt [done: 1.203s]
 [stage-1 2/3] COPY --from=builder /src/hi.txt /dest/hi.txt
-[stage-1 2/3] done | 1.274s
+[stage-1 2/3] COPY --from=builder /src/hi.txt /dest/hi.txt [done: 1.274s]
 [stage-1 3/3] RUN cat hi.txt
   → hi
-[stage-1 3/3] done | 1.024s
+[stage-1 3/3] RUN cat hi.txt [done: 1.024s]
 exporting to image
+exporting to image [done: 118ms]

--- a/internal/build/testdata/TestBuildkitPrinter/rust-success.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/rust-success.master.txt
@@ -1,7 +1,7 @@
 [1/3] FROM docker.io/library/rust:slim@sha256:c578c49322bf0af20ce1517a3a59095b2462f0d5b7e54274e3a9aea3103fcac5
-[1/3] done | 24.144s
+[1/3] FROM docker.io/library/rust:slim@sha256:c578c49322bf0af20ce1517a3a59095b2462f0d5b7e54274e3a9aea3103fcac5 [done: 24.144s]
 [2/3] COPY . .
-[2/3] done | 3.95s
+[2/3] COPY . . [done: 3.95s]
 [3/3] RUN cargo build
   →     Updating crates.io index
   →  Downloading crates ...
@@ -31,6 +31,6 @@
   →    Compiling regex v0.1.80
   →    Compiling hello_world v0.1.0 (/usr/src/app)
   →     Finished dev [unoptimized + debuginfo] target(s) in 28.39s
-[3/3] done | 30.751s
+[3/3] RUN cargo build [done: 30.751s]
 exporting to image
-exporting to image done | 843ms
+exporting to image [done: 843ms]

--- a/internal/build/testdata/TestBuildkitPrinter/sleep-cache.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/sleep-cache.master.txt
@@ -1,3 +1,4 @@
 [1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9
-[cached] [2/2] RUN sleep 5
+[2/2] RUN sleep 5 [cached]
 exporting to image
+exporting to image [done: 5ms]

--- a/internal/build/testdata/TestBuildkitPrinter/sleep-success.master.txt
+++ b/internal/build/testdata/TestBuildkitPrinter/sleep-success.master.txt
@@ -1,4 +1,5 @@
 [1/2] FROM docker.io/library/busybox@sha256:c94cf1b87ccb80f2e6414ef913c748b105060debda482058d2b8d0fce39f11b9
 [2/2] RUN sleep 5
-[2/2] done | 6.07s
+[2/2] RUN sleep 5 [done: 6.07s]
 exporting to image
+exporting to image [done: 56ms]


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/progress3:

243ae8a3ad70d1d06f926dda6c96c3119c992e31 (2020-01-27 16:38:51 -0500)
build: use progress ids to print buildkit output more effectively

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics