### PR TITLE
buildcontrol: don't parallelize updates that share images

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -142,7 +142,9 @@ func (m Manifest) TargetSpecs() []TargetSpec {
 	for _, t := range m.ImageTargets {
 		result = append(result, t)
 	}
-	result = append(result, m.deployTarget)
+	if m.deployTarget != nil {
+		result = append(result, m.deployTarget)
+	}
 	return result
 }
 


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch4317/busy:

04dc19fa7924f31488532c306f9ed2a3fe917419 (2020-02-25 12:47:20 -0500)
buildcontrol: don't parallelize updates that share images

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics