### PR TITLE
buildcontrol: don't parallelize local_resource with other commands

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -854,9 +854,9 @@ func TestBuildControllerLocalResourcesBeforeClusterResources(t *testing.T) {
 	}
 
 	expectedBuildOrder := []string{
-		model.UnresourcedYAMLManifestName.String(),
-		"local1", // local resource comes after UnresourcedYAML but before all cluster resources
+		"local1",
 		"local2",
+		model.UnresourcedYAMLManifestName.String(),
 		"clusterUnbuilt",
 		"clusterBuilt1",
 		"clusterBuilt2",


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch4318/locals:

958d40ba14fce685182488a2a3e4e309c40131af (2020-01-27 21:12:32 -0500)
buildcontrol: don't parallelize local_resource with other commands

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics