### PR TITLE
web: fix potential empty resource log

### DIFF
--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -119,6 +119,20 @@ describe("LogStore", () => {
     expect(logLinesToString(logs.manifestLog("fe"), false)).toEqual("line2")
   })
 
+  it("handles manifest spans with no segments", () => {
+    let logs = new LogStore()
+    logs.append({
+      spans: { "": {}, fe: { manifestName: "fe" }, "foo": { manifestName: "fe" } },
+      segments: [
+        newGlobalSegment("line1\n"),
+        newManifestSegment("fe", "line2\n"),
+        newGlobalSegment("line3\n"),
+      ],
+    })
+
+    expect(logLinesToString(logs.manifestLog("fe"), false)).toEqual("line2")
+  })
+
   it("handles multi-span manifest logs", () => {
     let logs = new LogStore()
     logs.append({

--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -122,7 +122,11 @@ describe("LogStore", () => {
   it("handles manifest spans with no segments", () => {
     let logs = new LogStore()
     logs.append({
-      spans: { "": {}, fe: { manifestName: "fe" }, "foo": { manifestName: "fe" } },
+      spans: {
+        "": {},
+        fe: { manifestName: "fe" },
+        foo: { manifestName: "fe" },
+      },
       segments: [
         newGlobalSegment("line1\n"),
         newManifestSegment("fe", "line2\n"),

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -277,11 +277,11 @@ class LogStore {
         let span = spansToLog[spanId]
         if (
           earliestStartIndex == -1 ||
-          span.firstLineIndex < earliestStartIndex
+          (span.firstLineIndex !== -1 && span.firstLineIndex < earliestStartIndex)
         ) {
           earliestStartIndex = span.firstLineIndex
         }
-        if (latestEndIndex == -1 || span.lastLineIndex > latestEndIndex) {
+        if (latestEndIndex == -1 || (span.lastLineIndex !== -1 && span.lastLineIndex > latestEndIndex)) {
           latestEndIndex = span.lastLineIndex
         }
       }

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -277,11 +277,15 @@ class LogStore {
         let span = spansToLog[spanId]
         if (
           earliestStartIndex == -1 ||
-          (span.firstLineIndex !== -1 && span.firstLineIndex < earliestStartIndex)
+          (span.firstLineIndex !== -1 &&
+            span.firstLineIndex < earliestStartIndex)
         ) {
           earliestStartIndex = span.firstLineIndex
         }
-        if (latestEndIndex == -1 || (span.lastLineIndex !== -1 && span.lastLineIndex > latestEndIndex)) {
+        if (
+          latestEndIndex == -1 ||
+          (span.lastLineIndex !== -1 && span.lastLineIndex > latestEndIndex)
+        ) {
           latestEndIndex = span.lastLineIndex
         }
       }


### PR DESCRIPTION
### Problem

Sometimes logs show up in the global log pane, but not the resource log pane, even though the UI clearly shows it's aware those logs came from that resource.

### Analysis

It turns out this happens when there is a span with no segments. I was able to repro this a few times by running DC resources prior to the networking fix, which resulted in the creation of both build and runtime spans, but the runtime span would have no segments. I haven't looked into why we create a runtime span with no segments, which feels like it's also a bug, but I think the fix in this PR is desirable either way.

In the logHelper filteredLog path, when a span has no segments, it ends up keeping its default firstLineIndex of -1, and we exit out with an empty list of lines, even if a prior span for that manifest *did* have segments.

### Solution

Don't set earliestStartIndex / latestEndIndex to -1, and instead just ignore those spans.

As mentioned above, this might be papering over a bug that we have a segmentless span, but probably isn't awful to have anyway?