### PR TITLE
k8swatch: fix flaky pod watch test

### DIFF
--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
@@ -118,7 +120,7 @@ func TestPodWatchExtraSelectors(t *testing.T) {
 	f.kClient.EmitPod(ls1, p)
 
 	f.assertObservedPods(p)
-	assert.Equal(t, []model.ManifestName{manifest.Name}, f.manifestNames)
+	f.assertObservedManifests(manifest.Name)
 }
 
 func TestPodWatchHandleSelectorChange(t *testing.T) {
@@ -330,9 +332,18 @@ func (f *pwFixture) assertObservedPods(pods ...*corev1.Pod) {
 		}
 	}
 
-	if !assert.ElementsMatch(f.t, pods, f.pods) {
-		f.t.FailNow()
+	require.ElementsMatch(f.t, pods, f.pods)
+}
+
+func (f *pwFixture) assertObservedManifests(manifests ...model.ManifestName) {
+	start := time.Now()
+	for time.Since(start) < 200*time.Millisecond {
+		if len(manifests) == len(f.manifestNames) {
+			break
+		}
 	}
+
+	require.ElementsMatch(f.t, manifests, f.manifestNames)
 }
 
 func (f *pwFixture) assertWatchedSelectors(ls ...labels.Selector) {

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -6,23 +6,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/internal/testutils"
 	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
 	"github.com/windmilleng/tilt/internal/testutils/podbuilder"
 	"github.com/windmilleng/tilt/internal/testutils/tempdir"
-
-	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/model"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestPodWatch(t *testing.T) {


### PR DESCRIPTION
TestPodWatchExtraSelectors [checks f.manifests](https://github.com/windmilleng/tilt/blob/4f58f76bd3a1b7fc1ab666059220912c7f5ed3e8/internal/engine/k8swatch/pod_watch_test.go#L121) immediately after `assertObservedPods` returns, but it is possible for `assertObservedPods` to return before `f.manifests` has been updated.