### PR TITLE
store: we should still live update unready containers

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -264,7 +264,7 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
-func TestBuildControllerWillContainerBuildWithSomeButNotAllReadyContainers(t *testing.T) {
+func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
@@ -291,7 +291,7 @@ func TestBuildControllerWillContainerBuildWithSomeButNotAllReadyContainers(t *te
 	// full rebuild, so don't return ANY RunningContainers.
 	call = f.nextCall()
 	runningContainers := call.oneState().RunningContainers
-	assert.NotEmpty(t, runningContainers)
+	assert.Empty(t, runningContainers)
 
 	err := f.Stop()
 	assert.NoError(t, err)

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/windmilleng/tilt/pkg/model"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/windmilleng/tilt/pkg/model"
 
 	"github.com/windmilleng/tilt/internal/container"
 	"github.com/windmilleng/tilt/internal/hud/server"

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -264,7 +264,7 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
-func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *testing.T) {
+func TestBuildControllerWillContainerBuildWithSomeButNotAllReadyContainers(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
@@ -291,7 +291,7 @@ func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *te
 	// full rebuild, so don't return ANY RunningContainers.
 	call = f.nextCall()
 	runningContainers := call.oneState().RunningContainers
-	assert.Empty(t, runningContainers)
+	assert.NotEmpty(t, runningContainers)
 
 	err := f.Stop()
 	assert.NoError(t, err)

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -211,11 +211,17 @@ func containerForStatus(ctx context.Context, pod *v1.Pod, cStatus v1.ContainerSt
 		ports = append(ports, cPort.ContainerPort)
 	}
 
+	isRunning := false
+	if cStatus.State.Running != nil && !cStatus.State.Running.StartedAt.IsZero() {
+		isRunning = true
+	}
+
 	return store.Container{
 		Name:     cName,
 		ID:       cID,
 		Ports:    ports,
 		Ready:    cStatus.Ready,
+		Running:  isRunning,
 		ImageRef: cRef,
 		Restarts: int(cStatus.RestartCount),
 	}, nil

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -444,7 +444,7 @@ func RunningContainersForTargetForOnePod(iTarget model.ImageTarget, runtimeState
 		}
 		if c.ID == "" || c.Name == "" || !c.Running {
 			// If we're missing any relevant info for this container, OR if the
-			// container isn't ready, we can't update it in place.
+			// container isn't running, we can't update it in place.
 			// (Since we'll need to fully rebuild this image, we shouldn't bother
 			// in-place updating ANY containers on this pod -- they'll all
 			// be recreated when we image build. So don't return ANY ContainerInfos.)

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -442,7 +442,7 @@ func RunningContainersForTargetForOnePod(iTarget model.ImageTarget, runtimeState
 		if c.ImageRef == nil || iTarget.Refs.ClusterRef().Name() != c.ImageRef.Name() {
 			continue
 		}
-		if c.ID == "" || c.Name == "" || !c.Ready {
+		if c.ID == "" || c.Name == "" {
 			// If we're missing any relevant info for this container, OR if the
 			// container isn't ready, we can't update it in place.
 			// (Since we'll need to fully rebuild this image, we shouldn't bother

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -442,7 +442,7 @@ func RunningContainersForTargetForOnePod(iTarget model.ImageTarget, runtimeState
 		if c.ImageRef == nil || iTarget.Refs.ClusterRef().Name() != c.ImageRef.Name() {
 			continue
 		}
-		if c.ID == "" || c.Name == "" {
+		if c.ID == "" || c.Name == "" || !c.Running {
 			// If we're missing any relevant info for this container, OR if the
 			// container isn't ready, we can't update it in place.
 			// (Since we'll need to fully rebuild this image, we shouldn't bother

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -158,6 +158,7 @@ type Container struct {
 	ID       container.ID
 	Ports    []int32
 	Ready    bool
+	Running  bool
 	ImageRef reference.Named
 	Restarts int
 }

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -314,10 +314,17 @@ func (b PodBuilder) buildContainerStatuses(spec v1.PodSpec) []v1.ContainerStatus
 		// if not specified, default to true
 		ready = !ok || ready
 
+		state := v1.ContainerState{
+			Running: &v1.ContainerStateRunning{
+				StartedAt: metav1.NewTime(time.Now()),
+			},
+		}
+
 		result[i] = v1.ContainerStatus{
 			Name:         cSpec.Name,
 			Image:        b.buildImage(cSpec.Image, i),
 			Ready:        ready,
+			State:        state,
 			ContainerID:  b.buildContainerID(i),
 			RestartCount: int32(restartCount),
 		}


### PR DESCRIPTION
To more explicitly spell out the bad case here:

1. User performs a live update, which recompiles and restarts the process
2. While the process is starting up, the readiness probe is failing for 5 seconds
3. User performs another live update while the readiness probe is still failing
4. Since the container is not ready, tilt says there's no container to live update, and does a full image build + redeploy

It seems like in practice this doesn't cause an issue with pods getting updated before their ready, in my manual testing.

Fixes #3000