### PR TITLE
Revert "watch: fix inotify tests on windows"

### DIFF
--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package watch
 
 import (
@@ -39,9 +41,6 @@ func TestNoWatches(t *testing.T) {
 }
 
 func TestEventOrdering(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on windows for now")
-	}
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 
@@ -74,9 +73,6 @@ func TestEventOrdering(t *testing.T) {
 // of directories, creates files in them, then deletes
 // them all quickly. Make sure there are no errors.
 func TestGitBranchSwitch(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on windows for now")
-	}
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 
@@ -147,11 +143,10 @@ func TestWatchesAreRecursive(t *testing.T) {
 	f.events = nil
 	// change sub directory
 	changeFilePath := filepath.Join(subPath, "change")
-	h, err := os.OpenFile(changeFilePath, os.O_RDONLY|os.O_CREATE, 0666)
+	_, err := os.OpenFile(changeFilePath, os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer h.Close()
 
 	f.assertEvents(changeFilePath)
 }
@@ -173,12 +168,10 @@ func TestNewDirectoriesAreRecursivelyWatched(t *testing.T) {
 
 	// change something inside sub directory
 	changeFilePath := filepath.Join(subPath, "change")
-	h, err := os.OpenFile(changeFilePath, os.O_RDONLY|os.O_CREATE, 0666)
+	_, err := os.OpenFile(changeFilePath, os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer h.Close()
-
 	f.assertEvents(subPath, changeFilePath)
 }
 
@@ -285,9 +278,6 @@ func TestSingleFile(t *testing.T) {
 }
 
 func TestWriteBrokenLink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Symlink creation requires admin privileges on Windows")
-	}
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 
@@ -302,9 +292,6 @@ func TestWriteBrokenLink(t *testing.T) {
 }
 
 func TestWriteGoodLink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Symlink creation requires admin privileges on Windows")
-	}
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 
@@ -324,9 +311,6 @@ func TestWriteGoodLink(t *testing.T) {
 }
 
 func TestWatchBrokenLink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Symlink creation requires admin privileges on Windows")
-	}
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 
@@ -355,10 +339,6 @@ func TestWatchBrokenLink(t *testing.T) {
 }
 
 func TestMoveAndReplace(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on windows for now")
-	}
-
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 

--- a/internal/watch/watcher_naive_test.go
+++ b/internal/watch/watcher_naive_test.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!windows
 
 package watch
 
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -93,9 +92,6 @@ func TestDontWatchEachFile(t *testing.T) {
 	f.events = nil
 
 	pid := os.Getpid()
-	if runtime.GOOS == "windows" {
-		return // skip the inotify count
-	}
 
 	output, err := exec.Command("bash", "-c", fmt.Sprintf(
 		"find /proc/%d/fd -lname anon_inode:inotify -printf '%%hinfo/%%f\n' | xargs cat | grep -c '^inotify'", pid)).Output()


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/revert:

00477417478e61a0a30261f688100cce3b8247b9 (2020-03-30 13:02:20 -0400)
Revert "watch: fix inotify tests on windows"
This reverts commit 74ac7997b1c8f497babbbd499ff1f047563d699a.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics