### PR TITLE
bump version to v0.12.10

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.12.9"
+const devVersion = "0.12.10"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.12.9"
+VERSION="0.12.10"
 BREW=$(command -v brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/bump:

c7ff56c73daec67b54ef081ab001d6bcdcdb3c96 (2020-03-26 20:18:53 -0400)
bump version to v0.12.10

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics