### PR TITLE
circleci: upgrade docker in the integration test container. They changed the URL format, so our download script was downloading an old version

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -2,9 +2,10 @@ FROM golang:1.13
 
 # Install docker
 # Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
+# Check https://download.docker.com/linux/static/stable/x86_64/ for latest versions
+ENV DOCKER_VERSION=19.03.5
 RUN set -exu \
-  && export DOCKER_VERSION=$(curl -sSf --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
-  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
   && echo Docker URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
   build-integration:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:75e5d29da4ff2b06f5ae356b70935155499901218cdcabbbb7cebb31410c578c
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:da50861fa4e8caaecefbd82986e1d13ad97cd1264d24ea7c1889e1aa91728ae5
     steps:
       - checkout
       - run: echo 'export PATH=~/go/bin:$PATH' >> $BASH_ENV


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/circleci:

89b556d52e37dc3bfc3475505e2c0a42ba9925ad (2020-01-31 15:34:20 -0500)
circleci: upgrade docker in the integration test container. They changed the URL format, so our download script was downloading an old version

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics