### PR TITLE
build: do progress backoff at render-time instead of at logging-time

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -87,8 +87,7 @@ var BaseWireSet = wire.NewSet(
 	cloudurl.ProvideAddress,
 
 	provideClock,
-	hud.NewRenderer,
-	hud.ProvideHud,
+	hud.WireSet,
 
 	provideLogActions,
 	store.NewStore,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -106,7 +106,9 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
-	headsUpDisplay, err := hud.ProvideHud(hudEnabled, renderer, webURL, analytics3)
+	stdout := hud.ProvideStdout()
+	incrementalPrinter := hud.NewIncrementalPrinter(stdout)
+	headsUpDisplay, err := hud.ProvideHud(hudEnabled, renderer, webURL, analytics3, incrementalPrinter)
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
@@ -440,7 +442,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, provideClock, hud.NewRenderer, hud.ProvideHud, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
+	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/hud/disabled_hud.go
+++ b/internal/hud/disabled_hud.go
@@ -2,7 +2,6 @@ package hud
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/windmilleng/tilt/internal/store"
@@ -13,10 +12,11 @@ var _ HeadsUpDisplay = &DisabledHud{}
 
 type DisabledHud struct {
 	ProcessedLogs logstore.Checkpoint
+	printer       *IncrementalPrinter
 }
 
-func NewDisabledHud() HeadsUpDisplay {
-	return &DisabledHud{}
+func NewDisabledHud(printer *IncrementalPrinter) HeadsUpDisplay {
+	return &DisabledHud{printer: printer}
 }
 
 func (h *DisabledHud) Run(ctx context.Context, dispatch func(action store.Action), refreshRate time.Duration) error {
@@ -25,10 +25,10 @@ func (h *DisabledHud) Run(ctx context.Context, dispatch func(action store.Action
 
 func (h *DisabledHud) OnChange(ctx context.Context, st store.RStore) {
 	state := st.RLockState()
-	logs := state.LogStore.ContinuingString(h.ProcessedLogs)
+	lines := state.LogStore.ContinuingLines(h.ProcessedLogs)
 	checkpoint := state.LogStore.Checkpoint()
 	st.RUnlockState()
 
-	fmt.Print(logs)
+	h.printer.Print(lines)
 	h.ProcessedLogs = checkpoint
 }

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -51,9 +51,9 @@ type Hud struct {
 
 var _ HeadsUpDisplay = (*Hud)(nil)
 
-func ProvideHud(hudEnabled HudEnabled, renderer *Renderer, webURL model.WebURL, analytics *analytics.TiltAnalytics) (HeadsUpDisplay, error) {
+func ProvideHud(hudEnabled HudEnabled, renderer *Renderer, webURL model.WebURL, analytics *analytics.TiltAnalytics, printer *IncrementalPrinter) (HeadsUpDisplay, error) {
 	if !hudEnabled {
-		return NewDisabledHud(), nil
+		return NewDisabledHud(printer), nil
 	}
 	return NewDefaultHeadsUpDisplay(renderer, webURL, analytics)
 }

--- a/internal/hud/hud_test.go
+++ b/internal/hud/hud_test.go
@@ -22,7 +22,7 @@ func TestRenderInit(t *testing.T) {
 	r := NewRenderer(clockForTest)
 	r.rty = rty.NewRTY(tcell.NewSimulationScreen(""))
 	webURL, _ := url.Parse("http://localhost:10350")
-	hud, err := ProvideHud(true, r, model.WebURL(*webURL), ta)
+	hud, err := ProvideHud(true, r, model.WebURL(*webURL), ta, NewIncrementalPrinter(logs))
 	assert.NoError(t, err)
 	hud.(*Hud).refresh(ctx)
 }

--- a/internal/hud/printer.go
+++ b/internal/hud/printer.go
@@ -1,0 +1,69 @@
+package hud
+
+import (
+	"io"
+	"time"
+
+	"github.com/windmilleng/tilt/pkg/model/logstore"
+)
+
+var backoffInit = 5 * time.Second
+var backoffMultiplier = time.Duration(2)
+
+type Stdout io.Writer
+
+type IncrementalPrinter struct {
+	progress map[progressKey]progressStatus
+	stdout   Stdout
+}
+
+func NewIncrementalPrinter(stdout Stdout) *IncrementalPrinter {
+	return &IncrementalPrinter{
+		progress: make(map[progressKey]progressStatus),
+		stdout:   stdout,
+	}
+}
+
+func (p *IncrementalPrinter) Print(lines []logstore.LogLine) {
+	for _, line := range lines {
+		// Naive progress implementation: skip lines that have already been printed
+		// recently. This works with any output stream.
+		//
+		// TODO(nick): Use ANSI codes to overwrite previous lines. It requires
+		// a little extra bookkeeping about where to find the progress line,
+		// and only works on terminals.
+		progressID := line.ProgressID
+		key := progressKey{spanID: line.SpanID, progressID: progressID}
+		if progressID != "" {
+			status, hasBeenPrinted := p.progress[key]
+			shouldPrint := !hasBeenPrinted ||
+				line.Time.Sub(status.lastPrinted) > status.printWait
+			if !shouldPrint {
+				continue
+			}
+		}
+		_, _ = io.WriteString(p.stdout, line.Text)
+
+		if progressID != "" {
+			status := p.progress[key]
+			newWait := backoffInit
+			if status.printWait > 0 {
+				newWait = backoffMultiplier * status.printWait
+			}
+			p.progress[key] = progressStatus{
+				lastPrinted: line.Time,
+				printWait:   newWait,
+			}
+		}
+	}
+}
+
+type progressKey struct {
+	spanID     logstore.SpanID
+	progressID string
+}
+
+type progressStatus struct {
+	lastPrinted time.Time
+	printWait   time.Duration
+}

--- a/internal/hud/printer_test.go
+++ b/internal/hud/printer_test.go
@@ -1,0 +1,36 @@
+package hud
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/pkg/model/logstore"
+)
+
+func TestPrinterProgressBackoff(t *testing.T) {
+	out := &bytes.Buffer{}
+	now := time.Now()
+	printer := NewIncrementalPrinter(Stdout(out))
+
+	printer.Print([]logstore.LogLine{
+		logstore.LogLine{Text: "layer 1: Pending\n", ProgressID: "layer 1", Time: now},
+		logstore.LogLine{Text: "layer 2: Pending\n", ProgressID: "layer 2", Time: now},
+	})
+
+	assert.Equal(t, "layer 1: Pending\nlayer 2: Pending\n", out.String())
+
+	printer.Print([]logstore.LogLine{
+		logstore.LogLine{Text: "layer 1: Partial\n", ProgressID: "layer 1", Time: now},
+	})
+	assert.Equal(t, "layer 1: Pending\nlayer 2: Pending\n", out.String())
+
+	now = now.Add(time.Hour)
+	printer.Print([]logstore.LogLine{
+		logstore.LogLine{Text: "layer 1: Done\n", ProgressID: "layer 1", Time: now.Add(time.Hour)},
+	})
+	assert.Equal(t, "layer 1: Pending\nlayer 2: Pending\nlayer 1: Done\n", out.String())
+
+}

--- a/internal/hud/wire.go
+++ b/internal/hud/wire.go
@@ -1,0 +1,17 @@
+package hud
+
+import (
+	"os"
+
+	"github.com/google/wire"
+)
+
+var WireSet = wire.NewSet(
+	NewRenderer,
+	ProvideHud,
+	ProvideStdout,
+	NewIncrementalPrinter)
+
+func ProvideStdout() Stdout {
+	return Stdout(os.Stdout)
+}

--- a/pkg/model/logstore/logstore.go
+++ b/pkg/model/logstore/logstore.go
@@ -107,6 +107,7 @@ type LogLine struct {
 	Text       string
 	SpanID     SpanID
 	ProgressID string
+	Time       time.Time
 }
 
 func linesToString(lines []LogLine) string {
@@ -433,6 +434,7 @@ func (s *LogStore) ContinuingLines(checkpoint Checkpoint) []LogLine {
 				Text:       "\n",
 				SpanID:     precedingSegment.SpanID,
 				ProgressID: precedingSegment.Fields[logger.FieldNameProgressID],
+				Time:       precedingSegment.Time,
 			},
 		}, result...)
 	}
@@ -590,6 +592,7 @@ func (s *LogStore) toLogLines(options logOptions) []LogLine {
 	result := []LogLine{}
 	sb := strings.Builder{}
 	spanID := SpanID("")
+	time := time.Time{}
 	progressID := ""
 	lastLineCompleted := false
 
@@ -603,6 +606,7 @@ func (s *LogStore) toLogLines(options logOptions) []LogLine {
 			Text:       sb.String(),
 			SpanID:     spanID,
 			ProgressID: progressID,
+			Time:       time,
 		})
 		sb = strings.Builder{}
 		lastLineCompleted = true
@@ -634,6 +638,7 @@ func (s *LogStore) toLogLines(options logOptions) []LogLine {
 			continue
 		}
 
+		time = segment.Time
 		spanID = segment.SpanID
 		span := s.spans[spanID]
 		if _, ok := options.spans[spanID]; !ok {

--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -348,14 +348,17 @@ func TestContinuingLines(t *testing.T) {
 	l := NewLogStore()
 	c1 := l.Checkpoint()
 
+	now := time.Now()
 	l.Append(testLogEvent{
 		name:    "fe",
 		message: "layer 1: pending\n",
+		ts:      now,
 		fields:  map[string]string{logger.FieldNameProgressID: "layer 1"},
 	}, nil)
 	l.Append(testLogEvent{
 		name:    "fe",
 		message: "layer 2: pending\n",
+		ts:      now,
 		fields:  map[string]string{logger.FieldNameProgressID: "layer 2"},
 	}, nil)
 
@@ -364,17 +367,18 @@ func TestContinuingLines(t *testing.T) {
 
 	c2 := l.Checkpoint()
 	assert.Equal(t, []LogLine{
-		LogLine{Text: "fe          ┊ layer 1: pending\n", SpanID: "fe", ProgressID: "layer 1"},
-		LogLine{Text: "fe          ┊ layer 2: pending\n", SpanID: "fe", ProgressID: "layer 2"},
+		LogLine{Text: "fe          ┊ layer 1: pending\n", SpanID: "fe", ProgressID: "layer 1", Time: now},
+		LogLine{Text: "fe          ┊ layer 2: pending\n", SpanID: "fe", ProgressID: "layer 2", Time: now},
 	}, l.ContinuingLines(c1))
 
 	l.Append(testLogEvent{
 		name:    "fe",
 		message: "layer 1: done\n",
+		ts:      now,
 		fields:  map[string]string{logger.FieldNameProgressID: "layer 1"},
 	}, nil)
 
 	assert.Equal(t, []LogLine{
-		LogLine{Text: "fe          ┊ layer 1: done\n", SpanID: "fe", ProgressID: "layer 1"},
+		LogLine{Text: "fe          ┊ layer 1: done\n", SpanID: "fe", ProgressID: "layer 1", Time: now},
 	}, l.ContinuingLines(c2))
 }


### PR DESCRIPTION
Hello @jazzdan, @hyu,

Please review the following commits I made in branch nicks/continuingstring2:

0523866877fa30469becf8855f10e40139993f05 (2020-01-28 14:56:32 -0500)
build: do progress backoff at render-time instead of at logging-time

611beb68a74d97fae1799bea0eda8b5b36e39c49 (2020-01-28 14:50:35 -0500)
logstore: Return structured log lines for printing to stdout

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics