### PR TITLE
extension: define extension storage API w/ filesystem implementation

### DIFF
--- a/internal/tiltfile/extension/store.go
+++ b/internal/tiltfile/extension/store.go
@@ -22,11 +22,11 @@ type Store interface {
 
 // TODO(dmiller): should this include an integrity hash?
 type ModuleContents struct {
-	Name             string
-	TiltfileContents string
-	GitCommitHash    string
-	Source           string
-	TimeFetched      time.Time
+	Name              string
+	TiltfileContents  string
+	GitCommitHash     string
+	ExtensionRegistry string
+	TimeFetched       time.Time
 }
 
 type LocalStore struct {

--- a/internal/tiltfile/extension/store.go
+++ b/internal/tiltfile/extension/store.go
@@ -2,12 +2,12 @@ package extension
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/windmilleng/tilt/internal/tiltfile"
 )
 
@@ -53,13 +53,13 @@ func (s *LocalStore) ModulePath(ctx context.Context, moduleName string) (string,
 func (s *LocalStore) Write(ctx context.Context, contents ModuleContents) (string, error) {
 	moduleDir := filepath.Join(s.baseDir, contents.Name)
 	if err := os.MkdirAll(moduleDir, os.FileMode(0700)); err != nil {
-		return "", fmt.Errorf("couldn't store module %s: %v", contents.Name, err)
+		return "", errors.Wrapf(err, "couldn't create module directory %s at path %s", contents.Name, moduleDir)
 	}
 
 	tiltfilePath := filepath.Join(moduleDir, tiltfile.FileName)
 	// TODO(dmiller): store hash, source, time fetched
-	if err := ioutil.WriteFile(tiltfilePath, []byte(contents.TiltfileContents), os.FileMode(0700)); err != nil {
-		return "", fmt.Errorf("couldn't store module %s: %v", contents.Name, err)
+	if err := ioutil.WriteFile(tiltfilePath, []byte(contents.TiltfileContents), os.FileMode(0600)); err != nil {
+		return "", errors.Wrapf(err, "couldn't store module %s at path %s", contents.Name, tiltfilePath)
 	}
 
 	return tiltfilePath, nil

--- a/internal/tiltfile/extension/store.go
+++ b/internal/tiltfile/extension/store.go
@@ -1,0 +1,71 @@
+package extension
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/windmilleng/tilt/internal/tiltfile"
+)
+
+const extensionDirName = "tilt_modules"
+
+type Store interface {
+	// Stat is used to check if an extension exists before fetching it
+	Stat(ctx context.Context, moduleName string) (string, error)
+	Write(ctx context.Context, contents ModuleContents) (string, error)
+}
+
+// TODO(dmiller): should this include an integrity hash?
+type ModuleContents struct {
+	Name             string
+	TiltfileContents string
+	GitCommitHash    string
+	Source           string
+	TimeFetched      time.Time
+}
+
+type LocalStore struct {
+	baseDir string
+}
+
+func NewLocalStore(baseDir string) *LocalStore {
+	return &LocalStore{
+		baseDir: filepath.Join(baseDir, extensionDirName),
+	}
+}
+
+func (s *LocalStore) Stat(ctx context.Context, moduleName string) (string, error) {
+	tiltfilePath := filepath.Join(s.baseDir, moduleName, tiltfile.FileName)
+
+	_, err := os.Stat(tiltfilePath)
+	if err == nil {
+		return tiltfilePath, nil
+	}
+
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+
+	return "", err
+}
+
+func (s *LocalStore) Write(ctx context.Context, contents ModuleContents) (string, error) {
+	moduleDir := filepath.Join(s.baseDir, contents.Name)
+	if err := os.MkdirAll(moduleDir, os.FileMode(0700)); err != nil {
+		return "", fmt.Errorf("couldn't store module %s: %v", contents.Name, err)
+	}
+
+	tiltfilePath := filepath.Join(moduleDir, tiltfile.FileName)
+	// TODO(dmiller): store hash, source, time fetched
+	if err := ioutil.WriteFile(tiltfilePath, []byte(contents.TiltfileContents), os.FileMode(0700)); err != nil {
+		return "", fmt.Errorf("couldn't store module %s: %v", contents.Name, err)
+	}
+
+	return tiltfilePath, nil
+}
+
+var _ Store = (*LocalStore)(nil)

--- a/internal/tiltfile/extension/store.go
+++ b/internal/tiltfile/extension/store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/windmilleng/tilt/internal/tiltfile"
 )
 

--- a/internal/tiltfile/extension/store.go
+++ b/internal/tiltfile/extension/store.go
@@ -14,8 +14,9 @@ import (
 const extensionDirName = "tilt_modules"
 
 type Store interface {
-	// Stat is used to check if an extension exists before fetching it
-	Stat(ctx context.Context, moduleName string) (string, error)
+	// ModulePath is used to check if an extension exists before fetching it
+	// Returns ErrNotExist if module doesn't exist
+	ModulePath(ctx context.Context, moduleName string) (string, error)
 	Write(ctx context.Context, contents ModuleContents) (string, error)
 }
 
@@ -38,19 +39,15 @@ func NewLocalStore(baseDir string) *LocalStore {
 	}
 }
 
-func (s *LocalStore) Stat(ctx context.Context, moduleName string) (string, error) {
+func (s *LocalStore) ModulePath(ctx context.Context, moduleName string) (string, error) {
 	tiltfilePath := filepath.Join(s.baseDir, moduleName, tiltfile.FileName)
 
 	_, err := os.Stat(tiltfilePath)
-	if err == nil {
-		return tiltfilePath, nil
+	if err != nil {
+		return "", err
 	}
 
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-
-	return "", err
+	return tiltfilePath, nil
 }
 
 func (s *LocalStore) Write(ctx context.Context, contents ModuleContents) (string, error) {

--- a/internal/tiltfile/extension/store_test.go
+++ b/internal/tiltfile/extension/store_test.go
@@ -3,6 +3,7 @@ package extension
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ func TestWriteAndStat(t *testing.T) {
 
 	f.assertExtension("test", "print('hi')", "aaaaaa", "https://github.com/windmill/extensions")
 
-	path := f.stat("test")
+	path := f.modulePath("test")
 	f.assertPath(path)
 }
 
@@ -48,7 +49,7 @@ func TestStatModuleDoesntExist(t *testing.T) {
 	f := newFixture(t)
 	defer f.tearDown()
 
-	assert.Equal(f.t, "", f.stat("test"))
+	f.assertModulePathDoesntExist("test")
 }
 
 type fixture struct {
@@ -78,11 +79,17 @@ func (f *fixture) writeModule(contents ModuleContents) string {
 	return path
 }
 
-func (f *fixture) stat(moduleName string) string {
-	path, err := f.store.Stat(f.ctx, moduleName)
+func (f *fixture) modulePath(moduleName string) string {
+	path, err := f.store.ModulePath(f.ctx, moduleName)
 	require.NoError(f.t, err)
 
 	return path
+}
+
+func (f *fixture) assertModulePathDoesntExist(moduleName string) {
+	path, err := f.store.ModulePath(f.ctx, moduleName)
+	assert.True(f.t, os.IsNotExist(err))
+	assert.Equal(f.t, "", path)
 }
 
 func (f *fixture) assertExtension(moduleName, contents, hash, source string) {

--- a/internal/tiltfile/extension/store_test.go
+++ b/internal/tiltfile/extension/store_test.go
@@ -18,10 +18,10 @@ func TestWrite(t *testing.T) {
 	defer f.tearDown()
 
 	path := f.writeModule(ModuleContents{
-		Name:             "test",
-		TiltfileContents: "print('hi')",
-		GitCommitHash:    "aaaaaa",
-		Source:           "https://github.com/windmill/extensions",
+		Name:              "test",
+		TiltfileContents:  "print('hi')",
+		GitCommitHash:     "aaaaaa",
+		ExtensionRegistry: "https://github.com/windmill/extensions",
 	})
 
 	f.assertPath(path)
@@ -33,10 +33,10 @@ func TestWriteAndStat(t *testing.T) {
 	defer f.tearDown()
 
 	f.writeModule(ModuleContents{
-		Name:             "test",
-		TiltfileContents: "print('hi')",
-		GitCommitHash:    "aaaaaa",
-		Source:           "https://github.com/windmill/extensions",
+		Name:              "test",
+		TiltfileContents:  "print('hi')",
+		GitCommitHash:     "aaaaaa",
+		ExtensionRegistry: "https://github.com/windmill/extensions",
 	})
 
 	f.assertExtension("test", "print('hi')", "aaaaaa", "https://github.com/windmill/extensions")

--- a/internal/tiltfile/extension/store_test.go
+++ b/internal/tiltfile/extension/store_test.go
@@ -1,0 +1,102 @@
+package extension
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+	"github.com/windmilleng/tilt/internal/tiltfile"
+)
+
+func TestWrite(t *testing.T) {
+	f := newFixture(t)
+	defer f.tearDown()
+
+	path := f.writeModule(ModuleContents{
+		Name:             "test",
+		TiltfileContents: "print('hi')",
+		GitCommitHash:    "aaaaaa",
+		Source:           "https://github.com/windmill/extensions",
+	})
+
+	f.assertPath(path)
+	f.assertExtension("test", "print('hi')", "aaaaaa", "https://github.com/windmill/extensions")
+}
+
+func TestWriteAndStat(t *testing.T) {
+	f := newFixture(t)
+	defer f.tearDown()
+
+	f.writeModule(ModuleContents{
+		Name:             "test",
+		TiltfileContents: "print('hi')",
+		GitCommitHash:    "aaaaaa",
+		Source:           "https://github.com/windmill/extensions",
+	})
+
+	f.assertExtension("test", "print('hi')", "aaaaaa", "https://github.com/windmill/extensions")
+
+	path := f.stat("test")
+	f.assertPath(path)
+}
+
+func TestStatModuleDoesntExist(t *testing.T) {
+	f := newFixture(t)
+	defer f.tearDown()
+
+	assert.Equal(f.t, "", f.stat("test"))
+}
+
+type fixture struct {
+	t       *testing.T
+	ctx     context.Context
+	tempdir *tempdir.TempDirFixture
+	store   *LocalStore
+}
+
+func newFixture(t *testing.T) *fixture {
+	ctx := context.Background()
+	temp := tempdir.NewTempDirFixture(t)
+	ls := NewLocalStore(temp.Path())
+
+	return &fixture{
+		t:       t,
+		ctx:     ctx,
+		tempdir: temp,
+		store:   ls,
+	}
+}
+
+func (f *fixture) writeModule(contents ModuleContents) string {
+	path, err := f.store.Write(f.ctx, contents)
+	require.NoError(f.t, err)
+
+	return path
+}
+
+func (f *fixture) stat(moduleName string) string {
+	path, err := f.store.Stat(f.ctx, moduleName)
+	require.NoError(f.t, err)
+
+	return path
+}
+
+func (f *fixture) assertExtension(moduleName, contents, hash, source string) {
+	tiltfileContents, err := ioutil.ReadFile(f.tempdir.JoinPath(extensionDirName, moduleName, tiltfile.FileName))
+	require.NoError(f.t, err)
+
+	assert.Equal(f.t, contents, string(tiltfileContents))
+	// TODO(dmiller): assert on hash and source
+}
+
+func (f *fixture) assertPath(path string) {
+	assert.Equal(f.t, f.tempdir.JoinPath("tilt_modules", "test", "Tiltfile"), path)
+}
+
+func (f *fixture) tearDown() {
+	f.tempdir.TearDown()
+}


### PR DESCRIPTION
This explicitly only stores the contents of the module's Tiltfile and doesn't deal with any of the other metadata yet, just to unblock work on other parts of functionality.