### PR TITLE
tiltfile: add read/decode/encode_yaml_stream functions

### DIFF
--- a/internal/tiltfile/encoding/extension.go
+++ b/internal/tiltfile/encoding/extension.go
@@ -8,18 +8,34 @@ func NewExtension() Extension {
 	return Extension{}
 }
 
+const (
+	readYAMLN         = "read_yaml"
+	readYAMLStreamN   = "read_yaml_stream"
+	decodeYAMLN       = "decode_yaml"
+	decodeYAMLStreamN = "decode_yaml_stream"
+	encodeYAMLN       = "encode_yaml"
+	encodeYAMLStreamN = "encode_yaml_stream"
+
+	readJSONN   = "read_json"
+	decodeJSONN = "decode_json"
+	encodeJSONN = "encode_json"
+)
+
 func (Extension) OnStart(env *starkit.Environment) error {
 	for _, b := range []struct {
 		name string
 		f    starkit.Function
 	}{
-		{"read_yaml", readYAML},
-		{"decode_yaml", decodeYAML},
-		{"encode_yaml", encodeYAML},
+		{readYAMLN, readYAML},
+		{readYAMLStreamN, readYAMLStream},
+		{decodeYAMLN, decodeYAML},
+		{decodeYAMLStreamN, decodeYAMLStream},
+		{encodeYAMLN, encodeYAML},
+		{encodeYAMLStreamN, encodeYAMLStream},
 
-		{"read_json", readJSON},
-		{"decode_json", decodeJSON},
-		{"encode_json", encodeJSON},
+		{readJSONN, readJSON},
+		{decodeJSONN, decodeJSON},
+		{encodeJSONN, encodeJSON},
 	} {
 		err := env.AddBuiltin(b.name, b.f)
 		if err != nil {

--- a/internal/tiltfile/encoding/fixture.go
+++ b/internal/tiltfile/encoding/fixture.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/windmilleng/tilt/internal/tiltfile/io"
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+	"github.com/windmilleng/tilt/internal/tiltfile/starlarkstruct"
 )
 
 type fixture struct {
@@ -12,5 +13,16 @@ type fixture struct {
 }
 
 func newFixture(t testing.TB) fixture {
-	return fixture{starkit.NewFixture(t, NewExtension(), io.NewExtension())}
+	f := fixture{starkit.NewFixture(t, NewExtension(), io.NewExtension(), starlarkstruct.NewExtension())}
+	f.UseRealFS()
+	f.File("assert.tilt", `
+def equals(expected, observed):
+	if expected != observed:
+		print("expected: '%s'" % (expected))
+		print("observed: '%s'" % (observed))
+		fail()
+
+assert = struct(equals=equals)
+`)
+	return f
 }

--- a/internal/tiltfile/encoding/yaml.go
+++ b/internal/tiltfile/encoding/yaml.go
@@ -2,11 +2,14 @@ package encoding
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 
 	tiltfile_io "github.com/windmilleng/tilt/internal/tiltfile/io"
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
@@ -14,7 +17,7 @@ import (
 )
 
 // reads yaml from a file
-func readYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func readYAMLStream(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var path starlark.String
 	var defaultValue starlark.Value
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "paths", &path, "default?", &defaultValue); err != nil {
@@ -35,11 +38,26 @@ func readYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 		return nil, err
 	}
 
-	return yamlStringToStarlark(string(contents), path.GoString())
+	return yamlStreamToStarlark(string(contents), path.GoString())
+}
+
+func readYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	v, err := readYAMLStream(thread, fn, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	l, ok := v.(*starlark.List)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected readYAMLStream to return a %T, but it returned a %T", starlark.List{}, l)
+	}
+	if l.Len() != 1 {
+		return nil, fmt.Errorf("expected a yaml document but found a yaml stream (documents separated by `---`). use %s instead to read a yaml stream", readYAMLStreamN)
+	}
+	return l.Index(0), nil
 }
 
 // reads yaml from a string
-func decodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func decodeYAMLStream(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var contents starlark.Value
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "yaml", &contents); err != nil {
 		return nil, err
@@ -50,29 +68,55 @@ func decodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 		return nil, fmt.Errorf("%s arg must be a string or blob. got %s", fn.Name(), contents.Type())
 	}
 
-	return yamlStringToStarlark(s, "")
+	return yamlStreamToStarlark(s, "")
 }
 
-func yamlStringToStarlark(s string, source string) (starlark.Value, error) {
-	var decodedYAML interface{}
-	err := yaml.Unmarshal([]byte(s), &decodedYAML)
+func decodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	v, err := decodeYAMLStream(thread, fn, args, kwargs)
 	if err != nil {
-		errmsg := "error parsing YAML"
-		if source != "" {
-			errmsg += fmt.Sprintf(" from %s", source)
+		return nil, err
+	}
+	l, ok := v.(*starlark.List)
+	if !ok {
+		return nil, fmt.Errorf("internal error: expected decodeYAMLStream to return a %T, but it returned a %T", starlark.List{}, l)
+	}
+	if l.Len() != 1 {
+		return nil, fmt.Errorf("expected a yaml document but found a yaml stream (documents separated by `---`). use %s instead to decode a yaml stream", decodeYAMLStreamN)
+	}
+	return l.Index(0), nil
+}
+
+func yamlStreamToStarlark(s string, source string) (*starlark.List, error) {
+	var ret []starlark.Value
+	var decodedYAML interface{}
+	d := k8syaml.NewYAMLToJSONDecoder(strings.NewReader(s))
+	for {
+		err := d.Decode(&decodedYAML)
+		if err == io.EOF {
+			break
 		}
-		return nil, errors.Wrap(err, errmsg)
+
+		if err != nil {
+			errmsg := "error parsing YAML"
+			if source != "" {
+				errmsg += fmt.Sprintf(" from %s", source)
+			}
+			return nil, errors.Wrap(err, errmsg)
+		}
+
+		v, err := convertStructuredDataToStarlark(decodedYAML)
+		if err != nil {
+			errmsg := "error converting YAML to Starlark"
+			if source != "" {
+				errmsg += fmt.Sprintf(" from %s", source)
+			}
+			return nil, errors.Wrap(err, errmsg)
+		}
+
+		ret = append(ret, v)
 	}
 
-	v, err := convertStructuredDataToStarlark(decodedYAML)
-	if err != nil {
-		errmsg := "error converting YAML to Starlark"
-		if source != "" {
-			errmsg += fmt.Sprintf(" from %s", source)
-		}
-		return nil, errors.Wrap(err, errmsg)
-	}
-	return v, nil
+	return starlark.NewList(ret), nil
 }
 
 // dumps yaml to a string
@@ -88,6 +132,28 @@ func encodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 	}
 
 	return tiltfile_io.NewBlob(ret, "encode_yaml"), nil
+}
+
+func encodeYAMLStream(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var objs *starlark.List
+	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "objs", &objs); err != nil {
+		return nil, err
+	}
+
+	var yamlDocs []string
+
+	it := objs.Iterate()
+	defer it.Done()
+	var v starlark.Value
+	for it.Next(&v) {
+		s, err := starlarkToYAMLString(v)
+		if err != nil {
+			return nil, err
+		}
+		yamlDocs = append(yamlDocs, s)
+	}
+
+	return tiltfile_io.NewBlob(strings.Join(yamlDocs, "---\n"), "encode_yaml_stream"), nil
 }
 
 func starlarkToYAMLString(obj starlark.Value) (string, error) {

--- a/internal/tiltfile/encoding/yaml_test.go
+++ b/internal/tiltfile/encoding/yaml_test.go
@@ -134,6 +134,37 @@ test()
 	}
 }
 
+func TestDecodeYAMLEmptyString(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	tf := `
+observed = decode_yaml('')
+expected = [
+  "foo",
+  {
+    "baz": [ "bar", "", 1, 2],
+  }
+]
+
+def test():
+	if expected != observed:
+		print('expected: %s' % (expected))
+		print('observed: %s' % (observed))
+		fail()
+
+test()
+
+`
+	f.File("Tiltfile", tf)
+
+	_, err := f.ExecFile("Tiltfile")
+	if err != nil {
+		fmt.Println(f.PrintOutput())
+	}
+	require.NoError(t, err)
+}
+
 const yamlStream = `- foo
 - baz:
   - bar

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -265,13 +265,9 @@ const (
 	workloadToResourceFunctionN = "workload_to_resource_function"
 
 	// file functions
-	localN      = "local"
-	kustomizeN  = "kustomize"
-	helmN       = "helm"
-	decodeJSONN = "decode_json"
-	decodeYAMLN = "decode_yaml"
-	readJSONN   = "read_json"
-	readYAMLN   = "read_yaml"
+	localN     = "local"
+	kustomizeN = "kustomize"
+	helmN      = "helm"
 
 	// live update functions
 	fallBackOnN       = "fall_back_on"


### PR DESCRIPTION
addresses #2960 

### Problem

Various k8s tools involve YAML streams rather than YAML docs (i.e., multiple YAML docs in the same string, separated by "\n---\n"). `decode_yaml` / `read_yaml` / `encode_yaml` don't handle these (and worse, `decode_yaml` and `read_yaml` just return the first doc in the stream and throw the rest away)

### Solution

1. Add `decode_yaml_stream`, `read_yaml_stream`, `encode_yaml_stream` functions, which operate work on streams of YAML docs
2. Make `decode_yaml` and `read_yaml` fail with an error pointing at the `_stream` variants if they're passed a stream, to protect people from unintentionally silently dropping yaml docs past the first

Another option would have been to just have `decode_yaml` / `read_yaml` return an array of objects when there's a stream, but it seems like it'd be annoying to have it return an array when you know just a single object and annoying to have to variously return a single object or an array depending on what string you pass it (also, then the caller wouldn't be able to distinguish between return values of an array of yaml documents, or a single yaml document with a top-level array). FWIW, both the Ruby and Python YAML libraries have separate _stream functions for handling YAML streams.