### PR TITLE
starkit: CurrentExecPath is based on what's being loaded rather than the call stack

### DIFF
--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -70,11 +70,7 @@ print(get_cwd_wrapper())
 	_, err := f.ExecFile("Tiltfile")
 	assert.NoError(t, err)
 
-	// NOTE(nick): A bunch of us agree that this behavior is currently wrong.
-	// The working directory should be the currently executing Tiltfile,
-	// not the Tiltfile where the function was evaluated.
-	// https://app.clubhouse.io/windmill/story/4708/extensions-are-executed-with-a-working-directory-in-the-tilt-modules-dir
-	assert.Equal(t, fmt.Sprintf("%s/foo\n", f.Path()), f.PrintOutput())
+	assert.Equal(t, fmt.Sprintf("%s\n", f.Path()), f.PrintOutput())
 }
 
 func TestRealpath(t *testing.T) {

--- a/internal/tiltfile/starkit/environment.go
+++ b/internal/tiltfile/starkit/environment.go
@@ -19,6 +19,7 @@ func ExecFile(path string, extensions ...Extension) (Model, error) {
 const argUnpackerKey = "starkit.ArgUnpacker"
 const modelKey = "starkit.Model"
 const ctxKey = "starkit.Ctx"
+const execingTiltfileKey = "starkit.ExecingTiltfile"
 
 // Unpacks args, using the arg unpacker on the current thread.
 func UnpackArgs(t *starlark.Thread, fnName string, args starlark.Tuple, kwargs []starlark.Tuple, pairs ...interface{}) error {
@@ -190,7 +191,13 @@ func (e *Environment) exec(t *starlark.Thread, path string) (starlark.StringDict
 		status: loadStatusExecuting,
 	}
 
+	oldPath := t.Local(execingTiltfileKey)
+	t.SetLocal(execingTiltfileKey, localPath)
+
 	exports, err := e.doLoad(t, localPath)
+
+	t.SetLocal(execingTiltfileKey, oldPath)
+
 	e.loadCache[localPath] = loadCacheEntry{
 		status:  loadStatusDone,
 		exports: exports,

--- a/internal/tiltfile/starkit/environment_test.go
+++ b/internal/tiltfile/starkit/environment_test.go
@@ -2,6 +2,7 @@ package starkit
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -175,7 +176,7 @@ hello()
 	require.NoError(t, err)
 
 	path := strings.TrimSpace(f.out.String())
-	require.True(t, strings.HasSuffix(path, "foo/Tiltfile"))
+	require.Equal(t, "foo", filepath.Base(filepath.Dir(path)))
 }
 
 // foo loads bar
@@ -195,5 +196,5 @@ load('../bar/Tiltfile', 'unused')
 	require.NoError(t, err)
 
 	path := strings.TrimSpace(f.out.String())
-	require.True(t, strings.HasSuffix(path, "bar/Tiltfile"))
+	require.Equal(t, "bar", filepath.Base(filepath.Dir(path)))
 }

--- a/internal/tiltfile/starkit/path.go
+++ b/internal/tiltfile/starkit/path.go
@@ -19,15 +19,11 @@ func AbsWorkingDir(t *starlark.Thread) string {
 	return filepath.Dir(CurrentExecPath(t))
 }
 
-// Path to the file at the bottom of the call stack.
+// Path to the file that's currently executing
 func CurrentExecPath(t *starlark.Thread) string {
-	depth := t.CallStackDepth()
-	for i := 0; i < depth; i++ {
-		filename := t.CallFrame(i).Pos.Filename()
-		if filename == "<builtin>" {
-			continue
-		}
-		return filename
+	ret := t.Local(execingTiltfileKey)
+	if ret == nil {
+		panic("internal error: currentExecPath must be called from an active starlark thread")
 	}
-	panic("internal error: currentExecPath must be called from an active starlark thread")
+	return ret.(string)
 }


### PR DESCRIPTION
### Problem

When we execute code from a Tiltfile, we set the CWD equal to the path to the Tiltfile at the bottom of the call stack. This prevents us from defining extensions that, e.g., expose a function that declares a `docker_build`, or runs a `local`, with the caller's working directory.

### Solution

Set the CWD from the currently executing Tiltfile instead of from the callstack.
(laid out more explicitly in unit tests below)