### PR TITLE
web: fix snapshot log highlight snippet

### DIFF
--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import LogPane from "./LogPane"
+import LogPane, { logText } from "./LogPane"
 import renderer from "react-test-renderer"
-import { mount } from "enzyme"
+import { mount, render } from "enzyme"
 import { logLinesFromString } from "./logs"
+import { LogLine } from "./types"
 
 const fakeHandleSetHighlight = () => {}
 const fakeHandleClearHighlight = () => {}
@@ -519,4 +520,25 @@ xit("sets highlighted text correctly", () => {
   // as of 2020-03-30, document.getSelection is not supported in Jest ("TypeError: document.getSelection is not a function"),
   // so this isn't really testable
   // https://github.com/jsdom/jsdom/issues/317#issuecomment-570948181
+})
+
+it("extracts the log text w/o resource prefixes", () => {
+  let log = logLinesFromString("l1\nl2", "manifest1")
+  let el = mount(
+    <LogPane
+      manifestName={""}
+      logLines={log}
+      showManifestPrefix={false}
+      handleSetHighlight={fakeHandleSetHighlight}
+      handleClearHighlight={fakeHandleClearHighlight}
+      highlight={null}
+      isSnapshot={true}
+    />
+  )
+
+  let df = document.createDocumentFragment()
+  df.append(el.getDOMNode())
+  let s = logText(df)
+
+  expect(s).toEqual("l1\nl2\n")
 })

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -513,3 +513,10 @@ it("doesn't set selection event handler if snapshot", () => {
   expect(registeredEventHandlers).toEqual(expect.arrayContaining(["scroll"]))
   expect(registeredEventHandlers).not.toEqual(expect.arrayContaining(["wheel"]))
 })
+
+xit("sets highlighted text correctly", () => {
+  // TODO(matt) test LogPane.handleSelectionChange
+  // as of 2020-03-30, document.getSelection is not supported in Jest ("TypeError: document.getSelection is not a function"),
+  // so this isn't really testable
+  // https://github.com/jsdom/jsdom/issues/317#issuecomment-570948181
+})

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -202,17 +202,8 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
         let endingLogLine = findLogLineID(end)
 
         if (beginningLogLine && endingLogLine) {
-          // cut out the resource name prefix
-          // 1. lining up multiple resource name prefixes in a way consistent with the UI is likely to be annoying
-          // 2. presumably most highlights are from a single resource anyway
-          // potentially we should pass prefix + logline as structured data in the future
-          let nodes = sel
-            .getRangeAt(0)
-            .cloneContents()
-            .querySelectorAll("code.LogPaneLine-content span")
-          let s = Array.from(nodes)
-            .map(node => node.textContent)
-            .join("")
+          let s = logText(sel.getRangeAt(0).cloneContents())
+
           this.props.handleSetHighlight({
             beginningLogID: beginningLogLine,
             endingLogID: endingLogLine,
@@ -385,5 +376,18 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
     return <LogPaneRoot className="LogPane">{logLineEls}</LogPaneRoot>
   }
 }
+
+// get log text w/o resource prefixes
+// 1. lining up multiple resource name prefixes in a way consistent with the UI is likely to be annoying
+// 2. presumably most highlights are from a single resource anyway
+// potentially we should pass prefix + logline as structured data in the future
+function logText(n: ParentNode): string {
+  let nodes = n.querySelectorAll("code.LogPaneLine-content span")
+  return Array.from(nodes)
+    .map(node => node.textContent)
+    .join("")
+}
+
+export { logText }
 
 export default LogPane

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -202,10 +202,21 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
         let endingLogLine = findLogLineID(end)
 
         if (beginningLogLine && endingLogLine) {
+          // cut out the resource name prefix
+          // 1. lining up multiple resource name prefixes in a way consistent with the UI is likely to be annoying
+          // 2. presumably most highlights are from a single resource anyway
+          // potentially we should pass prefix + logline as structured data in the future
+          let nodes = sel
+            .getRangeAt(0)
+            .cloneContents()
+            .querySelectorAll("code.LogPaneLine-content span")
+          let s = Array.from(nodes)
+            .map(node => node.textContent)
+            .join("")
           this.props.handleSetHighlight({
             beginningLogID: beginningLogLine,
             endingLogID: endingLogLine,
-            text: selection.toString(),
+            text: s,
           })
         }
       }


### PR DESCRIPTION
### Problem

When we take a snapshot with a highlighted snippet, Tilt sets the snippet text to "[object Object]", when it should be setting it to the selected text. This results in cloud.tilt.dev/snapshots showing this:
![image](https://user-images.githubusercontent.com/7453991/77944483-12d31500-728d-11ea-9b0b-e3831148eca1.png)

### Solution

[This line](https://github.com/windmilleng/tilt/blob/e6198fa9a41c5443dabcb700b04ad6ace538c878/web/src/LogPane.tsx#L208) was probably intended to be `sel.toString()`, and making that change gets us most of the way there. Unfortunately, now that the resource name prefixes are pulled out into separate HTML elements, simply using `sel.toString()` returns something like:
```
fortune
   line1
fortune
   line2
```

which looks really weird as a preview!

So I did something slightly more complicated, explained in the comments.