### PR TITLE
makefile: move comments out of makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ endif
 test: test-go test-js
 
 # skip some tests that are slow and not always relevant
+# TODO(matt) skipdockercomposetests only skips the tiltfile DC tests at the moment
+# we might also want to skip the ones in engine
 shorttest:
-	# TODO(matt) skipdockercomposetests only skips the tiltfile DC tests at the moment
-	# we might also want to skip the ones in engine
 	go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s ./...
 
 shorttestsum:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/makefile:

d3e5750a2685690224464b23618352614f86727e (2020-03-26 14:41:29 -0400)
makefile: move comments out of makefile rules
This implicitly turns the rule into a bash script.
This breaks the rule on Windows.
It's not even good on Linux, because it means that
running the rule prints the comment every time.