### PR TITLE
Revert "engine: if we fail to inject the synclet into a resource, try to recover gracefully (#3050)"

### DIFF
--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -147,7 +147,7 @@ func runTestCase(t *testing.T, f *bdFixture, tCase testCase) {
 		assert.Equal(t, tCase.expectSyncletDeploy, strings.Contains(f.k8s.Yaml, sidecar.DefaultSyncletImageName), "expected synclet-deploy = %t (deployed yaml was: %s)", tCase.expectSyncletDeploy, f.k8s.Yaml)
 		return
 	} else {
-		require.Empty(t, f.k8s.Yaml, "expected no k8s deploy")
+		require.Empty(t, f.k8s.Yaml, "expected no k8s deploy, but we deployed YAML: %s", f.k8s.Yaml)
 	}
 
 	expectUpdatedTargs := make(map[model.TargetID]bool)

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -110,27 +110,6 @@ func TestDeployPodWithMultipleLiveUpdateImages(t *testing.T) {
 
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, "gcr.io/windmill-public-containers/tilt-synclet:"),
 		"Expected synclet to be injected once in YAML: %s", f.k8s.Yaml)
-	assert.True(t, result[kTarget.ID()].(store.K8sBuildResult).HasEligibleSynclet)
-}
-
-func TestDeployWorkflow(t *testing.T) {
-	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
-	f.ibd.injectSynclet = true
-
-	iTarget := NewSanchoLiveUpdateImageTarget(f)
-	kTarget := model.K8sTarget{Name: "hello-world", YAML: testyaml.ArgoSanchoWorkflow}.
-		WithDependencyIDs([]model.TargetID{iTarget.ID()})
-	targets := []model.TargetSpec{iTarget, kTarget}
-
-	result, err := f.ibd.BuildAndDeploy(f.ctx, f.st, targets, store.BuildStateSet{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equalf(t, 0, strings.Count(f.k8s.Yaml, "gcr.io/windmill-public-containers/tilt-synclet:"),
-		"Expected no synclet in the YAML: %s", f.k8s.Yaml)
-	assert.False(t, result[kTarget.ID()].(store.K8sBuildResult).HasEligibleSynclet)
 }
 
 func TestNoImageTargets(t *testing.T) {

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -68,7 +68,7 @@ func (lubad *LiveUpdateBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		return store.BuildResultSet{}, err
 	}
 
-	containerUpdater := lubad.containerUpdaterForSpecs(specs, stateSet)
+	containerUpdater := lubad.containerUpdaterForSpecs(specs)
 	liveUpdInfos := make([]liveUpdInfo, 0, len(liveUpdateStateSet))
 
 	if len(liveUpdateStateSet) == 0 {
@@ -250,7 +250,7 @@ func liveUpdateInfoForStateTree(stateTree liveUpdateStateTree) (liveUpdInfo, err
 	}, nil
 }
 
-func (lubad *LiveUpdateBuildAndDeployer) containerUpdaterForSpecs(specs []model.TargetSpec, stateSet store.BuildStateSet) containerupdate.ContainerUpdater {
+func (lubad *LiveUpdateBuildAndDeployer) containerUpdaterForSpecs(specs []model.TargetSpec) containerupdate.ContainerUpdater {
 	isDC := len(model.ExtractDockerComposeTargets(specs)) > 0
 	if isDC || lubad.updMode == buildcontrol.UpdateModeContainer {
 		return lubad.dcu
@@ -264,7 +264,7 @@ func (lubad *LiveUpdateBuildAndDeployer) containerUpdaterForSpecs(specs []model.
 		return lubad.ecu
 	}
 
-	if lubad.shouldUseSynclet(specs, stateSet) {
+	if shouldUseSynclet(lubad.updMode, lubad.env, lubad.runtime) {
 		return lubad.scu
 	}
 
@@ -273,32 +273,4 @@ func (lubad *LiveUpdateBuildAndDeployer) containerUpdaterForSpecs(specs []model.
 	}
 
 	return lubad.ecu
-}
-
-func (lubad *LiveUpdateBuildAndDeployer) shouldUseSynclet(specs []model.TargetSpec, stateSet store.BuildStateSet) bool {
-	if !shouldUseSynclet(lubad.updMode, lubad.env, lubad.runtime) {
-		return false
-	}
-
-	k8sTargets := model.ExtractK8sTargets(specs)
-	if len(k8sTargets) == 0 {
-		return false
-	}
-
-	for _, t := range k8sTargets {
-		state := stateSet[t.ID()]
-		result := state.LastSuccessfulResult
-		k8sResult, ok := result.(store.K8sBuildResult)
-		if !ok {
-			return false
-		}
-
-		if !k8sResult.HasEligibleSynclet {
-			// If we failed to inject the synclet in one of the resources,
-			// then don't try to use this as an update method.
-			return false
-		}
-	}
-
-	return true
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -277,7 +277,7 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 			templateSpecHashes = b.nextPodTemplateSpecHashes
 			b.nextPodTemplateSpecHashes = nil
 		}
-		result[call.k8s().ID()] = store.NewK8sDeployResult(call.k8s().ID(), uids, templateSpecHashes, nil, false)
+		result[call.k8s().ID()] = store.NewK8sDeployResult(call.k8s().ID(), uids, templateSpecHashes, nil)
 	}
 
 	b.nextLiveUpdateContainerIDs = nil
@@ -4121,7 +4121,7 @@ func deployResultSet(manifest model.Manifest, uid types.UID, hashes []k8s.PodTem
 		resultSet[iTarget.ID()] = store.NewImageBuildResult(iTarget.ID(), localRefTagged, clusterRefTagged)
 	}
 	ktID := manifest.K8sTarget().ID()
-	resultSet[ktID] = store.NewK8sDeployResult(ktID, []types.UID{uid}, hashes, nil, false)
+	resultSet[ktID] = store.NewK8sDeployResult(ktID, []types.UID{uid}, hashes, nil)
 	return resultSet
 }
 

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -106,29 +106,36 @@ func (e K8sEntity) GVK() schema.GroupVersionKind {
 }
 
 func (e K8sEntity) meta() k8sMeta {
-	unstruct, ok := e.Obj.(*unstructured.Unstructured)
-	if ok {
+	if unstruct := e.maybeUnstructuredMeta(); unstruct != nil {
 		return unstruct
 	}
 
-	if structured := e.maybeStructuredMeta(); structured != nil {
+	if structured, _ := e.maybeStructuredMeta(); structured != nil {
 		return structured
 	}
 
 	return emptyMeta{}
 }
 
-func (e K8sEntity) maybeStructuredMeta() *metav1.ObjectMeta {
+func (e K8sEntity) maybeUnstructuredMeta() *unstructured.Unstructured {
+	unstruct, isUnstructured := e.Obj.(*unstructured.Unstructured)
+	if isUnstructured {
+		return unstruct
+	}
+	return nil
+}
+
+func (e K8sEntity) maybeStructuredMeta() (meta *metav1.ObjectMeta, fieldIndex int) {
 	objVal := reflect.ValueOf(e.Obj)
 	if objVal.Kind() == reflect.Ptr {
 		if objVal.IsNil() {
-			return nil
+			return nil, -1
 		}
 		objVal = objVal.Elem()
 	}
 
 	if objVal.Kind() != reflect.Struct {
-		return nil
+		return nil, -1
 	}
 
 	// Find a field with type ObjectMeta
@@ -148,25 +155,35 @@ func (e K8sEntity) maybeStructuredMeta() *metav1.ObjectMeta {
 			continue
 		}
 
-		return metadata
+		return metadata, i
 	}
-	return nil
+	return nil, -1
 }
 
 func SetUID(e *K8sEntity, UID string) error {
-	unstruct, ok := e.Obj.(*unstructured.Unstructured)
-	if ok {
-		unstruct.SetUID(types.UID(UID))
-		return nil
+	unstruct := e.maybeUnstructuredMeta()
+	if unstruct != nil {
+		return fmt.Errorf("SetUIDForTesting not yet implemented for unstructured metadata")
 	}
 
-	structured := e.maybeStructuredMeta()
-	if structured != nil {
-		structured.SetUID(types.UID(UID))
-		return nil
+	structured, i := e.maybeStructuredMeta()
+	if structured == nil {
+		return fmt.Errorf("Cannot set UID -- entity has neither unstructured nor structured metadata. k8s entity: %+v", e)
 	}
 
-	return fmt.Errorf("Cannot set UID -- entity has neither unstructured nor structured metadata. k8s entity: %+v", e)
+	structured.SetUID(types.UID(UID))
+	objVal := reflect.ValueOf(e.Obj)
+	if objVal.Kind() == reflect.Ptr {
+		if objVal.IsNil() {
+			return fmt.Errorf("Cannot set UID -- e.Obj is a pointer. k8s entity: %+v", e)
+		}
+		objVal = objVal.Elem()
+	}
+
+	fieldVal := objVal.Field(i)
+	metaVal := reflect.ValueOf(*structured)
+	fieldVal.Set(metaVal)
+	return nil
 }
 
 func SetUIDForTest(t *testing.T, e *K8sEntity, UID string) {

--- a/internal/k8s/entity_test.go
+++ b/internal/k8s/entity_test.go
@@ -268,20 +268,6 @@ func TestMutableAndImmutableEntities(t *testing.T) {
 	}
 }
 
-func TestSetUIDPod(t *testing.T) {
-	entity := NewK8sEntity(&v1.Pod{})
-	err := SetUID(&entity, "abc")
-	assert.NoError(t, err)
-	assert.Equal(t, "abc", string(entity.meta().GetUID()))
-}
-
-func TestSetUIDWorkflow(t *testing.T) {
-	entity := mustParseYAML(t, testyaml.ArgoSanchoWorkflow)[0]
-	err := SetUID(&entity, "abc")
-	assert.NoError(t, err)
-	assert.Equal(t, "abc", string(entity.meta().GetUID()))
-}
-
 func entitiesWithKinds(kinds []string) []K8sEntity {
 	entities := make([]K8sEntity, len(kinds))
 	for i, k := range kinds {

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1549,18 +1549,3 @@ items:
           image: gcr.io/windmill-public-containers/servantes/doggos
           command: ["/go/bin/doggos"]
 `
-
-const ArgoSanchoWorkflow = `
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: hello-world-
-spec:
-  entrypoint: whalesay
-  templates:
-  - name: whalesay
-    container:
-      image: gcr.io/some-project-162817/sancho
-      command: [cowsay]
-      args: ["hello world"]
-`

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -122,8 +122,6 @@ type K8sBuildResult struct {
 	PodTemplateSpecHashes []k8s.PodTemplateSpecHash
 
 	AppliedEntitiesText string
-
-	HasEligibleSynclet bool
 }
 
 func (r K8sBuildResult) TargetID() model.TargetID   { return r.id }
@@ -139,7 +137,7 @@ func (r K8sBuildResult) Facets() []model.Facet {
 }
 
 // For kubernetes deploy targets.
-func NewK8sDeployResult(id model.TargetID, uids []types.UID, hashes []k8s.PodTemplateSpecHash, appliedEntities []k8s.K8sEntity, hasEligibleSynclet bool) BuildResult {
+func NewK8sDeployResult(id model.TargetID, uids []types.UID, hashes []k8s.PodTemplateSpecHash, appliedEntities []k8s.K8sEntity) BuildResult {
 	appliedEntitiesText, err := k8s.SerializeSpecYAML(appliedEntities)
 	if err != nil {
 		appliedEntitiesText = fmt.Sprintf("unable to serialize entities to yaml: %s", err.Error())
@@ -150,7 +148,6 @@ func NewK8sDeployResult(id model.TargetID, uids []types.UID, hashes []k8s.PodTem
 		DeployedUIDs:          uids,
 		PodTemplateSpecHashes: hashes,
 		AppliedEntitiesText:   appliedEntitiesText,
-		HasEligibleSynclet:    hasEligibleSynclet,
 	}
 }
 

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -23,7 +23,7 @@ func TestToJSON(t *testing.T) {
 	state := newState([]model.Manifest{m})
 
 	mState, _ := state.ManifestState("fe")
-	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(m.K8sTarget().ID(), nil, nil, nil, false)
+	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(m.K8sTarget().ID(), nil, nil, nil)
 
 	buf := bytes.NewBuffer(nil)
 	encoder := CreateEngineStateEncoder(buf)


### PR DESCRIPTION
a user in #tilt reported consistent "ExecUpdater does not support `restart_container()` step" errors
even tho they expected tilt to use the Synclet.

the reverted commit is the cause: as a prerequiste to using the synclet, we check
the last result for the k8s target to see if it has the `HasEligibleSynclet` flag.
However, this didn't work in practice because, when we construct a buildEntry,
we [don't add k8s results to the buildStateSet](https://github.com/windmilleng/tilt/blob/136f1624c77c8eb585c6660c89a2fedba992c0a1/internal/engine/buildcontroller.go#L191);
no k8s result ever made it to the new code that checks the synclet eligibility flag.

will revisit this PR soon to make it do the right thing; for now, just revert to
fix the break.