### PR TITLE
cli: docstring for tiltfile-result

### DIFF
--- a/internal/cli/tiltfile_result.go
+++ b/internal/cli/tiltfile_result.go
@@ -43,6 +43,13 @@ func (c *tiltfileResultCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tiltfile-result",
 		Short: "Exec the Tiltfile and print results as JSON (note: the API is unstable and may change)",
+		Long: `Exec the Tiltfile and print results as JSON (note: the API is unstable and may change).
+
+Exit code 0: successful Tiltfile evaluation (JSON printed to stdout)
+Exit code 1: some failure in setup, printing results, etc. (any logs printed to stderr)
+Exit code 5: error when evaluating the Tiltfile, such as syntax error, illegal Tiltfile operation, etc. (any logs printed to stderr)
+
+Run with -v | --verbose to print Tiltfile execution logs on stderr, regardless of whether there was an error.`,
 	}
 
 	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")


### PR DESCRIPTION
Hello @,

Please review the following commits I made in branch maiamcc/tiltfile-result-docstring:

ad8511e8b42132d1c8213336bbde9f825abe5354 (2020-02-27 17:46:48 -0500)
cli: docstring for tiltfile-result

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics