### PR TITLE
cli: dump the snapshot to a file when exiting. Fixes https://github.com/windmilleng/tilt/issues/3049

### DIFF
--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -34,7 +34,7 @@ func TestHudEnabled(t *testing.T) {
 				expectedType = &hud.DisabledHud{}
 			}
 
-			assert.IsType(t, expectedType, threads.hud)
+			assert.IsType(t, expectedType, threads.Hud)
 		})
 	}
 }

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -124,7 +124,7 @@ var BaseWireSet = wire.NewSet(
 	dirs.UseWindmillDir,
 	token.GetOrCreateToken,
 
-	provideCmdUpDeps,
+	wire.Struct(new(CmdUpDeps), "*"),
 	engine.NewKINDLoader,
 
 	wire.Value(feature.MainDefaults),
@@ -146,15 +146,12 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics *analyt
 }
 
 type CmdUpDeps struct {
-	hud          hud.HeadsUpDisplay
-	upper        engine.Upper
-	tiltBuild    model.TiltBuild
-	token        token.Token
-	cloudAddress cloudurl.Address
-}
-
-func provideCmdUpDeps(h hud.HeadsUpDisplay, upper engine.Upper, b model.TiltBuild, token token.Token, cloudAddress cloudurl.Address) CmdUpDeps {
-	return CmdUpDeps{h, upper, b, token, cloudAddress}
+	Hud          hud.HeadsUpDisplay
+	Upper        engine.Upper
+	TiltBuild    model.TiltBuild
+	Token        token.Token
+	CloudAddress cloudurl.Address
+	Store        *store.Store
 }
 
 func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -259,7 +259,14 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
-	cmdUpDeps := provideCmdUpDeps(headsUpDisplay, upper, tiltBuild, tokenToken, address)
+	cmdUpDeps := CmdUpDeps{
+		Hud:          headsUpDisplay,
+		Upper:        upper,
+		TiltBuild:    tiltBuild,
+		Token:        tokenToken,
+		CloudAddress: address,
+		Store:        storeStore,
+	}
 	return cmdUpDeps, nil
 }
 
@@ -446,19 +453,16 @@ var BaseWireSet = wire.NewSet(
 	provideWebURL,
 	provideWebPort,
 	provideWebHost,
-	provideNoBrowserFlag, server.ProvideHeadsUpServer, provideAssetServer, server.ProvideHeadsUpServerController, tracer.NewSpanCollector, wire.Bind(new(trace2.SpanProcessor), new(*tracer.SpanCollector)), wire.Bind(new(tracer.SpanSource), new(*tracer.SpanCollector)), dirs.UseWindmillDir, token.GetOrCreateToken, provideCmdUpDeps, engine.NewKINDLoader, wire.Value(feature.MainDefaults),
+	provideNoBrowserFlag, server.ProvideHeadsUpServer, provideAssetServer, server.ProvideHeadsUpServerController, tracer.NewSpanCollector, wire.Bind(new(trace2.SpanProcessor), new(*tracer.SpanCollector)), wire.Bind(new(tracer.SpanSource), new(*tracer.SpanCollector)), dirs.UseWindmillDir, token.GetOrCreateToken, wire.Struct(new(CmdUpDeps), "*"), engine.NewKINDLoader, wire.Value(feature.MainDefaults),
 )
 
 type CmdUpDeps struct {
-	hud          hud.HeadsUpDisplay
-	upper        engine.Upper
-	tiltBuild    model.TiltBuild
-	token        token.Token
-	cloudAddress cloudurl.Address
-}
-
-func provideCmdUpDeps(h hud.HeadsUpDisplay, upper engine.Upper, b model.TiltBuild, token2 token.Token, cloudAddress cloudurl.Address) CmdUpDeps {
-	return CmdUpDeps{h, upper, b, token2, cloudAddress}
+	Hud          hud.HeadsUpDisplay
+	Upper        engine.Upper
+	TiltBuild    model.TiltBuild
+	Token        token.Token
+	CloudAddress cloudurl.Address
+	Store        *store.Store
 }
 
 type DownDeps struct {

--- a/internal/cloud/io.go
+++ b/internal/cloud/io.go
@@ -1,0 +1,40 @@
+package cloud
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/pkg/logger"
+)
+
+func WriteSnapshot(ctx context.Context, store *store.Store, path string) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		logger.Get(ctx).Errorf("Writing snapshot to file: %v", err)
+	}
+
+	state := store.RLockState()
+	defer store.RUnlockState()
+
+	err = WriteSnapshotTo(ctx, state, f)
+	if err != nil {
+		logger.Get(ctx).Errorf("Writing snapshot to file: %v", err)
+	}
+}
+
+func WriteSnapshotTo(ctx context.Context, state store.EngineState, w io.Writer) error {
+	snapshot, err := ToSnapshot(state)
+	if err != nil {
+		return err
+	}
+
+	jsEncoder := &runtime.JSONPb{
+		OrigName: false,
+		Indent:   "  ",
+	}
+	return jsEncoder.NewEncoder(w).Encode(snapshot)
+}

--- a/internal/cloud/io_test.go
+++ b/internal/cloud/io_test.go
@@ -1,0 +1,67 @@
+package cloud
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/testutils"
+)
+
+func TestWriteSnapshotTo(t *testing.T) {
+	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
+	buf := bytes.NewBuffer(nil)
+	state := store.NewState()
+	err := WriteSnapshotTo(ctx, *state, buf)
+	assert.NoError(t, err)
+	assert.Equal(t, `{
+  "view": {
+    "resources": [
+      {
+        "name": "(Tiltfile)",
+        "lastDeployTime": "0001-01-01T00:00:00Z",
+        "buildHistory": [
+          {
+            "warnings": [
+            ],
+            "startTime": "0001-01-01T00:00:00Z",
+            "finishTime": "0001-01-01T00:00:00Z",
+            "updateTypes": [
+            ]
+          }
+        ],
+        "currentBuild": {
+          "warnings": [
+          ],
+          "startTime": "0001-01-01T00:00:00Z",
+          "finishTime": "0001-01-01T00:00:00Z",
+          "updateTypes": [
+          ]
+        },
+        "runtimeStatus": "ok",
+        "isTiltfile": true
+      }
+    ],
+    "featureFlags": {
+    },
+    "runningTiltBuild": {
+
+    },
+    "latestTiltBuild": {
+
+    },
+    "versionSettings": {
+      "checkUpdates": true
+    },
+    "tiltCloudSchemeHost": "https:",
+    "logList": {
+      "fromCheckpoint": -1,
+      "toCheckpoint": -1
+    },
+    "tiltStartTime": "0001-01-01T00:00:00Z"
+  }
+}
+`, buf.String())
+}

--- a/internal/cloud/snapshot_uploader.go
+++ b/internal/cloud/snapshot_uploader.go
@@ -19,6 +19,14 @@ import (
 
 type SnapshotID string
 
+func ToSnapshot(state store.EngineState) (*proto_webview.Snapshot, error) {
+	view, err := webview.StateToProtoView(state, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &proto_webview.Snapshot{View: view}, nil
+}
+
 type SnapshotUploader interface {
 	TakeAndUpload(state store.EngineState) (SnapshotID, error)
 	Upload(token token.Token, teamID string, snapshot *proto_webview.Snapshot) (SnapshotID, error)
@@ -54,11 +62,11 @@ type snapshotIDResponse struct {
 }
 
 func (s snapshotUploader) TakeAndUpload(state store.EngineState) (SnapshotID, error) {
-	view, err := webview.StateToProtoView(state, 0)
+	snapshot, err := ToSnapshot(state)
 	if err != nil {
 		return "", err
 	}
-	return s.Upload(state.Token, state.TeamName, &proto_webview.Snapshot{View: view})
+	return s.Upload(state.Token, state.TeamName, snapshot)
 }
 
 func (s snapshotUploader) Upload(token token.Token, teamID string, snapshot *proto_webview.Snapshot) (SnapshotID, error) {


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch5077/dump:

09a457459fac84275ca5efe59c3580a2b51f0f5a (2020-03-06 15:03:53 -0500)
cli: dump the snapshot to a file when exiting. Fixes https://github.com/windmilleng/tilt/issues/3049

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics