### PR TITLE
build: skip sockets in docker build contexts. Fixes #3107

### DIFF
--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/windmilleng/tilt/internal/dockerfile"
+	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -182,7 +183,10 @@ func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string
 
 		header, err := tar.FileInfoHeader(info, linkname)
 		if err != nil {
-			return errors.Wrapf(err, "%s: making header", path)
+			// Not all types of files are allowed in a tarball. That's OK.
+			// Mimic the Docker behavior and just skip the file.
+			logger.Get(ctx).Debugf("Skipping file %s: %v", path, err)
+			return nil
 		}
 
 		clearUIDAndGID(header)


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/ch5780/socket:

585dc76e9eec476e3952e3f0d55141524bf00299 (2020-03-27 10:11:43 -0400)
build: skip sockets in docker build contexts. Fixes #3107