### PR TITLE
bump version to 0.12.7

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.12.6"
+const devVersion = "0.12.7"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.12.6"
+VERSION="0.12.7"
 BREW=$(command -v brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/bump-0.12.7:

0fdbf6d10e03987f774a0f9f8febd0b21c159c03 (2020-03-09 18:13:05 -0400)
bump version to 0.12.7

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics