### PR TITLE
tiltfile: make read_file error on missing file if default unspecified

### DIFF
--- a/internal/tiltfile/io/io_test.go
+++ b/internal/tiltfile/io/io_test.go
@@ -1,0 +1,100 @@
+package io
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
+	"github.com/windmilleng/tilt/internal/tiltfile/starlarkstruct"
+)
+
+func TestReadFile(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.File("foo.txt", "foo")
+	f.File("Tiltfile", `
+s = read_file('foo.txt')
+
+load('assert.tilt', 'assert')
+
+assert.equals('foo', str(s))
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+}
+
+func TestReadFileDefault(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+s = read_file('dne.txt', 'foo')
+
+load('assert.tilt', 'assert')
+
+assert.equals('foo', str(s))
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+}
+
+func TestReadFileDefaultEmptyString(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+s = read_file('dne.txt', '')
+
+load('assert.tilt', 'assert')
+
+assert.equals('', str(s))
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+}
+
+// make sure we generate an error on invalid type for default even if the file exists
+func TestReadFileInvalidDefaultFileExists(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.File("foo.txt", "foo")
+	f.File("Tiltfile", `
+s = read_file('foo.txt', 5)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "default must be starlark.NoneType or starlark.String. got starlark.Int")
+}
+
+func TestReadFileMissing(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+s = read_file('dne.txt')
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dne.txt: no such file or directory")
+}
+
+func newFixture(t *testing.T) *starkit.Fixture {
+	f := starkit.NewFixture(t, NewExtension(), starlarkstruct.NewExtension())
+	f.UseRealFS()
+	f.File("assert.tilt", `
+def equals(expected, observed):
+	if expected != observed:
+		fail("expected: '%s'. observed: '%s'" % (expected, observed))
+
+assert = struct(equals=equals)
+`)
+	return f
+}


### PR DESCRIPTION
### Problem

The (`read_file docs`)[https://docs.tilt.dev/api.html#api.read_file] state:

> If the file_path does not exist and default is not None , default will be returned. In any other case, an error reading file_path will be a Tiltfile load error.

However, the actual implementation is that `default` has a default value of `""` rather than `None`, and unpacks the arg into a string, so it's not actually possible to get read_file to error on a missing file.

### Solution

change `read_file` to error if the file doesn't exist and default is unspecified

### Result

We can now get errors when `read_file` targets are missing!

This might break users that were relying on the existing behavior.
1. It's easy for them to get the existing behavior back by adding a `default=""` to their `read_file` call.
2. My gut is that the documented behavior is far more desirable and a better default.