### PR TITLE
build/engine: inject clusterRef (rather than imageRef) into YAML

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -29,7 +29,7 @@ ADD dir/c.txt .
 	f.WriteFile("dir/c.txt", "c")
 	f.WriteFile("missing.txt", "missing")
 
-	ref, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), model.DockerBuild{
+	refs, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), model.DockerBuild{
 		Dockerfile: df.String(),
 		BuildPath:  f.Path(),
 	}, model.EmptyMatcher)
@@ -37,7 +37,7 @@ ADD dir/c.txt .
 		t.Fatal(err)
 	}
 
-	f.assertImageHasLabels(ref, docker.BuiltByTiltLabel)
+	f.assertImageHasLabels(refs.LocalRef, docker.BuiltByTiltLabel)
 
 	pcs := []expectedFile{
 		expectedFile{Path: "/src/a.txt", Contents: "a"},
@@ -46,7 +46,7 @@ ADD dir/c.txt .
 		expectedFile{Path: "/src/dir/c.txt", Missing: true},
 		expectedFile{Path: "/src/missing.txt", Missing: true},
 	}
-	f.assertFilesInImage(ref, pcs)
+	f.assertFilesInImage(refs.LocalRef, pcs)
 }
 
 func TestDockerBuildWithBuildArgs(t *testing.T) {
@@ -63,7 +63,7 @@ ADD $some_variable_name /test.txt`)
 	ba := model.DockerBuildArgs{
 		"some_variable_name": "awesome_variable",
 	}
-	ref, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), model.DockerBuild{
+	refs, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), model.DockerBuild{
 		Dockerfile: df.String(),
 		BuildPath:  f.Path(),
 		BuildArgs:  ba,
@@ -75,5 +75,5 @@ ADD $some_variable_name /test.txt`)
 	expected := []expectedFile{
 		expectedFile{Path: "/test.txt", Contents: "hi im an awesome variable"},
 	}
-	f.assertFilesInImage(ref, expected)
+	f.assertFilesInImage(refs.LocalRef, expected)
 }

--- a/internal/build/custom_builder_test.go
+++ b/internal/build/custom_builder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/docker"
@@ -24,12 +25,25 @@ func TestCustomBuildSuccess(t *testing.T) {
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
 	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "true"}
-	refs, err := f.cb.Build(f.ctx, f.RefSetFromString("gcr.io/foo/bar"), cb)
-	if err != nil {
-		f.t.Fatal(err)
-	}
+	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
+	require.NoError(t, err)
 
 	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-11cd0eb38bc3ceb9"), refs.LocalRef)
+	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-11cd0eb38bc3ceb9"), refs.ClusterRef)
+}
+
+func TestCustomBuildSuccessClusterRefTaggedWithDigest(t *testing.T) {
+	f := newFakeCustomBuildFixture(t)
+	defer f.teardown()
+
+	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
+	f.dCli.Images["localhost:1234/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "true"}
+	refs, err := f.cb.Build(f.ctx, refSetFromStrings("localhost:1234/foo/bar", "registry:1234/foo/bar"), cb)
+	require.NoError(t, err)
+
+	assert.Equal(f.t, container.MustParseNamed("localhost:1234/foo/bar:tilt-11cd0eb38bc3ceb9"), refs.LocalRef)
+	assert.Equal(f.t, container.MustParseNamed("registry:1234/foo/bar:tilt-11cd0eb38bc3ceb9"), refs.ClusterRef)
 }
 
 func TestCustomBuildSuccessSkipsLocalDocker(t *testing.T) {
@@ -37,9 +51,23 @@ func TestCustomBuildSuccessSkipsLocalDocker(t *testing.T) {
 	defer f.teardown()
 
 	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "true", SkipsLocalDocker: true}
-	refs, err := f.cb.Build(f.ctx, f.RefSetFromString("gcr.io/foo/bar"), cb)
-	assert.NoError(f.t, err)
+	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
+	require.NoError(f.t, err)
+
 	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-build-1551202573"), refs.LocalRef)
+	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-build-1551202573"), refs.ClusterRef)
+}
+
+func TestCustomBuildSuccessClusterRefTaggedIfSkipsLocalDocker(t *testing.T) {
+	f := newFakeCustomBuildFixture(t)
+	defer f.teardown()
+
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "true", SkipsLocalDocker: true}
+	refs, err := f.cb.Build(f.ctx, refSetFromStrings("localhost:1234/foo/bar", "registry:1234/foo/bar"), cb)
+	require.NoError(f.t, err)
+
+	assert.Equal(f.t, container.MustParseNamed("localhost:1234/foo/bar:tilt-build-1551202573"), refs.LocalRef)
+	assert.Equal(f.t, container.MustParseNamed("registry:1234/foo/bar:tilt-build-1551202573"), refs.ClusterRef)
 }
 
 func TestCustomBuildCmdFails(t *testing.T) {
@@ -47,7 +75,7 @@ func TestCustomBuildCmdFails(t *testing.T) {
 	defer f.teardown()
 
 	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "false"}
-	_, err := f.cb.Build(f.ctx, f.RefSetFromString("gcr.io/foo/bar"), cb)
+	_, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	// TODO(dmiller) better error message
 	assert.EqualError(t, err, "Custom build command failed: exit status 1")
 }
@@ -57,7 +85,7 @@ func TestCustomBuildImgNotFound(t *testing.T) {
 	defer f.teardown()
 
 	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "true"}
-	_, err := f.cb.Build(f.ctx, f.RefSetFromString("gcr.io/foo/bar"), cb)
+	_, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	assert.Contains(t, err.Error(), "fake docker client error: object not found")
 }
 
@@ -68,12 +96,11 @@ func TestCustomBuildExpectedTag(t *testing.T) {
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:the-tag"] = types.ImageInspect{ID: string(sha)}
 	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "true", Tag: "the-tag"}
-	refs, err := f.cb.Build(f.ctx, f.RefSetFromString("gcr.io/foo/bar"), cb)
-	if err != nil {
-		f.t.Fatal(err)
-	}
+	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
+	require.NoError(t, err)
 
 	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-11cd0eb38bc3ceb9"), refs.LocalRef)
+	assert.Equal(f.t, container.MustParseNamed("gcr.io/foo/bar:tilt-11cd0eb38bc3ceb9"), refs.ClusterRef)
 }
 
 func TestCustomBuilderExecsRelativeToTiltfile(t *testing.T) {
@@ -85,7 +112,7 @@ func TestCustomBuilderExecsRelativeToTiltfile(t *testing.T) {
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
 	cb := model.CustomBuild{WorkDir: filepath.Join(f.tdf.Path(), "proj"), Command: "./build.sh"}
-	refs, err := f.cb.Build(f.ctx, f.RefSetFromString("gcr.io/foo/bar"), cb)
+	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -123,9 +150,18 @@ func newFakeCustomBuildFixture(t *testing.T) *fakeCustomBuildFixture {
 	return f
 }
 
-func (f *fakeCustomBuildFixture) RefSetFromString(s string) container.RefSet {
+func refSetFromString(s string) container.RefSet {
 	sel := container.MustParseSelector(s)
 	return container.SimpleRefSet(sel)
+}
+
+func refSetFromStrings(local, cluster string) container.RefSet {
+	localNamed := container.MustParseNamed(local)
+	clusterNamed := container.MustParseNamed(cluster)
+	return container.RefSet{
+		LocalRef:   localNamed,
+		ClusterRef: clusterNamed,
+	}
 }
 
 func (f *fakeCustomBuildFixture) teardown() {

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+
 	"github.com/windmilleng/tilt/internal/container"
 
 	"github.com/windmilleng/tilt/internal/docker"

--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -128,14 +128,10 @@ func (f *dockerBuildFixture) teardown() {
 	f.TempDirFixture.TearDown()
 }
 
-func (f *dockerBuildFixture) getNameFromTest() reference.Named {
+func (f *dockerBuildFixture) getNameFromTest() wmcontainer.RefSet {
 	x := fmt.Sprintf("windmill.build/%s", strings.ToLower(f.t.Name()))
-	name, err := reference.WithName(x)
-	if err != nil {
-		f.t.Fatal(err)
-	}
-
-	return name
+	sel := wmcontainer.MustParseSelector(x)
+	return wmcontainer.SimpleRefSet(sel)
 }
 
 func (f *dockerBuildFixture) startRegistry() {

--- a/internal/container/reference.go
+++ b/internal/container/reference.go
@@ -33,6 +33,7 @@ func SimpleRefSet(ref RefSelector) RefSet {
 	}
 }
 
+// TagRefs tags both of the references used for build/deploy with the given tag.
 func (rs RefSet) TagRefs(tag string) (TaggedRefs, error) {
 	localTagged, err := reference.WithTag(rs.LocalRef, tag)
 	if err != nil {
@@ -48,6 +49,7 @@ func (rs RefSet) TagRefs(tag string) (TaggedRefs, error) {
 	}, nil
 }
 
+// Refs yielded by an image build
 type TaggedRefs struct {
 	LocalRef   reference.NamedTagged // Image name + tag as referenced from outside cluster
 	ClusterRef reference.NamedTagged // Image name + tag as referenced from within cluster

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -95,12 +95,12 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		// NOTE(maia): we assume that this func takes one DC target and up to one image target
 		// corresponding to that service. If this func ever supports specs for more than one
 		// service at once, we'll have to match up image build results to DC target by ref.
-		ref, err := bd.icb.Build(ctx, iTarget, currentState[iTarget.ID()], ps)
+		refs, err := bd.icb.Build(ctx, iTarget, currentState[iTarget.ID()], ps)
 		if err != nil {
 			return nil, err
 		}
 
-		ref, err = bd.tagWithExpected(ctx, ref, expectedRef)
+		ref, err := bd.tagWithExpected(ctx, refs.LocalRef, expectedRef)
 		if err != nil {
 			return nil, err
 		}
@@ -131,6 +131,9 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	return results, nil
 }
 
+// tagWithExpected tags the given ref as whatever Docker Compose expects, i.e. as
+// the `image` value given in docker-compose.yaml. (If DC yaml specifies an image
+// with a tag, use that name + tag; otherwise, tag as latest.)
 func (bd *DockerComposeBuildAndDeployer) tagWithExpected(ctx context.Context, ref reference.NamedTagged,
 	expected container.RefSelector) (reference.NamedTagged, error) {
 	var tagAs reference.NamedTagged

--- a/internal/engine/image_and_cache_builder.go
+++ b/internal/engine/image_and_cache_builder.go
@@ -29,7 +29,7 @@ func NewImageAndCacheBuilder(ib build.ImageBuilder, custb build.CustomBuilder, u
 }
 
 func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageTarget, state store.BuildState,
-	ps *build.PipelineState) (taggedRefs container.TaggedRefs, err error) {
+	ps *build.PipelineState) (refs container.TaggedRefs, err error) {
 	userFacingRefName := container.FamiliarString(iTarget.Refs.ConfigurationRef)
 
 	switch bd := iTarget.BuildDetails.(type) {
@@ -37,7 +37,7 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 		ps.StartPipelineStep(ctx, "Building Dockerfile: [%s]", userFacingRefName)
 		defer ps.EndPipelineStep(ctx)
 
-		taggedRefs, err = icb.ib.BuildImage(ctx, ps, iTarget.Refs, bd,
+		refs, err = icb.ib.BuildImage(ctx, ps, iTarget.Refs, bd,
 			ignore.CreateBuildContextFilter(iTarget))
 
 		if err != nil {
@@ -46,7 +46,7 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 	case model.CustomBuild:
 		ps.StartPipelineStep(ctx, "Building Custom Build: [%s]", userFacingRefName)
 		defer ps.EndPipelineStep(ctx)
-		taggedRefs, err = icb.custb.Build(ctx, iTarget.Refs, bd)
+		refs, err = icb.custb.Build(ctx, iTarget.Refs, bd)
 		if err != nil {
 			return container.TaggedRefs{}, err
 		}
@@ -57,5 +57,5 @@ func (icb *imageAndCacheBuilder) Build(ctx context.Context, iTarget model.ImageT
 			"DockerBuild nor CustomBuild)", iTarget.Refs.ConfigurationRef)
 	}
 
-	return taggedRefs, nil
+	return refs, nil
 }

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -154,7 +154,6 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		}
 
 		anyLiveUpdate = anyLiveUpdate || !iTarget.LiveUpdateInfo().Empty()
-		// 🤖 "new ibr" should probably take a TaggedRefs
 		return store.NewImageBuildResult(iTarget.ID(), refs.LocalRef, refs.ClusterRef), nil
 	})
 	if err != nil {


### PR DESCRIPTION
in next commit, will wire up tiltfile to allow someone to set distinct
localRef/clusterRef, and will make a unit test