### PR TITLE
k8s: entrypoint override shouldn't affect container args. Fixes issue #2918

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -333,8 +333,8 @@ func (ibd *ImageBuildAndDeployer) createEntitiesToDeploy(ctx context.Context,
 			if replaced {
 				injectedDepIDs[depID] = true
 
-				if !iTarget.OverrideCmd.Empty() {
-					e, err = k8s.InjectCommand(e, ref, iTarget.OverrideCmd)
+				if !iTarget.OverrideCmd.Empty() || iTarget.OverrideArgs.ShouldOverride {
+					e, err = k8s.InjectCommandAndArgs(e, ref, iTarget.OverrideCmd, iTarget.OverrideArgs)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1085,6 +1085,10 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 			iTarget = iTarget.WithOverrideCommand(image.entrypoint)
 		}
 
+		if image.containerArgs.ShouldOverride {
+			iTarget.OverrideArgs = image.containerArgs
+		}
+
 		lu := image.liveUpdate
 
 		switch image.Type() {

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -17,6 +17,10 @@ type ImageTarget struct {
 	// (i.e. overrides k8s yaml "command", container ENTRYPOINT, etc.)
 	OverrideCmd Cmd
 
+	// User-supplied args override when the container runs.
+	// (i.e. overrides k8s yaml "args")
+	OverrideArgs OverrideArgs
+
 	cachePaths []string
 
 	// TODO(nick): It might eventually make sense to represent
@@ -26,6 +30,13 @@ type ImageTarget struct {
 	dockerignores []Dockerignore
 	repos         []LocalGitRepo
 	dependencyIDs []TargetID
+}
+
+// Represent OverrideArgs as a special struct, to cleanly distinguish
+// "replace with 0 args" from "don't replace"
+type OverrideArgs struct {
+	ShouldOverride bool
+	Args           []string
 }
 
 func MustNewImageTarget(ref container.RefSelector) ImageTarget {


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/issue2918/args:

46ee4002f0414fb20054c24c0682194d05ee5473 (2020-02-11 15:53:05 -0500)
k8s: entrypoint override shouldn't affect container args. Fixes issue #2918

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics