### PR TITLE
rty: remove redundant terminal clear(). Fixes Windows flicker. Fixes …

### DIFF
--- a/internal/rty/interactive_tester.go
+++ b/internal/rty/interactive_tester.go
@@ -61,6 +61,7 @@ func (i *InteractiveTester) Run(name string, width int, height int, c Component)
 	if err != nil {
 		i.t.Errorf("error rendering %s: %v", name, err)
 	}
+	i.dummyScreen.Clear()
 }
 
 func (i *InteractiveTester) render(width int, height int, c Component) (canvas Canvas, err error) {

--- a/internal/rty/render.go
+++ b/internal/rty/render.go
@@ -21,7 +21,6 @@ type rty struct {
 type renderState map[string]interface{}
 
 func (r *rty) Render(c Component) (err error) {
-	r.screen.Clear()
 	g := &renderGlobals{
 		prev: r.state,
 		next: make(renderState),


### PR DESCRIPTION
…https://github.com/windmilleng/tilt/issues/2249

Thanks to @pleclech for suggesting