### PR TITLE
allow extra time for OS to free bind address after IsBindAddrFree check

### DIFF
--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -110,6 +110,10 @@ func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore)
 		return
 	}
 
+	// We need to pause for a bit to ensure the OS has a chance to free the socket
+	// from the test above (https://github.com/windmilleng/tilt/issues/2861)
+	time.Sleep(100 * time.Millisecond)
+
 	httpServer := &http.Server{
 		Addr:    network.BindAddr(string(s.host), int(s.port)),
 		Handler: http.DefaultServeMux,


### PR DESCRIPTION
See #2861 for more info.

This is a kludgy workaround -- I was still able to reproduce the underlying issue after sleeping for 10ms but have not seen it in ~2k `tilt up` executions after bumping the sleep time up to 100ms.

Some other options might be:
- to add the sleep directly to `IsBindAddrFree` [here](https://github.com/windmilleng/tilt/blob/8ea4b95e0f1fb39203faa2e95537337a211c19a5/internal/network/port.go#L25)
- eliminating all uses of `IsBindAddrFree` and always gracefully catching/handling the "address already in use" errors instead

No worries at all if you'd like to go with one of the above approaches (or something else entirely) instead of this PR.