### PR TITLE
Change `TiltCloud` to be `Tilt Cloud`

### DIFF
--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -181,7 +181,7 @@ export default class ShareSnapshotModal extends PureComponent<props> {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <span>TiltCloud</span>
+            <span>Tilt Cloud</span>
             <ArrowSvg />
           </a>
         </p>

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -88,7 +88,7 @@ export default class ShareSnapshotModal extends PureComponent<props> {
     return (
       <div className="ShareSnapshotModal-getStarted">
         <p className="u-inlineBlock">
-          Link Tilt to TiltCloud (just takes a minute)
+          Link Tilt to Tilt Cloud (just takes a minute)
         </p>
         <form
           action={this.props.tiltCloudSchemeHost + "/start_register_token"}

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`ShareSnapshotModal renders with modal open w/ known username 1`] = `
           target="_blank"
         >
           <span>
-            TiltCloud
+            Tilt Cloud
           </span>
           <svg>
             arrow.svg

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`ShareSnapshotModal renders team link 1`] = `
           target="_blank"
         >
           <span>
-            TiltCloud
+            Tilt Cloud
           </span>
           <svg>
             arrow.svg

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`ShareSnapshotModal renders with modal open w/o known username 1`] = `
           <p
             className="u-inlineBlock"
           >
-            Link Tilt to TiltCloud (just takes a minute)
+            Link Tilt to Tilt Cloud (just takes a minute)
           </p>
           <form
             action="https://cloud.tilt.dev/start_register_token"
@@ -416,7 +416,7 @@ exports[`ShareSnapshotModal renders without snapshotUrl 1`] = `
           <p
             className="u-inlineBlock"
           >
-            Link Tilt to TiltCloud (just takes a minute)
+            Link Tilt to Tilt Cloud (just takes a minute)
           </p>
           <form
             action="https://cloud.tilt.dev/start_register_token"


### PR DESCRIPTION
Related story: https://app.clubhouse.io/windmill/story/5317/check-that-all-user-facing-references-to-tilt-cloud-are-not-tiltcloud