### PR TITLE
Add space between multiple PortForwardLinks

### DIFF
--- a/web/src/ResourceInfo.tsx
+++ b/web/src/ResourceInfo.tsx
@@ -48,7 +48,10 @@ let PortForwardLabel = styled.span`
 
   ${s.mixinHideOnSmallScreen}
 `
-let PortForwardLink = styled.a``
+
+let PortForwardLink = styled.a`
+  margin-right: ${s.SizeUnit(0.25)};
+`
 
 let SnapshotButton = styled.button`
   border: 1px solid transparent;

--- a/web/src/ResourceInfo.tsx
+++ b/web/src/ResourceInfo.tsx
@@ -50,7 +50,7 @@ let PortForwardLabel = styled.span`
 `
 
 let PortForwardLink = styled.a`
-  & + &  {
+  & + & {
     padding-left: ${s.SizeUnit(0.25)};
     border-left: 1px dotted ${s.Color.grayLight};
     margin-left: ${s.SizeUnit(0.25)};

--- a/web/src/ResourceInfo.tsx
+++ b/web/src/ResourceInfo.tsx
@@ -50,7 +50,11 @@ let PortForwardLabel = styled.span`
 `
 
 let PortForwardLink = styled.a`
-  margin-right: ${s.SizeUnit(0.25)};
+  & + &  {
+    padding-left: ${s.SizeUnit(0.25)};
+    border-left: 1px dotted ${s.Color.grayLight};
+    margin-left: ${s.SizeUnit(0.25)};
+  }
 `
 
 let SnapshotButton = styled.button`


### PR DESCRIPTION
Clubhouse story: https://app.clubhouse.io/windmill/story/4269/no-spacing-between-multiple-k8s-port-forwards

### Multiple
| Before / After | Screenshot |
| --- | --- |
| Before | <img width="804" alt="multiple-before" src="https://user-images.githubusercontent.com/10860550/75098955-21415900-558a-11ea-828a-315d0178de8c.png"> | 
| After | <img width="776" alt="multiple-after" src="https://user-images.githubusercontent.com/10860550/75098957-26060d00-558a-11ea-89fe-25e231b4b6a8.png"> |

### Single
| Before / After | Screenshot |
| --- | --- |
| Before | <img width="395" alt="single-before" src="https://user-images.githubusercontent.com/10860550/75098942-ffe06d00-5589-11ea-9428-d8737d17072a.png"> | 
| After |  <img width="401" alt="single-after" src="https://user-images.githubusercontent.com/10860550/75098946-0373f400-558a-11ea-9b95-a051ae8a27ab.png"> |