### PR TITLE
integration: use the write log writer, so we get an error report if this command fails

### DIFF
--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -22,7 +22,7 @@ func TestTiltArgs(t *testing.T) {
 
 	f.logs.Reset()
 
-	err = f.tilt.Args([]string{"bar"}, f.logs)
+	err = f.tilt.Args([]string{"bar"}, f.LogWriter())
 	require.NoError(t, err)
 
 	err = f.logs.WaitUntilContains("bar run", time.Second)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/integration:

ad3a0355b0c5a99138838619a6e47d91afc827dd (2020-01-28 15:14:15 -0500)
integration: use the write log writer, so we get an error report if this command fails

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics