### PR TITLE
httptest: fix a bug in the fake http client

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3487,7 +3487,7 @@ func newTestFixtureWithHud(t *testing.T, h hud.HeadsUpDisplay) *testFixture {
 	hudsc := server.ProvideHeadsUpServerController("localhost", 0, &server.HeadsUpServer{}, assets.NewFakeServer(), model.WebURL{}, false)
 	ghc := &github.FakeClient{}
 	ewm := k8swatch.NewEventWatchManager(kCli, of)
-	tcum := cloud.NewStatusManager(httptest.NewFakeClient())
+	tcum := cloud.NewStatusManager(httptest.NewFakeClientEmptyJSON())
 	cuu := cloud.NewUpdateUploader(httptest.NewFakeClient(), "cloud-test.tilt.dev")
 	fe := local.NewFakeExecer()
 	lc := local.NewController(fe)

--- a/internal/testutils/httptest/http_client.go
+++ b/internal/testutils/httptest/http_client.go
@@ -8,9 +8,10 @@ import (
 )
 
 type FakeClient struct {
-	requests []http.Request
-	Response http.Response
-	Err      error
+	requests     []http.Request
+	responseCode int
+	responseBody string
+	Err          error
 
 	mu sync.Mutex
 }
@@ -20,16 +21,17 @@ func (fc *FakeClient) Do(req *http.Request) (*http.Response, error) {
 	defer fc.mu.Unlock()
 
 	fc.requests = append(fc.requests, *req)
-	r := fc.Response
+	r := http.Response{
+		StatusCode: fc.responseCode,
+		Body:       ioutil.NopCloser(strings.NewReader(fc.responseBody)),
+	}
 
 	return &r, fc.Err
 }
 
 func (fc *FakeClient) SetResponse(s string) {
-	fc.Response = http.Response{
-		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader(s)),
-	}
+	fc.responseCode = http.StatusOK
+	fc.responseBody = s
 }
 
 func (fc *FakeClient) Requests() []http.Request {
@@ -42,9 +44,14 @@ func (fc *FakeClient) Requests() []http.Request {
 
 func NewFakeClient() *FakeClient {
 	return &FakeClient{
-		Response: http.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(strings.NewReader("FakeClient response uninitialized")),
-		},
+		responseCode: http.StatusInternalServerError,
+		responseBody: "FakeClient response uninitialized",
+	}
+}
+
+func NewFakeClientEmptyJSON() *FakeClient {
+	return &FakeClient{
+		responseCode: http.StatusOK,
+		responseBody: "{}",
 	}
 }


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/httptest:

a722fe8b30ea6ca5bb9f89122372fdf6b5731daa (2020-03-26 16:44:33 -0400)
httptest: fix a bug in the fake http client
A reader can only be consumed once, so returning the same response
reader multiple times doesn't do what you'd expect.

Reduces a lot of the error spam in engine tests