### PR TITLE
tempdir: fix a bug where we were calling Chdir on an empty dir

### DIFF
--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -146,9 +146,12 @@ func (f *TempDirFixture) TempDir(prefix string) string {
 }
 
 func (f *TempDirFixture) TearDown() {
-	defer func() {
-		_ = os.Chdir(f.oldDir)
-	}()
+	if f.oldDir != "" {
+		err := os.Chdir(f.oldDir)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+	}
 
 	err := f.dir.TearDown()
 	if err != nil {

--- a/internal/tiltfile/tiltextension/extension_test.go
+++ b/internal/tiltfile/tiltextension/extension_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package tiltextension
 
 import (

--- a/internal/tiltfile/tiltextension/store_test.go
+++ b/internal/tiltfile/tiltextension/store_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package tiltextension
 
 import (


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/wintest:

bdea44e6911428898a40731daad0fa175ff47227 (2020-03-26 18:27:34 -0400)
tempdir: fix a bug where we were calling Chdir on an empty dir

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics