### PR TITLE
k8s: report runtime differently on read failure

### DIFF
--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -7,10 +7,11 @@ import "strings"
 type Runtime string
 
 const (
-	RuntimeDocker     Runtime = "docker"
-	RuntimeContainerd Runtime = "containerd"
-	RuntimeCrio       Runtime = "cri-o"
-	RuntimeUnknown    Runtime = "unknown"
+	RuntimeDocker      Runtime = "docker"
+	RuntimeContainerd  Runtime = "containerd"
+	RuntimeCrio        Runtime = "cri-o"
+	RuntimeUnknown     Runtime = "unknown"
+	RuntimeReadFailure Runtime = "read-failure"
 )
 
 func RuntimeFromVersionString(s string) Runtime {

--- a/internal/k8s/runtime.go
+++ b/internal/k8s/runtime.go
@@ -38,14 +38,15 @@ func (r *runtimeAsync) Runtime(ctx context.Context) container.Runtime {
 			if isStatusErr {
 				status := statusErr.ErrStatus
 				if status.Code == http.StatusForbidden {
-					logger.Get(ctx).Infof(
-						"ERROR: Tilt could not read your node configuration\n"+
+					logger.Get(ctx).Warnf(
+						"Tilt could not read your node configuration\n"+
 							"  Ask your Kubernetes admin for access to run `kubectl get nodes`.\n"+
 							"  Detail: %v", err)
 				}
 			}
 		}
 		if nodeList == nil || len(nodeList.Items) == 0 {
+			r.runtime = container.RuntimeReadFailure
 			return
 		}
 

--- a/internal/k8s/runtime_test.go
+++ b/internal/k8s/runtime_test.go
@@ -27,6 +27,6 @@ func TestRuntimeForbidden(t *testing.T) {
 	l := logger.NewLogger(logger.InfoLvl, out)
 	ctx := logger.WithLogger(context.Background(), l)
 	runtime := runtimeAsync.Runtime(ctx)
-	assert.Equal(t, container.RuntimeUnknown, runtime)
+	assert.Equal(t, container.RuntimeReadFailure, runtime)
 	assert.Contains(t, out.String(), "Tilt could not read your node configuration")
 }


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/crio:

0d5cf9e5245bb4f8af1340ff47ee90d5f4daa419 (2020-03-03 17:55:16 -0500)
k8s: report runtime differently on read failure

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics