### PR TITLE
Revert "Revert "engine/ospath: use tempdir.Chdir in more places (#2907)""

### DIFF
--- a/internal/engine/watchmanager_test.go
+++ b/internal/engine/watchmanager_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -146,10 +145,7 @@ func newWMFixture(t *testing.T) *wmFixture {
 	}()
 
 	f := tempdir.NewTempDirFixture(t)
-	err := os.Chdir(f.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
+	f.Chdir()
 
 	return &wmFixture{
 		ctx:              ctx,

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -5,8 +5,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
 )
 
@@ -76,18 +74,7 @@ func TestDirTrailingSlash(t *testing.T) {
 func TestTryAsCwdChildren(t *testing.T) {
 	f := NewOspathFixture(t)
 	defer f.TearDown()
-	oldPWD, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err := os.Chdir(oldPWD)
-		if err != nil {
-			t.Fatalf("error restoring pwd: %v", err)
-		}
-	}()
-	err = os.Chdir(f.Path())
-	require.NoError(t, err)
+	f.Chdir()
 
 	results := TryAsCwdChildren([]string{f.Path()})
 


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/revert2:

b9c22b53abb9a6c5a26d154ff0e5325df7f0f673 (2020-02-06 15:47:53 -0500)
Revert "Revert "engine/ospath: use tempdir.Chdir in more places (#2907)""
This reverts commit a6c9d4d87d25177f8c6e30466fc996fd2f1fe0cb.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics