### PR TITLE
makefile: increase the timeout on golangci-lint, and make sure it's using vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,10 @@ benchmark:
 
 golangci-lint:
 ifneq ($(CIRCLECI),true)
-	golangci-lint run -v
+	GOFLAGS="-mod=vendor" golangci-lint run -v --timeout 90s
 else
 	mkdir -p test-results
-	golangci-lint run -v --out-format junit-xml > test-results/lint.xml
+	GOFLAGS="-mod=vendor" golangci-lint run -v --timeout 90s --out-format junit-xml > test-results/lint.xml
 endif
 
 wire:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/timeout:

85a1c6713f3fd551fa2ef00a771c90e061e193fe (2020-01-27 18:49:11 -0500)
makefile: increase the timeout on golangci-lint, and make sure it's using vendoring

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics