### PR TITLE
rty: rendering errors shouldn't totally break Tilt. Fixes https://github.com/windmilleng/tilt/issues/3039

### DIFF
--- a/internal/hud/hud_test.go
+++ b/internal/hud/hud_test.go
@@ -21,10 +21,9 @@ func TestRenderInit(t *testing.T) {
 
 	clockForTest := func() time.Time { return time.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC) }
 	r := NewRenderer(clockForTest)
-	r.rty = rty.NewRTY(tcell.NewSimulationScreen(""))
+	r.rty = rty.NewRTY(tcell.NewSimulationScreen(""), t)
 	webURL, _ := url.Parse("http://localhost:10350")
 	hud, err := ProvideHud(true, r, model.WebURL(*webURL), ta, NewIncrementalPrinter(logs))
 	require.NoError(t, err)
-	err = hud.(*Hud).refresh(ctx)
-	require.NoError(t, err)
+	hud.(*Hud).refresh(ctx) // Ensure we render without error
 }

--- a/internal/hud/renderer.go
+++ b/internal/hud/renderer.go
@@ -31,18 +31,14 @@ func NewRenderer(clock func() time.Time) *Renderer {
 	}
 }
 
-func (r *Renderer) Render(v view.View, vs view.ViewState) error {
+func (r *Renderer) Render(v view.View, vs view.ViewState) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	rty := r.rty
 	if rty != nil {
 		layout := r.layout(v, vs)
-		err := rty.Render(layout)
-		if err != nil {
-			return err
-		}
+		rty.Render(layout)
 	}
-	return nil
 }
 
 var cText = tcell.Color232
@@ -313,7 +309,7 @@ func (r *Renderer) SetUp() (chan tcell.Event, error) {
 		}
 	}()
 
-	r.rty = rty.NewRTY(screen)
+	r.rty = rty.NewRTY(screen, rty.SkipErrorHandler{})
 
 	r.screen = screen
 

--- a/internal/hud/renderer_test.go
+++ b/internal/hud/renderer_test.go
@@ -871,7 +871,7 @@ func (rtf rendererTestFixture) run(name string, w int, h int, v view.View, vs vi
 	}
 
 	r := NewRenderer(clockForTest)
-	r.rty = rty.NewRTY(tcell.NewSimulationScreen(""))
+	r.rty = rty.NewRTY(tcell.NewSimulationScreen(""), rtf.i.T())
 	c := r.layout(v, vs)
 	rtf.i.Run(name, w, h, c)
 }

--- a/internal/rty/components.go
+++ b/internal/rty/components.go
@@ -9,7 +9,7 @@ import (
 // Components are able to render themselves onto a screen
 
 type RTY interface {
-	Render(c Component) error
+	Render(c Component)
 
 	// Register must be called before Render
 	RegisterElementScroll(name string, children []string) (l *ElementScrollLayout, selectedChild string)

--- a/internal/rty/error.go
+++ b/internal/rty/error.go
@@ -1,0 +1,17 @@
+package rty
+
+// We want our tests to be able to handle errors.
+//
+// But we don't want errors in RTY rendering to stop the rendering pipeline.
+//
+// So we need a way to accumulate errors.
+// By design, testing.T implements this interface.
+type ErrorHandler interface {
+	Errorf(format string, args ...interface{})
+}
+
+type SkipErrorHandler struct{}
+
+func (SkipErrorHandler) Errorf(format string, args ...interface{}) {
+	// do nothing
+}

--- a/internal/rty/layouts_benchmark_test.go
+++ b/internal/rty/layouts_benchmark_test.go
@@ -14,7 +14,7 @@ func BenchmarkNestedFlexLayouts(b *testing.B) {
 	assert.NoError(b, err)
 	sc.SetSize(100, 100)
 
-	r := NewRTY(sc)
+	r := NewRTY(sc, b)
 
 	run := func() {
 
@@ -27,8 +27,7 @@ func BenchmarkNestedFlexLayouts(b *testing.B) {
 		}
 
 		innerF.Add(TextString("hello"))
-		err = r.Render(topF)
-		assert.NoError(b, err)
+		r.Render(topF)
 	}
 	for i := 0; i < b.N; i++ {
 		run()

--- a/internal/rty/layouts_test.go
+++ b/internal/rty/layouts_test.go
@@ -14,13 +14,12 @@ func TestFlexLayoutOverflow(t *testing.T) {
 	err := sc.Init()
 	assert.NoError(t, err)
 
-	r := NewRTY(sc)
+	r := NewRTY(sc, t)
 
 	f := NewFlexLayout(DirHor)
 	f.Add(TextString("hello"))
 	f.Add(TextString("world"))
-	err = r.Render(f)
-	assert.NoError(t, err)
+	r.Render(f)
 
 	i := NewInteractiveTester(t, screen)
 	i.Run("text overflow", 8, 1, f)
@@ -87,7 +86,7 @@ func TestNestedConcatLayoutOverflow(t *testing.T) {
 	err := sc.Init()
 	assert.NoError(t, err)
 
-	r := NewRTY(sc)
+	r := NewRTY(sc, t)
 
 	f1 := NewConcatLayout(DirHor)
 	for i := 0; i < 10; i++ {
@@ -102,8 +101,7 @@ func TestNestedConcatLayoutOverflow(t *testing.T) {
 		f2.AddDynamic(NewFillerString(' '))
 	}
 
-	err = r.Render(NewFixedSize(f1, 8, 1))
-	assert.NoError(t, err)
+	r.Render(NewFixedSize(f1, 8, 1))
 
 	i := NewInteractiveTester(t, screen)
 	i.Run("concat text overflow", 8, 1, f1)
@@ -114,7 +112,7 @@ func TestMinWidthInNestedConcatLayoutOverflow(t *testing.T) {
 	err := sc.Init()
 	assert.NoError(t, err)
 
-	r := NewRTY(sc)
+	r := NewRTY(sc, t)
 
 	f1 := NewConcatLayout(DirHor)
 	for i := 0; i < 10; i++ {
@@ -125,8 +123,7 @@ func TestMinWidthInNestedConcatLayoutOverflow(t *testing.T) {
 	f2 := NewConcatLayout(DirHor)
 	f2.Add(f1)
 
-	err = r.Render(f2)
-	assert.NoError(t, err)
+	r.Render(f2)
 
 	i := NewInteractiveTester(t, screen)
 	i.Run("min width concat text overflow", 8, 1, f2)

--- a/internal/rty/scroll_test.go
+++ b/internal/rty/scroll_test.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestElementScroll(t *testing.T) {
@@ -139,19 +137,16 @@ func (f *elementScrollTestFixture) run(name string) {
 }
 
 func (f *elementScrollTestFixture) down() {
-	_, err := f.i.render(20, 10, f.layout())
-	require.NoError(f.t, err)
+	_ = f.i.render(20, 10, f.layout())
 	f.scroller().Down()
 }
 
 func (f *elementScrollTestFixture) up() {
-	_, err := f.i.render(20, 10, f.layout())
-	require.NoError(f.t, err)
+	_ = f.i.render(20, 10, f.layout())
 	f.scroller().Up()
 }
 
 func (f *elementScrollTestFixture) bottom() {
-	_, err := f.i.render(20, 10, f.layout())
-	require.NoError(f.t, err)
+	_ = f.i.render(20, 10, f.layout())
 	f.scroller().Bottom()
 }


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch4973/crash:

f746c53c911814e2ab2f5a6da35d4dcf123079f7 (2020-03-02 16:49:56 -0500)
rty: rendering errors shouldn't totally break Tilt. Fixes https://github.com/windmilleng/tilt/issues/3039
Given that Tilt has a browser UI now, TUI rendering errors shouldn't be world-stopping.
For now, let's just throw them out silently and see what happens.
The test frameworks still check for errors.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics