### PR TITLE
analytics: disable tilt analytics when DO_NOT_TRACK=1, CI=1

### DIFF
--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -43,7 +43,8 @@ func (af *analyticsFixture) SetupAnalyticsServer() {
 		af.t.FailNow()
 	}
 	af.mss = mss
-	delete(af.tilt.Environ, "TILT_DISABLE_ANALYTICS")
+	af.tilt.Environ["TILT_DISABLE_ANALYTICS"] = ""
+	af.tilt.Environ["CI"] = ""
 	af.tilt.Environ[AnalyticsUrlEnvVarName] = fmt.Sprintf("http://localhost:%d/report", port)
 }
 

--- a/internal/analytics/env.go
+++ b/internal/analytics/env.go
@@ -1,9 +1,28 @@
 package analytics
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
-const disableAnalyticsEnvVar = "TILT_DISABLE_ANALYTICS"
+var disableAnalyticsEnvVars = []string{
+	// Tilt-only analytics disabling
+	"TILT_DISABLE_ANALYTICS",
 
-func IsAnalyticsDisabledFromEnv() bool {
-	return os.Getenv(disableAnalyticsEnvVar) != ""
+	// https://consoledonottrack.com/
+	"DO_NOT_TRACK",
+
+	// We care about the number of humans using Tilt, not the number of CI machines
+	"CI",
+}
+
+// If analytics is disabled, return a string representing a human-readable reason.
+func IsAnalyticsDisabledFromEnv() (bool, string) {
+	for _, key := range disableAnalyticsEnvVars {
+		val := os.Getenv(key)
+		if val != "" {
+			return true, fmt.Sprintf("Environment variable %s=%s", key, val)
+		}
+	}
+	return false, ""
 }

--- a/internal/analytics/tilt_analytics_test.go
+++ b/internal/analytics/tilt_analytics_test.go
@@ -45,6 +45,7 @@ func TestCount(t *testing.T) {
 			ma := analytics.NewMemoryAnalytics()
 			os := &userOptSetting{opt: test.opt}
 			a, _ := NewTiltAnalytics(os, ma, versionTest)
+			a.envOpt = analytics.OptDefault
 			a.Count("foo", testTags, 1)
 			var expectedCounts []analytics.CountEvent
 			if test.expectRecord {
@@ -65,6 +66,7 @@ func TestIncr(t *testing.T) {
 			ma := analytics.NewMemoryAnalytics()
 			os := &userOptSetting{opt: test.opt}
 			a, _ := NewTiltAnalytics(os, ma, versionTest)
+			a.envOpt = analytics.OptDefault
 			a.Incr("foo", testTags)
 			var expectedCounts []analytics.CountEvent
 			if test.expectRecord {
@@ -85,6 +87,7 @@ func TestTimer(t *testing.T) {
 			ma := analytics.NewMemoryAnalytics()
 			os := &userOptSetting{opt: test.opt}
 			a, _ := NewTiltAnalytics(os, ma, versionTest)
+			a.envOpt = analytics.OptDefault
 			a.Timer("foo", time.Second, testTags)
 			var expectedTimes []analytics.TimeEvent
 			if test.expectRecord {
@@ -105,6 +108,7 @@ func TestIncrIfUnopted(t *testing.T) {
 			ma := analytics.NewMemoryAnalytics()
 			os := &userOptSetting{opt: test.opt}
 			a, _ := NewTiltAnalytics(os, ma, versionTest)
+			a.envOpt = analytics.OptDefault
 			a.IncrIfUnopted("foo")
 			var expectedCounts []analytics.CountEvent
 			if test.expectRecord {
@@ -123,6 +127,7 @@ func analyticsViaTransition(t *testing.T, initialOpt, newOpt analytics.Opt) (*Ti
 	ma := analytics.NewMemoryAnalytics()
 	os := &userOptSetting{opt: initialOpt}
 	a, _ := NewTiltAnalytics(os, ma, versionTest)
+	a.envOpt = analytics.OptDefault
 	err := a.SetUserOpt(newOpt)
 	if !assert.NoError(t, err) {
 		assert.FailNow(t, err.Error())

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -110,8 +110,8 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 
 	logOutput(fmt.Sprintf("Starting Tilt (%s)…", buildStamp()))
 
-	if analytics.IsAnalyticsDisabledFromEnv() {
-		logOutput("Tilt analytics manually disabled by environment")
+	if ok, reason := analytics.IsAnalyticsDisabledFromEnv(); ok {
+		log.Printf("Tilt analytics disabled: %s", reason)
 	}
 
 	hudEnabled := c.hud && isatty.IsTerminal(os.Stdout.Fd())

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3471,6 +3471,8 @@ func newTestFixtureWithHud(t *testing.T, h hud.HeadsUpDisplay) *testFixture {
 		tiltVersionCheckDelay: versionCheckInterval,
 	}
 
+	ret.disableEnvAnalyticsOpt()
+
 	tiltVersionCheckTimerMaker := func(d time.Duration) <-chan time.Time {
 		return time.After(ret.tiltVersionCheckDelay)
 	}
@@ -3536,6 +3538,12 @@ func (f *testFixture) setMaxParallelUpdates(n int) {
 
 	state := f.store.LockMutableStateForTesting()
 	state.MaxParallelUpdates = n
+	f.store.UnlockMutableState()
+}
+
+func (f *testFixture) disableEnvAnalyticsOpt() {
+	state := f.store.LockMutableStateForTesting()
+	state.AnalyticsEnvOpt = analytics.OptDefault
 	f.store.UnlockMutableState()
 }
 

--- a/internal/hud/webview/analytics_nudge_test.go
+++ b/internal/hud/webview/analytics_nudge_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNeedsNudgeK8sYaml(t *testing.T) {
-	state := store.NewState()
+	state := newState(nil)
 
 	m, err := k8s.NewK8sOnlyManifestFromYAML(testyaml.SanchoYAML)
 	assert.NoError(t, err)
@@ -28,7 +28,7 @@ func TestNeedsNudgeK8sYaml(t *testing.T) {
 }
 
 func TestNeedsNudgeRedManifest(t *testing.T) {
-	state := store.NewState()
+	state := newState(nil)
 
 	m := model.Manifest{Name: "server"}
 	targ := store.NewManifestTarget(m)
@@ -40,7 +40,7 @@ func TestNeedsNudgeRedManifest(t *testing.T) {
 }
 
 func TestNeedsNudgeGreenManifest(t *testing.T) {
-	state := store.NewState()
+	state := newState(nil)
 
 	m := model.Manifest{Name: "server"}
 	targ := store.NewManifestTarget(m)
@@ -53,7 +53,7 @@ func TestNeedsNudgeGreenManifest(t *testing.T) {
 }
 
 func TestNeedsNudgeAlreadyOpted(t *testing.T) {
-	state := store.NewState()
+	state := newState(nil)
 
 	state.AnalyticsUserOpt = analytics.OptIn
 	m := model.Manifest{Name: "server"}

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/windmilleng/wmclient/pkg/analytics"
+
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
@@ -225,6 +227,7 @@ func lastBuild(r *proto_webview.Resource) *proto_webview.BuildRecord {
 
 func newState(manifests []model.Manifest) *store.EngineState {
 	ret := store.NewState()
+	ret.AnalyticsEnvOpt = analytics.OptDefault
 	for _, m := range manifests {
 		ret.ManifestTargets[m.Name] = store.NewManifestTarget(m)
 		ret.ManifestDefinitionOrder = append(ret.ManifestDefinitionOrder, m.Name)

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -71,7 +71,7 @@ type EngineState struct {
 	VersionSettings model.VersionSettings
 
 	// Analytics Info
-
+	AnalyticsEnvOpt        analytics.Opt
 	AnalyticsUserOpt       analytics.Opt // changes to this field will propagate into the TiltAnalytics subscriber + we'll record them as user choice
 	AnalyticsTiltfileOpt   analytics.Opt // Set by the Tiltfile. Overrides the UserOpt.
 	AnalyticsNudgeSurfaced bool          // this flag is set the first time we show the analytics nudge to the user.
@@ -98,8 +98,8 @@ type EngineState struct {
 // Merge analytics opt-in status from different sources.
 // The Tiltfile opt-in takes precedence over the user opt-in.
 func (e *EngineState) AnalyticsEffectiveOpt() analytics.Opt {
-	if tiltanalytics.IsAnalyticsDisabledFromEnv() {
-		return analytics.OptOut
+	if e.AnalyticsEnvOpt != analytics.OptDefault {
+		return e.AnalyticsEnvOpt
 	}
 	if e.AnalyticsTiltfileOpt != analytics.OptDefault {
 		return e.AnalyticsTiltfileOpt
@@ -339,6 +339,11 @@ func NewState() *EngineState {
 	}
 	ret.MaxParallelUpdates = 1
 	ret.CurrentlyBuilding = make(map[model.ManifestName]bool)
+
+	if ok, _ := tiltanalytics.IsAnalyticsDisabledFromEnv(); ok {
+		ret.AnalyticsEnvOpt = analytics.OptOut
+	}
+
 	return ret
 }
 


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch3992/dnt:

3f73115e3b96961d018ebf66b6bcf0dbaf30ecc7 (2020-01-30 12:23:37 -0500)
analytics: disable tilt analytics when DO_NOT_TRACK=1, CI=1

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics