### PR TITLE
logger: fix a bug in log filtering

### DIFF
--- a/pkg/logger/func_logger.go
+++ b/pkg/logger/func_logger.go
@@ -87,7 +87,8 @@ type FuncLoggerWriter struct {
 var _ io.Writer = FuncLoggerWriter{}
 
 func (fw FuncLoggerWriter) Write(b []byte) (int, error) {
-	return len(b), fw.l.write(fw.level, fw.l.fields, b)
+	fw.l.Write(fw.level, b)
+	return len(b), nil
 }
 
 func (l funcLogger) Writer(level Level) io.Writer {

--- a/pkg/logger/func_logger_test.go
+++ b/pkg/logger/func_logger_test.go
@@ -23,6 +23,21 @@ func TestFuncLogger_Level(t *testing.T) {
 	require.NotContains(t, s, "debug")
 }
 
+func TestFuncLoggerWriter_Level(t *testing.T) {
+	out := &bytes.Buffer{}
+	fl := NewFuncLogger(true, InfoLvl, func(level Level, fields Fields, b []byte) error {
+		_, err := out.Write(b)
+		return err
+	})
+
+	_, _ = fl.Writer(InfoLvl).Write([]byte("info\n"))
+	_, _ = fl.Writer(DebugLvl).Write([]byte("debug\n"))
+
+	s := out.String()
+	require.Contains(t, s, "info")
+	require.NotContains(t, s, "debug")
+}
+
 func TestOneField(t *testing.T) {
 	out := &bytes.Buffer{}
 	fl := NewFuncLogger(true, InfoLvl, func(level Level, fields Fields, b []byte) error {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/filter:

fd0af381ecbb395594f5888d7d5e01601a044a90 (2020-02-26 15:00:18 -0500)
logger: fix a bug in log filtering
Because of this bug, low-level debug messages from the port-forwarder
were getting printed to the log stream.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics