### PR TITLE
hud: when printing push output, make sure we always print the last "finished" line

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -366,7 +366,11 @@ func readDockerOutput(ctx context.Context, reader io.Reader) (dockerOutput, erro
 			shouldSkip := message.Progress.Current == 0 &&
 				(message.Status == "Waiting" || message.Status == "Preparing")
 			if shouldPrint && !shouldSkip {
-				logger.Get(ctx).WithFields(logger.Fields{logger.FieldNameProgressID: message.ID}).
+				fields := logger.Fields{logger.FieldNameProgressID: message.ID}
+				if message.Progress.Current == message.Progress.Total {
+					fields[logger.FieldNameProgressMustPrint] = "1"
+				}
+				logger.Get(ctx).WithFields(fields).
 					Infof("%s: %s %s", id, message.Status, message.Progress.String())
 				progressLastPrinted[id] = time.Now()
 			}

--- a/internal/hud/printer.go
+++ b/internal/hud/printer.go
@@ -36,7 +36,8 @@ func (p *IncrementalPrinter) Print(lines []logstore.LogLine) {
 		key := progressKey{spanID: line.SpanID, progressID: progressID}
 		if progressID != "" {
 			status, hasBeenPrinted := p.progress[key]
-			shouldPrint := !hasBeenPrinted ||
+			shouldPrint := line.ProgressMustPrint ||
+				!hasBeenPrinted ||
 				line.Time.Sub(status.lastPrinted) > status.printWait
 			if !shouldPrint {
 				continue

--- a/internal/hud/printer_test.go
+++ b/internal/hud/printer_test.go
@@ -34,3 +34,21 @@ func TestPrinterProgressBackoff(t *testing.T) {
 	assert.Equal(t, "layer 1: Pending\nlayer 2: Pending\nlayer 1: Done\n", out.String())
 
 }
+func TestPrinterMustPrint(t *testing.T) {
+	out := &bytes.Buffer{}
+	now := time.Now()
+	printer := NewIncrementalPrinter(Stdout(out))
+
+	printer.Print([]logstore.LogLine{
+		logstore.LogLine{Text: "layer 1: Pending\n", ProgressID: "layer 1", Time: now},
+		logstore.LogLine{Text: "layer 2: Pending\n", ProgressID: "layer 2", Time: now},
+	})
+
+	assert.Equal(t, "layer 1: Pending\nlayer 2: Pending\n", out.String())
+
+	printer.Print([]logstore.LogLine{
+		logstore.LogLine{Text: "layer 1: Done\n", ProgressID: "layer 1", ProgressMustPrint: true, Time: now},
+	})
+	assert.Equal(t, "layer 1: Pending\nlayer 2: Pending\nlayer 1: Done\n", out.String())
+
+}

--- a/pkg/logger/fields.go
+++ b/pkg/logger/fields.go
@@ -6,3 +6,10 @@ package logger
 type Fields map[string]string
 
 const FieldNameProgressID = "progressID"
+
+// Most progress lines are optional. For example, if a bunch
+// of little upload updates come in, it's ok to skip some.
+//
+// progressMustPrint="1" indicates that this line must appear in the
+// output - e.g., a line that communicates that the upload finished.
+const FieldNameProgressMustPrint = "progressMustPrint"

--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -375,10 +375,19 @@ func TestContinuingLines(t *testing.T) {
 		name:    "fe",
 		message: "layer 1: done\n",
 		ts:      now,
-		fields:  map[string]string{logger.FieldNameProgressID: "layer 1"},
+		fields: map[string]string{
+			logger.FieldNameProgressID:        "layer 1",
+			logger.FieldNameProgressMustPrint: "1",
+		},
 	}, nil)
 
 	assert.Equal(t, []LogLine{
-		LogLine{Text: "fe          ┊ layer 1: done\n", SpanID: "fe", ProgressID: "layer 1", Time: now},
+		LogLine{
+			Text:              "fe          ┊ layer 1: done\n",
+			SpanID:            "fe",
+			ProgressID:        "layer 1",
+			ProgressMustPrint: true,
+			Time:              now,
+		},
 	}, l.ContinuingLines(c2))
 }


### PR DESCRIPTION
Hello @jazzdan, @hyu,

Please review the following commits I made in branch nicks/mustprint:

19cb7fbec692022e29906047ae2eba0b9a2f68a9 (2020-01-29 13:21:55 -0500)
hud: when printing push output, make sure we always print the last "finished" line

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics