### PR TITLE
shorttest: no more tiltfile DC tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ test: test-go test-js
 
 # skip some tests that are slow and not always relevant
 shorttest:
-	go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags 'skipcontainertests' -timeout 60s ./...
+	# TODO(matt) skipdockercomposetests only skips the tiltfile DC tests at the moment
+	# we might also want to skip the ones in engine
+	go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s ./...
 
 integration:
 ifneq ($(CIRCLECI),true)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2675,20 +2675,6 @@ default_registry('example.com')
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "bar/Dockerfile", "bar/.dockerignore", "bar.yaml", "baz/Dockerfile", "baz/.dockerignore", "baz.yaml")
 }
 
-func TestDefaultRegistryWithDockerCompose(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.dockerfile("foo/Dockerfile")
-	f.file("docker-compose.yml", simpleConfig)
-	f.file("Tiltfile", `
-docker_compose('docker-compose.yml')
-default_registry('bar.com')
-`)
-
-	f.loadErrString("default_registry is not supported with docker compose")
-}
-
 func TestDefaultReadFile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -3197,62 +3183,6 @@ docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
 %s
 `, globalTriggerModeDirective, k8sResourceDirective))
-
-			f.load()
-
-			f.assertNumManifests(1)
-			f.assertNextManifest("foo", testCase.expectedTriggerMode)
-		})
-	}
-}
-
-func TestTriggerModeDC(t *testing.T) {
-	for _, testCase := range []struct {
-		name                string
-		globalSetting       triggerMode
-		dcResourceSetting   triggerMode
-		expectedTriggerMode model.TriggerMode
-	}{
-		{"default", TriggerModeUnset, TriggerModeUnset, model.TriggerModeAuto},
-		{"explicit global auto", TriggerModeAuto, TriggerModeUnset, model.TriggerModeAuto},
-		{"explicit global manual", TriggerModeManual, TriggerModeUnset, model.TriggerModeManualAfterInitial},
-		{"dc auto", TriggerModeUnset, TriggerModeUnset, model.TriggerModeAuto},
-		{"dc manual", TriggerModeUnset, TriggerModeManual, model.TriggerModeManualAfterInitial},
-		{"dc override auto", TriggerModeManual, TriggerModeAuto, model.TriggerModeAuto},
-		{"dc override manual", TriggerModeAuto, TriggerModeManual, model.TriggerModeManualAfterInitial},
-	} {
-		t.Run(testCase.name, func(t *testing.T) {
-			f := newFixture(t)
-			defer f.TearDown()
-
-			f.dockerfile("foo/Dockerfile")
-			f.file("docker-compose.yml", simpleConfig)
-
-			var globalTriggerModeDirective string
-			switch testCase.globalSetting {
-			case TriggerModeUnset:
-				globalTriggerModeDirective = ""
-			case TriggerModeManual:
-				globalTriggerModeDirective = "trigger_mode(TRIGGER_MODE_MANUAL)"
-			case TriggerModeAuto:
-				globalTriggerModeDirective = "trigger_mode(TRIGGER_MODE_AUTO)"
-			}
-
-			var dcResourceDirective string
-			switch testCase.dcResourceSetting {
-			case TriggerModeUnset:
-				dcResourceDirective = ""
-			case TriggerModeManual:
-				dcResourceDirective = "dc_resource('foo', trigger_mode=TRIGGER_MODE_MANUAL)"
-			case TriggerModeAuto:
-				dcResourceDirective = "dc_resource('foo', trigger_mode=TRIGGER_MODE_AUTO)"
-			}
-
-			f.file("Tiltfile", fmt.Sprintf(`
-%s
-docker_compose('docker-compose.yml')
-%s
-`, globalTriggerModeDirective, dcResourceDirective))
 
 			f.load()
 
@@ -4175,20 +4105,6 @@ k8s_yaml('secret.yaml')
 	assert.Equal(t, "d29ybGQ=", string(secrets["world"].ValueEncoded))
 }
 
-func TestDCResourceNoImage(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupFoo()
-	f.file("docker-compose.yml", simpleConfig)
-	f.file("Tiltfile", `
-docker_compose('docker-compose.yml')
-dc_resource('foo', trigger_mode=TRIGGER_MODE_AUTO)
-`)
-
-	f.load()
-}
-
 func TestDockerPruneSettings(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -4252,22 +4168,6 @@ k8s_yaml('foo.yaml')
 docker_build('gcr.io/bar', 'bar')
 k8s_yaml('bar.yaml')
 k8s_resource('bar', resource_deps=['foo'])
-`)
-
-	f.load()
-	f.assertNextManifest("foo", resourceDeps())
-	f.assertNextManifest("bar", resourceDeps("foo"))
-}
-
-func TestDCDependsOn(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.dockerfile("foo/Dockerfile")
-	f.file("docker-compose.yml", twoServiceConfig)
-	f.file("Tiltfile", `
-docker_compose('docker-compose.yml')
-dc_resource('bar', resource_deps=['foo'])
 `)
 
 	f.load()


### PR DESCRIPTION
`go test -count 1 -tags skipcontainertests ./internal/tiltfile`: 23s
`go test -count 1 -tags skipcontainertests,skipdockercomposetests ./internal/tiltfile`: 5s
`go test -count 1 -tags skipcontainertests ./...`: 68s
`go test -count 1 -tags skipcontainertests,skipdockercomposetests ./...`: 49s
