### PR TITLE
k8s: rename private registry to local registry, to reduce confusion

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -101,8 +101,8 @@ type Client interface {
 
 	ContainerRuntime(ctx context.Context) container.Runtime
 
-	// Some clusters support a private image registry that we can push to.
-	PrivateRegistry(ctx context.Context) container.Registry
+	// Some clusters support a local image registry that we can push to.
+	LocalRegistry(ctx context.Context) container.Registry
 
 	Exec(ctx context.Context, podID PodID, cName container.Name, n Namespace, cmd []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
 }

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -77,7 +77,7 @@ func (ec *explodingClient) ContainerRuntime(ctx context.Context) container.Runti
 	return container.RuntimeUnknown
 }
 
-func (ec *explodingClient) PrivateRegistry(ctx context.Context) container.Registry {
+func (ec *explodingClient) LocalRegistry(ctx context.Context) container.Registry {
 	return container.Registry{}
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -345,7 +345,7 @@ func (c *FakeK8sClient) ContainerRuntime(ctx context.Context) container.Runtime 
 	return container.RuntimeDocker
 }
 
-func (c *FakeK8sClient) PrivateRegistry(ctx context.Context) container.Registry {
+func (c *FakeK8sClient) LocalRegistry(ctx context.Context) container.Registry {
 	return c.Registry
 }
 

--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -105,10 +105,10 @@ func (r *registryAsync) Registry(ctx context.Context) container.Registry {
 	return r.registry
 }
 
-func (c K8sClient) PrivateRegistry(ctx context.Context) container.Registry {
+func (c K8sClient) LocalRegistry(ctx context.Context) container.Registry {
 	return c.registryAsync.Registry(ctx)
 }
 
 func ProvideContainerRegistry(ctx context.Context, kCli Client) container.Registry {
-	return kCli.PrivateRegistry(ctx)
+	return kCli.LocalRegistry(ctx)
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -162,9 +162,9 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 
 	tlr.TiltIgnoreContents = string(tiltIgnoreContents)
 
-	privateRegistry := tfl.kCli.PrivateRegistry(ctx)
+	localRegistry := tfl.kCli.LocalRegistry(ctx)
 
-	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.k8sContextExt, privateRegistry, feature.FromDefaults(tfl.fDefaults))
+	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.k8sContextExt, localRegistry, feature.FromDefaults(tfl.fDefaults))
 
 	manifests, result, err := s.loadManifests(absFilename, userConfigState)
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2617,7 +2617,7 @@ default_registry('bar.com')
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo/Dockerfile", "foo/.dockerignore", "foo.yaml")
 }
 
-func TestPrivateRegistry(t *testing.T) {
+func TestLocalRegistry(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -2637,7 +2637,7 @@ k8s_yaml('foo.yaml')
 		deployment("foo"))
 }
 
-func TestPrivateRegistryDockerCompose(t *testing.T) {
+func TestLocalRegistryDockerCompose(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/autodetect:

704416f3730df5657d19b02cbbb8c22d91d8d436 (2020-02-04 14:42:15 -0500)
k8s: rename private registry to local registry, to reduce confusion

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics