### PR TITLE
logstore: factor out a lineBuilder to separate accumulation of segments from printing lines

### DIFF
--- a/pkg/model/logstore/logline.go
+++ b/pkg/model/logstore/logline.go
@@ -1,0 +1,127 @@
+package logstore
+
+import (
+	"strings"
+	"time"
+
+	"github.com/windmilleng/tilt/pkg/logger"
+)
+
+type LogLine struct {
+	Text       string
+	SpanID     SpanID
+	ProgressID string
+
+	// Most progress lines are optional. For example, if a bunch
+	// of little upload updates come in, it's ok to skip some.
+	//
+	// ProgressMustPrint indicates that this line must appear in the
+	// output - e.g., a line that communicates that the upload finished.
+	ProgressMustPrint bool
+
+	Time time.Time
+}
+
+type logLineBuilder struct {
+	span        *Span
+	segments    []LogSegment
+	isFirstLine bool
+
+	needsTrailingNewline bool
+}
+
+func newLogLineBuilder(span *Span, segment LogSegment, isFirstLine bool) *logLineBuilder {
+	return &logLineBuilder{
+		span:        span,
+		segments:    []LogSegment{segment},
+		isFirstLine: isFirstLine,
+	}
+}
+
+func (b *logLineBuilder) addSegment(segment LogSegment) {
+	b.segments = append(b.segments, segment)
+}
+
+func (b *logLineBuilder) lastSegment() LogSegment {
+	return b.segments[len(b.segments)-1]
+}
+
+func (b *logLineBuilder) isComplete() bool {
+	return b.lastSegment().IsComplete()
+}
+
+func (b *logLineBuilder) build(options logOptions) []LogLine {
+	result := []LogLine{}
+
+	segment := b.segments[0]
+	buildEvent := segment.Fields[logger.FieldNameBuildEvent]
+	if buildEvent == "init" {
+		result = append(result, b.buildSpaceLine(options))
+	}
+
+	result = append(result, b.buildMainLine(options))
+	return result
+}
+
+func (b *logLineBuilder) buildSpaceLine(options logOptions) LogLine {
+	sb := strings.Builder{}
+	span := b.span
+	segment := b.segments[0]
+	spanID := segment.SpanID
+	time := segment.Time
+	if options.showManifestPrefix && span.ManifestName != "" {
+		shouldSkip := options.skipFirstLineManifestPrefix && b.isFirstLine
+		if !shouldSkip {
+			sb.WriteString(SourcePrefix(span.ManifestName))
+		}
+	}
+	sb.WriteString("\n")
+
+	return LogLine{
+		Text:   sb.String(),
+		SpanID: spanID,
+		Time:   time,
+	}
+}
+
+func (b *logLineBuilder) buildMainLine(options logOptions) LogLine {
+	segment := b.segments[0]
+	span := b.span
+	spanID := segment.SpanID
+	time := segment.Time
+	progressID := segment.Fields[logger.FieldNameProgressID]
+	progressMustPrint := segment.Fields[logger.FieldNameProgressMustPrint] == "1"
+
+	sb := strings.Builder{}
+	if options.showManifestPrefix && span.ManifestName != "" {
+		shouldSkip := options.skipFirstLineManifestPrefix && b.isFirstLine
+		if !shouldSkip {
+			sb.WriteString(SourcePrefix(span.ManifestName))
+		}
+	}
+
+	if segment.Anchor {
+		// TODO(nick): Add Terminal colors when supported.
+		if segment.Level == logger.WarnLvl {
+			sb.WriteString("WARNING: ")
+		} else if segment.Level == logger.ErrorLvl {
+			sb.WriteString("ERROR: ")
+		}
+	}
+
+	for _, segment := range b.segments {
+		sb.Write(segment.Text)
+	}
+
+	if !b.isComplete() && b.needsTrailingNewline {
+		sb.WriteString("\n")
+	}
+
+	return LogLine{
+		Text:              sb.String(),
+		SpanID:            spanID,
+		ProgressID:        progressID,
+		ProgressMustPrint: progressMustPrint,
+		Time:              time,
+	}
+}

--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -391,3 +391,35 @@ func TestContinuingLines(t *testing.T) {
 		},
 	}, l.ContinuingLines(c2))
 }
+
+func TestBuildEventInit(t *testing.T) {
+	l := NewLogStore()
+
+	now := time.Now()
+	l.Append(testLogEvent{
+		name:    "",
+		message: "starting tilt\n",
+		ts:      now,
+	}, nil)
+	l.Append(testLogEvent{
+		name:    "fe",
+		message: "init fe build\n",
+		ts:      now,
+		fields:  map[string]string{logger.FieldNameBuildEvent: "init"},
+	}, nil)
+	l.Append(testLogEvent{
+		name:    "db",
+		message: "init db build\n",
+		ts:      now,
+		fields:  map[string]string{logger.FieldNameBuildEvent: "init"},
+	}, nil)
+
+	assert.Equal(t, 5, len(l.toLogLines(logOptions{spans: l.spans})))
+	assert.Equal(t, strings.Join([]string{
+		"starting tilt\n",
+		"fe          ┊ \n",
+		"fe          ┊ init fe build\n",
+		"db          ┊ \n",
+		"db          ┊ init db build\n",
+	}, ""), l.String())
+}


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/linebuilder:

5475707bfee549e87bb1481fa4525faa5cf05ccc (2020-02-04 19:06:52 -0500)
logstore: factor out a lineBuilder to separate accumulation of segments from printing lines

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics