### PR TITLE
web: fix the header box-shadow, which looks like it broke in the transition from scss -> styled-components

### DIFF
--- a/web/src/HUDLayout.tsx
+++ b/web/src/HUDLayout.tsx
@@ -72,7 +72,6 @@ let Header = styled.header`
   padding-right: ${s.Width.sidebar}px;
   height: ${s.Height.HUDheader}px;
   background-color: ${s.Color.grayDarkest};
-  box-shadow: inset 0px -2px 10px 0px rgba(${s.Color.black}, ${s.ColorAlpha.translucent});
   transition: padding-right ${s.AnimDuration.default} ease;
   z-index: ${s.ZIndex.HUDheader};
 


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/boxshadow:

6d4915f6b0645fccae792ccaf52ba26da961670b (2020-03-06 17:07:49 -0500)
web: fix the header box-shadow, which looks like it broke in the transition from scss -> styled-components

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics