### PR TITLE
fix data race between hud and renderer

### DIFF
--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -92,9 +92,7 @@ func (h *Hud) Run(ctx context.Context, dispatch func(action store.Action), refre
 		h.mu.Unlock()
 	}()
 
-	h.mu.RLock()
 	screenEvents, err := h.r.SetUp()
-	h.mu.RUnlock()
 
 	if err != nil {
 		return errors.Wrap(err, "setting up screen")

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -92,7 +92,10 @@ func (h *Hud) Run(ctx context.Context, dispatch func(action store.Action), refre
 		h.mu.Unlock()
 	}()
 
+	h.mu.RLock()
 	screenEvents, err := h.r.SetUp()
+	h.mu.RUnlock()
+
 	if err != nil {
 		return errors.Wrap(err, "setting up screen")
 	}
@@ -110,9 +113,8 @@ func (h *Hud) Run(ctx context.Context, dispatch func(action store.Action), refre
 			err := ctx.Err()
 			if err != context.Canceled {
 				return err
-			} else {
-				return nil
 			}
+			return nil
 		case e := <-screenEvents:
 			done := h.handleScreenEvent(ctx, dispatch, e)
 			if done {
@@ -325,7 +327,7 @@ func (h *Hud) Update(v view.View, vs view.ViewState) error {
 }
 
 func (h *Hud) resetResourceSelection() {
-	rty := h.r.rty
+	rty := h.r.RTY()
 	if rty == nil {
 		return
 	}
@@ -335,7 +337,7 @@ func (h *Hud) resetResourceSelection() {
 }
 
 func (h *Hud) refreshSelectedIndex() {
-	rty := h.r.rty
+	rty := h.r.RTY()
 	if rty == nil {
 		return
 	}

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -320,7 +320,7 @@ func (r *Renderer) SetUp() (chan tcell.Event, error) {
 	return screenEvents, nil
 }
 
-func (r Renderer) RTY() rty.RTY {
+func (r *Renderer) RTY() rty.RTY {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -20,23 +20,24 @@ const defaultLogPaneHeight = 8
 type Renderer struct {
 	rty    rty.RTY
 	screen tcell.Screen
-	mu     *sync.Mutex
+	mu     *sync.RWMutex
 	clock  func() time.Time
 }
 
 func NewRenderer(clock func() time.Time) *Renderer {
 	return &Renderer{
-		mu:    new(sync.Mutex),
+		mu:    new(sync.RWMutex),
 		clock: clock,
 	}
 }
 
 func (r *Renderer) Render(v view.View, vs view.ViewState) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.rty != nil {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	rty := r.rty
+	if rty != nil {
 		layout := r.layout(v, vs)
-		err := r.rty.Render(layout)
+		err := rty.Render(layout)
 		if err != nil {
 			return err
 		}
@@ -317,6 +318,13 @@ func (r *Renderer) SetUp() (chan tcell.Event, error) {
 	r.screen = screen
 
 	return screenEvents, nil
+}
+
+func (r Renderer) RTY() rty.RTY {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.rty
 }
 
 func (r *Renderer) Reset() {


### PR DESCRIPTION
Hi,
Running with go --race, go complain there is a data race :

WARNING: DATA RACE
Write at 0x00c000694330 by goroutine 51:
  github.com/windmilleng/tilt/internal/hud.(*Renderer).SetUp()
     tilt/internal/hud/renderer.go:315 +0x3a7
  github.com/windmilleng/tilt/internal/hud.(*Hud).Run()
     tilt/internal/hud/hud.go:95 +0x1fb
  github.com/windmilleng/tilt/internal/cli.(*upCmd).run.func1()
     tilt/internal/cli/up.go:144 +0x10d
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      go/pkg/mod/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:57 +0x78

Previous read at 0x00c000694330 by goroutine 56:
  github.com/windmilleng/tilt/internal/hud.(*Hud).refreshSelectedIndex()
     tilt/internal/hud/hud.go:338 +0x5d
  github.com/windmilleng/tilt/internal/hud.(*Hud).OnChange()
     tilt/internal/hud/hud.go:294 +0x3b3
  github.com/windmilleng/tilt/internal/store.(*subscriberEntry).notify()
     tilt/internal/store/subscriber.go:125 +0x151
  github.com/windmilleng/tilt/internal/store.(*subscriberList).NotifyAll.func1()
     tilt/internal/store/subscriber.go:105 +0x63
  github.com/windmilleng/tilt/internal/store.SafeGo.func1()
     tilt/internal/store/safe.go:28 +0x79