### PR TITLE
k8s: add warnings if you're not using a local registry but should be

### DIFF
--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -142,6 +142,16 @@ func (r *registryAsync) Registry(ctx context.Context) container.Registry {
 		if !reg.Empty() {
 			r.registry = reg
 		}
+
+		if r.env == EnvKIND6 && r.registry.Empty() {
+			logger.Get(ctx).Warnf("You are running Kind without a local image registry.\n" +
+				"Tilt can use the local registry to speed up builds.\n" +
+				"Instructions: https://github.com/windmilleng/kind-local")
+		} else if r.env == EnvK3D && r.registry.Empty() {
+			logger.Get(ctx).Warnf("You are running K3D without a local image registry.\n" +
+				"Tilt can use the local registry to speed up builds.\n" +
+				"Instructions: https://github.com/windmilleng/k3d-local-registry")
+		}
 	})
 	return r.registry
 }

--- a/internal/k8s/registry_test.go
+++ b/internal/k8s/registry_test.go
@@ -69,6 +69,28 @@ func TestRegistryFoundInLabelsWithClusterHost(t *testing.T) {
 	assert.Equal(t, "registry:5000", registry.HostFromCluster())
 }
 
+func TestKINDWarning(t *testing.T) {
+	cs := &fake.Clientset{}
+	core := cs.CoreV1()
+	registryAsync := newRegistryAsync(EnvKIND6, core, NewNaiveRuntimeSource(container.RuntimeContainerd))
+
+	out := bytes.NewBuffer(nil)
+	registry := registryAsync.Registry(newLoggerCtx(out))
+	assert.True(t, registry.Empty())
+	assert.Contains(t, out.String(), "https://github.com/windmilleng/kind-local")
+}
+
+func TestK3DWarning(t *testing.T) {
+	cs := &fake.Clientset{}
+	core := cs.CoreV1()
+	registryAsync := newRegistryAsync(EnvK3D, core, NewNaiveRuntimeSource(container.RuntimeContainerd))
+
+	out := bytes.NewBuffer(nil)
+	registry := registryAsync.Registry(newLoggerCtx(out))
+	assert.True(t, registry.Empty())
+	assert.Contains(t, out.String(), "https://github.com/windmilleng/k3d-local-registry")
+}
+
 func TestRegistryFoundInLabelsWithLocalOnly(t *testing.T) {
 	cs := &fake.Clientset{}
 	tracker := ktesting.NewObjectTracker(scheme.Scheme, scheme.Codecs.UniversalDecoder())


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch5539/registry:

6838a1549c3e5dd9ac51916a04a39f9e4857f61e (2020-03-20 18:28:36 -0400)
k8s: add warnings if you're not using a local registry but should be

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics