### PR TITLE
k8s: move all minikube calls out of wire injection. Fixes https://github.com/windmilleng/tilt/issues/3021

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -51,11 +51,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	env := k8s.EnvGKE
 
-	dEnv, err := docker.ProvideClusterEnv(ctx, env, wmcontainer.RuntimeDocker, minikube.FakeClient{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	dEnv := docker.ProvideClusterEnv(ctx, env, wmcontainer.RuntimeDocker, minikube.FakeClient{})
 	dCli := docker.NewDockerClient(ctx, docker.Env(dEnv))
 	_, ok := dCli.(*docker.Cli)
 	// If it wasn't an actual Docker client, it's an exploding client

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -43,7 +43,6 @@ import (
 
 var K8sWireSet = wire.NewSet(
 	k8s.ProvideEnv,
-	k8s.DetectNodeIP,
 	k8s.ProvideClusterName,
 	k8s.ProvideKubeContext,
 	k8s.ProvideKubeConfig,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -72,20 +72,14 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	extension := k8scontext.NewExtension(kubeContext, env)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
-	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
-	if err != nil {
-		return cmdTiltfileResultDeps{}, err
-	}
-	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
-	if err != nil {
-		return cmdTiltfileResultDeps{}, err
-	}
+	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	modelWebHost := provideWebHost()
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, dockerComposeClient, modelWebHost, defaults, env)
-	cliTiltfileResultDeps := newTiltfileResultDeps(tiltfileLoader)
-	return cliTiltfileResultDeps, nil
+	cliCmdTiltfileResultDeps := newTiltfileResultDeps(tiltfileLoader)
+	return cliCmdTiltfileResultDeps, nil
 }
 
 var (
@@ -112,14 +106,8 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics) (
 	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
-	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
-	if err != nil {
-		return dpDeps{}, err
-	}
-	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
-	if err != nil {
-		return dpDeps{}, err
-	}
+	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -172,11 +160,7 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	ownerFetcher := k8s.ProvideOwnerFetcher(client)
 	podWatcher := k8swatch.NewPodWatcher(client, ownerFetcher)
-	nodeIP, err := k8s.DetectNodeIP(ctx, env)
-	if err != nil {
-		return CmdUpDeps{}, err
-	}
-	serviceWatcher := k8swatch.NewServiceWatcher(client, ownerFetcher, nodeIP)
+	serviceWatcher := k8swatch.NewServiceWatcher(client, ownerFetcher)
 	podLogManager := runtimelog.NewPodLogManager(client)
 	portForwardController := engine.NewPortForwardController(client)
 	fsWatcherMaker := engine.ProvideFsWatcherMaker()
@@ -184,14 +168,8 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	watchManager := engine.NewWatchManager(fsWatcherMaker, timerMaker)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
-	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
-	if err != nil {
-		return CmdUpDeps{}, err
-	}
-	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
-	if err != nil {
-		return CmdUpDeps{}, err
-	}
+	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -391,14 +369,8 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
-	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
-	if err != nil {
-		return nil, err
-	}
-	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
-	if err != nil {
-		return nil, err
-	}
+	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -427,14 +399,8 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, kubectlRunner, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
-	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
-	if err != nil {
-		return nil, err
-	}
-	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
-	if err != nil {
-		return nil, err
-	}
+	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	return localClient, nil
 }
@@ -460,14 +426,8 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 	extension := k8scontext.NewExtension(kubeContext, env)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	minikubeClient := minikube.ProvideMinikubeClient()
-	clusterEnv, err := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
-	if err != nil {
-		return DownDeps{}, err
-	}
-	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
-	if err != nil {
-		return DownDeps{}, err
-	}
+	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	modelWebHost := provideWebHost()
 	defaults := _wireDefaultsValue
@@ -478,7 +438,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.DetectNodeIP, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
+var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -137,6 +137,10 @@ type Cli struct {
 }
 
 func NewDockerClient(ctx context.Context, env Env) Client {
+	if env.Error != nil {
+		return newExplodingClient(env.Error)
+	}
+
 	opts, err := CreateClientOpts(ctx, env)
 	if err != nil {
 		return newExplodingClient(err)

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -253,15 +253,11 @@ func TestProvideEnv(t *testing.T) {
 			}()
 
 			mkClient := minikube.FakeClient{DockerEnvMap: c.mkEnv}
-			cluster, err := ProvideClusterEnv(context.Background(), c.env, c.runtime, mkClient)
-			if assert.NoError(t, err) {
-				assert.Equal(t, c.expectedCluster, Env(cluster))
-			}
+			cluster := ProvideClusterEnv(context.Background(), c.env, c.runtime, mkClient)
+			assert.Equal(t, c.expectedCluster, Env(cluster))
 
-			local, err := ProvideLocalEnv(context.Background(), cluster)
-			if assert.NoError(t, err) {
-				assert.Equal(t, c.expectedLocal, Env(local))
-			}
+			local := ProvideLocalEnv(context.Background(), cluster)
+			assert.Equal(t, c.expectedLocal, Env(local))
 		})
 	}
 }

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -113,14 +113,16 @@ type swFixture struct {
 }
 
 func newSWFixture(t *testing.T) *swFixture {
+	nip := k8s.NodeIP("fakeip")
+
 	kClient := k8s.NewFakeK8sClient()
+	kClient.FakeNodeIP = nip
 
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 
-	nip := k8s.NodeIP("fakeip")
 	of := k8s.ProvideOwnerFetcher(kClient)
-	sw := NewServiceWatcher(kClient, of, nip)
+	sw := NewServiceWatcher(kClient, of)
 
 	ret := &swFixture{
 		kClient: kClient,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3451,7 +3451,7 @@ func newTestFixtureWithHud(t *testing.T, h hud.HeadsUpDisplay) *testFixture {
 	kCli := k8s.NewFakeK8sClient()
 	of := k8s.ProvideOwnerFetcher(kCli)
 	pw := k8swatch.NewPodWatcher(kCli, of)
-	sw := k8swatch.NewServiceWatcher(kCli, of, "")
+	sw := k8swatch.NewServiceWatcher(kCli, of)
 
 	fSub := fixtureSub{ch: make(chan bool, 1000)}
 	st := store.NewStore(UpperReducer, store.LogActionsFlag(false))

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -104,6 +104,9 @@ type Client interface {
 	// Some clusters support a local image registry that we can push to.
 	LocalRegistry(ctx context.Context) container.Registry
 
+	// Some clusters support a node IP where all servers are reachable.
+	NodeIP(ctx context.Context) NodeIP
+
 	Exec(ctx context.Context, podID PodID, cName container.Name, n Namespace, cmd []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
 }
 
@@ -118,6 +121,7 @@ type K8sClient struct {
 	dynamic           dynamic.Interface
 	runtimeAsync      *runtimeAsync
 	registryAsync     *registryAsync
+	nodeIPAsync       *nodeIPAsync
 	drm               meta.RESTMapper
 }
 
@@ -150,6 +154,7 @@ func ProvideK8sClient(
 	core := clientset.CoreV1()
 	runtimeAsync := newRuntimeAsync(core)
 	registryAsync := newRegistryAsync(env, core, runtimeAsync)
+	nodeIPAsync := newNodeIPAsync(env)
 
 	di, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
@@ -178,6 +183,7 @@ func ProvideK8sClient(
 		clientset:         clientset,
 		runtimeAsync:      runtimeAsync,
 		registryAsync:     registryAsync,
+		nodeIPAsync:       nodeIPAsync,
 		dynamic:           di,
 		drm:               drm,
 	}

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -81,6 +81,10 @@ func (ec *explodingClient) LocalRegistry(ctx context.Context) container.Registry
 	return container.Registry{}
 }
 
+func (ec *explodingClient) NodeIP(ctx context.Context) NodeIP {
+	return ""
+}
+
 func (ec *explodingClient) Exec(ctx context.Context, podID PodID, cName container.Name, n Namespace, cmd []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 	return errors.Wrap(ec.err, "could not set up k8s client")
 }

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -60,8 +60,9 @@ type FakeK8sClient struct {
 	UpsertError      error
 	LastUpsertResult []K8sEntity
 
-	Runtime  container.Runtime
-	Registry container.Registry
+	Runtime    container.Runtime
+	Registry   container.Registry
+	FakeNodeIP NodeIP
 
 	entityByName            map[string]K8sEntity
 	getByReferenceCallCount int
@@ -347,6 +348,10 @@ func (c *FakeK8sClient) ContainerRuntime(ctx context.Context) container.Runtime 
 
 func (c *FakeK8sClient) LocalRegistry(ctx context.Context) container.Registry {
 	return c.Registry
+}
+
+func (c *FakeK8sClient) NodeIP(ctx context.Context) NodeIP {
+	return c.FakeNodeIP
 }
 
 func (c *FakeK8sClient) Exec(ctx context.Context, podID PodID, cName container.Name, n Namespace, cmd []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -16,10 +16,7 @@ import (
 
 func WireSynclet(ctx context.Context, runtime container.Runtime) (*Synclet, error) {
 	clusterEnv := docker.ProvideEmptyClusterEnv()
-	localEnv, err := docker.ProvideLocalEnv(ctx, clusterEnv)
-	if err != nil {
-		return nil, err
-	}
+	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	client := docker.ProvideLocalAsDefault(localClient)
 	synclet := NewSynclet(client)


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch4928/minikube:

745a08f35ee6178b049675a0d012e772bcc07751 (2020-02-28 17:00:27 -0500)
k8s: move all minikube calls out of wire injection. Fixes https://github.com/windmilleng/tilt/issues/3021

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics