### PR TITLE
tiltfile: add encode_yaml and encode_json

### DIFF
--- a/internal/tiltfile/encoding/extension.go
+++ b/internal/tiltfile/encoding/extension.go
@@ -15,9 +15,11 @@ func (Extension) OnStart(env *starkit.Environment) error {
 	}{
 		{"read_yaml", readYAML},
 		{"decode_yaml", decodeYAML},
+		{"encode_yaml", encodeYAML},
 
 		{"read_json", readJSON},
 		{"decode_json", decodeJSON},
+		{"encode_json", encodeJSON},
 	} {
 		err := env.AddBuiltin(b.name, b.f)
 		if err != nil {

--- a/internal/tiltfile/encoding/json.go
+++ b/internal/tiltfile/encoding/json.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -40,12 +41,22 @@ func readJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 
 // reads json from a string
 func decodeJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var contents starlark.String
+	var contents starlark.Value
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "json", &contents); err != nil {
 		return nil, err
 	}
 
-	return jsonStringToStarlark(contents.GoString(), "")
+	var s string
+	switch x := contents.(type) {
+	case starlark.String:
+		s = x.GoString()
+	case tiltfile_io.Blob:
+		s = x.Text
+	default:
+		return nil, fmt.Errorf("%s arg must be a string or blob. got %s", fn.Name(), contents.Type())
+	}
+
+	return jsonStringToStarlark(s, "")
 }
 
 func jsonStringToStarlark(s string, source string) (starlark.Value, error) {
@@ -67,4 +78,35 @@ func jsonStringToStarlark(s string, source string) (starlark.Value, error) {
 		return nil, errors.Wrap(err, errmsg)
 	}
 	return v, nil
+}
+
+func encodeJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var obj starlark.Value
+	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "obj", &obj); err != nil {
+		return nil, err
+	}
+
+	ret, err := starlarkToJSONString(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return starlark.String(ret), nil
+}
+
+func starlarkToJSONString(obj starlark.Value) (string, error) {
+	v, err := convertStarlarkToStructuredData(obj)
+	if err != nil {
+		return "", errors.Wrap(err, "error converting object from starlark")
+	}
+
+	w := bytes.Buffer{}
+	e := json.NewEncoder(&w)
+	e.SetIndent("", "  ")
+	err = e.Encode(v)
+	if err != nil {
+		return "", errors.Wrap(err, "error serializing object to json")
+	}
+
+	return w.String(), nil
 }

--- a/internal/tiltfile/encoding/json.go
+++ b/internal/tiltfile/encoding/json.go
@@ -46,13 +46,8 @@ func decodeJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 		return nil, err
 	}
 
-	var s string
-	switch x := contents.(type) {
-	case starlark.String:
-		s = x.GoString()
-	case tiltfile_io.Blob:
-		s = x.Text
-	default:
+	s, ok := value.AsString(contents)
+	if !ok {
 		return nil, fmt.Errorf("%s arg must be a string or blob. got %s", fn.Name(), contents.Type())
 	}
 

--- a/internal/tiltfile/encoding/starlark.go
+++ b/internal/tiltfile/encoding/starlark.go
@@ -49,3 +49,58 @@ func convertStructuredDataToStarlark(j interface{}) (starlark.Value, error) {
 
 	return nil, errors.New(fmt.Sprintf("Unable to convert to starlark value, unexpected type %T", j))
 }
+
+func convertStarlarkToStructuredData(v starlark.Value) (interface{}, error) {
+	switch v := v.(type) {
+	case starlark.Bool:
+		return bool(v), nil
+	case starlark.String:
+		return v.GoString(), nil
+	case starlark.Int:
+		return v.BigInt().Int64(), nil
+	case starlark.Float:
+		return float64(v), nil
+	case *starlark.List:
+		var ret []interface{}
+
+		it := v.Iterate()
+		defer it.Done()
+		var e starlark.Value
+		for it.Next(&e) {
+			ee, err := convertStarlarkToStructuredData(e)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, ee)
+		}
+		return ret, nil
+	case *starlark.Dict:
+		ret := make(map[string]interface{})
+		for _, t := range v.Items() {
+			key := t.Index(0)
+			kk, err := convertStarlarkToStructuredData(key)
+			if err != nil {
+				return nil, err
+			}
+
+			s, ok := kk.(string)
+			if !ok {
+				return nil, fmt.Errorf("only string keys are supported in maps. found key '%s' of type %T", key.String(), kk)
+			}
+
+			val := t.Index(1)
+			vv, err := convertStarlarkToStructuredData(val)
+			if err != nil {
+				return nil, err
+			}
+
+			ret[s] = vv
+		}
+
+		return ret, nil
+	case starlark.NoneType:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("unable to convert from starlark value, unsupported type %T", v)
+}

--- a/internal/tiltfile/encoding/yaml.go
+++ b/internal/tiltfile/encoding/yaml.go
@@ -40,12 +40,22 @@ func readYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 
 // reads yaml from a string
 func decodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var contents starlark.String
+	var contents starlark.Value
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "yaml", &contents); err != nil {
 		return nil, err
 	}
 
-	return yamlStringToStarlark(contents.GoString(), "")
+	var s string
+	switch x := contents.(type) {
+	case starlark.String:
+		s = x.GoString()
+	case tiltfile_io.Blob:
+		s = x.Text
+	default:
+		return nil, fmt.Errorf("%s arg must be a string or blob. got %s", fn.Name(), contents.Type())
+	}
+
+	return yamlStringToStarlark(s, "")
 }
 
 func yamlStringToStarlark(s string, source string) (starlark.Value, error) {
@@ -68,4 +78,33 @@ func yamlStringToStarlark(s string, source string) (starlark.Value, error) {
 		return nil, errors.Wrap(err, errmsg)
 	}
 	return v, nil
+}
+
+// dumps yaml to a string
+func encodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var obj starlark.Value
+	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "obj", &obj); err != nil {
+		return nil, err
+	}
+
+	ret, err := starlarkToYAMLString(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return tiltfile_io.NewBlob(ret, "encode_yaml"), nil
+}
+
+func starlarkToYAMLString(obj starlark.Value) (string, error) {
+	v, err := convertStarlarkToStructuredData(obj)
+	if err != nil {
+		return "", errors.Wrap(err, "error converting object from starlark")
+	}
+
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return "", errors.Wrap(err, "error serializing object to yaml")
+	}
+
+	return string(b), nil
 }

--- a/internal/tiltfile/encoding/yaml.go
+++ b/internal/tiltfile/encoding/yaml.go
@@ -45,13 +45,8 @@ func decodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 		return nil, err
 	}
 
-	var s string
-	switch x := contents.(type) {
-	case starlark.String:
-		s = x.GoString()
-	case tiltfile_io.Blob:
-		s = x.Text
-	default:
+	s, ok := value.AsString(contents)
+	if !ok {
 		return nil, fmt.Errorf("%s arg must be a string or blob. got %s", fn.Name(), contents.Type())
 	}
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -356,7 +356,7 @@ func starlarkTriggerModeToModel(triggerMode triggerMode, autoInit bool) (model.T
 	}
 }
 
-// count how many times each builtin is called, for analytics
+// count how many times each Builtin is called, for analytics
 func (s *tiltfileState) OnBuiltinCall(name string, fn *starlark.Builtin) {
 	s.builtinCallCounts[name]++
 }


### PR DESCRIPTION
the complement of `decode_yaml` and `decode_json`, i.e., from a starlark object to a yaml/json-encoded string (or, really, a `Blob`, to make it easier to pass to `k8s_yaml`)

also: changed `decode_yaml` and `decode_json` to take a `Union[str|Blob]` instead of a `str`, since it's likely most of the inputs to those functions will be `Blob`s already (e.g., from the output of `read_file` or `local`)

I really wanted to name all these `yaml.load` / `yaml.loads` / `yaml.dumps`, but `load` is a keyword in starlark, making that impossible :(