### PR TITLE
tiltfile: enable recursion

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -38,6 +38,7 @@ func init() {
 	resolve.AllowLambda = true
 	resolve.AllowNestedDef = true
 	resolve.AllowGlobalReassign = true
+	resolve.AllowRecursion = true
 }
 
 type TiltfileLoadResult struct {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4175,6 +4175,25 @@ func TestMaxParallelUpdates(t *testing.T) {
 	}
 }
 
+// recursion is disabled by default in Starlark. Make sure we've enabled it for Tiltfiles.
+func TestRecursionEnabled(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+def fact(n):
+  if not n:
+    return 1
+  return n * fact(n - 1)
+
+print("fact: %d" % (fact(10)))
+`)
+
+	f.load()
+
+	require.Contains(t, f.out.String(), fmt.Sprintf("fact: %d", 10*9*8*7*6*5*4*3*2*1))
+}
+
 type fixture struct {
 	ctx context.Context
 	out *bytes.Buffer


### PR DESCRIPTION
what's the worst that could happen?

sample use case:
I want to write a function that traverses k8s yaml and sets namespaces
