### PR TITLE
rename NewImageTarget to MustNewImageTarget to make a future PR smaller

### DIFF
--- a/internal/engine/analytics/analytics_reporter_test.go
+++ b/internal/engine/analytics/analytics_reporter_test.go
@@ -202,5 +202,5 @@ func (artf *analyticsReporterTestFixture) assertStats(t *testing.T, expectedTags
 func iTargetForRef(ref string) model.ImageTarget {
 	named := container.MustParseNamed(ref)
 	selector := container.NameSelector(named)
-	return model.NewImageTarget(selector)
+	return model.MustNewImageTarget(selector)
 }

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -364,11 +364,11 @@ func TestLiveUpdateDiffImgMultipleContainersOnlySomeSyncsMatch(t *testing.T) {
 	sanchoLU := assembleLiveUpdate(sanchoSyncs, SanchoRunSteps, false, nil, f)
 	sidecarLU := assembleLiveUpdate(sidecarSyncs, RunStepsForApp("sidecar"),
 		false, nil, f)
-	sanchoTarg := model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+	sanchoTarg := model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,
 		BuildPath:  sanchoPath,
 	})
-	sidecarTarg := model.NewImageTarget(SanchoSidecarRef).WithBuildDetails(model.DockerBuild{
+	sidecarTarg := model.MustNewImageTarget(SanchoSidecarRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,
 		BuildPath:  sidecarPath,
 	})
@@ -405,11 +405,11 @@ func TestLiveUpdateDiffImgMultipleContainersSameContextOnlyOneLiveUpdate(t *test
 	sanchoSyncs[0].Source = buildContext
 
 	sanchoLU := assembleLiveUpdate(sanchoSyncs, SanchoRunSteps, false, nil, f)
-	sanchoTarg := model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+	sanchoTarg := model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,
 		BuildPath:  buildContext,
 	})
-	sidecarTarg := model.NewImageTarget(SanchoSidecarRef).WithBuildDetails(model.DockerBuild{
+	sidecarTarg := model.MustNewImageTarget(SanchoSidecarRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,
 		BuildPath:  buildContext,
 	})

--- a/internal/engine/buildcontrol/target_queue_test.go
+++ b/internal/engine/buildcontrol/target_queue_test.go
@@ -18,7 +18,7 @@ import (
 func TestTargetQueue_Simple(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
-	t1 := model.NewImageTarget(container.MustParseSelector("vigoda"))
+	t1 := model.MustNewImageTarget(container.MustParseSelector("vigoda"))
 	s1 := store.BuildState{}
 
 	targets := []model.ImageTarget{t1}
@@ -37,9 +37,9 @@ func TestTargetQueue_Simple(t *testing.T) {
 func TestTargetQueue_DepsBuilt(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
-	fooTarget := model.NewImageTarget(container.MustParseSelector("foo"))
+	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{LastSuccessfulResult: store.NewImageBuildResultSingleRef(fooTarget.ID(), container.MustParseNamedTagged("foo:1234"))}
-	barTarget := model.NewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
+	barTarget := model.MustNewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
 	s2 := store.BuildState{}
 
 	targets := []model.ImageTarget{fooTarget, barTarget}
@@ -64,9 +64,9 @@ func TestTargetQueue_DepsBuilt(t *testing.T) {
 func TestTargetQueue_DepsUnbuilt(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
-	fooTarget := model.NewImageTarget(container.MustParseSelector("foo"))
+	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{}
-	barTarget := model.NewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
+	barTarget := model.MustNewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
 	var s2 = store.BuildState{LastSuccessfulResult: store.NewImageBuildResultSingleRef(
 		barTarget.ID(),
 		container.MustParseNamedTagged("bar:54321"),
@@ -93,7 +93,7 @@ func TestTargetQueue_DepsUnbuilt(t *testing.T) {
 func TestTargetQueue_IncrementalBuild(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
-	fooTarget := model.NewImageTarget(container.MustParseSelector("foo"))
+	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{
 		LastSuccessfulResult: store.NewImageBuildResultSingleRef(
 			fooTarget.ID(),
@@ -118,7 +118,7 @@ func TestTargetQueue_IncrementalBuild(t *testing.T) {
 func TestTargetQueue_CachedBuild(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
-	fooTarget := model.NewImageTarget(container.MustParseSelector("foo"))
+	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{
 		LastSuccessfulResult: store.NewImageBuildResultSingleRef(
 			fooTarget.ID(),
@@ -139,9 +139,9 @@ func TestTargetQueue_CachedBuild(t *testing.T) {
 func TestTargetQueue_DepsBuiltButReaped(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
-	fooTarget := model.NewImageTarget(container.MustParseSelector("foo"))
+	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{LastSuccessfulResult: store.NewImageBuildResultSingleRef(fooTarget.ID(), container.MustParseNamedTagged("foo:1234"))}
-	barTarget := model.NewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
+	barTarget := model.MustNewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
 	s2 := store.BuildState{}
 
 	targets := []model.ImageTarget{fooTarget, barTarget}

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -167,7 +167,7 @@ ENTRYPOINT /go/bin/sancho
 var SanchoRef = container.MustParseSelector(testyaml.SanchoImage)
 
 func NewSanchoDockerBuildImageTarget(f *ccFixture) model.ImageTarget {
-	return model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+	return model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,
 		BuildPath:  f.Path(),
 	})

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -81,7 +81,7 @@ func TestTiltBuildsImageWithTag(t *testing.T) {
 	defer f.TearDown()
 
 	refWithTag := "gcr.io/foo:bar"
-	iTarget := model.NewImageTarget(container.MustParseSelector(refWithTag)).
+	iTarget := model.MustNewImageTarget(container.MustParseSelector(refWithTag)).
 		WithBuildDetails(model.DockerBuild{})
 	manifest := manifestbuilder.New(f, "fe").
 		WithDockerCompose().

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -216,12 +216,12 @@ func TestMultiStageDockerBuildPreservesSyntaxDirective(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	baseImage := model.NewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
+	baseImage := model.MustNewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM golang:1.10`,
 		BuildPath:  f.JoinPath("sancho-base"),
 	})
 
-	srcImage := model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+	srcImage := model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `# syntax = docker/dockerfile:experimental
 
 FROM sancho-base
@@ -379,7 +379,7 @@ func TestCustomBuildSkipsLocalDocker(t *testing.T) {
 
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
-		WithImageTarget(model.NewImageTarget(SanchoRef).WithBuildDetails(cb)).
+		WithImageTarget(model.MustNewImageTarget(SanchoRef).WithBuildDetails(cb)).
 		Build()
 
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), store.BuildStateSet{})

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -87,7 +87,7 @@ func NewSanchoLiveUpdateDCManifest(f Fixture) model.Manifest {
 }
 
 func NewSanchoManifestWithImageInEnvVar(f Fixture) model.Manifest {
-	it2 := model.NewImageTarget(container.MustParseSelector(SanchoRef.String() + "2")).WithBuildDetails(model.DockerBuild{
+	it2 := model.MustNewImageTarget(container.MustParseSelector(SanchoRef.String() + "2")).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,
 		BuildPath:  f.Path(),
 	})
@@ -112,7 +112,7 @@ func NewSanchoCustomBuildImageTargetWithTag(fixture Fixture, tag string) model.I
 		Deps:    []string{fixture.JoinPath("app")},
 		Tag:     tag,
 	}
-	return model.NewImageTarget(SanchoRef).WithBuildDetails(cb)
+	return model.MustNewImageTarget(SanchoRef).WithBuildDetails(cb)
 }
 
 func NewSanchoCustomBuildManifestWithTag(fixture Fixture, tag string) model.Manifest {
@@ -131,7 +131,7 @@ func NewSanchoCustomBuildManifestWithLiveUpdate(fixture Fixture) model.Manifest 
 
 	return manifestbuilder.New(fixture, "sancho").
 		WithK8sYAML(SanchoYAML).
-		WithImageTarget(model.NewImageTarget(SanchoRef).WithBuildDetails(cb)).
+		WithImageTarget(model.MustNewImageTarget(SanchoRef).WithBuildDetails(cb)).
 		Build()
 }
 
@@ -145,12 +145,12 @@ func NewSanchoCustomBuildManifestWithPushDisabled(fixture Fixture) model.Manifes
 
 	return manifestbuilder.New(fixture, "sancho").
 		WithK8sYAML(SanchoYAML).
-		WithImageTarget(model.NewImageTarget(SanchoRef).WithBuildDetails(cb)).
+		WithImageTarget(model.MustNewImageTarget(SanchoRef).WithBuildDetails(cb)).
 		Build()
 }
 
 func NewSanchoDockerBuildImageTarget(f Fixture) model.ImageTarget {
-	return model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+	return model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,
 		BuildPath:  f.Path(),
 	})
@@ -205,12 +205,12 @@ func NewSanchoDockerBuildManifestWithYaml(f Fixture, yaml string) model.Manifest
 }
 
 func NewSanchoDockerBuildMultiStageManifest(fixture Fixture) model.Manifest {
-	baseImage := model.NewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
+	baseImage := model.MustNewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM golang:1.10`,
 		BuildPath:  fixture.JoinPath("sancho-base"),
 	})
 
-	srcImage := model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+	srcImage := model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `
 FROM sancho-base
 ADD . .
@@ -227,12 +227,12 @@ ENTRYPOINT /go/bin/sancho
 }
 
 func NewSanchoDockerBuildMultiStageManifestWithLiveUpdate(fixture Fixture, lu model.LiveUpdate) model.Manifest {
-	baseImage := model.NewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
+	baseImage := model.MustNewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM golang:1.10`,
 		BuildPath:  fixture.JoinPath("sancho-base"),
 	})
 
-	srcImage := model.NewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+	srcImage := model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `
 FROM sancho-base
 ADD . .
@@ -250,7 +250,7 @@ ENTRYPOINT /go/bin/sancho
 }
 
 func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {
-	baseImage := model.NewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
+	baseImage := model.MustNewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM golang:1.10`,
 		BuildPath:  fixture.Path(),
 	})
@@ -280,15 +280,15 @@ func NewManifestsWithCommonAncestor(fixture Fixture) (model.Manifest, model.Mani
 	fixture.MkdirAll("image-1")
 	fixture.MkdirAll("image-2")
 
-	targetCommon := model.NewImageTarget(refCommon).WithBuildDetails(model.DockerBuild{
+	targetCommon := model.MustNewImageTarget(refCommon).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM golang:1.10`,
 		BuildPath:  fixture.JoinPath("common"),
 	})
-	target1 := model.NewImageTarget(ref1).WithBuildDetails(model.DockerBuild{
+	target1 := model.MustNewImageTarget(ref1).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM ` + refCommon.String(),
 		BuildPath:  fixture.JoinPath("image-1"),
 	})
-	target2 := model.NewImageTarget(ref2).WithBuildDetails(model.DockerBuild{
+	target2 := model.MustNewImageTarget(ref2).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM ` + refCommon.String(),
 		BuildPath:  fixture.JoinPath("image-2"),
 	})

--- a/pkg/model/custom_build_test.go
+++ b/pkg/model/custom_build_test.go
@@ -30,7 +30,7 @@ func TestValidate(t *testing.T) {
 		Command: "true",
 		Deps:    []string{"foo", "bar"},
 	}
-	it := NewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).
+	it := MustNewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).
 		WithBuildDetails(cb)
 
 	assert.Nil(t, it.Validate())
@@ -41,7 +41,7 @@ func TestDoesNotValidate(t *testing.T) {
 		Command: "",
 		Deps:    []string{"foo", "bar"},
 	}
-	it := NewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).
+	it := MustNewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).
 		WithBuildDetails(cb)
 
 	assert.Error(t, it.Validate())

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -28,7 +28,7 @@ type ImageTarget struct {
 	dependencyIDs []TargetID
 }
 
-func NewImageTarget(ref container.RefSelector) ImageTarget {
+func MustNewImageTarget(ref container.RefSelector) ImageTarget {
 	return ImageTarget{Refs: container.SimpleRefSet(ref)}
 }
 

--- a/pkg/model/target_test.go
+++ b/pkg/model/target_test.go
@@ -106,7 +106,7 @@ func newDepTarget(name string, deps ...string) ImageTarget {
 	for i, dep := range deps {
 		depIDs[i] = ImageID(container.MustParseSelector(dep))
 	}
-	return NewImageTarget(ref).WithDependencyIDs(depIDs)
+	return MustNewImageTarget(ref).WithDependencyIDs(depIDs)
 }
 
 func newK8sTarget(name string, deps ...string) K8sTarget {


### PR DESCRIPTION
as of #2883 this func needs to either return or igore/panic on an error.
since it seems to only be used in tests right now, i'm having it
panic on the error instead of returning in, so changed the name
to reflect.