### PR TITLE
engine: handle pod deletion properly

### DIFF
--- a/internal/engine/k8swatch/actions.go
+++ b/internal/engine/k8swatch/actions.go
@@ -6,6 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -25,6 +26,20 @@ func NewPodChangeAction(pod *v1.Pod, mn model.ManifestName, matchedAncestorUID t
 		Pod:                pod,
 		ManifestName:       mn,
 		MatchedAncestorUID: matchedAncestorUID,
+	}
+}
+
+type PodDeleteAction struct {
+	PodID     k8s.PodID
+	Namespace k8s.Namespace
+}
+
+func (PodDeleteAction) Action() {}
+
+func NewPodDeleteAction(podID k8s.PodID, namespace k8s.Namespace) PodDeleteAction {
+	return PodDeleteAction{
+		PodID:     podID,
+		Namespace: namespace,
 	}
 }
 

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -18,6 +18,16 @@ import (
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
+func handlePodDeleteAction(ctx context.Context, state *store.EngineState, action k8swatch.PodDeleteAction) {
+	// PodDeleteActions only have the pod id. We don't have a good way to tie them back to their ancestors.
+	// So just brute-force it.
+	for _, target := range state.ManifestTargets {
+		ms := target.State
+		runtime := ms.K8sRuntimeState()
+		delete(runtime.Pods, action.PodID)
+	}
+}
+
 func handlePodChangeAction(ctx context.Context, state *store.EngineState, action k8swatch.PodChangeAction) {
 	mt := matchPodChangeToManifest(state, action)
 	if mt == nil {

--- a/internal/engine/pod_test.go
+++ b/internal/engine/pod_test.go
@@ -1,0 +1,69 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/internal/engine/k8swatch"
+	"github.com/windmilleng/tilt/internal/k8s"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/testutils"
+	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
+	"github.com/windmilleng/tilt/internal/testutils/podbuilder"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+func TestPodDeleteAction(t *testing.T) {
+	f := newReducerFixture(t)
+	defer f.TearDown()
+
+	ms, _ := f.state.ManifestState("sancho")
+	m, _ := f.state.Manifest("sancho")
+	hash := k8s.PodTemplateSpecHash("ptsh")
+	pod := podbuilder.New(f.T(), m).WithTemplateSpecHash(hash).Build()
+	runtime := ms.GetOrCreateK8sRuntimeState()
+	runtime.DeployedPodTemplateSpecHashSet.Add(hash)
+
+	assert.Equal(t, 0, len(ms.K8sRuntimeState().Pods))
+
+	handlePodChangeAction(f.ctx, f.state, k8swatch.PodChangeAction{
+		Pod:          pod,
+		ManifestName: m.Name,
+	})
+
+	assert.Equal(t, 1, len(ms.K8sRuntimeState().Pods))
+
+	handlePodDeleteAction(f.ctx, f.state, k8swatch.PodDeleteAction{
+		PodID: k8s.PodIDFromPod(pod),
+	})
+	assert.Equal(t, 0, len(ms.K8sRuntimeState().Pods))
+}
+
+// A simple fixture for testing reducers, independently of a store.
+type reducerFixture struct {
+	*tempdir.TempDirFixture
+	ctx   context.Context
+	state *store.EngineState
+}
+
+func newReducerFixture(t *testing.T) *reducerFixture {
+	f := tempdir.NewTempDirFixture(t)
+	state := store.NewState()
+
+	iTarget := NewSanchoLiveUpdateImageTarget(f)
+	manifest := manifestbuilder.New(f, model.ManifestName("sancho")).
+		WithK8sYAML(SanchoYAML).
+		WithImageTarget(iTarget).
+		Build()
+	state.UpsertManifestTarget(store.NewManifestTarget(manifest))
+	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
+
+	return &reducerFixture{
+		TempDirFixture: f,
+		ctx:            ctx,
+		state:          state,
+	}
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -156,6 +156,8 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleFSEvent(ctx, state, action)
 	case k8swatch.PodChangeAction:
 		handlePodChangeAction(ctx, state, action)
+	case k8swatch.PodDeleteAction:
+		handlePodDeleteAction(ctx, state, action)
 	case store.PodResetRestartsAction:
 		handlePodResetRestartsAction(state, action)
 	case k8swatch.ServiceChangeAction:

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -91,7 +91,7 @@ type Client interface {
 	// Opens a tunnel to the specified pod+port. Returns the tunnel's local port and a function that closes the tunnel
 	CreatePortForwarder(ctx context.Context, namespace Namespace, podID PodID, optionalLocalPort, remotePort int, host string) (PortForwarder, error)
 
-	WatchPods(ctx context.Context, lps labels.Selector) (<-chan *v1.Pod, error)
+	WatchPods(ctx context.Context, lps labels.Selector) (<-chan ObjectUpdate, error)
 
 	WatchServices(ctx context.Context, lps labels.Selector) (<-chan *v1.Service, error)
 

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -57,7 +57,7 @@ func (ec *explodingClient) CreatePortForwarder(ctx context.Context, namespace Na
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchPods(ctx context.Context, lps labels.Selector) (<-chan *v1.Pod, error) {
+func (ec *explodingClient) WatchPods(ctx context.Context, lps labels.Selector) (<-chan ObjectUpdate, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -20,6 +20,50 @@ import (
 	"github.com/windmilleng/tilt/pkg/logger"
 )
 
+var PodGVR = v1.SchemeGroupVersion.WithResource("pods")
+var ServiceGVR = v1.SchemeGroupVersion.WithResource("services")
+var EventGVR = v1.SchemeGroupVersion.WithResource("events")
+
+// A wrapper object around SharedInformer objects, to make them
+// a bit easier to use correctly.
+type ObjectUpdate struct {
+	obj      interface{}
+	isDelete bool
+}
+
+// Returns a Pod if this is a pod Add or a pod Update.
+func (r ObjectUpdate) AsPod() (*v1.Pod, bool) {
+	if r.isDelete {
+		return nil, false
+	}
+	pod, ok := r.obj.(*v1.Pod)
+	return pod, ok
+}
+
+// Returns (namespace, name, isDelete).
+//
+// The informer's OnDelete handler sometimes gives us a structured object, and
+// sometimes returns a DeletedFinalStateUnknown object. To make this easier to
+// handle correctly, we never allow access to the OnDelete object. Instead, we
+// force the caller to use AsDeletedKey() to get the identifier of the object.
+//
+// For more info, see:
+// https://godoc.org/k8s.io/client-go/tools/cache#ResourceEventHandler
+func (r ObjectUpdate) AsDeletedKey() (Namespace, string, bool) {
+	if !r.isDelete {
+		return "", "", false
+	}
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(r.obj)
+	if err != nil {
+		return "", "", false
+	}
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return "", "", false
+	}
+	return Namespace(ns), name, true
+}
+
 type watcherFactory func(namespace string) watcher
 type watcher interface {
 	Watch(options metav1.ListOptions) (watch.Interface, error)
@@ -97,7 +141,7 @@ func (kCli K8sClient) makeInformer(
 }
 
 func (kCli K8sClient) WatchEvents(ctx context.Context) (<-chan *v1.Event, error) {
-	gvr := v1.SchemeGroupVersion.WithResource("events")
+	gvr := EventGVR
 	informer, err := kCli.makeInformer(ctx, gvr, labels.Everything())
 	if err != nil {
 		return nil, errors.Wrap(err, "WatchEvents")
@@ -132,28 +176,28 @@ func (kCli K8sClient) WatchEvents(ctx context.Context) (<-chan *v1.Event, error)
 	return ch, nil
 }
 
-func (kCli K8sClient) WatchPods(ctx context.Context, ls labels.Selector) (<-chan *v1.Pod, error) {
-	gvr := v1.SchemeGroupVersion.WithResource("pods")
+func (kCli K8sClient) WatchPods(ctx context.Context, ls labels.Selector) (<-chan ObjectUpdate, error) {
+	gvr := PodGVR
 	informer, err := kCli.makeInformer(ctx, gvr, ls)
 	if err != nil {
 		return nil, errors.Wrap(err, "WatchPods")
 	}
 
-	ch := make(chan *v1.Pod)
+	ch := make(chan ObjectUpdate)
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			mObj, ok := obj.(*v1.Pod)
 			if ok {
 				FixContainerStatusImages(mObj)
-				ch <- mObj
 			}
+			ch <- ObjectUpdate{obj: obj}
 		},
 		DeleteFunc: func(obj interface{}) {
 			mObj, ok := obj.(*v1.Pod)
 			if ok {
 				FixContainerStatusImages(mObj)
-				ch <- mObj
 			}
+			ch <- ObjectUpdate{obj: obj, isDelete: true}
 		},
 		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
 			oldPod, ok := oldObj.(*v1.Pod)
@@ -162,14 +206,12 @@ func (kCli K8sClient) WatchPods(ctx context.Context, ls labels.Selector) (<-chan
 			}
 
 			newPod, ok := newObj.(*v1.Pod)
-			if !ok {
+			if !ok || oldPod == newPod {
 				return
 			}
 
-			if oldPod != newPod {
-				FixContainerStatusImages(newPod)
-				ch <- newPod
-			}
+			FixContainerStatusImages(newPod)
+			ch <- ObjectUpdate{obj: newPod}
 		},
 	})
 
@@ -179,7 +221,7 @@ func (kCli K8sClient) WatchPods(ctx context.Context, ls labels.Selector) (<-chan
 }
 
 func (kCli K8sClient) WatchServices(ctx context.Context, ls labels.Selector) (<-chan *v1.Service, error) {
-	gvr := v1.SchemeGroupVersion.WithResource("services")
+	gvr := ServiceGVR
 	informer, err := kCli.makeInformer(ctx, gvr, ls)
 	if err != nil {
 		return nil, errors.Wrap(err, "WatchServices")

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -42,6 +42,36 @@ func TestK8sClient_WatchPods(t *testing.T) {
 	tf.runPods(pods, pods)
 }
 
+func TestK8sClient_WatchPodDeletion(t *testing.T) {
+	tf := newWatchTestFixture(t)
+	defer tf.TearDown()
+
+	podID := PodID("pod1")
+	pod := fakePod(podID, "image1")
+	ch := tf.watchPods()
+	tf.addObjects(pod)
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out waiting for pod update")
+	case obj := <-ch:
+		asPod, _ := obj.AsPod()
+		assert.Equal(t, podID, PodIDFromPod(asPod))
+	}
+
+	err := tf.tracker.Delete(PodGVR, "default", "pod1")
+	assert.NoError(t, err)
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out waiting for pod delete")
+	case obj := <-ch:
+		ns, name, _ := obj.AsDeletedKey()
+		assert.Equal(t, "pod1", name)
+		assert.Equal(t, Namespace("default"), ns)
+	}
+}
+
 func TestK8sClient_WatchPodsFilterNonPods(t *testing.T) {
 	tf := newWatchTestFixture(t)
 	defer tf.TearDown()
@@ -309,7 +339,7 @@ func (tf *watchTestFixture) TearDown() {
 	tf.cancel()
 }
 
-func (tf *watchTestFixture) watchPods() <-chan *v1.Pod {
+func (tf *watchTestFixture) watchPods() <-chan ObjectUpdate {
 	ch, err := tf.kCli.WatchPods(tf.ctx, labels.Everything())
 	if err != nil {
 		tf.t.Fatalf("watchPods: %v", err)
@@ -348,16 +378,20 @@ func (tf *watchTestFixture) runPods(input []runtime.Object, expected []runtime.O
 	tf.assertPods(expected, ch)
 }
 
-func (tf *watchTestFixture) assertPods(expectedOutput []runtime.Object, ch <-chan *v1.Pod) {
+func (tf *watchTestFixture) assertPods(expectedOutput []runtime.Object, ch <-chan ObjectUpdate) {
 	var observedPods []runtime.Object
 
 	done := false
 	for !done {
 		select {
-		case pod, ok := <-ch:
+		case obj, ok := <-ch:
 			if !ok {
 				done = true
-			} else {
+				continue
+			}
+
+			pod, ok := obj.AsPod()
+			if ok {
 				observedPods = append(observedPods, pod)
 			}
 		case <-time.After(10 * time.Millisecond):


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/deletepod:

5294b2349e7d2b3f4546cbd79ac85b8558fa5113 (2020-01-31 14:47:02 -0500)
engine: handle pod deletion properly
This is part of a larger change to make our watch code more
generalizable, so that we can watch ReplicaSets and Deployments

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics