### PR TITLE
integration: fix a race condition in the tilt args integration test

### DIFF
--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,7 +24,16 @@ func TestTiltArgs(t *testing.T) {
 	f.logs.Reset()
 
 	err = f.tilt.Args([]string{"bar"}, f.LogWriter())
-	require.NoError(t, err)
+	if err != nil {
+		// Currently, Tilt starts printing logs before the webserver has bound to a port.
+		// If this happens, just sleep for a second and try again.
+		duration := 2 * time.Second
+		fmt.Printf("Error setting args. Sleeping (%s): %v\n", duration, err)
+
+		time.Sleep(duration)
+		err = f.tilt.Args([]string{"bar"}, f.LogWriter())
+		require.NoError(t, err)
+	}
 
 	err = f.logs.WaitUntilContains("bar run", time.Second)
 	require.NoError(t, err)


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/argsfailure:

e6102eb5983a0a4e15381940278dce5b75dd9765 (2020-01-28 18:26:52 -0500)
integration: fix a race condition in the tilt args integration test

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics