### PR TITLE
k8s: auto-detect local registry from node annotations

### DIFF
--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -14,6 +14,9 @@ import (
 	"github.com/windmilleng/tilt/pkg/logger"
 )
 
+const annotationRegistry = "tilt.dev/registry"
+const annotationRegistryFromCluster = "tilt.dev/registry-from-cluster"
+
 const microk8sRegistryNamespace = "container-registry"
 const microk8sRegistryName = "registry"
 
@@ -49,56 +52,94 @@ func newRegistryAsync(env Env, core apiv1.CoreV1Interface, runtimeSource Runtime
 	}
 }
 
+func (r *registryAsync) inferRegistryFromMicrok8s(ctx context.Context) container.Registry {
+	// If Microk8s is using the docker runtime, we can just use the microk8s docker daemon
+	// instead of the registry.
+	runtime := r.runtimeSource.Runtime(ctx)
+	if runtime == container.RuntimeDocker {
+		return container.Registry{}
+	}
+
+	// Microk8s might have a registry enabled.
+	// https://microk8s.io/docs/working
+	svc, err := r.core.Services(microk8sRegistryNamespace).Get(microk8sRegistryName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Get(ctx).Warnf("You are running microk8s without a local image registry.\n" +
+				"Run: `sudo microk8s.enable registry`\n" +
+				"Tilt will use the local registry to speed up builds")
+		} else {
+			logger.Get(ctx).Debugf("Error fetching services: %v", err)
+		}
+		return container.Registry{}
+	}
+
+	portSpecs := svc.Spec.Ports
+	if len(portSpecs) == 0 {
+		return container.Registry{}
+	}
+
+	// Check to make sure localhost resolves to an IPv4 address. If it doesn't,
+	// then we won't be able to connect to the registry. See:
+	// https://github.com/windmilleng/tilt/issues/2369
+	ips, err := net.LookupIP("localhost")
+	if err != nil || len(ips) == 0 || ips[0].To4() == nil {
+		logger.Get(ctx).Warnf("Your /etc/hosts is resolving localhost to ::1 (IPv6).\n" +
+			"This breaks the microk8s image registry.\n" +
+			"Please fix your /etc/hosts to default to IPv4. This will make image pushes much faster.")
+		return container.Registry{}
+	}
+
+	portSpec := portSpecs[0]
+	host := fmt.Sprintf("localhost:%d", portSpec.NodePort)
+	reg, err := container.NewRegistry(host)
+	if err != nil {
+		logger.Get(ctx).Warnf("Error validating private registry host %q: %v", host, err)
+		return container.Registry{}
+	}
+
+	return reg
+}
+
+// If this node has the Tilt registry annotations on it, then we can
+// infer it was set up with a Tilt script and thus has a local registry.
+func (r *registryAsync) inferRegistryFromTiltNodeAnnotations(ctx context.Context) container.Registry {
+	nodeList, err := r.core.Nodes().List(metav1.ListOptions{Limit: 1})
+	if err != nil || len(nodeList.Items) == 0 {
+		return container.Registry{}
+	}
+
+	node := nodeList.Items[0]
+	annotations := node.Annotations
+
+	fromLocal := annotations[annotationRegistry]
+	fromCluster := annotations[annotationRegistryFromCluster]
+
+	if fromLocal != "" {
+		reg, err := container.NewRegistryWithHostFromCluster(fromLocal, fromCluster)
+		if err != nil {
+			logger.Get(ctx).Warnf("Local registry read from node failed to parse (%s, %s): %v", fromLocal, fromCluster, err)
+			return container.Registry{}
+		}
+		return reg
+	}
+
+	return container.Registry{}
+}
+
 func (r *registryAsync) Registry(ctx context.Context) container.Registry {
 	r.once.Do(func() {
-		// Right now, we only recognize the microk8s private registry.
-		if r.env != EnvMicroK8s {
-			return
-		}
-
-		// If Microk8s is using the docker runtime, we can just use the microk8s docker daemon
-		// instead of the registry.
-		runtime := r.runtimeSource.Runtime(ctx)
-		if runtime == container.RuntimeDocker {
-			return
-		}
-
-		// Microk8s might have a registry enabled.
-		// https://microk8s.io/docs/working
-		svc, err := r.core.Services(microk8sRegistryNamespace).Get(microk8sRegistryName, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				logger.Get(ctx).Warnf("You are running microk8s without a local image registry.\n" +
-					"Run: `sudo microk8s.enable registry`\n" +
-					"Tilt will use the local registry to speed up builds")
-			} else {
-				logger.Get(ctx).Debugf("Error fetching services: %v", err)
+		// Auto-infer the microk8s local registry.
+		if r.env == EnvMicroK8s {
+			reg := r.inferRegistryFromMicrok8s(ctx)
+			if !reg.Empty() {
+				r.registry = reg
+				return
 			}
-			return
 		}
 
-		portSpecs := svc.Spec.Ports
-		if len(portSpecs) == 0 {
-			return
-		}
-
-		// Check to make sure localhost resolves to an IPv4 address. If it doesn't,
-		// then we won't be able to connect to the registry. See:
-		// https://github.com/windmilleng/tilt/issues/2369
-		ips, err := net.LookupIP("localhost")
-		if err != nil || len(ips) == 0 || ips[0].To4() == nil {
-			logger.Get(ctx).Warnf("Your /etc/hosts is resolving localhost to ::1 (IPv6).\n" +
-				"This breaks the microk8s image registry.\n" +
-				"Please fix your /etc/hosts to default to IPv4. This will make image pushes much faster.")
-			return
-		}
-
-		portSpec := portSpecs[0]
-		host := fmt.Sprintf("localhost:%d", portSpec.NodePort)
-		reg, err := container.NewRegistry(host)
-		if err != nil {
-			logger.Get(ctx).Warnf("Error validating private registry host %q: %v", host, err)
-		} else {
+		reg := r.inferRegistryFromTiltNodeAnnotations(ctx)
+		if !reg.Empty() {
 			r.registry = reg
 		}
 	})
@@ -107,8 +148,4 @@ func (r *registryAsync) Registry(ctx context.Context) container.Registry {
 
 func (c K8sClient) LocalRegistry(ctx context.Context) container.Registry {
 	return c.registryAsync.Registry(ctx)
-}
-
-func ProvideContainerRegistry(ctx context.Context, kCli Client) container.Registry {
-	return kCli.LocalRegistry(ctx)
 }


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/autodetect2:

cc5b8d24210338b7b80fbd99a63affffb8eb1612 (2020-02-04 15:56:06 -0500)
k8s: auto-detect local registry from node labels

d785b12a7bf1b6e50f8157c3397d118bf4b92e9b (2020-02-04 14:44:49 -0500)
k8s: rename private registry to local registry, to reduce confusion

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics