### PR TITLE
store: separate localref and clusterref in ImageBuildResult [ch4292]

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -43,7 +43,7 @@ var imageTargetID = model.TargetID{
 	Name: "gcr.io/some-project-162817/sancho",
 }
 
-var alreadyBuilt = store.NewImageBuildResult(imageTargetID, testImageRef)
+var alreadyBuilt = store.NewImageBuildResultSingleRef(imageTargetID, testImageRef)
 var alreadyBuiltSet = store.BuildResultSet{imageTargetID: alreadyBuilt}
 
 type expectedFile = testutils.ExpectedFile
@@ -608,7 +608,7 @@ func TestContainerBuildMultiStage(t *testing.T) {
 	// There are two image targets. The first has a build result,
 	// the second does not --> second target needs build
 	iTargetID := targets[0].ID()
-	firstResult := store.NewImageBuildResult(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
+	firstResult := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
 	bs[iTargetID] = store.NewBuildState(firstResult, nil)
 
 	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
@@ -782,9 +782,9 @@ func TestOneLiveUpdateOneDockerBuildDoesImageBuild(t *testing.T) {
 		WithImageTargets(sanchoTarg, sidecarTarg).
 		Build()
 	changed := f.WriteFile("a.txt", "a")
-	sanchoState := store.NewBuildState(store.NewImageBuildResult(sanchoTarg.ID(), sanchoRef), []string{changed}).
+	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}).
 		WithRunningContainers([]store.ContainerInfo{sanchoCInfo})
-	sidecarState := store.NewBuildState(store.NewImageBuildResult(sidecarTarg.ID(), sidecarRef), []string{changed})
+	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed})
 
 	bs := store.BuildStateSet{sanchoTarg.ID(): sanchoState, sidecarTarg.ID(): sidecarState}
 
@@ -927,9 +927,9 @@ func multiImageLiveUpdateManifestAndBuildState(f *bdFixture) (model.Manifest, st
 		Build()
 
 	changed := f.WriteFile("a.txt", "a")
-	sanchoState := store.NewBuildState(store.NewImageBuildResult(sanchoTarg.ID(), sanchoRef), []string{changed}).
+	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}).
 		WithRunningContainers([]store.ContainerInfo{sanchoCInfo})
-	sidecarState := store.NewBuildState(store.NewImageBuildResult(sidecarTarg.ID(), sidecarRef), []string{changed}).
+	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed}).
 		WithRunningContainers([]store.ContainerInfo{sidecarCInfo})
 
 	bs := store.BuildStateSet{sanchoTarg.ID(): sanchoState, sidecarTarg.ID(): sidecarState}

--- a/internal/engine/buildcontrol/target_queue.go
+++ b/internal/engine/buildcontrol/target_queue.go
@@ -60,7 +60,7 @@ func NewImageTargetQueue(ctx context.Context, iTargets []model.ImageTarget, stat
 		if state[id].NeedsImageBuild() {
 			needsOwnBuild[id] = true
 		} else if state[id].LastSuccessfulResult != nil {
-			image := store.ImageFromBuildResult(state[id].LastSuccessfulResult)
+			image := store.LocalImageRefFromBuildResult(state[id].LastSuccessfulResult)
 			exists, err := imageExists(ctx, image)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error looking up whether last image built for %s exists", image.String())
@@ -126,7 +126,7 @@ func (q *TargetQueue) RunBuilds(handler BuildHandler) error {
 			// Otherwise, we can re-use results from the previous build.
 			// If needsOwnBuild is false, then LastSuccessfulResult must exist if it's empty.
 			lastResult := q.state[id].LastSuccessfulResult
-			image := store.ImageFromBuildResult(lastResult)
+			image := store.LocalImageRefFromBuildResult(lastResult)
 			if image == nil {
 				return fmt.Errorf("Internal error: build marked clean but last result not found: %+v", q.state[id])
 			}

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -105,7 +105,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 			return nil, err
 		}
 
-		return store.NewImageBuildResult(iTarget.ID(), ref), nil
+		return store.NewImageBuildResultSingleRef(iTarget.ID(), ref), nil
 	})
 
 	if err != nil {

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -143,7 +143,7 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 		WithDeployTarget(defaultDockerComposeTarget(f, "sancho"))
 
 	iTargetID := manifest.ImageTargets[0].ID()
-	result := store.NewImageBuildResult(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
+	result := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
 	state := store.NewBuildState(result, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
 	f.dCli.ImageListCount = 1

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -161,7 +161,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		}
 
 		anyLiveUpdate = anyLiveUpdate || !iTarget.LiveUpdateInfo().Empty()
-		return store.NewImageBuildResult(iTarget.ID(), ref), nil
+		return store.NewImageBuildResultSingleRef(iTarget.ID(), ref), nil
 	})
 	if err != nil {
 		return store.BuildResultSet{}, buildcontrol.WrapDontFallBackError(err)
@@ -302,7 +302,7 @@ func (ibd *ImageBuildAndDeployer) createEntitiesToDeploy(ctx context.Context,
 		}
 
 		for _, depID := range depIDs {
-			ref := store.ImageFromBuildResult(results[depID])
+			ref := store.ClusterImageRefFromBuildResult(results[depID])
 			if ref == nil {
 				return nil, fmt.Errorf("Internal error: missing image build result for dependency ID: %s", depID)
 			}
@@ -390,7 +390,7 @@ func injectImageDependencies(iTarget model.ImageTarget, iTargetMap map[model.Tar
 	}
 
 	for _, dep := range deps {
-		image := store.ImageFromBuildResult(dep)
+		image := store.LocalImageRefFromBuildResult(dep)
 		if image == nil {
 			return model.ImageTarget{}, fmt.Errorf("Internal error: image is nil")
 		}

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -41,7 +41,7 @@ func TestDeployTwinImages(t *testing.T) {
 
 	id := manifest.ImageTargetAt(0).ID()
 	expectedImage := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	image := store.ImageFromBuildResult(result[id])
+	image := store.ClusterImageRefFromBuildResult(result[id])
 	assert.Equal(t, expectedImage, image.String())
 	assert.Equalf(t, 2, strings.Count(f.k8s.Yaml, expectedImage),
 		"Expected image to update twice in YAML: %s", f.k8s.Yaml)
@@ -65,13 +65,13 @@ func TestDeployPodWithMultipleImages(t *testing.T) {
 	assert.Equal(t, 2, f.docker.BuildCount)
 
 	expectedSanchoRef := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	image := store.ImageFromBuildResult(result[iTarget1.ID()])
+	image := store.ClusterImageRefFromBuildResult(result[iTarget1.ID()])
 	assert.Equal(t, expectedSanchoRef, image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSanchoRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
 
 	expectedSidecarRef := "gcr.io/some-project-162817/sancho-sidecar:tilt-11cd0b38bc3ceb95"
-	image = store.ImageFromBuildResult(result[iTarget2.ID()])
+	image = store.ClusterImageRefFromBuildResult(result[iTarget2.ID()])
 	assert.Equal(t, expectedSidecarRef, image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSidecarRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
@@ -97,13 +97,13 @@ func TestDeployPodWithMultipleLiveUpdateImages(t *testing.T) {
 	assert.Equal(t, 2, f.docker.BuildCount)
 
 	expectedSanchoRef := "gcr.io/some-project-162817/sancho:tilt-11cd0b38bc3ceb95"
-	image := store.ImageFromBuildResult(result[iTarget1.ID()])
+	image := store.ClusterImageRefFromBuildResult(result[iTarget1.ID()])
 	assert.Equal(t, expectedSanchoRef, image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSanchoRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
 
 	expectedSidecarRef := "gcr.io/some-project-162817/sancho-sidecar:tilt-11cd0b38bc3ceb95"
-	image = store.ImageFromBuildResult(result[iTarget2.ID()])
+	image = store.ClusterImageRefFromBuildResult(result[iTarget2.ID()])
 	assert.Equal(t, expectedSidecarRef, image.String())
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedSidecarRef),
 		"Expected image to appear once in YAML: %s", f.k8s.Yaml)
@@ -144,7 +144,7 @@ func TestImageIsClean(t *testing.T) {
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
-	result1 := store.NewImageBuildResult(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
+	result1 := store.NewImageBuildResultSingleRef(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
 
 	f.docker.ImageListCount = 1
 
@@ -267,8 +267,8 @@ func TestMultiStageDockerBuildWithFirstImageDirty(t *testing.T) {
 	manifest := NewSanchoDockerBuildMultiStageManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
 	iTargetID2 := manifest.ImageTargets[1].ID()
-	result1 := store.NewImageBuildResult(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
-	result2 := store.NewImageBuildResult(iTargetID2, container.MustParseNamedTagged("sancho:tilt-prebuilt2"))
+	result1 := store.NewImageBuildResultSingleRef(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
+	result2 := store.NewImageBuildResultSingleRef(iTargetID2, container.MustParseNamedTagged("sancho:tilt-prebuilt2"))
 
 	newFile := f.WriteFile("sancho-base/message.txt", "message")
 
@@ -303,8 +303,8 @@ func TestMultiStageDockerBuildWithSecondImageDirty(t *testing.T) {
 	manifest := NewSanchoDockerBuildMultiStageManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
 	iTargetID2 := manifest.ImageTargets[1].ID()
-	result1 := store.NewImageBuildResult(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
-	result2 := store.NewImageBuildResult(iTargetID2, container.MustParseNamedTagged("sancho:tilt-prebuilt2"))
+	result1 := store.NewImageBuildResultSingleRef(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
+	result2 := store.NewImageBuildResultSingleRef(iTargetID2, container.MustParseNamedTagged("sancho:tilt-prebuilt2"))
 
 	newFile := f.WriteFile("sancho/message.txt", "message")
 
@@ -432,7 +432,7 @@ func TestDeployUsesInjectRef(t *testing.T) {
 			var observedImages []string
 			for i := range manifest.ImageTargets {
 				id := manifest.ImageTargets[i].ID()
-				image := store.ImageFromBuildResult(result[id])
+				image := store.LocalImageRefFromBuildResult(result[id])
 				observedImages = append(observedImages, image.Name())
 			}
 

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -28,7 +28,9 @@ func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 
 	resultSet := store.BuildResultSet{}
 	resultSet[iTargetID] = store.NewLiveUpdateBuildResult(
-		res.TargetID(), store.ImageFromBuildResult(res),
+		res.TargetID(),
+		// TODO(maia): does LiveUpdateBuildResult actually need to know this?
+		store.ClusterImageRefFromBuildResult(res),
 		liveUpdatedContainerIDs)
 
 	// Invalidate all the image builds for images we depend on.

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -195,7 +195,7 @@ func (b *fakeBuildAndDeployer) nextBuildResult(iTarget model.ImageTarget, deploy
 	if len(containerIDs) > 0 {
 		result = store.NewLiveUpdateBuildResult(iTarget.ID(), nt, containerIDs)
 	} else {
-		result = store.NewImageBuildResult(iTarget.ID(), nt)
+		result = store.NewImageBuildResultSingleRef(iTarget.ID(), nt)
 	}
 	return result
 }
@@ -1354,7 +1354,7 @@ func TestPodEventContainerStatus(t *testing.T) {
 	var ref reference.NamedTagged
 	f.WaitUntilManifestState("image appears", "foobar", func(ms store.ManifestState) bool {
 		result := ms.BuildStatus(manifest.ImageTargetAt(0).ID()).LastSuccessfulResult
-		ref = store.ImageFromBuildResult(result)
+		ref = store.ClusterImageRefFromBuildResult(result)
 		return ref != nil
 	})
 
@@ -1744,7 +1744,7 @@ func TestPodContainerStatus(t *testing.T) {
 	var ref reference.NamedTagged
 	f.WaitUntilManifestState("image appears", "fe", func(ms store.ManifestState) bool {
 		result := ms.BuildStatus(manifest.ImageTargetAt(0).ID()).LastSuccessfulResult
-		ref = store.ImageFromBuildResult(result)
+		ref = store.ClusterImageRefFromBuildResult(result)
 		return ref != nil
 	})
 
@@ -4055,7 +4055,7 @@ func deployResultSet(manifest model.Manifest, uid types.UID, hashes []k8s.PodTem
 	resultSet := store.BuildResultSet{}
 	for _, iTarget := range manifest.ImageTargets {
 		ref, _ := reference.WithTag(iTarget.DeploymentRef, "deadbeef")
-		resultSet[iTarget.ID()] = store.NewImageBuildResult(iTarget.ID(), ref)
+		resultSet[iTarget.ID()] = store.NewImageBuildResultSingleRef(iTarget.ID(), ref)
 	}
 	ktID := manifest.K8sTarget().ID()
 	resultSet[ktID] = store.NewK8sDeployResult(ktID, []types.UID{uid}, hashes, nil)

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -37,10 +37,11 @@ func NewLocalBuildResult(id model.TargetID) LocalBuildResult {
 type ImageBuildResult struct {
 	id model.TargetID
 
-	// The name+tag of the image that the pod is running.
-	//
-	// The tag is derived from a content-addressable digest.
-	Image reference.NamedTagged
+	// Note: image tag is derived from a content-addressable digest.
+	ImageLocalRef   reference.NamedTagged // built image, as referenced from outside the cluster (in Dockerfile, docker push etc.)
+	ImageClusterRef reference.NamedTagged // built image, as referenced from the cluster (in K8s YAML, etc.)
+	// Often LocalRef and ClusterRef will be the same, but may diverge: e.g. when using KIND + local registry,
+	// LocalRef is localhost:1234/my-img:tilt-abc, ClusterRef is http://registry/my-img:tilt-abc
 }
 
 func (r ImageBuildResult) TargetID() model.TargetID   { return r.id }
@@ -48,11 +49,17 @@ func (r ImageBuildResult) BuildType() model.BuildType { return model.BuildTypeIm
 func (r ImageBuildResult) Facets() []model.Facet      { return nil }
 
 // For image targets.
-func NewImageBuildResult(id model.TargetID, image reference.NamedTagged) ImageBuildResult {
+func NewImageBuildResult(id model.TargetID, localRef, clusterRef reference.NamedTagged) ImageBuildResult {
 	return ImageBuildResult{
-		id:    id,
-		Image: image,
+		id:              id,
+		ImageLocalRef:   localRef,
+		ImageClusterRef: clusterRef,
 	}
+}
+
+// When LocalRef == ClusterRef
+func NewImageBuildResultSingleRef(id model.TargetID, ref reference.NamedTagged) ImageBuildResult {
+	return NewImageBuildResult(id, ref, ref)
 }
 
 type LiveUpdateBuildResult struct {
@@ -144,12 +151,20 @@ func NewK8sDeployResult(id model.TargetID, uids []types.UID, hashes []k8s.PodTem
 	}
 }
 
-func ImageFromBuildResult(r BuildResult) reference.NamedTagged {
+func LocalImageRefFromBuildResult(r BuildResult) reference.NamedTagged {
 	switch r := r.(type) {
 	case ImageBuildResult:
-		return r.Image
+		return r.ImageLocalRef
+	}
+	return nil
+}
+
+func ClusterImageRefFromBuildResult(r BuildResult) reference.NamedTagged {
+	switch r := r.(type) {
+	case ImageBuildResult:
+		return r.ImageClusterRef
 	case LiveUpdateBuildResult:
-		return r.Image
+		return r.Image // TODO(maia): is this right? unclear what ref LiveUpdateBuildResult knows about/if it even should
 	}
 	return nil
 }
@@ -301,7 +316,7 @@ func (b BuildState) OneContainerInfo() ContainerInfo {
 	return b.RunningContainers[0]
 }
 func (b BuildState) LastImageAsString() string {
-	img := ImageFromBuildResult(b.LastSuccessfulResult)
+	img := LocalImageRefFromBuildResult(b.LastSuccessfulResult)
 	if img == nil {
 		return ""
 	}
@@ -326,7 +341,7 @@ func (b BuildState) IsEmpty() bool {
 }
 
 func (b BuildState) HasImage() bool {
-	return ImageFromBuildResult(b.LastSuccessfulResult) != nil
+	return LocalImageRefFromBuildResult(b.LastSuccessfulResult) != nil
 }
 
 // Whether the image represented by this state needs to be built.


### PR DESCRIPTION
Hello @nicks, @hyu,

Please review the following commits I made in branch maiamcc/better-image-build-results:

2d2576938775177aa72a6d36b09a356b9a2ac26a (2020-01-28 12:58:48 -0500)
separate localref and clusterref in ImageBuildResult

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics