### PR TITLE
tiltfile: error in default_registry if registry is not canonical

### DIFF
--- a/internal/container/default_registry.go
+++ b/internal/container/default_registry.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
 )
 
 // The Host of a container registry where we can push images.
@@ -30,7 +31,7 @@ func ReplaceRegistry(defaultRegistry Registry, rs RefSelector) (reference.Named,
 	newNs := fmt.Sprintf("%s/%s", defaultRegistry, escapeName(rs.RefFamiliarName()))
 	newN, err := reference.ParseNamed(newNs)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing %s after applying default registry %s: %w", newNs, defaultRegistry, err)
+		return nil, errors.Wrapf(err, "Error parsing %s after applying default registry %s", newNs, defaultRegistry)
 	}
 
 	return newN, nil

--- a/internal/container/default_registry.go
+++ b/internal/container/default_registry.go
@@ -30,7 +30,7 @@ func ReplaceRegistry(defaultRegistry Registry, rs RefSelector) (reference.Named,
 	newNs := fmt.Sprintf("%s/%s", defaultRegistry, escapeName(rs.RefFamiliarName()))
 	newN, err := reference.ParseNamed(newNs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error parsing %s after applying default registry %s: %w", newNs, defaultRegistry, err)
 	}
 
 	return newN, nil

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -458,6 +458,12 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 		return nil, err
 	}
 
+	fakeRef := fmt.Sprintf("%s/%s", dr, "fake")
+	_, err := reference.ParseNamed(fakeRef)
+	if err != nil {
+		return starlark.None, err
+	}
+
 	s.defaultRegistryHost = container.Registry(dr)
 
 	return starlark.None, nil

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -458,11 +458,6 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 		return nil, err
 	}
 
-	_, err := reference.ParseNamed(dr)
-	if err != nil {
-		return starlark.None, err
-	}
-
 	s.defaultRegistryHost = container.Registry(dr)
 
 	return starlark.None, nil

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -458,6 +458,11 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 		return nil, err
 	}
 
+	_, err := reference.ParseNamed(dr)
+	if err != nil {
+		return starlark.None, err
+	}
+
 	s.defaultRegistryHost = container.Registry(dr)
 
 	return starlark.None, nil

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -458,6 +458,9 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 		return nil, err
 	}
 
+	// NOTE(dmiller): we append a fake path to the domain so that we can try and validate it _during_ Tiltfile execution
+	// rather than wait to do it when converting the data to the Engine state.
+	// As far as I can tell there's no way in Docker to validate a domain _independently_ from a canonical ref.
 	fakeRef := fmt.Sprintf("%s/%s", dr, "fake")
 	_, err := reference.ParseNamed(fakeRef)
 	if err != nil {

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -146,14 +146,14 @@ func TestLiveUpdateDockerBuildDefaultRegistry(t *testing.T) {
 	defer f.TearDown()
 
 	f.tiltfileCode = `
-default_registry('gcr.io/bar')
+default_registry('gcr.io')
 docker_build('foo', 'foo', live_update=%s)`
 	f.init()
 
 	f.load("foo")
 
 	i := image("foo")
-	i.deploymentRef = "gcr.io/bar/foo"
+	i.deploymentRef = "gcr.io/foo"
 	f.assertNextManifest("foo", db(i, f.expectedLU))
 }
 

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -146,14 +146,14 @@ func TestLiveUpdateDockerBuildDefaultRegistry(t *testing.T) {
 	defer f.TearDown()
 
 	f.tiltfileCode = `
-default_registry('gcr.io')
+default_registry('gcr.io/bar')
 docker_build('foo', 'foo', live_update=%s)`
 	f.init()
 
 	f.load("foo")
 
 	i := image("foo")
-	i.deploymentRef = "gcr.io/foo"
+	i.deploymentRef = "gcr.io/bar/foo"
 	f.assertNextManifest("foo", db(i, f.expectedLU))
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2560,8 +2560,8 @@ func TestTwoDefaultRegistries(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-default_registry("foo")
-default_registry("bar")`)
+default_registry("gcr.io/foo")
+default_registry("gcr.io/bar")`)
 
 	f.loadErrString("default registry already defined")
 }
@@ -2576,6 +2576,7 @@ default_registry("foo")
 docker_build('gcr.io/foo', 'foo')
 `)
 
+	f.loadErrString("Traceback")
 	f.loadErrString("repository name must be canonical")
 }
 
@@ -2588,13 +2589,13 @@ func TestDefaultRegistryAtEndOfTiltfile(t *testing.T) {
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
-default_registry('bar.com')
+default_registry('bar.com/baz')
 `)
 
 	f.load()
 
 	f.assertNextManifest("foo",
-		db(image("gcr.io/foo").withInjectedRef("bar.com/gcr.io_foo")),
+		db(image("gcr.io/foo").withInjectedRef("bar.com/baz/gcr.io_foo")),
 		deployment("foo"))
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo/.dockerignore", "foo.yaml")
 }
@@ -2607,7 +2608,7 @@ func TestPrivateRegistry(t *testing.T) {
 
 	f.setupFoo()
 	f.file("Tiltfile", `
-default_registry('bar.com')
+default_registry('bar.com/baz')
 docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
 `)
@@ -2661,16 +2662,16 @@ docker_build('gcr.io/foo:bar', 'bar')
 docker_build('gcr.io/foo:baz', 'baz')
 k8s_yaml('bar.yaml')
 k8s_yaml('baz.yaml')
-default_registry('example.com')
+default_registry('example.com/qux')
 `)
 
 	f.load()
 
 	f.assertNextManifest("bar",
-		db(image("gcr.io/foo:bar").withInjectedRef("example.com/gcr.io_foo")),
+		db(image("gcr.io/foo:bar").withInjectedRef("example.com/qux/gcr.io_foo")),
 		deployment("bar"))
 	f.assertNextManifest("baz",
-		db(image("gcr.io/foo:baz").withInjectedRef("example.com/gcr.io_foo")),
+		db(image("gcr.io/foo:baz").withInjectedRef("example.com/qux/gcr.io_foo")),
 		deployment("baz"))
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "bar/Dockerfile", "bar/.dockerignore", "bar.yaml", "baz/Dockerfile", "baz/.dockerignore", "baz.yaml")
 }
@@ -2683,7 +2684,7 @@ func TestDefaultRegistryWithDockerCompose(t *testing.T) {
 	f.file("docker-compose.yml", simpleConfig)
 	f.file("Tiltfile", `
 docker_compose('docker-compose.yml')
-default_registry('bar.com')
+default_registry('bar.com/baz')
 `)
 
 	f.loadErrString("default_registry is not supported with docker compose")

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2560,8 +2560,8 @@ func TestTwoDefaultRegistries(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-default_registry("gcr.io/foo")
-default_registry("gcr.io/bar")`)
+default_registry("foo")
+default_registry("bar")`)
 
 	f.loadErrString("default registry already defined")
 }
@@ -2576,7 +2576,6 @@ default_registry("foo")
 docker_build('gcr.io/foo', 'foo')
 `)
 
-	f.loadErrString("Traceback")
 	f.loadErrString("repository name must be canonical")
 }
 
@@ -2589,13 +2588,13 @@ func TestDefaultRegistryAtEndOfTiltfile(t *testing.T) {
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
-default_registry('bar.com/baz')
+default_registry('bar.com')
 `)
 
 	f.load()
 
 	f.assertNextManifest("foo",
-		db(image("gcr.io/foo").withInjectedRef("bar.com/baz/gcr.io_foo")),
+		db(image("gcr.io/foo").withInjectedRef("bar.com/gcr.io_foo")),
 		deployment("foo"))
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo/.dockerignore", "foo.yaml")
 }
@@ -2608,7 +2607,7 @@ func TestPrivateRegistry(t *testing.T) {
 
 	f.setupFoo()
 	f.file("Tiltfile", `
-default_registry('bar.com/baz')
+default_registry('bar.com')
 docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
 `)
@@ -2662,16 +2661,16 @@ docker_build('gcr.io/foo:bar', 'bar')
 docker_build('gcr.io/foo:baz', 'baz')
 k8s_yaml('bar.yaml')
 k8s_yaml('baz.yaml')
-default_registry('example.com/qux')
+default_registry('example.com')
 `)
 
 	f.load()
 
 	f.assertNextManifest("bar",
-		db(image("gcr.io/foo:bar").withInjectedRef("example.com/qux/gcr.io_foo")),
+		db(image("gcr.io/foo:bar").withInjectedRef("example.com/gcr.io_foo")),
 		deployment("bar"))
 	f.assertNextManifest("baz",
-		db(image("gcr.io/foo:baz").withInjectedRef("example.com/qux/gcr.io_foo")),
+		db(image("gcr.io/foo:baz").withInjectedRef("example.com/gcr.io_foo")),
 		deployment("baz"))
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "bar/Dockerfile", "bar/.dockerignore", "bar.yaml", "baz/Dockerfile", "baz/.dockerignore", "baz.yaml")
 }
@@ -2684,7 +2683,7 @@ func TestDefaultRegistryWithDockerCompose(t *testing.T) {
 	f.file("docker-compose.yml", simpleConfig)
 	f.file("Tiltfile", `
 docker_compose('docker-compose.yml')
-default_registry('bar.com/baz')
+default_registry('bar.com')
 `)
 
 	f.loadErrString("default_registry is not supported with docker compose")

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2560,8 +2560,8 @@ func TestTwoDefaultRegistries(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-default_registry("foo")
-default_registry("bar")`)
+default_registry("gcr.io")
+default_registry("docker.io")`)
 
 	f.loadErrString("default registry already defined")
 }
@@ -2576,6 +2576,7 @@ default_registry("foo")
 docker_build('gcr.io/foo', 'foo')
 `)
 
+	f.loadErrString("Traceback ")
 	f.loadErrString("repository name must be canonical")
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2576,8 +2576,7 @@ default_registry("foo")
 docker_build('gcr.io/foo', 'foo')
 `)
 
-	f.loadErrString("Traceback ")
-	f.loadErrString("repository name must be canonical")
+	f.loadErrString("Traceback ", "repository name must be canonical")
 }
 
 func TestDefaultRegistryAtEndOfTiltfile(t *testing.T) {


### PR DESCRIPTION
This causes a stack trace to be printed during Tiltfile execution
which makes it more obvious where this error is coming from.

Previously the error would only surface when the default registry
was being transformed in to the engine state model, at which point
we don't know what line it occurred on.

Fixes #2768