### PR TITLE
dockerfile: handle ARG variables when injecting images. Fixes issue #2943

### DIFF
--- a/internal/dockerfile/dockerfile_test.go
+++ b/internal/dockerfile/dockerfile_test.go
@@ -187,3 +187,15 @@ func TestFindImagesCopyFrom(t *testing.T) {
 		assert.Equal(t, "gcr.io/image-a", images[0].String())
 	}
 }
+
+func TestFindImagesWithArg(t *testing.T) {
+	df := Dockerfile(`
+ARG TAG="latest"
+FROM gcr.io/image-a:${TAG}
+`)
+	images, err := df.FindImages()
+	assert.NoError(t, err)
+	if assert.Equal(t, 1, len(images)) {
+		assert.Equal(t, "gcr.io/image-a:latest", images[0].String())
+	}
+}

--- a/internal/dockerfile/inject_test.go
+++ b/internal/dockerfile/inject_test.go
@@ -149,3 +149,21 @@ ADD . .
 `, string(newDf))
 	}
 }
+
+func TestInjectBuildArg(t *testing.T) {
+	df := Dockerfile(`
+ARG TAG="latest"
+FROM gcr.io/windmill/foo:${TAG}
+ADD . .
+`)
+	ref := container.MustParseNamedTagged("gcr.io/windmill/foo:deadbeef")
+	newDf, modified, err := InjectImageDigest(df, container.NameSelector(ref), ref)
+	if assert.NoError(t, err) {
+		assert.True(t, modified)
+		assert.Equal(t, `
+ARG TAG="latest"
+FROM gcr.io/windmill/foo:deadbeef
+ADD . .
+`, string(newDf))
+	}
+}


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/issue2943:

03bdc9e205a085e36ef39c20567a4e96e04bb3b0 (2020-02-13 00:35:23 -0500)
dockerfile: handle ARG variables when injecting images. Fixes issue #2943

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics