### PR TITLE
Fix data race image builder

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -225,14 +225,14 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 	}
 
 	pr, pw := io.Pipe()
-	go func() {
+	go func(ctx context.Context) {
 		err := tarContextAndUpdateDf(ctx, pw, dockerfile.Dockerfile(db.Dockerfile), paths, filter)
 		if err != nil {
 			_ = pw.CloseWithError(err)
 		} else {
 			_ = pw.Close()
 		}
-	}()
+	}(ctx)
 
 	ps.StartBuildStep(ctx, "Building image")
 	spanBuild, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuild")

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -92,9 +92,7 @@ func (h *Hud) Run(ctx context.Context, dispatch func(action store.Action), refre
 		h.mu.Unlock()
 	}()
 
-	h.mu.RLock()
 	screenEvents, err := h.r.SetUp()
-	h.mu.RUnlock()
 
 	if err != nil {
 		return errors.Wrap(err, "setting up screen")

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -92,7 +92,10 @@ func (h *Hud) Run(ctx context.Context, dispatch func(action store.Action), refre
 		h.mu.Unlock()
 	}()
 
+	h.mu.RLock()
 	screenEvents, err := h.r.SetUp()
+	h.mu.RUnlock()
+
 	if err != nil {
 		return errors.Wrap(err, "setting up screen")
 	}
@@ -110,9 +113,8 @@ func (h *Hud) Run(ctx context.Context, dispatch func(action store.Action), refre
 			err := ctx.Err()
 			if err != context.Canceled {
 				return err
-			} else {
-				return nil
 			}
+			return nil
 		case e := <-screenEvents:
 			done := h.handleScreenEvent(ctx, dispatch, e)
 			if done {
@@ -325,7 +327,7 @@ func (h *Hud) Update(v view.View, vs view.ViewState) error {
 }
 
 func (h *Hud) resetResourceSelection() {
-	rty := h.r.rty
+	rty := h.r.RTY()
 	if rty == nil {
 		return
 	}
@@ -335,7 +337,7 @@ func (h *Hud) resetResourceSelection() {
 }
 
 func (h *Hud) refreshSelectedIndex() {
-	rty := h.r.rty
+	rty := h.r.RTY()
 	if rty == nil {
 		return
 	}

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -320,7 +320,7 @@ func (r *Renderer) SetUp() (chan tcell.Event, error) {
 	return screenEvents, nil
 }
 
-func (r Renderer) RTY() rty.RTY {
+func (r *Renderer) RTY() rty.RTY {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -20,23 +20,24 @@ const defaultLogPaneHeight = 8
 type Renderer struct {
 	rty    rty.RTY
 	screen tcell.Screen
-	mu     *sync.Mutex
+	mu     *sync.RWMutex
 	clock  func() time.Time
 }
 
 func NewRenderer(clock func() time.Time) *Renderer {
 	return &Renderer{
-		mu:    new(sync.Mutex),
+		mu:    new(sync.RWMutex),
 		clock: clock,
 	}
 }
 
 func (r *Renderer) Render(v view.View, vs view.ViewState) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.rty != nil {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	rty := r.rty
+	if rty != nil {
 		layout := r.layout(v, vs)
-		err := r.rty.Render(layout)
+		err := rty.Render(layout)
 		if err != nil {
 			return err
 		}
@@ -317,6 +318,13 @@ func (r *Renderer) SetUp() (chan tcell.Event, error) {
 	r.screen = screen
 
 	return screenEvents, nil
+}
+
+func (r Renderer) RTY() rty.RTY {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.rty
 }
 
 func (r *Renderer) Reset() {


### PR DESCRIPTION
Hi another data race complain, the last catch by go --race. 
After correcting this and the previous one no warning are left.

WARNING: DATA RACE
Read at 0x00c0001fc630 by goroutine 63:
  github.com/windmilleng/tilt/internal/build.(*dockerImageBuilder).buildFromDf.func1()
      tilt/internal/build/image_builder.go:229 +0x57

Previous write at 0x00c0001fc630 by goroutine 119:
  github.com/windmilleng/tilt/internal/build.(*dockerImageBuilder).buildFromDf()
      tilt/internal/build/image_builder.go:238 +0xab7
  github.com/windmilleng/tilt/internal/build.(*dockerImageBuilder).BuildImage()
      tilt/internal/build/image_builder.go:70 +0x39e
  github.com/windmilleng/tilt/internal/engine.(*imageAndCacheBuilder).Build()
      tilt/internal/engine/image_and_cache_builder.go:40 +0x654
  github.com/windmilleng/tilt/internal/engine.(*ImageBuildAndDeployer).BuildAndDeploy.func3()
      tilt/internal/engine/image_build_and_deployer.go:146 +0x44b
  github.com/windmilleng/tilt/internal/engine/buildcontrol.(*TargetQueue).RunBuilds()
      tilt/internal/engine/buildcontrol/target_queue.go:120 +0xa6f
  github.com/windmilleng/tilt/internal/engine.(*ImageBuildAndDeployer).BuildAndDeploy()
      tilt/internal/engine/image_build_and_deployer.go:135 +0x6d7
  github.com/windmilleng/tilt/internal/engine.(*CompositeBuildAndDeployer).BuildAndDeploy()
      tilt/internal/engine/build_and_deployer.go:71 +0x588
  github.com/windmilleng/tilt/internal/engine.(*BuildController).buildAndDeploy()
      tilt/internal/engine/buildcontroller.go:124 +0x173
  github.com/windmilleng/tilt/internal/engine.(*BuildController).OnChange.func1()
      tilt/internal/engine/buildcontroller.go:111 +0x269