### PR TITLE
enging: move process exiting logic into exit.Controller

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -25,6 +25,7 @@ import (
 	engineanalytics "github.com/windmilleng/tilt/internal/engine/analytics"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
+	"github.com/windmilleng/tilt/internal/engine/exit"
 	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
@@ -87,6 +88,7 @@ var BaseWireSet = wire.NewSet(
 	cloudurl.ProvideAddress,
 	k8srollout.NewPodMonitor,
 	telemetry.NewStartTracker,
+	exit.NewController,
 
 	provideClock,
 	hud.WireSet,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -30,6 +30,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/buildcontrol"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
+	"github.com/windmilleng/tilt/internal/engine/exit"
 	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
@@ -241,14 +242,15 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	tiltVersionChecker := engine.NewTiltVersionChecker(githubClientFactory, timerMaker)
 	analyticsUpdater := analytics2.NewAnalyticsUpdater(analytics3, cmdUpTags)
 	eventWatchManager := k8swatch.NewEventWatchManager(client, ownerFetcher)
-	cloudUsernameManager := cloud.NewStatusManager(httpClient)
+	cloudStatusManager := cloud.NewStatusManager(httpClient)
 	updateUploader := cloud.NewUpdateUploader(httpClient, address)
 	dockerPruner := dockerprune.NewDockerPruner(switchCli)
 	controller := telemetry.NewController(clock, spanCollector)
 	execer := local.ProvideExecer()
 	localController := local.NewController(execer)
 	podMonitor := k8srollout.NewPodMonitor()
-	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, tiltVersionChecker, analyticsUpdater, eventWatchManager, cloudUsernameManager, updateUploader, dockerPruner, controller, localController, podMonitor)
+	exitController := exit.NewController()
+	v2 := engine.ProvideSubscribers(headsUpDisplay, podWatcher, serviceWatcher, podLogManager, portForwardController, watchManager, buildController, configsController, dockerComposeEventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, tiltVersionChecker, analyticsUpdater, eventWatchManager, cloudStatusManager, updateUploader, dockerPruner, controller, localController, podMonitor, exitController)
 	upper := engine.NewUpper(ctx, storeStore, v2)
 	windmillDir, err := dirs.UseWindmillDir()
 	if err != nil {
@@ -448,7 +450,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
+	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, engine.NewDockerComposeEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, exit.NewController, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/engine/exit/actions.go
+++ b/internal/engine/exit/actions.go
@@ -1,0 +1,8 @@
+package exit
+
+type Action struct {
+	ExitSignal bool
+	ExitError  error
+}
+
+func (Action) Action() {}

--- a/internal/engine/exit/controller.go
+++ b/internal/engine/exit/controller.go
@@ -1,0 +1,61 @@
+package exit
+
+import (
+	"context"
+
+	"github.com/windmilleng/tilt/internal/store"
+)
+
+// Controls normal process termination. Either Tilt completed all its work,
+// or it determined that it was unable to complete the work it was assigned.
+type Controller struct {
+}
+
+func NewController() *Controller {
+	return &Controller{}
+}
+
+func (c *Controller) shouldExit(store store.RStore) Action {
+	state := store.RLockState()
+	defer store.RUnlockState()
+
+	// Already processing the exit
+	if state.ExitSignal {
+		return Action{}
+	}
+
+	// If we're in dev/interactive mode, there's never a reason to exit.
+	if state.WatchFiles {
+		return Action{}
+	}
+
+	// If the tiltfile failed, exit immediately.
+	err := state.TiltfileState.LastBuild().Error
+	if err != nil {
+		return Action{ExitSignal: true, ExitError: err}
+	}
+
+	// If any of the individual builds failed, exit immediately.
+	for _, mt := range state.ManifestTargets {
+		err := mt.State.LastBuild().Error
+		if err != nil {
+			return Action{ExitSignal: true, ExitError: err}
+		}
+	}
+
+	// If all builds completed, we're done!
+	if len(state.ManifestTargets) > 0 && state.InitialBuildsCompleted() {
+		return Action{ExitSignal: true}
+	}
+
+	return Action{}
+}
+
+func (c *Controller) OnChange(ctx context.Context, store store.RStore) {
+	action := c.shouldExit(store)
+	if action.ExitSignal {
+		store.Dispatch(action)
+	}
+}
+
+var _ store.Subscriber = &Controller{}

--- a/internal/engine/exit/controller_test.go
+++ b/internal/engine/exit/controller_test.go
@@ -1,0 +1,120 @@
+package exit
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/windmilleng/tilt/internal/k8s/testyaml"
+	"github.com/windmilleng/tilt/internal/store"
+	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
+	"github.com/windmilleng/tilt/internal/testutils/tempdir"
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+func TestExitControlAllSuccess(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.store.WithState(func(state *store.EngineState) {
+		m := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
+		state.UpsertManifestTarget(store.NewManifestTarget(m))
+
+		m2 := manifestbuilder.New(f, "fe2").WithK8sYAML(testyaml.SanchoYAML).Build()
+		state.UpsertManifestTarget(store.NewManifestTarget(m2))
+
+		state.ManifestTargets["fe"].State.AddCompletedBuild(model.BuildRecord{
+			StartTime:  time.Now(),
+			FinishTime: time.Now(),
+		})
+	})
+
+	f.c.OnChange(f.ctx, f.store)
+	assert.False(t, f.store.exitSignal)
+
+	f.store.WithState(func(state *store.EngineState) {
+		state.ManifestTargets["fe2"].State.AddCompletedBuild(model.BuildRecord{
+			StartTime:  time.Now(),
+			FinishTime: time.Now(),
+		})
+	})
+
+	// Verify that completing the second build causes an exit
+	f.c.OnChange(f.ctx, f.store)
+	assert.True(t, f.store.exitSignal)
+}
+
+func TestExitControlFirstFailure(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.store.WithState(func(state *store.EngineState) {
+		m := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
+		state.UpsertManifestTarget(store.NewManifestTarget(m))
+
+		m2 := manifestbuilder.New(f, "fe2").WithK8sYAML(testyaml.SanchoYAML).Build()
+		state.UpsertManifestTarget(store.NewManifestTarget(m2))
+	})
+
+	f.c.OnChange(f.ctx, f.store)
+	assert.False(t, f.store.exitSignal)
+
+	f.store.WithState(func(state *store.EngineState) {
+		state.ManifestTargets["fe"].State.AddCompletedBuild(model.BuildRecord{
+			StartTime:  time.Now(),
+			FinishTime: time.Now(),
+			Error:      fmt.Errorf("does not compile"),
+		})
+	})
+
+	// Verify that if one build fails with an error, it fails immediately.
+	f.c.OnChange(f.ctx, f.store)
+	assert.True(t, f.store.exitSignal)
+}
+
+type fixture struct {
+	*tempdir.TempDirFixture
+	ctx   context.Context
+	store *testStore
+	c     *Controller
+}
+
+func newFixture(t *testing.T) *fixture {
+	f := tempdir.NewTempDirFixture(t)
+
+	st := NewTestingStore()
+	c := NewController()
+	ctx := context.Background()
+
+	return &fixture{
+		TempDirFixture: f,
+		ctx:            ctx,
+		store:          st,
+		c:              c,
+	}
+}
+
+type testStore struct {
+	*store.TestingStore
+	exitSignal bool
+	exitError  error
+}
+
+func NewTestingStore() *testStore {
+	return &testStore{
+		TestingStore: store.NewTestingStore(),
+	}
+}
+
+func (s *testStore) Dispatch(action store.Action) {
+	s.TestingStore.Dispatch(action)
+
+	exitAction, ok := action.(Action)
+	if ok {
+		s.exitSignal = exitAction.ExitSignal
+		s.exitError = exitAction.ExitError
+	}
+}

--- a/internal/engine/subscribers.go
+++ b/internal/engine/subscribers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/analytics"
 	"github.com/windmilleng/tilt/internal/engine/configs"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
+	"github.com/windmilleng/tilt/internal/engine/exit"
 	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
@@ -40,6 +41,7 @@ func ProvideSubscribers(
 	tc *telemetry.Controller,
 	lc *local.Controller,
 	podm *k8srollout.PodMonitor,
+	ec *exit.Controller,
 ) []store.Subscriber {
 	return []store.Subscriber{
 		hud,
@@ -65,5 +67,6 @@ func ProvideSubscribers(
 		tc,
 		lc,
 		podm,
+		ec,
 	}
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -45,6 +45,7 @@ type EngineState struct {
 	MaxParallelUpdates int
 
 	FatalError error
+
 	HUDEnabled bool
 
 	// The user has indicated they want to exit
@@ -52,6 +53,18 @@ type EngineState struct {
 
 	// We recovered from a panic(). We need to clean up the RTY and print the error.
 	PanicExited error
+
+	// Normal process termination. Either Tilt completed all its work,
+	// or it determined that it was unable to complete the work it was assigned.
+	//
+	// Note that ExitSignal/ExitError is never triggered in normal
+	// 'tilt up`/dev mode. It's more for CI modes and tilt up --watch=false modes.
+	//
+	// We don't provide the ability to customize exit codes. Either the
+	// process exited successfully, or with an error. In the future, we might
+	// add the ability to put an exit code in the error.
+	ExitSignal bool
+	ExitError  error
 
 	// All logs in Tilt, stored in a structured format.
 	LogStore *logstore.LogStore `testdiff:"ignore"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -190,13 +190,11 @@ func (s *Store) maybeFinished() (bool, error) {
 		return true, state.FatalError
 	}
 
-	if len(state.ManifestTargets) == 0 {
-		return false, nil
+	if state.ExitSignal {
+		return true, state.ExitError
 	}
 
-	finished := !state.WatchFiles && state.InitialBuildsCompleted()
-
-	return finished, nil
+	return false, nil
 }
 
 func (s *Store) drainActions() {

--- a/internal/store/testing_store.go
+++ b/internal/store/testing_store.go
@@ -19,13 +19,21 @@ type TestingStore struct {
 }
 
 func NewTestingStore() *TestingStore {
-	return &TestingStore{}
+	return &TestingStore{
+		state: NewState(),
+	}
 }
 
 func (s *TestingStore) SetState(state EngineState) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 	s.state = &state
+}
+
+func (s *TestingStore) WithState(f func(state *EngineState)) {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	f(s.state)
 }
 
 func (s *TestingStore) StateMutex() *sync.RWMutex {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/exitcontrol:

7e6200481f6d56511a083f62c6e03de21b7c186d (2020-03-27 17:53:56 -0400)
enging: move process exiting logic into exit.Controller

8f244fca99878b79388b4df04aea134ca5652651 (2020-03-27 17:11:32 -0400)
store: Simplify subscription notification
In the old world, every Notify() would create a new goroutine.
The goroutine would block until the subscriber was done processing the last event,
then double-check if it still needed to process.
This made debugging difficult, because you could have 1000s of
goroutines blocked on a single slow subscriber.

In the new world, there are at most two goroutines in flight.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics