### PR TITLE
tiltfile: add config.define_{bool,string}

### DIFF
--- a/internal/tiltfile/config/bool.go
+++ b/internal/tiltfile/config/bool.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+
+	"go.starlark.net/starlark"
+)
+
+type boolSetting struct {
+	value bool
+	isSet bool
+}
+
+var _ configValue = &boolSetting{}
+var _ flag.Value = &boolSetting{}
+
+func (s *boolSetting) starlark() starlark.Value {
+	return starlark.Bool(s.value)
+}
+
+func (s *boolSetting) IsSet() bool {
+	return s.isSet
+}
+
+func (s *boolSetting) MarshalJSON() ([]byte, error) {
+	ret := &bytes.Buffer{}
+	err := json.NewEncoder(ret).Encode(s.value)
+	if err != nil {
+		return nil, err
+	}
+	return ret.Bytes(), nil
+}
+
+func (s *boolSetting) setFromInterface(i interface{}) error {
+	if i == nil {
+		return nil
+	}
+	v, ok := i.(bool)
+	if !ok {
+		return fmt.Errorf("expected %T, found %T", s.value, i)
+	}
+
+	s.value = v
+	s.isSet = true
+
+	return nil
+}
+
+func (s *boolSetting) Set(v string) error {
+	if s.isSet {
+		return fmt.Errorf("bool settings can only be specified once. multiple values found (last value: %s)", v)
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return err
+	}
+	s.value = b
+	s.isSet = true
+	return nil
+}
+
+func (s *boolSetting) String() string {
+	return strconv.FormatBool(s.value)
+}
+
+func (s *boolSetting) IsBoolFlag() bool {
+	return true
+}

--- a/internal/tiltfile/config/bool.go
+++ b/internal/tiltfile/config/bool.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"strconv"
@@ -24,15 +22,6 @@ func (s *boolSetting) starlark() starlark.Value {
 
 func (s *boolSetting) IsSet() bool {
 	return s.isSet
-}
-
-func (s *boolSetting) MarshalJSON() ([]byte, error) {
-	ret := &bytes.Buffer{}
-	err := json.NewEncoder(ret).Encode(s.value)
-	if err != nil {
-		return nil, err
-	}
-	return ret.Bytes(), nil
 }
 
 func (s *boolSetting) setFromInterface(i interface{}) error {

--- a/internal/tiltfile/config/config.go
+++ b/internal/tiltfile/config/config.go
@@ -66,6 +66,12 @@ func (e *Extension) OnStart(env *starkit.Environment) error {
 		{"config.define_string_list", configSettingDefinitionBuiltin(func() configValue {
 			return &stringList{}
 		})},
+		{"config.define_string", configSettingDefinitionBuiltin(func() configValue {
+			return &stringSetting{}
+		})},
+		{"config.define_bool", configSettingDefinitionBuiltin(func() configValue {
+			return &boolSetting{}
+		})},
 	} {
 		err := env.AddBuiltin(b.name, b.f)
 		if err != nil {

--- a/internal/tiltfile/config/config_def.go
+++ b/internal/tiltfile/config/config_def.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -16,7 +15,6 @@ import (
 
 type configValue interface {
 	flag.Value
-	json.Marshaler
 	starlark() starlark.Value
 	setFromInterface(interface{}) error
 	IsSet() bool

--- a/internal/tiltfile/config/string.go
+++ b/internal/tiltfile/config/string.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 
@@ -23,15 +21,6 @@ func (s *stringSetting) starlark() starlark.Value {
 
 func (s *stringSetting) IsSet() bool {
 	return s.isSet
-}
-
-func (s *stringSetting) MarshalJSON() ([]byte, error) {
-	ret := &bytes.Buffer{}
-	err := json.NewEncoder(ret).Encode(s.value)
-	if err != nil {
-		return nil, err
-	}
-	return ret.Bytes(), nil
 }
 
 func (s *stringSetting) setFromInterface(i interface{}) error {

--- a/internal/tiltfile/config/string.go
+++ b/internal/tiltfile/config/string.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+type stringSetting struct {
+	value string
+	isSet bool
+}
+
+var _ configValue = &stringSetting{}
+var _ flag.Value = &stringSetting{}
+
+func (s *stringSetting) starlark() starlark.Value {
+	return starlark.String(s.value)
+}
+
+func (s *stringSetting) IsSet() bool {
+	return s.isSet
+}
+
+func (s *stringSetting) MarshalJSON() ([]byte, error) {
+	ret := &bytes.Buffer{}
+	err := json.NewEncoder(ret).Encode(s.value)
+	if err != nil {
+		return nil, err
+	}
+	return ret.Bytes(), nil
+}
+
+func (s *stringSetting) setFromInterface(i interface{}) error {
+	if i == nil {
+		return nil
+	}
+	v, ok := i.(string)
+	if !ok {
+		return fmt.Errorf("expected %T, found %T", s.value, i)
+	}
+
+	s.value = v
+	s.isSet = true
+
+	return nil
+}
+
+func (s *stringSetting) Set(v string) error {
+	if s.isSet {
+		return fmt.Errorf("string settings can only be specified once. multiple values found (last value: %s", v)
+	}
+
+	s.value = v
+	s.isSet = true
+	return nil
+}
+
+func (s *stringSetting) String() string {
+	return s.value
+}

--- a/internal/tiltfile/config/string_list.go
+++ b/internal/tiltfile/config/string_list.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"strings"
@@ -26,15 +24,6 @@ func (s *stringList) starlark() starlark.Value {
 
 func (s *stringList) IsSet() bool {
 	return s.isSet
-}
-
-func (s *stringList) MarshalJSON() ([]byte, error) {
-	ret := &bytes.Buffer{}
-	err := json.NewEncoder(ret).Encode(s.Values)
-	if err != nil {
-		return nil, err
-	}
-	return ret.Bytes(), nil
 }
 
 func (s *stringList) setFromInterface(i interface{}) error {


### PR DESCRIPTION
### Problem

Lots of use cases for config settings don't actually want a list of strings, and it's annoying that we make users deal with that type when it's so cheap to just provide other types (and when pretty much all other arg-parsing APIs provide other types). Especially since for a bool you really want a flag, but the existing syntax makes you say `--foo true`

### Solution

add setting types for bool and string