### PR TITLE
logstore: Return structured log lines for printing to stdout

### DIFF
--- a/pkg/model/logstore/reader.go
+++ b/pkg/model/logstore/reader.go
@@ -52,6 +52,16 @@ func (r Reader) ContinuingString(c Checkpoint) string {
 	return r.store.ContinuingString(c)
 }
 
+func (r Reader) ContinuingLines(c Checkpoint) []LogLine {
+	if r.store == nil {
+		return nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.store.ContinuingLines(c)
+}
+
 func (r Reader) Tail(n int) string {
 	if r.store == nil {
 		return ""


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/continuingstring:

902a694256e1f2cfc52d3e6731360bdf7e767390 (2020-01-28 13:15:50 -0500)
logstore: Return structured log lines for printing to stdout

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics