### PR TITLE
web: add data model for trace navigation, broken off from https://github.com/windmilleng/tilt/pull/3008

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -17,12 +17,14 @@ import SocketBar from "./SocketBar"
 import "./HUD.scss"
 import {
   LogLine,
+  LogTrace,
+  LogTraceNav,
   ResourceView,
   ShowFatalErrorModal,
   SnapshotHighlight,
   SocketState,
 } from "./types"
-import { logLinesFromString } from "./logs"
+import { logLinesFromString, isBuildSpanId } from "./logs"
 import HudState from "./HudState"
 import AlertPane from "./AlertPane"
 import AnalyticsNudge from "./AnalyticsNudge"
@@ -467,11 +469,7 @@ class HUD extends Component<HudProps, HudState> {
     }
 
     let logsRoute = (props: RouteComponentProps<any>) => {
-      let name =
-        props.match.params && props.match.params.name
-          ? props.match.params.name
-          : ""
-
+      let name = props.match.params?.name ?? ""
       let r = resources.find(r => r.name === name)
       if (r === undefined) {
         return <Route component={NotFound} />

--- a/web/src/LogPane.stories.tsx
+++ b/web/src/LogPane.stories.tsx
@@ -21,7 +21,7 @@ function logPane(lines: LogLine[]) {
 
 function line(manifestName: string, text: string, level?: string): LogLine {
   level = level || "INFO"
-  return { manifestName, text, level }
+  return { manifestName, text, level, spanId: manifestName }
 }
 
 function threeResources() {

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -12,6 +12,7 @@ export function logLinesFromString(
       text: text,
       manifestName: manifestName ?? "",
       level: "INFO",
+      spanId: "",
     }
   })
 }
@@ -43,4 +44,8 @@ export function sourcePrefix(n: string) {
     spaces = " ".repeat(max - n.length)
   }
   return n + spaces + "┊ "
+}
+
+export function isBuildSpanId(spanId: string): boolean {
+  return spanId.indexOf("build:") != -1
 }

--- a/web/src/trace.test.ts
+++ b/web/src/trace.test.ts
@@ -1,0 +1,56 @@
+import LogStore from "./LogStore"
+import PathBuilder from "./PathBuilder"
+import { traceNav } from "./trace"
+
+function now() {
+  return new Date().toString()
+}
+
+function newManifestSegment(
+  name: string,
+  text: string
+): Proto.webviewLogSegment {
+  return { spanId: name, text: text, time: now() }
+}
+
+it("generates trace nav data", () => {
+  let logs = new LogStore()
+  logs.append({
+    spans: {
+      "": {},
+      "build:1": { manifestName: "fe" },
+      "pod:1": { manifestName: "fe" },
+      "build:2": { manifestName: "fe" },
+      "pod:2": { manifestName: "fe" },
+    },
+    segments: [
+      newManifestSegment("build:1", "build 1\n"),
+      newManifestSegment("pod:1", "pod 1\n"),
+      newManifestSegment("build:2", "build 2\n"),
+      newManifestSegment("pod:2", "pod 2\n"),
+      newManifestSegment("pod:1", "pod 1 line 2\n"),
+    ],
+  })
+
+  let pb = new PathBuilder("localhost:10350", "/r/fe")
+  expect(traceNav(logs, pb, "build:1")).toEqual({
+    current: {
+      label: "Build #1",
+      url: "/r/fe/trace/build:1",
+    },
+    next: {
+      label: "Build #2",
+      url: "/r/fe/trace/build:2",
+    },
+  })
+  expect(traceNav(logs, pb, "build:2")).toEqual({
+    prev: {
+      label: "Build #1",
+      url: "/r/fe/trace/build:1",
+    },
+    current: {
+      label: "Build #2",
+      url: "/r/fe/trace/build:2",
+    },
+  })
+})

--- a/web/src/trace.ts
+++ b/web/src/trace.ts
@@ -1,0 +1,46 @@
+import { LogTraceNav, LogTrace } from "./types"
+import { isBuildSpanId } from "./logs"
+import PathBuilder from "./PathBuilder"
+import LogStore from "./LogStore"
+
+function traceData(
+  pb: PathBuilder,
+  span: { spanId: string; manifestName: string },
+  index: number
+): LogTrace {
+  let url = pb.path(`/r/${span.manifestName}/trace/${span.spanId}`)
+  let label = `Build #${index + 1}`
+  return { url, label }
+}
+
+// Build navigational data for the trace we're currently looking at.
+function traceNav(
+  logStore: LogStore,
+  pb: PathBuilder,
+  spanId: string
+): LogTraceNav | null {
+  // Currently, we only support tracing of build logs.
+  if (!isBuildSpanId(spanId) || !logStore) {
+    return null
+  }
+
+  let spans = logStore.getOrderedBuildSpans(spanId)
+  let currentIndex = spans.findIndex(span => span.spanId == spanId)
+  let span = spans[currentIndex]
+  if (!span) {
+    return null
+  }
+  let nav: LogTraceNav = {
+    current: traceData(pb, span, currentIndex),
+  }
+
+  if (currentIndex < spans.length - 1) {
+    nav.next = traceData(pb, spans[currentIndex + 1], currentIndex + 1)
+  }
+  if (currentIndex > 0) {
+    nav.prev = traceData(pb, spans[currentIndex - 1], currentIndex - 1)
+  }
+  return nav
+}
+
+export { traceData, traceNav }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -69,4 +69,18 @@ export type LogLine = {
   manifestName: string
   level: string
   buildEvent?: string
+  spanId: string
+}
+
+// Display data about the current log trace.
+export type LogTrace = {
+  url: string
+  label: string
+}
+
+// Display data that lets us navigate between log traces.
+export type LogTraceNav = {
+  current: LogTrace
+  prev?: LogTrace
+  next?: LogTrace
 }


### PR DESCRIPTION
Hello @hyu, @maiamcc,

Please review the following commits I made in branch nicks/logstore:

defa2b193c6ce594800ed0277b0bf2fadb0f95d9 (2020-02-26 17:41:36 -0500)
web: add data model for trace navigation, broken off from https://github.com/windmilleng/tilt/pull/3008

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics