### PR TITLE
cloud: change whoami to POST

### DIFF
--- a/internal/cloud/cloud_username_manager.go
+++ b/internal/cloud/cloud_username_manager.go
@@ -91,7 +91,7 @@ func (c *CloudUsernameManager) CheckUsername(ctx context.Context, st store.RStor
 		return
 	}
 
-	req, err := http.NewRequest("GET", u.String(), body)
+	req, err := http.NewRequest("POST", u.String(), body)
 	if err != nil {
 		logger.Get(ctx).Debugf("error making whoami request: %v", err)
 		c.error()

--- a/internal/cloud/cloud_username_manager_test.go
+++ b/internal/cloud/cloud_username_manager_test.go
@@ -18,7 +18,7 @@ import (
 
 const testCloudAddress = "tiltcloud.example.com"
 
-func TestLongGet(t *testing.T) {
+func TestLongPost(t *testing.T) {
 	f := newCloudUsernameManagerTestFixture(t)
 
 	f.httpClient.SetResponse(`{"foo": "bar"}`)
@@ -110,6 +110,7 @@ func (f *cloudUsernameManagerTestFixture) waitForRequest(expectedURL string) htt
 			f.t.Fatalf("%T made more than one http request! requests: %v", f.um, urls)
 		} else if len(reqs) == 1 {
 			require.Equal(f.t, expectedURL, reqs[0].URL.String())
+			require.Equal(f.t, "POST", reqs[0].Method)
 			return reqs[0]
 		} else {
 			select {


### PR DESCRIPTION
### Problem

/api/whoami is making a GET request with a body, which blows up on some proxies / caches

besides, we don't really want it to get cached anyway

### Solution

make it a POST