### PR TITLE
k8srollout: first pass at a pod rollout monitor

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -25,6 +25,7 @@ import (
 	engineanalytics "github.com/windmilleng/tilt/internal/engine/analytics"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
+	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
 	"github.com/windmilleng/tilt/internal/engine/runtimelog"
@@ -85,6 +86,7 @@ var BaseWireSet = wire.NewSet(
 	engine.NewTiltVersionChecker,
 	cloud.WireSet,
 	cloudurl.ProvideAddress,
+	k8srollout.NewPodMonitor,
 
 	provideClock,
 	hud.WireSet,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -30,6 +30,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/buildcontrol"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
+	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
 	"github.com/windmilleng/tilt/internal/engine/runtimelog"
@@ -232,7 +233,8 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	controller := telemetry.NewController(clock, spanCollector)
 	execer := local.ProvideExecer()
 	localController := local.NewController(execer)
-	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, tiltVersionChecker, analyticsUpdater, eventWatchManager, cloudUsernameManager, updateUploader, dockerPruner, controller, localController)
+	podMonitor := k8srollout.NewPodMonitor()
+	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, tiltVersionChecker, analyticsUpdater, eventWatchManager, cloudUsernameManager, updateUploader, dockerPruner, controller, localController, podMonitor)
 	upper := engine.NewUpper(ctx, storeStore, v2)
 	windmillDir, err := dirs.UseWindmillDir()
 	if err != nil {
@@ -442,7 +444,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
+	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -1,0 +1,160 @@
+package k8srollout
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/pkg/logger"
+	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/windmilleng/tilt/pkg/model/logstore"
+)
+
+type PodMonitor struct {
+	pods            map[k8s.PodID]podStatus
+	trackingStarted map[k8s.PodID]bool
+}
+
+func NewPodMonitor() *PodMonitor {
+	return &PodMonitor{
+		pods:            make(map[k8s.PodID]podStatus),
+		trackingStarted: make(map[k8s.PodID]bool),
+	}
+}
+
+func (m *PodMonitor) diff(st store.RStore) []podStatus {
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	updates := make([]podStatus, 0)
+	active := make(map[k8s.PodID]bool)
+
+	for _, mt := range state.Targets() {
+		ms := mt.State
+		manifest := mt.Manifest
+		pod := ms.MostRecentPod()
+		podID := pod.PodID
+		if podID == "" {
+			continue
+		}
+
+		active[podID] = true
+
+		currentStatus := newPodStatus(pod, manifest.Name)
+		if !podStatusesEqual(currentStatus, m.pods[podID]) {
+			updates = append(updates, currentStatus)
+			m.pods[podID] = currentStatus
+		}
+	}
+
+	for key := range m.pods {
+		if !active[key] {
+			delete(m.pods, key)
+		}
+	}
+
+	return updates
+}
+
+func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore) {
+	updates := m.diff(st)
+	for _, update := range updates {
+		ctx := logger.CtxWithLogHandler(ctx, podStatusWriter{
+			store:        st,
+			manifestName: update.manifestName,
+			podID:        update.podID,
+		})
+		m.print(ctx, update)
+	}
+}
+
+func (m *PodMonitor) print(ctx context.Context, update podStatus) {
+	if !m.trackingStarted[update.podID] {
+		logger.Get(ctx).Infof("Tracking new pod rollout (%s):", update.podID)
+		m.trackingStarted[update.podID] = true
+	}
+
+	m.printCondition(ctx, "Scheduled", update.scheduled, update.startTime)
+	m.printCondition(ctx, "Initialized", update.initialized, update.scheduled.LastTransitionTime.Time)
+	m.printCondition(ctx, "Ready", update.ready, update.initialized.LastTransitionTime.Time)
+}
+
+func (m *PodMonitor) printCondition(ctx context.Context, name string, cond v1.PodCondition, startTime time.Time) {
+	l := logger.Get(ctx).WithFields(logger.Fields{logger.FieldNameProgressID: name})
+
+	suffix := ""
+	dur := cond.LastTransitionTime.Sub(startTime)
+	if !startTime.IsZero() && !cond.LastTransitionTime.IsZero() {
+		if dur == 0 {
+			suffix = " [<1s]"
+		} else {
+			suffix = fmt.Sprintf(" [%s]", dur.Truncate(time.Millisecond))
+		}
+	}
+
+	if cond.Status == v1.ConditionTrue {
+		l.Infof("✔️ OK %s%s", name, suffix)
+		return
+	}
+
+	message := cond.Message
+	reason := cond.Reason
+	if cond.Status == "" || reason == "" || message == "" {
+		l.Infof("⌛ Pending %s", name)
+		return
+	}
+
+	l.Infof("❌ Not %s (%s): %s", name, reason, message)
+}
+
+type podStatus struct {
+	podID        k8s.PodID
+	manifestName model.ManifestName
+	startTime    time.Time
+	scheduled    v1.PodCondition
+	initialized  v1.PodCondition
+	ready        v1.PodCondition
+}
+
+func newPodStatus(pod store.Pod, manifestName model.ManifestName) podStatus {
+	s := podStatus{podID: pod.PodID, manifestName: manifestName, startTime: pod.StartedAt}
+	for _, condition := range pod.Conditions {
+		switch condition.Type {
+		case v1.PodScheduled:
+			s.scheduled = condition
+		case v1.PodInitialized:
+			s.initialized = condition
+		case v1.PodReady:
+			s.ready = condition
+		}
+	}
+	return s
+}
+
+var podStatusAllowUnexported = cmp.AllowUnexported(podStatus{})
+
+func podStatusesEqual(a, b podStatus) bool {
+	return cmp.Equal(a, b, podStatusAllowUnexported)
+}
+
+type podStatusWriter struct {
+	store        store.RStore
+	podID        k8s.PodID
+	manifestName model.ManifestName
+}
+
+func (w podStatusWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
+	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForPod(w.podID), level, fields, p))
+	return nil
+}
+
+func SpanIDForPod(podID k8s.PodID) logstore.SpanID {
+	return logstore.SpanID(fmt.Sprintf("monitor:%s", podID))
+}
+
+var _ store.Subscriber = &PodMonitor{}

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -1,0 +1,115 @@
+package k8srollout
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/testutils/bufsync"
+	"github.com/windmilleng/tilt/internal/testutils/manifestutils"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+	"github.com/windmilleng/tilt/pkg/logger"
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+func TestMonitorReady(t *testing.T) {
+	f := newPMFixture(t)
+	defer f.TearDown()
+
+	start := time.Now()
+	p := store.Pod{
+		PodID:     "pod-id",
+		StartedAt: start,
+		Conditions: []v1.PodCondition{
+			v1.PodCondition{
+				Type:               v1.PodScheduled,
+				Status:             v1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: start.Add(time.Second)},
+			},
+			v1.PodCondition{
+				Type:               v1.PodInitialized,
+				Status:             v1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: start.Add(5 * time.Second)},
+			},
+			v1.PodCondition{
+				Type:               v1.PodReady,
+				Status:             v1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: start.Add(10 * time.Second)},
+			},
+		},
+	}
+
+	state := store.NewState()
+	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
+		model.Manifest{Name: "server"}, p))
+	f.store.SetState(*state)
+
+	f.pm.OnChange(f.ctx, f.store)
+	assert.Equal(t, `Tracking new pod rollout (pod-id):
+✔️ OK Scheduled [1s]
+✔️ OK Initialized [4s]
+✔️ OK Ready [5s]
+`, f.out.String())
+}
+
+type pmFixture struct {
+	*tempdir.TempDirFixture
+	ctx    context.Context
+	pm     *PodMonitor
+	cancel func()
+	out    *bufsync.ThreadSafeBuffer
+	store  *testStore
+}
+
+func newPMFixture(t *testing.T) *pmFixture {
+	f := tempdir.NewTempDirFixture(t)
+
+	out := bufsync.NewThreadSafeBuffer()
+	st := NewTestingStore(out)
+	pm := NewPodMonitor()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l := logger.NewLogger(logger.DebugLvl, out)
+	ctx = logger.WithLogger(ctx, l)
+
+	return &pmFixture{
+		TempDirFixture: f,
+		pm:             pm,
+		ctx:            ctx,
+		cancel:         cancel,
+		out:            out,
+		store:          st,
+	}
+}
+
+func (f *pmFixture) TearDown() {
+	f.cancel()
+	f.TempDirFixture.TearDown()
+}
+
+type testStore struct {
+	*store.TestingStore
+	out io.Writer
+}
+
+func NewTestingStore(out io.Writer) *testStore {
+	return &testStore{
+		TestingStore: store.NewTestingStore(),
+		out:          out,
+	}
+}
+
+func (s *testStore) Dispatch(action store.Action) {
+	s.TestingStore.Dispatch(action)
+
+	logAction, ok := action.(store.LogAction)
+	if ok {
+		_, _ = s.out.Write(logAction.Message())
+	}
+}

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -39,6 +39,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 	podInfo.Phase = pod.Status.Phase
 	podInfo.Status = k8swatch.PodStatusToString(*pod)
 	podInfo.StatusMessages = k8swatch.PodStatusErrorMessages(*pod)
+	podInfo.Conditions = pod.Status.Conditions
 
 	prunePods(ms)
 

--- a/internal/engine/subscribers.go
+++ b/internal/engine/subscribers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/analytics"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
+	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
 	"github.com/windmilleng/tilt/internal/engine/runtimelog"
@@ -38,6 +39,7 @@ func ProvideSubscribers(
 	dp *dockerprune.DockerPruner,
 	tc *telemetry.Controller,
 	lc *local.Controller,
+	podm *k8srollout.PodMonitor,
 ) []store.Subscriber {
 	return []store.Subscriber{
 		hud,
@@ -62,5 +64,6 @@ func ProvideSubscribers(
 		dp,
 		tc,
 		lc,
+		podm,
 	}
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/buildcontrol"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
+	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
 	"github.com/windmilleng/tilt/internal/engine/runtimelog"
@@ -3476,8 +3477,9 @@ func newTestFixtureWithHud(t *testing.T, h hud.HeadsUpDisplay) *testFixture {
 	}
 	tvc := NewTiltVersionChecker(func() github.Client { return ghc }, tiltVersionCheckTimerMaker)
 	tc := telemetry.NewController(fakeClock{}, tracer.NewSpanCollector(ctx))
+	podm := k8srollout.NewPodMonitor()
 
-	subs := ProvideSubscribers(h, pw, sw, plm, pfc, fwm, bc, cc, dcw, dclm, pm, sm, ar, hudsc, tvc, au, ewm, tcum, cuu, dp, tc, lc)
+	subs := ProvideSubscribers(h, pw, sw, plm, pfc, fwm, bc, cc, dcw, dclm, pm, sm, ar, hudsc, tvc, au, ewm, tcum, cuu, dp, tc, lc, podm)
 	ret.upper = NewUpper(ctx, st, subs)
 
 	go func() {

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -148,6 +148,8 @@ type Pod struct {
 	// i.e. Total Restarts - BaselineRestarts
 	BaselineRestarts int
 
+	Conditions []v1.PodCondition
+
 	SpanID model.LogSpanID
 }
 


### PR DESCRIPTION
Hello @hyu, @maiamcc,

Please review the following commits I made in branch nicks/pods:

7bc6c2d2613712b52d09ea1e9973a7b436871eed (2020-01-28 20:31:13 -0500)
k8srollout: first pass at a pod rollout monitor

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics