### PR TITLE
go.mod: upgrade to go 1.14

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.13
+FROM circleci/golang:1.14
 
 RUN go get -u github.com/kisielk/errcheck
 
@@ -41,7 +41,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
 
 RUN /tmp/google-cloud-sdk/install.sh
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
 
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.0
 

--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.14
 
 # Install docker
 # Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build-linux:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:0868ccf686cba2adf4c6c82b9a5c7062eeea123de49283676b066060f3381d3a
+      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:62d0b5b9668e41165b132a86a599b34331f199c95a4e4d8ba82d64a97f654c7c
 
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
           only_for_branches: master
   helm2:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:125580447b213fbb1d66522f9b0efb76ed736e49e95130f8a6fdcd868a05b645
+      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:62d0b5b9668e41165b132a86a599b34331f199c95a4e4d8ba82d64a97f654c7c
     steps:
       - checkout
       - run: sudo mv /usr/bin/helm2 /usr/bin/helm
@@ -59,7 +59,7 @@ jobs:
 
   publish-assets:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:168fcc4ab364bf330a7a524b07da56cf54c2fe134b2e78be78f6b7c2791a5d2f
+      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:62d0b5b9668e41165b132a86a599b34331f199c95a4e4d8ba82d64a97f654c7c
     steps:
       - checkout
       - run: echo $GCLOUD_SERVICE_KEY > /tmp/gcloud-service-key.json
@@ -80,7 +80,7 @@ jobs:
 
   build-integration:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:132dd09f30d3b5f9b70899e900c2cc48cf0d6f5c9caf2b99e19615793a21a357
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:67d6cb938c2333c1483cfc6afbf2ef08a95e937ef4feafe15f8a0adf02596a89
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ features that we have in mind and might already be in-progress.
 If you just want to build Tilt:
 
 - **[make](https://www.gnu.org/software/make/)**
-- **[go 1.13](https://golang.org/dl/)**
+- **[go 1.14](https://golang.org/dl/)**
 - **[golangci-lint](https://github.com/golangci/golangci-lint)** (to run lint)
 - [yarn](https://yarnpkg.com/lang/en/docs/install/) (for JS resources)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/windmilleng/tilt
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Azure/azure-sdk-for-go v16.2.1+incompatible // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,12 @@
 # cloud.google.com/go v0.38.0
 cloud.google.com/go/compute/metadata
+# github.com/Azure/azure-sdk-for-go v16.2.1+incompatible
+## explicit
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
+# github.com/Azure/go-autorest v10.8.1+incompatible => github.com/Azure/go-autorest v12.4.3+incompatible
+## explicit
 # github.com/Azure/go-autorest/autorest v0.9.0
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
@@ -42,23 +46,49 @@ github.com/Microsoft/hcsshim/osversion
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
+# github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d
+## explicit
 # github.com/Shopify/sarama v1.18.0
+## explicit
 github.com/Shopify/sarama
+# github.com/Shopify/toxiproxy v2.1.4+incompatible
+## explicit
 # github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
+## explicit
 github.com/agl/ed25519
 github.com/agl/ed25519/edwards25519
 # github.com/apache/thrift v0.0.0-20171203172758-327ebb6c2b6d
+## explicit
 github.com/apache/thrift/lib/go/thrift
+# github.com/aws/aws-sdk-go v1.15.11
+## explicit
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
+# github.com/bitly/go-hostpool v0.1.0
+## explicit
 # github.com/blang/semver v3.5.1+incompatible
+## explicit
 github.com/blang/semver
+# github.com/bugsnag/bugsnag-go v1.5.3
+## explicit
+# github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b
+## explicit
+# github.com/bugsnag/panicwrap v1.2.0
+## explicit
+# github.com/cenkalti/backoff v2.2.1+incompatible
+## explicit
 # github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1
+## explicit
 github.com/chai2010/gettext-go/gettext
 github.com/chai2010/gettext-go/gettext/mo
 github.com/chai2010/gettext-go/gettext/plural
 github.com/chai2010/gettext-go/gettext/po
+# github.com/cloudflare/cfssl v1.4.1
+## explicit
+# github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
+## explicit
 # github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901
+## explicit
 github.com/containerd/cgroups/stats/v1
 # github.com/containerd/containerd v1.3.1-0.20191217142032-9b5581cc9c5b
 github.com/containerd/containerd/archive/compression
@@ -82,20 +112,30 @@ github.com/containerd/containerd/snapshots
 github.com/containerd/containerd/sys
 github.com/containerd/containerd/version
 # github.com/containerd/continuity v0.0.0-20191214063359-1097c8bae83b
+## explicit
 github.com/containerd/continuity/fs
 github.com/containerd/continuity/syscallx
 github.com/containerd/continuity/sysx
 # github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c
+## explicit
 github.com/containerd/ttrpc
 # github.com/cpuguy83/go-md2man v1.0.10
 github.com/cpuguy83/go-md2man/md2man
+# github.com/d4l3k/messagediff v1.2.1
+## explicit
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/denisbrodbeck/machineid v1.0.0
 github.com/denisbrodbeck/machineid
+# github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba
+## explicit
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
+# github.com/dnaeon/go-vcr v1.0.1
+## explicit
 # github.com/docker/cli v0.0.0-20191220145525-ba63a92655c0
+## explicit
 github.com/docker/cli/cli/command
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
@@ -117,6 +157,7 @@ github.com/docker/cli/cli/trust
 github.com/docker/cli/cli/version
 github.com/docker/cli/opts
 # github.com/docker/distribution v2.7.1+incompatible
+## explicit
 github.com/docker/distribution
 github.com/docker/distribution/digestset
 github.com/docker/distribution/manifest
@@ -134,6 +175,7 @@ github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
 # github.com/docker/docker v1.4.2-0.20191210192822-1347481b9eb5
+## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
@@ -170,26 +212,36 @@ github.com/docker/docker/registry
 github.com/docker/docker/registry/resumable
 github.com/docker/docker/rootless
 # github.com/docker/docker-credential-helpers v0.6.3
+## explicit
 github.com/docker/docker-credential-helpers/client
 github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go v1.5.1-1
+## explicit
 github.com/docker/go/canonical/json
 # github.com/docker/go-connections v0.4.0
+## explicit
 github.com/docker/go-connections/nat
 github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
+## explicit
 github.com/docker/go-metrics
 # github.com/docker/go-units v0.4.0
+## explicit
 github.com/docker/go-units
+# github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
+## explicit
 # github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/eapache/go-resiliency v1.1.0
+## explicit
 github.com/eapache/go-resiliency/breaker
 # github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
+## explicit
 github.com/eapache/go-xerial-snappy
 # github.com/eapache/queue v1.1.0
+## explicit
 github.com/eapache/queue
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
@@ -199,16 +251,22 @@ github.com/evanphx/json-patch
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 github.com/exponent-io/jsonpath
 # github.com/fatih/color v1.7.0
+## explicit
 github.com/fatih/color
+# github.com/frankban/quicktest v1.7.2
+## explicit
 # github.com/gdamore/encoding v1.0.0
 github.com/gdamore/encoding
 # github.com/gdamore/tcell v1.1.3
+## explicit
 github.com/gdamore/tcell
 github.com/gdamore/tcell/terminfo
 github.com/gdamore/tcell/terminfo/dynamic
 # github.com/gentlemanautomaton/graceful v0.0.0-20170727140743-803ae396410c
+## explicit
 github.com/gentlemanautomaton/graceful
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/go-logfmt/logfmt v0.4.0
 github.com/go-logfmt/logfmt
@@ -220,6 +278,10 @@ github.com/go-openapi/jsonreference
 github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.5
 github.com/go-openapi/swag
+# github.com/go-sql-driver/mysql v1.5.0
+## explicit
+# github.com/gofrs/uuid v3.2.0+incompatible
+## explicit
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/proto
@@ -229,6 +291,7 @@ github.com/gogo/protobuf/types
 # github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.3.2
+## explicit
 github.com/golang/protobuf/descriptor
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
@@ -240,10 +303,12 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
+## explicit
 github.com/golang/snappy
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/go-cmp v0.3.1
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -251,18 +316,23 @@ github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/go-github v17.0.0+incompatible
+## explicit
 github.com/google/go-github/github
 # github.com/google/go-github/v29 v29.0.3
+## explicit
 github.com/google/go-github/v29/github
 # github.com/google/go-querystring v1.0.0
 github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.0.0
 github.com/google/gofuzz
 # github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
+## explicit
 github.com/google/shlex
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/google/wire v0.3.0
+## explicit
 github.com/google/wire
 # github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d
 github.com/googleapis/gnostic/OpenAPIv2
@@ -277,18 +347,25 @@ github.com/gophercloud/gophercloud/openstack/identity/v3/tokens
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/mux v1.7.2
+## explicit
 github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.0
+## explicit
 github.com/gorilla/websocket
 # github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
+## explicit
 github.com/gregjones/httpcache
 github.com/gregjones/httpcache/diskcache
 # github.com/grpc-ecosystem/grpc-gateway v1.11.3
+## explicit
 github.com/grpc-ecosystem/grpc-gateway/internal
 github.com/grpc-ecosystem/grpc-gateway/runtime
 github.com/grpc-ecosystem/grpc-gateway/utilities
 # github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
+## explicit
 github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc
+# github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
+## explicit
 # github.com/hashicorp/golang-lru v0.5.1
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
@@ -296,11 +373,19 @@ github.com/hashicorp/golang-lru/simplelru
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
+# github.com/jinzhu/gorm v1.9.12
+## explicit
+# github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7
+## explicit
 # github.com/jonboulle/clockwork v0.1.0
+## explicit
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.8
+## explicit
 github.com/json-iterator/go
 github.com/json-iterator/go/extra
+# github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
+## explicit
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
@@ -308,6 +393,7 @@ github.com/kr/logfmt
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/liggitt/tabwriter
 # github.com/lightstep/lightstep-tracer-go v0.15.6
+## explicit
 github.com/lightstep/lightstep-tracer-go
 github.com/lightstep/lightstep-tracer-go/collectorpb
 github.com/lightstep/lightstep-tracer-go/lightstep/rand
@@ -315,6 +401,7 @@ github.com/lightstep/lightstep-tracer-go/lightstep_thrift
 github.com/lightstep/lightstep-tracer-go/lightsteppb
 github.com/lightstep/lightstep-tracer-go/thrift_0_9_2/lib/go/thrift
 # github.com/looplab/tarjan v0.0.0-20161115091335-9cc6d6cebfb5
+## explicit
 github.com/looplab/tarjan
 # github.com/lucasb-eyer/go-colorful v1.0.2
 github.com/lucasb-eyer/go-colorful
@@ -322,21 +409,31 @@ github.com/lucasb-eyer/go-colorful
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+# github.com/marstr/guid v1.1.0
+## explicit
 # github.com/mattn/go-colorable v0.1.4
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.10
+## explicit
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.4
 github.com/mattn/go-runewidth
+# github.com/mattn/go-sqlite3 v2.0.2+incompatible
+## explicit
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/pkcs11 v0.0.0-20180817151620-df0db7a16a9e
+## explicit
 github.com/miekg/pkcs11
 # github.com/mitchellh/go-homedir v1.1.0
+## explicit
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
+# github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f
+## explicit
 # github.com/moby/buildkit v0.6.3 => github.com/zachbadgett/buildkit v0.6.2-0.20191220071605-814e2794095f
+## explicit
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types
 github.com/moby/buildkit/client/llb
@@ -366,10 +463,15 @@ github.com/moby/buildkit/util/system
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
+## explicit
 github.com/modern-go/reflect2
 # github.com/morikuni/aec v1.0.0
+## explicit
 github.com/morikuni/aec
+# github.com/ncw/swift v1.0.47
+## explicit
 # github.com/opencontainers/go-digest v1.0.0-rc1
+## explicit
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/image-spec/specs-go
@@ -378,14 +480,18 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
 # github.com/opencontainers/runtime-spec v1.0.1
+## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492
+## explicit
 github.com/opentracing-contrib/go-observer
 # github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e
+## explicit
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
 # github.com/openzipkin/zipkin-go-opentracing v0.3.2
+## explicit
 github.com/openzipkin/zipkin-go-opentracing
 github.com/openzipkin/zipkin-go-opentracing/flag
 github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/scribe
@@ -395,11 +501,14 @@ github.com/openzipkin/zipkin-go-opentracing/wire
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pierrec/lz4 v2.4.0+incompatible
+## explicit
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15
+## explicit
 github.com/pkg/browser
 # github.com/pkg/errors v0.8.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -418,26 +527,37 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
+## explicit
 github.com/rcrowley/go-metrics
 # github.com/rivo/tview v0.0.0-20180926100353-bc39bf8d245d
+## explicit
 github.com/rivo/tview
 # github.com/russross/blackfriday v1.5.2
 github.com/russross/blackfriday
+# github.com/satori/go.uuid v1.2.0
+## explicit
 # github.com/schollz/closestmatch v2.1.0+incompatible
+## explicit
 github.com/schollz/closestmatch
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
+# github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
+## explicit
 # github.com/spf13/cobra v0.0.5
+## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 github.com/syndtr/gocapability/capability
 # github.com/theupdateframework/notary v0.6.1
+## explicit
 github.com/theupdateframework/notary
 github.com/theupdateframework/notary/client
 github.com/theupdateframework/notary/client/changelist
@@ -455,8 +575,10 @@ github.com/theupdateframework/notary/tuf/validation
 # github.com/tonistiigi/fsutil v0.0.0-20191018213012-0f039a052ca1
 github.com/tonistiigi/fsutil/types
 # github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
+## explicit
 github.com/tonistiigi/units
 # github.com/uber/jaeger-client-go v2.21.1+incompatible
+## explicit
 github.com/uber/jaeger-client-go
 github.com/uber/jaeger-client-go/config
 github.com/uber/jaeger-client-go/internal/baggage
@@ -475,25 +597,32 @@ github.com/uber/jaeger-client-go/thrift-gen/zipkincore
 github.com/uber/jaeger-client-go/transport
 github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.2.0+incompatible
+## explicit
 github.com/uber/jaeger-lib/metrics
 # github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa
+## explicit
 github.com/whilp/git-urls
 # github.com/windmilleng/fsevents v0.0.0-20190206153914-2ad75e5ddeed
+## explicit
 github.com/windmilleng/fsevents
 # github.com/windmilleng/fsnotify v1.4.7
+## explicit
 github.com/windmilleng/fsnotify
 # github.com/windmilleng/wmclient v0.0.0-20200205181513-6c994672553a
+## explicit
 github.com/windmilleng/wmclient/pkg/analytics
 github.com/windmilleng/wmclient/pkg/dirs
 github.com/windmilleng/wmclient/pkg/env
 github.com/windmilleng/wmclient/pkg/os/temp
 # go.opencensus.io v0.22.2
+## explicit
 go.opencensus.io
 go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
 # go.opentelemetry.io/otel v0.2.0
+## explicit
 go.opentelemetry.io/otel/api/core
 go.opentelemetry.io/otel/api/trace
 go.opentelemetry.io/otel/sdk
@@ -502,6 +631,7 @@ go.opentelemetry.io/otel/sdk/internal
 go.opentelemetry.io/otel/sdk/trace
 go.opentelemetry.io/otel/sdk/trace/internal
 # go.starlark.net v0.0.0-20191021185836-28350e608555
+## explicit
 go.starlark.net/internal/compile
 go.starlark.net/internal/spell
 go.starlark.net/resolve
@@ -509,6 +639,7 @@ go.starlark.net/starlark
 go.starlark.net/starlarkstruct
 go.starlark.net/syntax
 # go.uber.org/atomic v1.5.1
+## explicit
 go.uber.org/atomic
 # golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd => golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 golang.org/x/crypto/cast5
@@ -529,9 +660,11 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+## explicit
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -549,9 +682,11 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20191220142924-d4481acd189f
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/unix
 golang.org/x/sys/windows
@@ -571,6 +706,7 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2
+## explicit
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter
@@ -585,12 +721,16 @@ google.golang.org/appengine/internal/modules
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
+# google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8
+## explicit
 # google.golang.org/genproto v0.0.0-20191220175831-5c49e3ecc1c1
+## explicit
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.26.0
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -630,12 +770,21 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # gopkg.in/d4l3k/messagediff.v1 v1.2.1
+## explicit
 gopkg.in/d4l3k/messagediff.v1
+# gopkg.in/dancannon/gorethink.v3 v3.0.5
+## explicit
+# gopkg.in/fatih/pool.v2 v2.0.0
+## explicit
+# gopkg.in/gorethink/gorethink.v3 v3.0.5
+## explicit
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.4
+## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.17.2
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -680,6 +829,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.17.3-beta.0
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -733,6 +883,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/cli-runtime v0.17.2
+## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps
@@ -746,6 +897,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.17.2 => github.com/windmilleng/client-go v0.17.3-0.20200124220244-8b86781afe3b
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
@@ -974,15 +1126,18 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 # k8s.io/component-base v0.17.2
+## explicit
 k8s.io/component-base/cli/flag
 k8s.io/component-base/version
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 # k8s.io/kubectl v0.17.2
+## explicit
 k8s.io/kubectl/pkg/cmd/apply
 k8s.io/kubectl/pkg/cmd/delete
 k8s.io/kubectl/pkg/cmd/replace
@@ -1008,6 +1163,7 @@ k8s.io/utils/exec
 k8s.io/utils/integer
 k8s.io/utils/trace
 # sigs.k8s.io/kustomize v2.0.3+incompatible
+## explicit
 sigs.k8s.io/kustomize/pkg/commands/build
 sigs.k8s.io/kustomize/pkg/constants
 sigs.k8s.io/kustomize/pkg/expansion
@@ -1031,6 +1187,12 @@ sigs.k8s.io/kustomize/pkg/transformers/config
 sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig
 sigs.k8s.io/kustomize/pkg/types
 # sigs.k8s.io/yaml v1.1.0
+## explicit
 sigs.k8s.io/yaml
 # vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787
+## explicit
 vbom.ml/util/sortorder
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.4.3+incompatible
+# github.com/moby/buildkit => github.com/zachbadgett/buildkit v0.6.2-0.20191220071605-814e2794095f
+# golang.org/x/crypto => golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
+# k8s.io/client-go => github.com/windmilleng/client-go v0.17.3-0.20200124220244-8b86781afe3b


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/go14:

27f0f56bc4e03a7ee88ffc616420d48448af744e (2020-03-09 19:05:15 -0400)
go.mod: upgrade to go 1.14

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics