### PR TITLE
k8srollout: tweak pod rollout logs

### DIFF
--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -119,7 +119,7 @@ func (m *PodMonitor) printCondition(ctx context.Context, name string, cond v1.Po
 		return
 	}
 
-	l.Infof("%s┣ Not %s%s(%s):\n%s%s", prefix, name, spacer, reason, prefix, message)
+	l.Infof("%s┃ Not %s%s(%s):\n%s┃ %s", prefix, name, spacer, reason, prefix, message)
 }
 
 type podStatus struct {

--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -76,7 +76,7 @@ func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore) {
 
 func (m *PodMonitor) print(ctx context.Context, update podStatus) {
 	if !m.trackingStarted[update.podID] {
-		logger.Get(ctx).Infof("Tracking new pod rollout (%s):", update.podID)
+		logger.Get(ctx).Infof("\nTracking new pod rollout (%s):", update.podID)
 		m.trackingStarted[update.podID] = true
 	}
 
@@ -88,7 +88,7 @@ func (m *PodMonitor) print(ctx context.Context, update podStatus) {
 func (m *PodMonitor) printCondition(ctx context.Context, name string, cond v1.PodCondition, startTime time.Time) {
 	l := logger.Get(ctx).WithFields(logger.Fields{logger.FieldNameProgressID: name})
 
-	prefix := "     "
+	indent := "     "
 	duration := ""
 	spacerMax := 16
 	spacer := ""
@@ -108,18 +108,20 @@ func (m *PodMonitor) printCondition(ctx context.Context, name string, cond v1.Po
 	}
 
 	if cond.Status == v1.ConditionTrue {
-		l.Infof("%s┊ %s%s- %s", prefix, name, spacer, duration)
+		l.Infof("%s┊ %s%s- %s", indent, name, spacer, duration)
 		return
 	}
 
 	message := cond.Message
 	reason := cond.Reason
 	if cond.Status == "" || reason == "" || message == "" {
-		l.Infof("%s┊ %s%s- (…) Pending", prefix, name, spacer)
+		l.Infof("%s┊ %s%s- (…) Pending", indent, name, spacer)
 		return
 	}
 
-	l.Infof("%s┃ Not %s%s(%s):\n%s┃ %s", prefix, name, spacer, reason, prefix, message)
+	prefix := "Not "
+	spacer = strings.Repeat(" ", spacerMax-len(name)-len(prefix))
+	l.Infof("%s┃ %s%s%s- (%s): %s", indent, prefix, name, spacer, reason, message)
 }
 
 type podStatus struct {

--- a/internal/engine/k8srollout/testdata/TestMonitorReady_master
+++ b/internal/engine/k8srollout/testdata/TestMonitorReady_master
@@ -1,0 +1,5 @@
+
+Tracking new pod rollout (pod-id):
+     ┊ Scheduled         - (1s)
+     ┊ Initialized       - (4s)
+     ┊ Ready             - (5s)

--- a/internal/engine/k8srollout/testdata/TestMonitorReady_master
+++ b/internal/engine/k8srollout/testdata/TestMonitorReady_master
@@ -1,3 +1,4 @@
+
 Tracking new pod rollout (pod-id):
      ┊ Scheduled       - 1s
      ┊ Initialized     - 4s

--- a/internal/engine/k8srollout/testdata/TestMonitorReady_master
+++ b/internal/engine/k8srollout/testdata/TestMonitorReady_master
@@ -1,5 +1,4 @@
-
 Tracking new pod rollout (pod-id):
-     ┊ Scheduled         - (1s)
-     ┊ Initialized       - (4s)
-     ┊ Ready             - (5s)
+     ┊ Scheduled       - 1s
+     ┊ Initialized     - 4s
+     ┊ Ready           - 5s


### PR DESCRIPTION
- Use a dotted box-drawing vertical to visually group Pod Rollout events
- The aligned durations makes it clearer when something is Pending, without using an emoji (which doesn't currently render well on RTY)
- No longer using the ❌ emoji, which was alarming

Please note this PR does not include additional visual changes to the Web UI, which may come as a separate PR.

```
 Tracking new pod rollout (blog-site-55bf44cbf9-lfx2n):
      ┊ Scheduled       - <1s
      ┊ Initialized     - (…) Pending
      ┊ Ready           - (…) Pending
```

The "Not.." progress events have a slightly different prefix:

```
      ┊ Scheduled       - <1s
      ┃ Not Ready       - (ContainersNotReady): containers with unready status: [docs-site tilt-synclet]
```

<img width="1407" alt="Screen Shot 2020-02-13 at 2 30 59 PM copy" src="https://user-images.githubusercontent.com/20349/74471076-98ca0680-4e6d-11ea-8355-b4417eebea84.png">

## Previously

<img width="1792" alt="Screen Shot 2020-02-06 at 5 07 10 PM" src="https://user-images.githubusercontent.com/20349/74467323-d70ff780-4e66-11ea-83e2-a38174511ed9.png">
