### PR TITLE
circleci: cache golangci-lint cache on git rev, fallback to most recent otherwise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,13 @@ jobs:
       - run: sudo mv /usr/bin/helm3 /usr/bin/helm
       - restore_cache:
           keys:
-            - golangci_lint_v1
+            - golangci_lint_{{ .Revision }}
+            - golangci_lint_ # Else find the most recently generated cache
       - run: make lint
       - save_cache:
           paths:
             - /home/circleci/.cache/golangci-lint
-          key: golangci_lint_v1
+          key: golangci_lint_{{ .Revision }}
       - run: make wire-check
       - run: make test-go
       - store_test_results:


### PR DESCRIPTION
This strategy is based off of [this CircleCI doc](https://circleci.com/docs/2.0/caching/#restoring-cache).

Basically:
1. After each run cache the golangci-lint cache by git revision. Should look something like `golangci_lint_be4d2b3`.
2. Before each run look for a cached version of this revision. I expect this will rarely hit, except in rebase cases. If it can't be found fallback to _the most recently created_ cached version.