### PR TITLE
analytics: send anonymized analytics by default. update the README and nudge to reflect this

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ status of running services, errors, logs, and more.
 **Follow along:** [@tilt_dev](https://twitter.com/tilt_dev) on Twitter. Updates
 and announcements on the [Tilt blog](https://blog.tilt.dev).
 
-**Help us make Tilt even better:** Run `tilt analytics opt in` to enable telemetry, so we can improve Tilt on every platform. Details in ["What does Tilt send?"](http://docs.tilt.dev/telemetry_faq.html).
+**Help us make Tilt even better:** Tilt sends anonymized usage data, so we can
+improve Tilt on every platform. Details in ["What does Tilt
+send?"](http://docs.tilt.dev/telemetry_faq.html).
 
 We expect everyone in our community (users, contributors, followers, and employees alike) to abide by our [**Code of Conduct**](CODE_OF_CONDUCT.md).
 

--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -153,18 +153,20 @@ func TestOptDefault(t *testing.T) {
 	defer cancel()
 	f.WaitForAllPodsReady(ctx, "app=analytics")
 
-	var metricNames []string
-
+	var observedEventNames []string
 	for _, c := range f.mss.ma.Counts {
-		var tagKeys []string
-		for k := range c.Tags {
-			tagKeys = append(tagKeys, k)
-		}
-		// optdefault is not allowed to send any tags other than time & version
-		assert.ElementsMatch(t, []string{"time", "version"}, tagKeys)
-
-		metricNames = append(metricNames, c.Name)
+		observedEventNames = append(observedEventNames, c.Name)
 	}
 
-	assert.Contains(t, metricNames, "tilt.analytics.up.optdefault")
+	var observedTimerNames []string
+	for _, c := range f.mss.ma.Timers {
+		observedTimerNames = append(observedTimerNames, c.Name)
+	}
+
+	// just check that a couple metrics were successfully reported rather than asserting an exhaustive list
+	// the goal is to ensure that analytics is working in general, not to test which specific metrics are reported
+	// and we don't want to have to update this every time we change which metrics we report
+	assert.Contains(t, observedEventNames, "tilt.cmd.up")
+	assert.Contains(t, observedEventNames, "tilt.tiltfile.loaded")
+	assert.Contains(t, observedTimerNames, "tilt.tiltfile.load")
 }

--- a/internal/analytics/tilt_analytics_test.go
+++ b/internal/analytics/tilt_analytics_test.go
@@ -40,7 +40,7 @@ func (os *userOptSetting) SetUserOpt(opt analytics.Opt) error {
 }
 
 func TestCount(t *testing.T) {
-	for _, test := range testCases(true, false, false) {
+	for _, test := range testCases(true, false, true) {
 		t.Run(test.name, func(t *testing.T) {
 			ma := analytics.NewMemoryAnalytics()
 			os := &userOptSetting{opt: test.opt}
@@ -61,7 +61,7 @@ func TestCount(t *testing.T) {
 }
 
 func TestIncr(t *testing.T) {
-	for _, test := range testCases(true, false, false) {
+	for _, test := range testCases(true, false, true) {
 		t.Run(test.name, func(t *testing.T) {
 			ma := analytics.NewMemoryAnalytics()
 			os := &userOptSetting{opt: test.opt}
@@ -82,7 +82,7 @@ func TestIncr(t *testing.T) {
 }
 
 func TestTimer(t *testing.T) {
-	for _, test := range testCases(true, false, false) {
+	for _, test := range testCases(true, false, true) {
 		t.Run(test.name, func(t *testing.T) {
 			ma := analytics.NewMemoryAnalytics()
 			os := &userOptSetting{opt: test.opt}
@@ -112,27 +112,6 @@ func TestWithoutGlobalTags(t *testing.T) {
 	// memory analytics doesn't have global tags, so there's really
 	// nothing to test. We mainly want to make sure this doesn't crash.
 	assert.Equal(t, 1, len(ma.Counts))
-}
-
-func TestIncrIfUnopted(t *testing.T) {
-	for _, test := range testCases(false, false, true) {
-		t.Run(test.name, func(t *testing.T) {
-			ma := analytics.NewMemoryAnalytics()
-			os := &userOptSetting{opt: test.opt}
-			a, _ := NewTiltAnalytics(os, ma, versionTest)
-			a.opt.env = analytics.OptDefault
-			a.IncrIfUnopted("foo")
-			var expectedCounts []analytics.CountEvent
-			if test.expectRecord {
-				expectedCounts = append(expectedCounts, analytics.CountEvent{
-					Name: "foo",
-					Tags: map[string]string{"version": versionTest},
-					N:    1,
-				})
-			}
-			assert.Equal(t, expectedCounts, ma.Counts)
-		})
-	}
 }
 
 func analyticsViaTransition(t *testing.T, initialOpt, newOpt analytics.Opt) (*TiltAnalytics, *analytics.MemoryAnalytics) {
@@ -177,29 +156,6 @@ func TestOptTransitionIncr(t *testing.T) {
 				expectedCounts = append(expectedCounts, analytics.CountEvent{
 					Name: "foo",
 					Tags: testTags,
-					N:    1,
-				})
-			}
-			assert.Equal(t, expectedCounts, ma.Counts)
-		})
-	}
-}
-
-func TestOptTransitionIncrIfUnopted(t *testing.T) {
-	for _, test := range []transitionTestCase{
-		{"default -> out", analytics.OptDefault, analytics.OptOut, false},
-		{"default -> in", analytics.OptDefault, analytics.OptIn, false},
-		{"in -> out", analytics.OptIn, analytics.OptOut, false},
-		{"out -> in", analytics.OptOut, analytics.OptIn, false},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			a, ma := analyticsViaTransition(t, test.initialOpt, test.newOpt)
-			a.IncrIfUnopted("foo")
-			var expectedCounts []analytics.CountEvent
-			if test.expectRecord {
-				expectedCounts = append(expectedCounts, analytics.CountEvent{
-					Name: "foo",
-					Tags: map[string]string{},
 					N:    1,
 				})
 			}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -93,7 +93,6 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		"mode":  string(updateModeFlag),
 	})
 	a.Incr("cmd.up", cmdUpTags.AsMap())
-	a.IncrIfUnopted("analytics.up.optdefault")
 	defer a.Flush(time.Second)
 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Up")

--- a/internal/engine/analytics/analytics_updater.go
+++ b/internal/engine/analytics/analytics_updater.go
@@ -26,7 +26,7 @@ func NewAnalyticsUpdater(ta *analytics.TiltAnalytics, cmdUpTags CmdUpTags) *Anal
 	return &AnalyticsUpdater{
 		ta:            ta,
 		cmdUpTags:     cmdUpTags,
-		reportedCmdUp: ta.EffectiveOpt() == wmanalytics.OptIn,
+		reportedCmdUp: ta.EffectiveOpt() != wmanalytics.OptOut,
 	}
 }
 
@@ -40,7 +40,7 @@ func (sub *AnalyticsUpdater) OnChange(ctx context.Context, st store.RStore) {
 		logger.Get(ctx).Infof("error saving analytics opt (tried to record opt: '%s')", state.AnalyticsUserOpt)
 	}
 
-	if sub.ta.EffectiveOpt() == wmanalytics.OptIn && !sub.reportedCmdUp {
+	if sub.ta.EffectiveOpt() != wmanalytics.OptOut && !sub.reportedCmdUp {
 		sub.reportedCmdUp = true
 		sub.ta.Incr("cmd.up", sub.cmdUpTags.AsMap())
 	}

--- a/internal/engine/analytics/analytics_updater_test.go
+++ b/internal/engine/analytics/analytics_updater_test.go
@@ -28,7 +28,7 @@ func TestOnChange(t *testing.T) {
 func TestReportOnOptIn(t *testing.T) {
 	to := tiltanalytics.NewFakeOpter(analytics.OptIn)
 	mem, a := tiltanalytics.NewMemoryTiltAnalyticsForTest(to)
-	err := a.SetUserOpt(analytics.OptDefault)
+	err := a.SetUserOpt(analytics.OptOut)
 	require.NoError(t, err)
 
 	cmdUpTags := CmdUpTags(map[string]string{"watch": "true"})
@@ -37,7 +37,7 @@ func TestReportOnOptIn(t *testing.T) {
 	setUserOpt(st, analytics.OptIn)
 	au.OnChange(context.Background(), st)
 
-	assert.Equal(t, []analytics.Opt{analytics.OptDefault, analytics.OptIn}, to.Calls())
+	assert.Equal(t, []analytics.Opt{analytics.OptOut, analytics.OptIn}, to.Calls())
 	if assert.Equal(t, 1, len(mem.Counts)) {
 		assert.Equal(t, "cmd.up", mem.Counts[0].Name)
 		assert.Equal(t, "true", mem.Counts[0].Tags["watch"])

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -723,7 +723,7 @@ func handleAnalyticsUserOptAction(state *store.EngineState, action store.Analyti
 // users, so the numbers need to be as accurate as possible).
 func handleAnalyticsNudgeSurfacedAction(ctx context.Context, state *store.EngineState) {
 	if !state.AnalyticsNudgeSurfaced {
-		tiltanalytics.Get(ctx).IncrIfUnopted("analytics.nudge.surfaced")
+		tiltanalytics.Get(ctx).Incr("analytics.nudge.surfaced", nil)
 		state.AnalyticsNudgeSurfaced = true
 	}
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -186,7 +186,7 @@ func (s *HeadsUpServer) HandleAnalyticsOpt(w http.ResponseWriter, req *http.Requ
 
 	// only logging on opt-in, because, well, opting out means the user just told us not to report data on them!
 	if opt == analytics.OptIn {
-		s.a.IncrIfUnopted("analytics.opt.in")
+		s.a.Incr("analytics.opt.in", nil)
 	}
 
 	s.store.Dispatch(store.AnalyticsUserOptAction{Opt: opt})

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -167,7 +167,6 @@ func TestHandleAnalyticsOptIn(t *testing.T) {
 
 	assert.Equal(t, []analytics.CountEvent{{
 		Name: "analytics.opt.in",
-		Tags: map[string]string{"version": "v0.0.0"},
 		N:    1,
 	}}, f.a.Counts)
 }

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -5,9 +5,10 @@ const nudgeTimeoutMs = 15000
 const nudgeElem = (): JSX.Element => {
   return (
     <p>
-      Welcome to Tilt! May we collect usage data to help us improve? (
+      Welcome to Tilt! We collect anonymized usage data to help us improve. Is
+      that OK? (
       <a
-        href="https://github.com/windmilleng/tilt#telemetry-and-privacy"
+        href="https://docs.tilt.dev/telemetry_faq.html"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/web/src/__snapshots__/AnalyticsNudge.test.tsx.snap
+++ b/web/src/__snapshots__/AnalyticsNudge.test.tsx.snap
@@ -28,9 +28,9 @@ exports[`hides nudge if !needsNudge and no request made 1`] = `
   className="AnalyticsNudge"
 >
   <p>
-    Welcome to Tilt! May we collect usage data to help us improve? (
+    Welcome to Tilt! We collect anonymized usage data to help us improve. Is that OK? (
     <a
-      href="https://github.com/windmilleng/tilt#telemetry-and-privacy"
+      href="https://docs.tilt.dev/telemetry_faq.html"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -60,9 +60,9 @@ exports[`hides nudge if dismissed, even if needsNudge = true 1`] = `
   className="AnalyticsNudge"
 >
   <p>
-    Welcome to Tilt! May we collect usage data to help us improve? (
+    Welcome to Tilt! We collect anonymized usage data to help us improve. Is that OK? (
     <a
-      href="https://github.com/windmilleng/tilt#telemetry-and-privacy"
+      href="https://docs.tilt.dev/telemetry_faq.html"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -122,9 +122,9 @@ exports[`shows nudge if needsNudge 1`] = `
   className="AnalyticsNudge is-visible"
 >
   <p>
-    Welcome to Tilt! May we collect usage data to help us improve? (
+    Welcome to Tilt! We collect anonymized usage data to help us improve. Is that OK? (
     <a
-      href="https://github.com/windmilleng/tilt#telemetry-and-privacy"
+      href="https://docs.tilt.dev/telemetry_faq.html"
       rel="noopener noreferrer"
       target="_blank"
     >


### PR DESCRIPTION
Hello @dbentley, @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch4422/analytics:

37c2f58a6f1013f1f59aec7df6a4e376b087d039 (2020-02-05 13:55:08 -0500)
analytics: send anonymized analytics by default. update the README and nudge to reflect this
We're having trouble understanding the early part of the Tilt experience.
Are people making it to the web UI?
Are they able to run a project successfully?
Are they able to set up a local kubernetes cluster?

We're going to try enabling it by default on tilt v0.12 and see
what happens. Previous PRs have cleaned up some of the existing
analytics behavior so that it doesn't pick up CI and respects DO_NOT_TRACK=1,
so we feel more comfortable with this.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics