### PR TITLE
tiltfile: always use unix abs-path check when verifying live update remote path

### DIFF
--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -2,7 +2,6 @@ package tiltfile
 
 import (
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -203,7 +202,7 @@ func (s *tiltfileState) liveUpdateStepToModel(t *starlark.Thread, l liveUpdateSt
 	case liveUpdateFallBackOnStep:
 		return model.LiveUpdateFallBackOnStep{Files: x.files}, nil
 	case liveUpdateSyncStep:
-		if !filepath.IsAbs(x.remotePath) {
+		if !unixIsAbs(x.remotePath) {
 			return nil, fmt.Errorf("sync destination '%s' (%s) is not absolute", x.remotePath, x.position.String())
 		}
 		return model.LiveUpdateSyncStep{Source: x.localPath, Dest: x.remotePath}, nil
@@ -259,4 +258,10 @@ func (s *tiltfileState) checkForUnconsumedLiveUpdateSteps() error {
 	}
 
 	return nil
+}
+
+// Regardless of the OS the binary is built for, assume a Linux container and so use the Unix abs-path check
+// (see https://github.com/golang/go/blob/master/src/path/filepath/path_unix.go#L12)
+func unixIsAbs(path string) bool {
+	return strings.HasPrefix(path, "/")
 }


### PR DESCRIPTION
hopefully addresses #2870

in so doing, might break windows containers -- which we never purported
to support anyway, so I don't think this is a regression? maybe?