### PR TITLE
Revert "engine/ospath: use tempdir.Chdir in more places (#2907)"

### DIFF
--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -125,7 +126,19 @@ func (f *ccFixture) run(m model.Manifest) ConfigsReloadedAction {
 	// configs_controller uses state.RelativeTiltfilePath, which is relative to wd
 	// sometimes the original directory was invalid (e.g., it was another test's temp dir, which was deleted,
 	// but not changed out of), and if it was already invalid, then let's not worry about it.
-	f.Chdir()
+	origDir, _ := os.Getwd()
+	err := os.Chdir(f.Path())
+	if err != nil {
+		f.T().Fatalf("error changing dir: %v", err)
+	}
+	defer func() {
+		if origDir != "" {
+			err = os.Chdir(origDir)
+			if err != nil {
+				f.T().Fatalf("unable to restore original wd: '%v'", err)
+			}
+		}
+	}()
 
 	f.st.SetUpSubscribersForTesting(f.ctx)
 

--- a/internal/engine/watchmanager_test.go
+++ b/internal/engine/watchmanager_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -145,7 +146,10 @@ func newWMFixture(t *testing.T) *wmFixture {
 	}()
 
 	f := tempdir.NewTempDirFixture(t)
-	f.Chdir()
+	err := os.Chdir(f.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	return &wmFixture{
 		ctx:              ctx,

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
@@ -74,7 +76,18 @@ func TestDirTrailingSlash(t *testing.T) {
 func TestTryAsCwdChildren(t *testing.T) {
 	f := NewOspathFixture(t)
 	defer f.TearDown()
-	f.Chdir()
+	oldPWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := os.Chdir(oldPWD)
+		if err != nil {
+			t.Fatalf("error restoring pwd: %v", err)
+		}
+	}()
+	err = os.Chdir(f.Path())
+	require.NoError(t, err)
 
 	results := TryAsCwdChildren([]string{f.Path()})
 


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/revert:

a6c9d4d87d25177f8c6e30466fc996fd2f1fe0cb (2020-02-06 15:38:51 -0500)
Revert "engine/ospath: use tempdir.Chdir in more places (#2907)"
This reverts commit 284ed0748138e3b33d96cd32810c7e6af0ea1bab.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics