### PR TITLE
container: make clusterref optional, return localref if no clusterref provided

### DIFF
--- a/internal/build/custom_builder_test.go
+++ b/internal/build/custom_builder_test.go
@@ -158,10 +158,7 @@ func refSetFromString(s string) container.RefSet {
 func refSetFromStrings(local, cluster string) container.RefSet {
 	localNamed := container.MustParseNamed(local)
 	clusterNamed := container.MustParseNamed(cluster)
-	return container.RefSet{
-		LocalRef:   localNamed,
-		ClusterRef: clusterNamed,
-	}
+	return container.NewRefSet(container.NameSelector(localNamed), localNamed, clusterNamed)
 }
 
 func (f *fakeCustomBuildFixture) teardown() {

--- a/internal/container/default_registry.go
+++ b/internal/container/default_registry.go
@@ -8,31 +8,67 @@ import (
 	"github.com/pkg/errors"
 )
 
-// The Host of a container registry where we can push images.
-// ex)
-// localhost:32000
-// gcr.io/windmill-public-containers
-type Registry string
-
 var escapeRegex = regexp.MustCompile(`[/:@]`)
 
 func escapeName(s string) string {
 	return string(escapeRegex.ReplaceAll([]byte(s), []byte("_")))
 }
 
-// Produces a new image name that is in the specified registry.
+type Registry struct {
+	// The Host of a container registry where we can push images. e.g.:
+	//   - localhost:32000
+	//   - gcr.io/windmill-public-containers
+	PushHost string
+
+	// The prefix we use with image names when attempt to pull them from the registry.
+	// In most cases, this is equivalent to PushHost (the host of the container registry that we push to),
+	// but sometimes users will specify a pullHost separately (e.g. using a local registry with KIND:
+	// YAMLs will specify the image as `registry:5000/my-img`, so the pullHost will be `registry:5000`).
+	pullHost string
+}
+
+func (r Registry) Empty() bool { return r.PushHost == "" }
+
+func NewRegistry(host string) Registry {
+	// TODO(maia): validate
+	return Registry{PushHost: host}
+}
+
+func NewPushPullRegistry(push, pull string) Registry {
+	// TODO(maia): validate
+	return Registry{PushHost: push, pullHost: pull}
+}
+
+// PullHost returns the pullHost, if specified; otherwise the PushHost.
+func (r Registry) PullHost() string {
+	if r.pullHost != "" {
+		return r.pullHost
+	}
+	return r.PushHost
+}
+
+// replaceRegistry produces a new image name that is in the specified registry.
 // The name might be ugly, favoring uniqueness and simplicity and assuming that the prettiness of ephemeral dev image
 // names is not that important.
-func ReplaceRegistry(defaultRegistry Registry, rs RefSelector) (reference.Named, error) {
-	if defaultRegistry == "" {
+func replaceRegistry(defaultReg string, rs RefSelector) (reference.Named, error) {
+	if defaultReg == "" {
 		return rs.AsNamedOnly(), nil
 	}
 
-	newNs := fmt.Sprintf("%s/%s", defaultRegistry, escapeName(rs.RefFamiliarName()))
+	// validate the ref produced
+	newNs := fmt.Sprintf("%s/%s", defaultReg, escapeName(rs.RefFamiliarName()))
 	newN, err := reference.ParseNamed(newNs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error parsing %s after applying default registry %s", newNs, defaultRegistry)
+		return nil, errors.Wrapf(err, "Error parsing %s after applying default registry %s", newNs, defaultReg)
 	}
 
 	return newN, nil
+}
+
+func (r Registry) ReplaceRegistryForLocalRef(rs RefSelector) (reference.Named, error) {
+	return replaceRegistry(r.PushHost, rs)
+}
+
+func (r Registry) ReplaceRegistryForClusterRef(rs RefSelector) (reference.Named, error) {
+	return replaceRegistry(r.PullHost(), rs)
 }

--- a/internal/container/default_registry_test.go
+++ b/internal/container/default_registry_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var namedTaggedTestCases = []struct {
-	defaultRegistry Registry
+	defaultRegistry string
 	name            string
 	expected        string
 }{
@@ -17,7 +17,7 @@ var namedTaggedTestCases = []struct {
 }
 
 var namedTestCases = []struct {
-	defaultRegistry Registry
+	defaultRegistry string
 	name            string
 	expected        string
 }{
@@ -31,8 +31,9 @@ var namedTestCases = []struct {
 func TestReplaceTaggedRefDomain(t *testing.T) {
 	for i, tc := range namedTaggedTestCases {
 		t.Run(fmt.Sprintf("Test Case #%d", i), func(t *testing.T) {
+			reg := NewRegistry(tc.defaultRegistry)
 			rs := NewRefSelector(MustParseNamedTagged(tc.name))
-			actual, err := ReplaceRegistry(tc.defaultRegistry, rs)
+			actual, err := reg.ReplaceRegistryForLocalRef(rs)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, actual.String())
 		})
@@ -42,8 +43,9 @@ func TestReplaceTaggedRefDomain(t *testing.T) {
 func TestReplaceNamed(t *testing.T) {
 	for i, tc := range namedTestCases {
 		t.Run(fmt.Sprintf("Test case #%d", i), func(t *testing.T) {
+			reg := NewRegistry(tc.defaultRegistry)
 			rs := NewRefSelector(MustParseNamed(tc.name))
-			actual, err := ReplaceRegistry(tc.defaultRegistry, rs)
+			actual, err := reg.ReplaceRegistryForLocalRef(rs)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, actual.String())
 		})

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -76,7 +76,8 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 		// a container(s). Check to see if we have enough information about the
 		// container(s) that would need to be updated.
 		if len(state.RunningContainers) == 0 {
-			return nil, buildcontrol.RedirectToNextBuilderInfof("don't have info for running container of image %q (often a result of the deployment not yet being ready)", container.FamiliarString(iTarget.Refs.ClusterRef))
+			return nil, buildcontrol.RedirectToNextBuilderInfof("don't have info for running container of image %q "+
+				"(often a result of the deployment not yet being ready)", container.FamiliarString(iTarget.Refs.ClusterRef()))
 		}
 
 		filesChanged, err := filesChangedTree(g, iTarget, stateSet)

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -425,12 +425,12 @@ func TestBuildAndDeployUsesCorrectRef(t *testing.T) {
 				withRegistry, err := container.ReplaceRegistry("foo.com", manifest.ImageTargets[i].Refs.ConfigurationRef)
 				require.NoError(t, err)
 				manifest.ImageTargets[i].Refs.LocalRef = withRegistry
-				manifest.ImageTargets[i].Refs.ClusterRef = withRegistry
+				manifest.ImageTargets[i].Refs = manifest.ImageTargets[i].Refs.WithClusterRef(withRegistry)
 
 				if test.useLocalRegistry {
 					clusterRefWithRegistry, err := container.ReplaceRegistry("registry:1234", manifest.ImageTargets[i].Refs.ConfigurationRef)
 					require.NoError(t, err)
-					manifest.ImageTargets[i].Refs.ClusterRef = clusterRefWithRegistry
+					manifest.ImageTargets[i].Refs = manifest.ImageTargets[i].Refs.WithClusterRef(clusterRefWithRegistry)
 				}
 			}
 

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -92,7 +92,7 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 
 	var dontFallBackErr error
 	for _, info := range liveUpdInfos {
-		ps.StartPipelineStep(ctx, "updating image %s", info.iTarget.Refs.ClusterRef.Name())
+		ps.StartPipelineStep(ctx, "updating image %s", info.iTarget.Refs.ClusterRef().Name())
 		err = lubad.buildAndDeploy(ctx, ps, containerUpdater, info.iTarget, info.state, info.changedFiles, info.runs, info.hotReload)
 		if err != nil {
 			if !buildcontrol.IsDontFallBackError(err) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -189,7 +189,7 @@ var _ BuildAndDeployer = &fakeBuildAndDeployer{}
 func (b *fakeBuildAndDeployer) nextBuildResult(iTarget model.ImageTarget, deployTarget model.TargetSpec) store.BuildResult {
 	tag := fmt.Sprintf("tilt-%d", b.buildCount)
 	localRefTagged := container.MustWithTag(iTarget.Refs.LocalRef, tag)
-	clusterRefTagged := container.MustWithTag(iTarget.Refs.ClusterRef, tag)
+	clusterRefTagged := container.MustWithTag(iTarget.Refs.ClusterRef(), tag)
 
 	var result store.BuildResult
 	containerIDs := b.nextLiveUpdateContainerIDs
@@ -3862,7 +3862,7 @@ func (f *testFixture) newManifestWithRef(name string, ref reference.Named) model
 	iTarget := NewSanchoLiveUpdateImageTarget(f)
 	iTarget.Refs.ConfigurationRef = refSel
 	iTarget.Refs.LocalRef = ref
-	iTarget.Refs.ClusterRef = ref
+	iTarget.Refs = iTarget.Refs.WithClusterRef(ref)
 
 	return manifestbuilder.New(f, model.ManifestName(name)).
 		WithK8sYAML(SanchoYAML).

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -78,7 +78,7 @@ func (ec *explodingClient) ContainerRuntime(ctx context.Context) container.Runti
 }
 
 func (ec *explodingClient) PrivateRegistry(ctx context.Context) container.Registry {
-	return ""
+	return container.Registry{}
 }
 
 func (ec *explodingClient) Exec(ctx context.Context, podID PodID, cName container.Name, n Namespace, cmd []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {

--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -94,7 +94,7 @@ func (r *registryAsync) Registry(ctx context.Context) container.Registry {
 		}
 
 		portSpec := portSpecs[0]
-		r.registry = container.Registry(fmt.Sprintf("localhost:%d", portSpec.NodePort))
+		r.registry = container.NewRegistry(fmt.Sprintf("localhost:%d", portSpec.NodePort))
 	})
 	return r.registry
 }

--- a/internal/k8s/registry_test.go
+++ b/internal/k8s/registry_test.go
@@ -42,7 +42,7 @@ func TestRegistryFound(t *testing.T) {
 	l := logger.NewLogger(logger.InfoLvl, out)
 	ctx := logger.WithLogger(context.Background(), l)
 	registry := registryAsync.Registry(ctx)
-	assert.Equal(t, "localhost:32000", string(registry))
+	assert.Equal(t, "localhost:32000", registry.PushHost)
 }
 
 func TestRegistryNotFound(t *testing.T) {
@@ -63,6 +63,6 @@ func TestRegistryNotFound(t *testing.T) {
 	l := logger.NewLogger(logger.InfoLvl, out)
 	ctx := logger.WithLogger(context.Background(), l)
 	registry := registryAsync.Registry(ctx)
-	assert.Equal(t, "", string(registry))
+	assert.Equal(t, "", registry.PushHost)
 	assert.Contains(t, out.String(), "microk8s.enable registry")
 }

--- a/internal/k8s/registry_test.go
+++ b/internal/k8s/registry_test.go
@@ -42,7 +42,7 @@ func TestRegistryFound(t *testing.T) {
 	l := logger.NewLogger(logger.InfoLvl, out)
 	ctx := logger.WithLogger(context.Background(), l)
 	registry := registryAsync.Registry(ctx)
-	assert.Equal(t, "localhost:32000", registry.PushHost)
+	assert.Equal(t, "localhost:32000", registry.Host)
 }
 
 func TestRegistryNotFound(t *testing.T) {
@@ -63,6 +63,6 @@ func TestRegistryNotFound(t *testing.T) {
 	l := logger.NewLogger(logger.InfoLvl, out)
 	ctx := logger.WithLogger(context.Background(), l)
 	registry := registryAsync.Registry(ctx)
-	assert.Equal(t, "", registry.PushHost)
+	assert.Equal(t, "", registry.Host)
 	assert.Contains(t, out.String(), "microk8s.enable registry")
 }

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -37,6 +37,9 @@ func NewLocalBuildResult(id model.TargetID) LocalBuildResult {
 type ImageBuildResult struct {
 	id model.TargetID
 
+	// TODO(maia): it would make the most sense for the ImageBuildResult to know what it BUILT, and for us
+	//   to calculate the ClusterRef (if different from LocalRef) when we have to inject it, but
+	//   storing all the info on ImageBuildResult for now was the fastest/safest way to ship this.
 	// Note: image tag is derived from a content-addressable digest.
 	ImageLocalRef   reference.NamedTagged // built image, as referenced from outside the cluster (in Dockerfile, docker push etc.)
 	ImageClusterRef reference.NamedTagged // built image, as referenced from the cluster (in K8s YAML, etc.)
@@ -435,7 +438,7 @@ func RunningContainersForTargetForOnePod(iTarget model.ImageTarget, runtimeState
 	var containers []ContainerInfo
 	for _, c := range pod.Containers {
 		// Only return containers matching our image
-		if c.ImageRef == nil || iTarget.Refs.ClusterRef.Name() != c.ImageRef.Name() {
+		if c.ImageRef == nil || iTarget.Refs.ClusterRef().Name() != c.ImageRef.Name() {
 			continue
 		}
 		if c.ID == "" || c.Name == "" || !c.Ready {

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -449,7 +449,7 @@ func (s *tiltfileState) reposForImage(image *dockerImage) []model.LocalGitRepo {
 }
 
 func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if s.defaultRegistryHost != "" {
+	if !s.defaultRegistryHost.Empty() {
 		return starlark.None, errors.New("default registry already defined")
 	}
 
@@ -467,7 +467,7 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 		return starlark.None, err
 	}
 
-	s.defaultRegistryHost = container.Registry(dr)
+	s.defaultRegistryHost = container.NewRegistry(dr)
 
 	return starlark.None, nil
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1069,12 +1069,7 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 		claimStatus[id] = claimPending
 
 		iTarget := model.ImageTarget{
-			Refs: container.RefSet{
-				ConfigurationRef: image.configurationRef,
-				// TODO(maia): LocalRef and ClusterRef may be different!
-				LocalRef:   image.deploymentRef,
-				ClusterRef: image.deploymentRef,
-			},
+			Refs:           container.NewRefSet(image.configurationRef, image.deploymentRef, image.deploymentRef),
 			MatchInEnvVars: image.matchInEnvVars,
 		}
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -534,7 +534,7 @@ func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 
 func (s *tiltfileState) assembleImages() error {
 	registry := s.defaultRegistryHost
-	if s.orchestrator() == model.OrchestratorK8s && s.privateRegistry != "" {
+	if s.orchestrator() == model.OrchestratorK8s && !s.privateRegistry.Empty() {
 		// If we've found a private registry in the cluster at run-time,
 		// use that instead of the one in the tiltfile
 		s.logger.Infof("Auto-detected private registry from environment: %s", s.privateRegistry)
@@ -543,7 +543,7 @@ func (s *tiltfileState) assembleImages() error {
 
 	for _, imageBuilder := range s.buildIndex.images {
 		var err error
-		imageBuilder.deploymentRef, err = container.ReplaceRegistry(registry, imageBuilder.configurationRef)
+		imageBuilder.deploymentRef, err = registry.ReplaceRegistryForLocalRef(imageBuilder.configurationRef)
 		if err != nil {
 			return err
 		}
@@ -568,7 +568,7 @@ func (s *tiltfileState) assembleImages() error {
 }
 
 func (s *tiltfileState) assembleDC() error {
-	if len(s.dc.services) > 0 && s.defaultRegistryHost != "" {
+	if len(s.dc.services) > 0 && !s.defaultRegistryHost.Empty() {
 		return errors.New("default_registry is not supported with docker compose")
 	}
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4724,9 +4724,9 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 				f.t.FailNow()
 			}
 
-			// TODO(maia): also verify expectedBuildRef
+			// TODO(maia): also verify expectedLocalRef
 			expectedDeployRef := container.MustParseNamed(opt.image.deploymentRef)
-			if !assert.Equal(f.t, expectedDeployRef.String(), image.Refs.ClusterRef.String(), "manifest %v image injected ref", m.Name) {
+			if !assert.Equal(f.t, expectedDeployRef.String(), image.Refs.ClusterRef().String(), "manifest %v image injected ref", m.Name) {
 				f.t.FailNow()
 			}
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2603,7 +2603,7 @@ func TestPrivateRegistry(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	f.kCli.Registry = "localhost:32000"
+	f.kCli.Registry = container.NewRegistry("localhost:32000")
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -2623,7 +2623,7 @@ func TestPrivateRegistryDockerCompose(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	f.kCli.Registry = "localhost:32000"
+	f.kCli.Registry = container.NewRegistry("localhost:32000")
 
 	f.setupFoo()
 	f.file("docker-compose.yml", `version: '3'

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -66,10 +66,6 @@ func (i ImageTarget) Validate() error {
 		return fmt.Errorf("[Validate] Image %q missing LocalRef", confRef)
 	}
 
-	if i.Refs.ClusterRef.String() == "" {
-		return fmt.Errorf("[Validate] Image %q missing ClusterRef", confRef)
-	}
-
 	switch bd := i.BuildDetails.(type) {
 	case DockerBuild:
 		if bd.BuildPath == "" {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -396,6 +396,7 @@ var labelRequirementAllowUnexported = cmp.AllowUnexported(labels.Requirement{})
 var k8sTargetAllowUnexported = cmp.AllowUnexported(K8sTarget{})
 var localTargetAllowUnexported = cmp.AllowUnexported(LocalTarget{})
 var selectorAllowUnexported = cmp.AllowUnexported(container.RefSelector{})
+var refSetAllowUnexported = cmp.AllowUnexported(container.RefSet{})
 
 var dockerRefEqual = cmp.Comparer(func(a, b reference.Named) bool {
 	aNil := a == nil
@@ -420,5 +421,6 @@ func DeepEqual(x, y interface{}) bool {
 		k8sTargetAllowUnexported,
 		localTargetAllowUnexported,
 		selectorAllowUnexported,
+		refSetAllowUnexported,
 		dockerRefEqual)
 }

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -168,20 +168,6 @@ var equalitytests = []struct {
 		false,
 	},
 	{
-		"ImageTarget.ClusterRef unequal",
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ClusterRef: img1.AsNamedOnly()}}),
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ClusterRef: img2.AsNamedOnly()}}),
-		false,
-		true,
-	},
-	{
-		"ImageTarget.ClusterRef equal",
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ClusterRef: img1.AsNamedOnly()}}),
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ClusterRef: img1.AsNamedOnly()}}),
-		true,
-		false,
-	},
-	{
 		"ImageTarget.DockerIgnores unequal",
 		Manifest{}.WithImageTarget(ImageTarget{dockerignores: []Dockerignore{{"a", "b"}}}),
 		Manifest{}.WithImageTarget(ImageTarget{dockerignores: []Dockerignore{{"b", "a"}}}),


### PR DESCRIPTION
not strictly necessary but i think this fits better with our mental models
of localRef vs. clusterRef -- i.e. clusterRef is only specified in very specific
situations, and otherwise, we assume that localRef is usaable everywhere