### PR TITLE
tiltfile: allow commands to be specified as arrays

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -77,8 +77,8 @@ func (d *dockerImage) Type() dockerImageBuildType {
 }
 
 func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var dockerRef, entrypoint, targetStage string
-	var contextVal, dockerfilePathVal, buildArgs, dockerfileContentsVal, cacheVal, liveUpdateVal, ignoreVal, onlyVal, sshVal, networkVal starlark.Value
+	var dockerRef, targetStage string
+	var contextVal, dockerfilePathVal, buildArgs, dockerfileContentsVal, cacheVal, liveUpdateVal, ignoreVal, onlyVal, sshVal, networkVal, entrypoint starlark.Value
 	var matchInEnvVars bool
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
@@ -182,9 +182,9 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		}
 	}
 
-	var entrypointCmd model.Cmd
-	if entrypoint != "" {
-		entrypointCmd = model.ToShellCmd(entrypoint)
+	entrypointCmd, err := value.ValueToCmd(entrypoint)
+	if err != nil {
+		return nil, err
 	}
 
 	r := &dockerImage{
@@ -239,7 +239,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 	var disablePush bool
 	var liveUpdateVal, ignoreVal starlark.Value
 	var matchInEnvVars bool
-	var entrypoint string
+	var entrypoint starlark.Value
 	var skipsLocalDocker bool
 
 	err := s.unpackArgs(fn.Name(), args, kwargs,
@@ -293,9 +293,9 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	var entrypointCmd model.Cmd
-	if entrypoint != "" {
-		entrypointCmd = model.ToShellCmd(entrypoint)
+	entrypointCmd, err := value.ValueToCmd(entrypoint)
+	if err != nil {
+		return nil, err
 	}
 
 	img := &dockerImage{

--- a/internal/tiltfile/telemetry/telemetry_test.go
+++ b/internal/tiltfile/telemetry/telemetry_test.go
@@ -3,19 +3,31 @@ package telemetry
 import (
 	"testing"
 
+	"github.com/windmilleng/tilt/pkg/model"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
 )
 
-func TestTelemetryCmd(t *testing.T) {
+func TestTelemetryCmdString(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 	f.File("Tiltfile", "experimental_telemetry_cmd('foo.sh')")
 	result, err := f.ExecFile("Tiltfile")
 
 	assert.NoError(t, err)
-	assert.Equal(t, "foo.sh", MustState(result).Cmd.String())
+	assert.Equal(t, model.ToShellCmd("foo.sh"), MustState(result).Cmd)
+}
+
+func TestTelemetryCmdArray(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.File("Tiltfile", "experimental_telemetry_cmd(['foo.sh'])")
+	result, err := f.ExecFile("Tiltfile")
+
+	assert.NoError(t, err)
+	assert.Equal(t, model.Cmd{Argv: []string{"foo.sh"}}, MustState(result).Cmd)
 }
 
 func TestTelemetryCmdEmpty(t *testing.T) {

--- a/internal/tiltfile/value/value.go
+++ b/internal/tiltfile/value/value.go
@@ -120,6 +120,9 @@ func StringSliceToList(slice []string) *starlark.List {
 // an array of strings gets interpreted as a raw argv to exec
 func ValueToCmd(v starlark.Value) (model.Cmd, error) {
 	switch x := v.(type) {
+	// If a starlark function takes an optional command argument, then UnpackArgs will set its starlark.Value to nil
+	// we convert nils here to an empty Cmd, since otherwise every callsite would have to do a nil check with presumably
+	// the same outcome
 	case nil:
 		return model.Cmd{}, nil
 	case starlark.String:


### PR DESCRIPTION
### Problem

At the moment, any place a command is specified in the Tiltfile, it's specified as a string, which then gets wrapped in an sh -c '', which forces the user to deal with shell evaluation.

This means that any time a user constructs a command from starlark variables, they potentially have to worry about those starlark variables containing characters with special meaning to the shell, and we provide no way to escape them, so there's not really anything to be done.

### Solution

Allow commands to be specified as either shell-interpreted strings or raw argv, [Dockerfile-style](https://docs.docker.com/engine/reference/builder/#run).

This PR pretty much consists of:
1. add a new `value.ValueToCmd` function that takes a `starlark.Value` and converts the `string|[]string` to a `model.Cmd`, as appropriate
2. replace all calls to `model.ToShellCmd` in the tiltfile dir with calls to `value.ValueToCmd`
3. unit tests for above