### PR TITLE
k8s: delete + create when metadata.annotations too long

### DIFF
--- a/internal/cli/kubectl.go
+++ b/internal/cli/kubectl.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/cmd/create"
 	"k8s.io/kubectl/pkg/cmd/delete"
 	"k8s.io/kubectl/pkg/cmd/replace"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -50,13 +51,15 @@ func newKubectlCmd() *cobra.Command {
 	ioStreams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	cmdApply := apply.NewCmdApply("kubectl", f, ioStreams)
 
-	// TODO(nick): It might make more sense to implement replace and delete with client-go.
+	// TODO(nick): It might make more sense to implement these with client-go.
 	cmdReplace := replace.NewCmdReplace(f, ioStreams)
 	cmdDelete := delete.NewCmdDelete(f, ioStreams)
+	cmdCreate := create.NewCmdCreate(f, ioStreams)
 
 	result.AddCommand(cmdApply)
 	result.AddCommand(cmdReplace)
 	result.AddCommand(cmdDelete)
+	result.AddCommand(cmdCreate)
 	return result
 }
 

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -1,0 +1,469 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
+	"k8s.io/kubectl/pkg/generate"
+	"k8s.io/kubectl/pkg/rawhttp"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// CreateOptions is the commandline options for 'create' sub command
+type CreateOptions struct {
+	PrintFlags  *genericclioptions.PrintFlags
+	RecordFlags *genericclioptions.RecordFlags
+
+	DryRunStrategy cmdutil.DryRunStrategy
+	DryRunVerifier *resource.DryRunVerifier
+
+	FilenameOptions  resource.FilenameOptions
+	Selector         string
+	EditBeforeCreate bool
+	Raw              string
+
+	Recorder genericclioptions.Recorder
+	PrintObj func(obj kruntime.Object) error
+
+	genericclioptions.IOStreams
+}
+
+var (
+	createLong = templates.LongDesc(i18n.T(`
+		Create a resource from a file or from stdin.
+
+		JSON and YAML formats are accepted.`))
+
+	createExample = templates.Examples(i18n.T(`
+		# Create a pod using the data in pod.json.
+		kubectl create -f ./pod.json
+
+		# Create a pod based on the JSON passed into stdin.
+		cat pod.json | kubectl create -f -
+
+		# Edit the data in docker-registry.yaml in JSON then create the resource using the edited data.
+		kubectl create -f docker-registry.yaml --edit -o json`))
+)
+
+// NewCreateOptions returns an initialized CreateOptions instance
+func NewCreateOptions(ioStreams genericclioptions.IOStreams) *CreateOptions {
+	return &CreateOptions{
+		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		RecordFlags: genericclioptions.NewRecordFlags(),
+
+		Recorder: genericclioptions.NoopRecorder{},
+
+		IOStreams: ioStreams,
+	}
+}
+
+// NewCmdCreate returns new initialized instance of create sub command
+func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCreateOptions(ioStreams)
+
+	cmd := &cobra.Command{
+		Use:                   "create -f FILENAME",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a resource from a file or from stdin."),
+		Long:                  createLong,
+		Example:               createExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			if cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
+				ioStreams.ErrOut.Write([]byte("Error: must specify one of -f and -k\n\n"))
+				defaultRunFunc := cmdutil.DefaultSubCommandRun(ioStreams.ErrOut)
+				defaultRunFunc(cmd, args)
+				return
+			}
+			cmdutil.CheckErr(o.Complete(f, cmd))
+			cmdutil.CheckErr(o.ValidateArgs(cmd, args))
+			cmdutil.CheckErr(o.RunCreate(f, cmd))
+		},
+	}
+
+	// bind flag structs
+	o.RecordFlags.AddFlags(cmd)
+
+	usage := "to use to create the resource"
+	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddValidateFlags(cmd)
+	cmd.Flags().BoolVar(&o.EditBeforeCreate, "edit", o.EditBeforeCreate, "Edit the API resource before creating")
+	cmd.Flags().Bool("windows-line-endings", runtime.GOOS == "windows",
+		"Only relevant if --edit=true. Defaults to the line ending native to your platform.")
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to POST to the server.  Uses the transport specified by the kubeconfig file.")
+
+	o.PrintFlags.AddFlags(cmd)
+
+	// create subcommands
+	cmd.AddCommand(NewCmdCreateNamespace(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateQuota(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateSecret(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateConfigMap(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateServiceAccount(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateService(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateDeployment(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateClusterRole(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateClusterRoleBinding(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateRole(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateRoleBinding(f, ioStreams))
+	cmd.AddCommand(NewCmdCreatePodDisruptionBudget(f, ioStreams))
+	cmd.AddCommand(NewCmdCreatePriorityClass(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateJob(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateCronJob(f, ioStreams))
+	return cmd
+}
+
+// ValidateArgs makes sure there is no discrepency in command options
+func (o *CreateOptions) ValidateArgs(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
+	}
+	if len(o.Raw) > 0 {
+		if o.EditBeforeCreate {
+			return cmdutil.UsageErrorf(cmd, "--raw and --edit are mutually exclusive")
+		}
+		if len(o.FilenameOptions.Filenames) != 1 {
+			return cmdutil.UsageErrorf(cmd, "--raw can only use a single local file or stdin")
+		}
+		if strings.Index(o.FilenameOptions.Filenames[0], "http://") == 0 || strings.Index(o.FilenameOptions.Filenames[0], "https://") == 0 {
+			return cmdutil.UsageErrorf(cmd, "--raw cannot read from a url")
+		}
+		if o.FilenameOptions.Recursive {
+			return cmdutil.UsageErrorf(cmd, "--raw and --recursive are mutually exclusive")
+		}
+		if len(o.Selector) > 0 {
+			return cmdutil.UsageErrorf(cmd, "--raw and --selector (-l) are mutually exclusive")
+		}
+		if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
+			return cmdutil.UsageErrorf(cmd, "--raw and --output are mutually exclusive")
+		}
+		if _, err := url.ParseRequestURI(o.Raw); err != nil {
+			return cmdutil.UsageErrorf(cmd, "--raw must be a valid URL path: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Complete completes all the required options
+func (o *CreateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
+	var err error
+	o.RecordFlags.Complete(cmd)
+	o.Recorder, err = o.RecordFlags.ToRecorder()
+	if err != nil {
+		return err
+	}
+
+	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	o.PrintObj = func(obj kruntime.Object) error {
+		return printer.PrintObj(obj, o.Out)
+	}
+
+	return nil
+}
+
+// RunCreate performs the creation
+func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
+	// raw only makes sense for a single file resource multiple objects aren't likely to do what you want.
+	// the validator enforces this, so
+	if len(o.Raw) > 0 {
+		restClient, err := f.RESTClient()
+		if err != nil {
+			return err
+		}
+		return rawhttp.RawPost(restClient, o.IOStreams, o.Raw, o.FilenameOptions.Filenames[0])
+	}
+
+	if o.EditBeforeCreate {
+		return RunEditOnCreate(f, o.PrintFlags, o.RecordFlags, o.IOStreams, cmd, &o.FilenameOptions)
+	}
+	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
+	if err != nil {
+		return err
+	}
+
+	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	r := f.NewBuilder().
+		Unstructured().
+		Schema(schema).
+		ContinueOnError().
+		NamespaceParam(cmdNamespace).DefaultNamespace().
+		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		LabelSelectorParam(o.Selector).
+		Flatten().
+		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
+
+	count := 0
+	err = r.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := util.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info.Object, scheme.DefaultJSONEncoder()); err != nil {
+			return cmdutil.AddSourceToErr("creating", info.Source, err)
+		}
+
+		if err := o.Recorder.Record(info.Object); err != nil {
+			klog.V(4).Infof("error recording current command: %v", err)
+		}
+
+		if o.DryRunStrategy != cmdutil.DryRunClient {
+			if o.DryRunStrategy == cmdutil.DryRunServer {
+				if err := o.DryRunVerifier.HasSupport(info.Mapping.GroupVersionKind); err != nil {
+					return cmdutil.AddSourceToErr("creating", info.Source, err)
+				}
+			}
+			obj, err := resource.
+				NewHelper(info.Client, info.Mapping).
+				DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+				Create(info.Namespace, true, info.Object)
+			if err != nil {
+				return cmdutil.AddSourceToErr("creating", info.Source, err)
+			}
+			info.Refresh(obj, true)
+		}
+
+		count++
+
+		return o.PrintObj(info.Object)
+	})
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return fmt.Errorf("no objects passed to create")
+	}
+	return nil
+}
+
+// RunEditOnCreate performs edit on creation
+func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags, recordFlags *genericclioptions.RecordFlags, ioStreams genericclioptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions) error {
+	editOptions := editor.NewEditOptions(editor.EditBeforeCreateMode, ioStreams)
+	editOptions.FilenameOptions = *options
+	editOptions.ValidateOptions = cmdutil.ValidateOptions{
+		EnableValidation: cmdutil.GetFlagBool(cmd, "validate"),
+	}
+	editOptions.PrintFlags = printFlags
+	editOptions.ApplyAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
+	editOptions.RecordFlags = recordFlags
+
+	err := editOptions.Complete(f, []string{}, cmd)
+	if err != nil {
+		return err
+	}
+	return editOptions.Run()
+}
+
+// NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name
+func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
+	argsLen := cmd.ArgsLenAtDash()
+	// ArgsLenAtDash returns -1 when -- was not specified
+	if argsLen == -1 {
+		argsLen = len(args)
+	}
+	if argsLen != 1 {
+		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", argsLen)
+	}
+	return args[0], nil
+}
+
+// CreateSubcommandOptions is an options struct to support create subcommands
+type CreateSubcommandOptions struct {
+	// PrintFlags holds options necessary for obtaining a printer
+	PrintFlags *genericclioptions.PrintFlags
+	// Name of resource being created
+	Name string
+	// StructuredGenerator is the resource generator for the object being created
+	StructuredGenerator generate.StructuredGenerator
+	DryRunStrategy      cmdutil.DryRunStrategy
+	DryRunVerifier      *resource.DryRunVerifier
+	CreateAnnotation    bool
+
+	Namespace        string
+	EnforceNamespace bool
+
+	Mapper        meta.RESTMapper
+	DynamicClient dynamic.Interface
+
+	PrintObj printers.ResourcePrinterFunc
+
+	genericclioptions.IOStreams
+}
+
+// NewCreateSubcommandOptions returns initialized CreateSubcommandOptions
+func NewCreateSubcommandOptions(ioStreams genericclioptions.IOStreams) *CreateSubcommandOptions {
+	return &CreateSubcommandOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		IOStreams:  ioStreams,
+	}
+}
+
+// Complete completes all the required options
+func (o *CreateSubcommandOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string, generator generate.StructuredGenerator) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	o.Name = name
+	o.StructuredGenerator = generator
+	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	o.CreateAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
+
+	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	o.PrintObj = func(obj kruntime.Object, out io.Writer) error {
+		return printer.PrintObj(obj, out)
+	}
+
+	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	o.DynamicClient, err = f.DynamicClient()
+	if err != nil {
+		return err
+	}
+
+	o.Mapper, err = f.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run executes a create subcommand using the specified options
+func (o *CreateSubcommandOptions) Run() error {
+	obj, err := o.StructuredGenerator.StructuredGenerate()
+	if err != nil {
+		return err
+	}
+	if o.DryRunStrategy != cmdutil.DryRunClient {
+		// create subcommands have compiled knowledge of things they create, so type them directly
+		gvks, _, err := scheme.Scheme.ObjectKinds(obj)
+		if err != nil {
+			return err
+		}
+		gvk := gvks[0]
+		mapping, err := o.Mapper.RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
+		if err != nil {
+			return err
+		}
+
+		if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, obj, scheme.DefaultJSONEncoder()); err != nil {
+			return err
+		}
+
+		asUnstructured := &unstructured.Unstructured{}
+
+		if err := scheme.Scheme.Convert(obj, asUnstructured, nil); err != nil {
+			return err
+		}
+		if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+			o.Namespace = ""
+		}
+		createOptions := metav1.CreateOptions{}
+		if o.DryRunStrategy == cmdutil.DryRunServer {
+			if err := o.DryRunVerifier.HasSupport(mapping.GroupVersionKind); err != nil {
+				return err
+			}
+			createOptions.DryRun = []string{metav1.DryRunAll}
+		}
+		actualObject, err := o.DynamicClient.Resource(mapping.Resource).Namespace(o.Namespace).Create(context.TODO(), asUnstructured, createOptions)
+		if err != nil {
+			return err
+		}
+
+		// ensure we pass a versioned object to the printer
+		obj = actualObject
+	} else {
+		if meta, err := meta.Accessor(obj); err == nil && o.EnforceNamespace {
+			meta.SetNamespace(o.Namespace)
+		}
+	}
+
+	return o.PrintObj(obj, o.Out)
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cliflag "k8s.io/component-base/cli/flag"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	clusterRoleLong = templates.LongDesc(i18n.T(`
+		Create a ClusterRole.`))
+
+	clusterRoleExample = templates.Examples(i18n.T(`
+		# Create a ClusterRole named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
+		kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods
+
+		# Create a ClusterRole named "pod-reader" with ResourceName specified
+		kubectl create clusterrole pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+
+		# Create a ClusterRole named "foo" with API Group specified
+		kubectl create clusterrole foo --verb=get,list,watch --resource=rs.extensions
+
+		# Create a ClusterRole named "foo" with SubResource specified
+		kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
+
+		# Create a ClusterRole name "foo" with NonResourceURL specified
+		kubectl create clusterrole "foo" --verb=get --non-resource-url=/logs/*
+
+		# Create a ClusterRole name "monitoring" with AggregationRule specified
+		kubectl create clusterrole monitoring --aggregation-rule="rbac.example.com/aggregate-to-monitoring=true"`))
+
+	// Valid nonResource verb list for validation.
+	validNonResourceVerbs = []string{"*", "get", "post", "put", "delete", "patch", "head", "options"}
+)
+
+// CreateClusterRoleOptions is returned by NewCmdCreateClusterRole
+type CreateClusterRoleOptions struct {
+	*CreateRoleOptions
+	NonResourceURLs []string
+	AggregationRule map[string]string
+}
+
+// NewCmdCreateClusterRole initializes and returns new ClusterRoles command
+func NewCmdCreateClusterRole(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	c := &CreateClusterRoleOptions{
+		CreateRoleOptions: NewCreateRoleOptions(ioStreams),
+		AggregationRule:   map[string]string{},
+	}
+	cmd := &cobra.Command{
+		Use:                   "clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 clusterRoleLong,
+		Long:                  clusterRoleLong,
+		Example:               clusterRoleExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(c.Complete(f, cmd, args))
+			cmdutil.CheckErr(c.Validate())
+			cmdutil.CheckErr(c.RunCreateRole())
+		},
+	}
+
+	c.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().StringSliceVar(&c.Verbs, "verb", c.Verbs, "Verb that applies to the resources contained in the rule")
+	cmd.Flags().StringSliceVar(&c.NonResourceURLs, "non-resource-url", c.NonResourceURLs, "A partial url that user should have access to.")
+	cmd.Flags().StringSlice("resource", []string{}, "Resource that the rule applies to")
+	cmd.Flags().StringArrayVar(&c.ResourceNames, "resource-name", c.ResourceNames, "Resource in the white list that the rule applies to, repeat this flag for multiple items")
+	cmd.Flags().Var(cliflag.NewMapStringString(&c.AggregationRule), "aggregation-rule", "An aggregation label selector for combining ClusterRoles.")
+
+	return cmd
+}
+
+// Complete completes all the required options
+func (c *CreateClusterRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	// Remove duplicate nonResourceURLs
+	nonResourceURLs := []string{}
+	for _, n := range c.NonResourceURLs {
+		if !arrayContains(nonResourceURLs, n) {
+			nonResourceURLs = append(nonResourceURLs, n)
+		}
+	}
+	c.NonResourceURLs = nonResourceURLs
+
+	return c.CreateRoleOptions.Complete(f, cmd, args)
+}
+
+// Validate makes sure there is no discrepency in CreateClusterRoleOptions
+func (c *CreateClusterRoleOptions) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("name must be specified")
+	}
+
+	if len(c.AggregationRule) > 0 {
+		if len(c.NonResourceURLs) > 0 || len(c.Verbs) > 0 || len(c.Resources) > 0 || len(c.ResourceNames) > 0 {
+			return fmt.Errorf("aggregation rule must be specified without nonResourceURLs, verbs, resources or resourceNames")
+		}
+		return nil
+	}
+
+	// validate verbs.
+	if len(c.Verbs) == 0 {
+		return fmt.Errorf("at least one verb must be specified")
+	}
+
+	if len(c.Resources) == 0 && len(c.NonResourceURLs) == 0 {
+		return fmt.Errorf("one of resource or nonResourceURL must be specified")
+	}
+
+	// validate resources
+	if len(c.Resources) > 0 {
+		for _, v := range c.Verbs {
+			if !arrayContains(validResourceVerbs, v) {
+				return fmt.Errorf("invalid verb: '%s'", v)
+			}
+		}
+		if err := c.validateResource(); err != nil {
+			return err
+		}
+	}
+
+	//validate non-resource-url
+	if len(c.NonResourceURLs) > 0 {
+		for _, v := range c.Verbs {
+			if !arrayContains(validNonResourceVerbs, v) {
+				return fmt.Errorf("invalid verb: '%s' for nonResourceURL", v)
+			}
+		}
+
+		for _, nonResourceURL := range c.NonResourceURLs {
+			if nonResourceURL == "*" {
+				continue
+			}
+
+			if nonResourceURL == "" || !strings.HasPrefix(nonResourceURL, "/") {
+				return fmt.Errorf("nonResourceURL should start with /")
+			}
+
+			if strings.ContainsRune(nonResourceURL[:len(nonResourceURL)-1], '*') {
+				return fmt.Errorf("nonResourceURL only supports wildcard matches when '*' is at the end")
+			}
+		}
+	}
+
+	return nil
+
+}
+
+// RunCreateRole creates a new clusterRole
+func (c *CreateClusterRoleOptions) RunCreateRole() error {
+	clusterRole := &rbacv1.ClusterRole{
+		// this is ok because we know exactly how we want to be serialized
+		TypeMeta: metav1.TypeMeta{APIVersion: rbacv1.SchemeGroupVersion.String(), Kind: "ClusterRole"},
+	}
+	clusterRole.Name = c.Name
+
+	var err error
+	if len(c.AggregationRule) == 0 {
+		rules, err := generateResourcePolicyRules(c.Mapper, c.Verbs, c.Resources, c.ResourceNames, c.NonResourceURLs)
+		if err != nil {
+			return err
+		}
+		clusterRole.Rules = rules
+	} else {
+		clusterRole.AggregationRule = &rbacv1.AggregationRule{
+			ClusterRoleSelectors: []metav1.LabelSelector{
+				{
+					MatchLabels: c.AggregationRule,
+				},
+			},
+		}
+	}
+
+	// Create ClusterRole.
+	if c.DryRunStrategy != cmdutil.DryRunClient {
+		createOptions := metav1.CreateOptions{}
+		if c.DryRunStrategy == cmdutil.DryRunServer {
+			if err := c.DryRunVerifier.HasSupport(clusterRole.GroupVersionKind()); err != nil {
+				return err
+			}
+			createOptions.DryRun = []string{metav1.DryRunAll}
+		}
+		clusterRole, err = c.Client.ClusterRoles().Create(context.TODO(), clusterRole, createOptions)
+		if err != nil {
+			return err
+		}
+	}
+
+	return c.PrintObj(clusterRole)
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	clusterRoleBindingLong = templates.LongDesc(i18n.T(`
+		Create a ClusterRoleBinding for a particular ClusterRole.`))
+
+	clusterRoleBindingExample = templates.Examples(i18n.T(`
+		  # Create a ClusterRoleBinding for user1, user2, and group1 using the cluster-admin ClusterRole
+		  kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1`))
+)
+
+// ClusterRoleBindingOpts is returned by NewCmdCreateClusterRoleBinding
+type ClusterRoleBindingOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateClusterRoleBinding returns an initialized command instance of ClusterRoleBinding
+func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := &ClusterRoleBindingOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a ClusterRoleBinding for a particular ClusterRole"),
+		Long:                  clusterRoleBindingLong,
+		Example:               clusterRoleBindingExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	o.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ClusterRoleBindingV1GeneratorName)
+	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this ClusterRoleBinding should reference"))
+	cmd.MarkFlagCustom("clusterrole", "__kubectl_get_resource_clusterrole")
+	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the clusterrole")
+	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the clusterrole")
+	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the clusterrole, in the format <namespace>:<name>")
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *ClusterRoleBindingOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ClusterRoleBindingV1GeneratorName:
+		generator = &generateversioned.ClusterRoleBindingGeneratorV1{
+			Name:            name,
+			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
+			Users:           cmdutil.GetFlagStringArray(cmd, "user"),
+			Groups:          cmdutil.GetFlagStringArray(cmd, "group"),
+			ServiceAccounts: cmdutil.GetFlagStringArray(cmd, "serviceaccount"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in ClusterRoleBindingOpts instance
+func (o *ClusterRoleBindingOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	configMapLong = templates.LongDesc(i18n.T(`
+		Create a configmap based on a file, directory, or specified literal value.
+
+		A single configmap may package one or more key/value pairs.
+
+		When creating a configmap based on a file, the key will default to the basename of the file, and the value will
+		default to the file content.  If the basename is an invalid key, you may specify an alternate key.
+
+		When creating a configmap based on a directory, each file whose basename is a valid key in the directory will be
+		packaged into the configmap.  Any directory entries except regular files are ignored (e.g. subdirectories,
+		symlinks, devices, pipes, etc).`))
+
+	configMapExample = templates.Examples(i18n.T(`
+		  # Create a new configmap named my-config based on folder bar
+		  kubectl create configmap my-config --from-file=path/to/bar
+
+		  # Create a new configmap named my-config with specified keys instead of file basenames on disk
+		  kubectl create configmap my-config --from-file=key1=/path/to/bar/file1.txt --from-file=key2=/path/to/bar/file2.txt
+
+		  # Create a new configmap named my-config with key1=config1 and key2=config2
+		  kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
+
+		  # Create a new configmap named my-config from the key=value pairs in the file
+		  kubectl create configmap my-config --from-file=path/to/bar
+
+		  # Create a new configmap named my-config from an env file
+		  kubectl create configmap my-config --from-env-file=path/to/bar.env`))
+)
+
+// ConfigMapOpts holds properties for create configmap sub-command
+type ConfigMapOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateConfigMap initializes and returns ConfigMapOpts
+func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &ConfigMapOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"cm"},
+		Short:                 i18n.T("Create a configmap from a local file, directory or literal value"),
+		Long:                  configMapLong,
+		Example:               configMapExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ConfigMapV1GeneratorName)
+	cmd.Flags().StringSlice("from-file", []string{}, "Key file can be specified using its file path, in which case file basename will be used as configmap key, or optionally with a key and file path, in which case the given key will be used.  Specifying a directory will iterate each named file in the directory whose basename is a valid configmap key.")
+	cmd.Flags().StringArray("from-literal", []string{}, "Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)")
+	cmd.Flags().String("from-env-file", "", "Specify the path to a file to read lines of key=val pairs to create a configmap (i.e. a Docker .env file).")
+	cmd.Flags().Bool("append-hash", false, "Append a hash of the configmap to its name.")
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *ConfigMapOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ConfigMapV1GeneratorName:
+		generator = &generateversioned.ConfigMapGeneratorV1{
+			Name:           name,
+			FileSources:    cmdutil.GetFlagStringSlice(cmd, "from-file"),
+			LiteralSources: cmdutil.GetFlagStringArray(cmd, "from-literal"),
+			EnvFileSource:  cmdutil.GetFlagString(cmd, "from-env-file"),
+			AppendHash:     cmdutil.GetFlagBool(cmd, "append-hash"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run performs the execution of 'create' sub command options
+func (o *ConfigMapOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	batchv1beta1client "k8s.io/client-go/kubernetes/typed/batch/v1beta1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	cronjobLong = templates.LongDesc(`
+		Create a cronjob with the specified name.`)
+
+	cronjobExample = templates.Examples(`
+		# Create a cronjob
+		kubectl create cronjob my-job --image=busybox
+
+		# Create a cronjob with command
+		kubectl create cronjob my-job --image=busybox -- date
+
+		# Create a cronjob with schedule
+		kubectl create cronjob test-job --image=busybox --schedule="*/1 * * * *"`)
+)
+
+type CreateCronJobOptions struct {
+	PrintFlags *genericclioptions.PrintFlags
+
+	PrintObj func(obj runtime.Object) error
+
+	Name     string
+	Image    string
+	Schedule string
+	Command  []string
+	Restart  string
+
+	Namespace      string
+	Client         batchv1beta1client.BatchV1beta1Interface
+	DryRunStrategy cmdutil.DryRunStrategy
+	DryRunVerifier *resource.DryRunVerifier
+	Builder        *resource.Builder
+	Cmd            *cobra.Command
+
+	genericclioptions.IOStreams
+}
+
+func NewCreateCronJobOptions(ioStreams genericclioptions.IOStreams) *CreateCronJobOptions {
+	return &CreateCronJobOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		IOStreams:  ioStreams,
+	}
+}
+
+// NewCmdCreateCronJob is a command to create CronJobs.
+func NewCmdCreateCronJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCreateCronJobOptions(ioStreams)
+	cmd := &cobra.Command{
+		Use:     "cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] [args...]",
+		Aliases: []string{"cj"},
+		Short:   cronjobLong,
+		Long:    cronjobLong,
+		Example: cronjobExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	o.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().StringVar(&o.Image, "image", o.Image, "Image name to run.")
+	cmd.Flags().StringVar(&o.Schedule, "schedule", o.Schedule, "A schedule in the Cron format the job should be run with.")
+	cmd.Flags().StringVar(&o.Restart, "restart", o.Restart, "job's restart policy. supported values: OnFailure, Never")
+
+	return cmd
+}
+
+func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	o.Name = name
+	if len(args) > 1 {
+		o.Command = args[1:]
+	}
+	if len(o.Restart) == 0 {
+		o.Restart = "OnFailure"
+	}
+
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	o.Client, err = batchv1beta1client.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+	o.Builder = f.NewBuilder()
+	o.Cmd = cmd
+
+	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+	o.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
+	}
+
+	return nil
+}
+
+func (o *CreateCronJobOptions) Validate() error {
+	if len(o.Image) == 0 {
+		return fmt.Errorf("--image must be specified")
+	}
+	if len(o.Schedule) == 0 {
+		return fmt.Errorf("--schedule must be specified")
+	}
+	return nil
+}
+
+func (o *CreateCronJobOptions) Run() error {
+	var cronjob *batchv1beta1.CronJob
+	cronjob = o.createCronJob()
+
+	if o.DryRunStrategy != cmdutil.DryRunClient {
+		createOptions := metav1.CreateOptions{}
+		if o.DryRunStrategy == cmdutil.DryRunServer {
+			if err := o.DryRunVerifier.HasSupport(cronjob.GroupVersionKind()); err != nil {
+				return err
+			}
+			createOptions.DryRun = []string{metav1.DryRunAll}
+		}
+		var err error
+		cronjob, err = o.Client.CronJobs(o.Namespace).Create(context.TODO(), cronjob, createOptions)
+		if err != nil {
+			return fmt.Errorf("failed to create cronjob: %v", err)
+		}
+	}
+
+	return o.PrintObj(cronjob)
+}
+
+func (o *CreateCronJobOptions) createCronJob() *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
+		TypeMeta: metav1.TypeMeta{APIVersion: batchv1beta1.SchemeGroupVersion.String(), Kind: "CronJob"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.Name,
+		},
+		Spec: batchv1beta1.CronJobSpec{
+			Schedule: o.Schedule,
+			JobTemplate: batchv1beta1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: o.Name,
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    o.Name,
+									Image:   o.Image,
+									Command: o.Command,
+								},
+							},
+							RestartPolicy: corev1.RestartPolicy(o.Restart),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	deploymentLong = templates.LongDesc(i18n.T(`
+	Create a deployment with the specified name.`))
+
+	deploymentExample = templates.Examples(i18n.T(`
+	# Create a new deployment named my-dep that runs the busybox image.
+	kubectl create deployment my-dep --image=busybox`))
+)
+
+// DeploymentOpts is returned by NewCmdCreateDeployment
+type DeploymentOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateDeployment is a macro command to create a new deployment.
+// This command is better known to users as `kubectl create deployment`.
+// Note that this command overlaps significantly with the `kubectl run` command.
+func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &DeploymentOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "deployment NAME --image=image [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"deploy"},
+		Short:                 i18n.T("Create a deployment with the specified name."),
+		Long:                  deploymentLong,
+		Example:               deploymentExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, "")
+	cmd.Flags().StringSlice("image", []string{}, "Image name to run.")
+	cmd.MarkFlagRequired("image")
+	return cmd
+}
+
+// generatorFromName returns the appropriate StructuredGenerator based on the
+// generatorName. If the generatorName is unrecognized, then return (nil,
+// false).
+func generatorFromName(
+	generatorName string,
+	imageNames []string,
+	deploymentName string,
+) (generate.StructuredGenerator, bool) {
+
+	switch generatorName {
+	case generateversioned.DeploymentBasicAppsV1GeneratorName:
+		generator := &generateversioned.DeploymentBasicAppsGeneratorV1{
+			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
+				Name:   deploymentName,
+				Images: imageNames,
+			},
+		}
+		return generator, true
+
+	case generateversioned.DeploymentBasicAppsV1Beta1GeneratorName:
+		generator := &generateversioned.DeploymentBasicAppsGeneratorV1Beta1{
+			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
+				Name:   deploymentName,
+				Images: imageNames,
+			},
+		}
+		return generator, true
+
+	case generateversioned.DeploymentBasicV1Beta1GeneratorName:
+		generator := &generateversioned.DeploymentBasicGeneratorV1{
+			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
+				Name:   deploymentName,
+				Images: imageNames,
+			},
+		}
+		return generator, true
+	}
+
+	return nil, false
+}
+
+// Complete completes all the options
+func (o *DeploymentOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	clientset, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+
+	generatorName := cmdutil.GetFlagString(cmd, "generator")
+
+	if len(generatorName) == 0 {
+		generatorName = generateversioned.DeploymentBasicAppsV1GeneratorName
+		generatorNameTemp, err := generateversioned.FallbackGeneratorNameIfNecessary(generatorName, clientset.Discovery(), o.CreateSubcommandOptions.ErrOut)
+		if err != nil {
+			return err
+		}
+		if generatorNameTemp != generatorName {
+			cmdutil.Warning(o.CreateSubcommandOptions.ErrOut, generatorName, generatorNameTemp)
+		} else {
+			generatorName = generatorNameTemp
+		}
+	}
+
+	imageNames := cmdutil.GetFlagStringSlice(cmd, "image")
+	generator, ok := generatorFromName(generatorName, imageNames, name)
+	if !ok {
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run performs the execution of 'create deployment' sub command
+func (o *DeploymentOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	jobLong = templates.LongDesc(i18n.T(`
+		Create a job with the specified name.`))
+
+	jobExample = templates.Examples(i18n.T(`
+		# Create a job
+		kubectl create job my-job --image=busybox
+
+		# Create a job with command
+		kubectl create job my-job --image=busybox -- date
+
+		# Create a job from a CronJob named "a-cronjob"
+		kubectl create job test-job --from=cronjob/a-cronjob`))
+)
+
+// CreateJobOptions is the command line options for 'create job'
+type CreateJobOptions struct {
+	PrintFlags *genericclioptions.PrintFlags
+
+	PrintObj func(obj runtime.Object) error
+
+	Name    string
+	Image   string
+	From    string
+	Command []string
+
+	Namespace      string
+	Client         batchv1client.BatchV1Interface
+	DryRunStrategy cmdutil.DryRunStrategy
+	DryRunVerifier *resource.DryRunVerifier
+	Builder        *resource.Builder
+	Cmd            *cobra.Command
+
+	genericclioptions.IOStreams
+}
+
+// NewCreateJobOptions initializes and returns new CreateJobOptions instance
+func NewCreateJobOptions(ioStreams genericclioptions.IOStreams) *CreateJobOptions {
+	return &CreateJobOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		IOStreams:  ioStreams,
+	}
+}
+
+// NewCmdCreateJob is a command to ease creating Jobs from CronJobs.
+func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCreateJobOptions(ioStreams)
+	cmd := &cobra.Command{
+		Use:     "job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]",
+		Short:   jobLong,
+		Long:    jobLong,
+		Example: jobExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	o.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().StringVar(&o.Image, "image", o.Image, "Image name to run.")
+	cmd.Flags().StringVar(&o.From, "from", o.From, "The name of the resource to create a Job from (only cronjob is supported).")
+
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *CreateJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	o.Name = name
+	if len(args) > 1 {
+		o.Command = args[1:]
+	}
+
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	o.Client, err = batchv1client.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+	o.Builder = f.NewBuilder()
+	o.Cmd = cmd
+
+	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+	o.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
+	}
+
+	return nil
+}
+
+// Validate makes sure provided values and valid Job options
+func (o *CreateJobOptions) Validate() error {
+	if (len(o.Image) == 0 && len(o.From) == 0) || (len(o.Image) != 0 && len(o.From) != 0) {
+		return fmt.Errorf("either --image or --from must be specified")
+	}
+	if o.Command != nil && len(o.Command) != 0 && len(o.From) != 0 {
+		return fmt.Errorf("cannot specify --from and command")
+	}
+	return nil
+}
+
+// Run performs the execution of 'create job' sub command
+func (o *CreateJobOptions) Run() error {
+	var job *batchv1.Job
+	if len(o.Image) > 0 {
+		job = o.createJob()
+	} else {
+		infos, err := o.Builder.
+			Unstructured().
+			NamespaceParam(o.Namespace).DefaultNamespace().
+			ResourceTypeOrNameArgs(false, o.From).
+			Flatten().
+			Latest().
+			Do().
+			Infos()
+		if err != nil {
+			return err
+		}
+		if len(infos) != 1 {
+			return fmt.Errorf("from must be an existing cronjob")
+		}
+
+		uncastVersionedObj, err := scheme.Scheme.ConvertToVersion(infos[0].Object, batchv1beta1.SchemeGroupVersion)
+		if err != nil {
+			return fmt.Errorf("from must be an existing cronjob: %v", err)
+		}
+		cronJob, ok := uncastVersionedObj.(*batchv1beta1.CronJob)
+		if !ok {
+			return fmt.Errorf("from must be an existing cronjob")
+		}
+
+		job = o.createJobFromCronJob(cronJob)
+	}
+	if o.DryRunStrategy != cmdutil.DryRunClient {
+		createOptions := metav1.CreateOptions{}
+		if o.DryRunStrategy == cmdutil.DryRunServer {
+			if err := o.DryRunVerifier.HasSupport(job.GroupVersionKind()); err != nil {
+				return err
+			}
+			createOptions.DryRun = []string{metav1.DryRunAll}
+		}
+		var err error
+		job, err = o.Client.Jobs(o.Namespace).Create(context.TODO(), job, createOptions)
+		if err != nil {
+			return fmt.Errorf("failed to create job: %v", err)
+		}
+	}
+
+	return o.PrintObj(job)
+}
+
+func (o *CreateJobOptions) createJob() *batchv1.Job {
+	return &batchv1.Job{
+		// this is ok because we know exactly how we want to be serialized
+		TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.Name,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    o.Name,
+							Image:   o.Image,
+							Command: o.Command,
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+}
+
+func (o *CreateJobOptions) createJobFromCronJob(cronJob *batchv1beta1.CronJob) *batchv1.Job {
+	annotations := make(map[string]string)
+	annotations["cronjob.kubernetes.io/instantiate"] = "manual"
+	for k, v := range cronJob.Spec.JobTemplate.Annotations {
+		annotations[k] = v
+	}
+
+	return &batchv1.Job{
+		// this is ok because we know exactly how we want to be serialized
+		TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        o.Name,
+			Annotations: annotations,
+			Labels:      cronJob.Spec.JobTemplate.Labels,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(cronJob, appsv1.SchemeGroupVersion.WithKind("CronJob")),
+			},
+		},
+		Spec: cronJob.Spec.JobTemplate.Spec,
+	}
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	namespaceLong = templates.LongDesc(i18n.T(`
+		Create a namespace with the specified name.`))
+
+	namespaceExample = templates.Examples(i18n.T(`
+	  # Create a new namespace named my-namespace
+	  kubectl create namespace my-namespace`))
+)
+
+// NamespaceOpts is the options for 'create namespace' sub command
+type NamespaceOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateNamespace is a macro command to create a new namespace
+func NewCmdCreateNamespace(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &NamespaceOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "namespace NAME [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"ns"},
+		Short:                 i18n.T("Create a namespace with the specified name"),
+		Long:                  namespaceLong,
+		Example:               namespaceExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.NamespaceV1GeneratorName)
+
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *NamespaceOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.NamespaceV1GeneratorName:
+		generator = &generateversioned.NamespaceGeneratorV1{Name: name}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in NamespaceOpts instance
+func (o *NamespaceOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	pdbLong = templates.LongDesc(i18n.T(`
+		Create a pod disruption budget with the specified name, selector, and desired minimum available pods`))
+
+	pdbExample = templates.Examples(i18n.T(`
+		# Create a pod disruption budget named my-pdb that will select all pods with the app=rails label
+		# and require at least one of them being available at any point in time.
+		kubectl create poddisruptionbudget my-pdb --selector=app=rails --min-available=1
+
+		# Create a pod disruption budget named my-pdb that will select all pods with the app=nginx label
+		# and require at least half of the pods selected to be available at any point in time.
+		kubectl create pdb my-pdb --selector=app=nginx --min-available=50%`))
+)
+
+// PodDisruptionBudgetOpts holds the command-line options for poddisruptionbudget sub command
+type PodDisruptionBudgetOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreatePodDisruptionBudget is a macro command to create a new pod disruption budget.
+func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &PodDisruptionBudgetOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"pdb"},
+		Short:                 i18n.T("Create a pod disruption budget with the specified name."),
+		Long:                  pdbLong,
+		Example:               pdbExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.PodDisruptionBudgetV2GeneratorName)
+
+	cmd.Flags().String("min-available", "", i18n.T("The minimum number or percentage of available pods this budget requires."))
+	cmd.Flags().String("max-unavailable", "", i18n.T("The maximum number or percentage of unavailable pods this budget requires."))
+	cmd.Flags().String("selector", "", i18n.T("A label selector to use for this budget. Only equality-based selector requirements are supported."))
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *PodDisruptionBudgetOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.PodDisruptionBudgetV1GeneratorName:
+		generator = &generateversioned.PodDisruptionBudgetV1Generator{
+			Name:         name,
+			MinAvailable: cmdutil.GetFlagString(cmd, "min-available"),
+			Selector:     cmdutil.GetFlagString(cmd, "selector"),
+		}
+	case generateversioned.PodDisruptionBudgetV2GeneratorName:
+		generator = &generateversioned.PodDisruptionBudgetV2Generator{
+			Name:           name,
+			MinAvailable:   cmdutil.GetFlagString(cmd, "min-available"),
+			MaxUnavailable: cmdutil.GetFlagString(cmd, "max-unavailable"),
+			Selector:       cmdutil.GetFlagString(cmd, "selector"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in PodDisruptionBudgetOpts instance
+func (o *PodDisruptionBudgetOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	pcLong = templates.LongDesc(i18n.T(`
+		Create a priorityclass with the specified name, value, globalDefault and description`))
+
+	pcExample = templates.Examples(i18n.T(`
+		# Create a priorityclass named high-priority
+		kubectl create priorityclass high-priority --value=1000 --description="high priority"
+
+		# Create a priorityclass named default-priority that considered as the global default priority
+		kubectl create priorityclass default-priority --value=1000 --global-default=true --description="default priority"
+
+		# Create a priorityclass named high-priority that can not preempt pods with lower priority
+		kubectl create priorityclass high-priority --value=1000 --description="high priority" --preemption-policy="Never"`))
+)
+
+// PriorityClassOpts holds the options for 'create priorityclass' sub command
+type PriorityClassOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreatePriorityClass is a macro command to create a new priorityClass.
+func NewCmdCreatePriorityClass(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &PriorityClassOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "priorityclass NAME --value=VALUE --global-default=BOOL [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"pc"},
+		Short:                 i18n.T("Create a priorityclass with the specified name."),
+		Long:                  pcLong,
+		Example:               pcExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.PriorityClassV1GeneratorName)
+
+	cmd.Flags().Int32("value", 0, i18n.T("the value of this priority class."))
+	cmd.Flags().Bool("global-default", false, i18n.T("global-default specifies whether this PriorityClass should be considered as the default priority."))
+	cmd.Flags().String("description", "", i18n.T("description is an arbitrary string that usually provides guidelines on when this priority class should be used."))
+	cmd.Flags().String("preemption-policy", "", i18n.T("preemption-policy is the policy for preempting pods with lower priority."))
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *PriorityClassOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.PriorityClassV1GeneratorName:
+		generator = &generateversioned.PriorityClassV1Generator{
+			Name:             name,
+			Value:            cmdutil.GetFlagInt32(cmd, "value"),
+			GlobalDefault:    cmdutil.GetFlagBool(cmd, "global-default"),
+			Description:      cmdutil.GetFlagString(cmd, "description"),
+			PreemptionPolicy: apiv1.PreemptionPolicy(cmdutil.GetFlagString(cmd, "preemption-policy")),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in the PriorityClassOpts instance
+func (o *PriorityClassOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	quotaLong = templates.LongDesc(i18n.T(`
+		Create a resourcequota with the specified name, hard limits and optional scopes`))
+
+	quotaExample = templates.Examples(i18n.T(`
+		# Create a new resourcequota named my-quota
+		kubectl create quota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
+
+		# Create a new resourcequota named best-effort
+		kubectl create quota best-effort --hard=pods=100 --scopes=BestEffort`))
+)
+
+// QuotaOpts holds the command-line options for 'create quota' sub command
+type QuotaOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateQuota is a macro command to create a new quota
+func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &QuotaOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"resourcequota"},
+		Short:                 i18n.T("Create a quota with the specified name."),
+		Long:                  quotaLong,
+		Example:               quotaExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ResourceQuotaV1GeneratorName)
+	cmd.Flags().String("hard", "", i18n.T("A comma-delimited set of resource=quantity pairs that define a hard limit."))
+	cmd.Flags().String("scopes", "", i18n.T("A comma-delimited set of quota scopes that must all match each object tracked by the quota."))
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *QuotaOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ResourceQuotaV1GeneratorName:
+		generator = &generateversioned.ResourceQuotaGeneratorV1{
+			Name:   name,
+			Hard:   cmdutil.GetFlagString(cmd, "hard"),
+			Scopes: cmdutil.GetFlagString(cmd, "scopes"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in QuotaOpts instance
+func (o *QuotaOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	clientgorbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	roleLong = templates.LongDesc(i18n.T(`
+		Create a role with single rule.`))
+
+	roleExample = templates.Examples(i18n.T(`
+		# Create a Role named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
+		kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
+
+		# Create a Role named "pod-reader" with ResourceName specified
+		kubectl create role pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+
+		# Create a Role named "foo" with API Group specified
+		kubectl create role foo --verb=get,list,watch --resource=rs.extensions
+
+		# Create a Role named "foo" with SubResource specified
+		kubectl create role foo --verb=get,list,watch --resource=pods,pods/status`))
+
+	// Valid resource verb list for validation.
+	validResourceVerbs = []string{"*", "get", "delete", "list", "create", "update", "patch", "watch", "proxy", "deletecollection", "use", "bind", "escalate", "impersonate"}
+
+	// Specialized verbs and GroupResources
+	specialVerbs = map[string][]schema.GroupResource{
+		"use": {
+			{
+				Group:    "policy",
+				Resource: "podsecuritypolicies",
+			},
+			{
+				Group:    "extensions",
+				Resource: "podsecuritypolicies",
+			},
+		},
+		"bind": {
+			{
+				Group:    "rbac.authorization.k8s.io",
+				Resource: "roles",
+			},
+			{
+				Group:    "rbac.authorization.k8s.io",
+				Resource: "clusterroles",
+			},
+		},
+		"escalate": {
+			{
+				Group:    "rbac.authorization.k8s.io",
+				Resource: "roles",
+			},
+			{
+				Group:    "rbac.authorization.k8s.io",
+				Resource: "clusterroles",
+			},
+		},
+		"impersonate": {
+			{
+				Group:    "",
+				Resource: "users",
+			},
+			{
+				Group:    "",
+				Resource: "serviceaccounts",
+			},
+			{
+				Group:    "",
+				Resource: "groups",
+			},
+			{
+				Group:    "authentication.k8s.io",
+				Resource: "userextras",
+			},
+		},
+	}
+)
+
+// ResourceOptions holds the related options for '--resource' option
+type ResourceOptions struct {
+	Group       string
+	Resource    string
+	SubResource string
+}
+
+// CreateRoleOptions holds the options for 'create role' sub command
+type CreateRoleOptions struct {
+	PrintFlags *genericclioptions.PrintFlags
+
+	Name          string
+	Verbs         []string
+	Resources     []ResourceOptions
+	ResourceNames []string
+
+	DryRunStrategy cmdutil.DryRunStrategy
+	DryRunVerifier *resource.DryRunVerifier
+	OutputFormat   string
+	Namespace      string
+	Client         clientgorbacv1.RbacV1Interface
+	Mapper         meta.RESTMapper
+	PrintObj       func(obj runtime.Object) error
+
+	genericclioptions.IOStreams
+}
+
+// NewCreateRoleOptions returns an initialized CreateRoleOptions instance
+func NewCreateRoleOptions(ioStreams genericclioptions.IOStreams) *CreateRoleOptions {
+	return &CreateRoleOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+
+		IOStreams: ioStreams,
+	}
+}
+
+// NewCmdCreateRole returnns an initialized Command instance for 'create role' sub command
+func NewCmdCreateRole(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCreateRoleOptions(ioStreams)
+
+	cmd := &cobra.Command{
+		Use:                   "role NAME --verb=verb --resource=resource.group/subresource [--resource-name=resourcename] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 roleLong,
+		Long:                  roleLong,
+		Example:               roleExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.RunCreateRole())
+		},
+	}
+
+	o.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().StringSliceVar(&o.Verbs, "verb", o.Verbs, "Verb that applies to the resources contained in the rule")
+	cmd.Flags().StringSlice("resource", []string{}, "Resource that the rule applies to")
+	cmd.Flags().StringArrayVar(&o.ResourceNames, "resource-name", o.ResourceNames, "Resource in the white list that the rule applies to, repeat this flag for multiple items")
+
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	o.Name = name
+
+	// Remove duplicate verbs.
+	verbs := []string{}
+	for _, v := range o.Verbs {
+		// VerbAll respresents all kinds of verbs.
+		if v == "*" {
+			verbs = []string{"*"}
+			break
+		}
+		if !arrayContains(verbs, v) {
+			verbs = append(verbs, v)
+		}
+	}
+	o.Verbs = verbs
+
+	// Support resource.group pattern. If no API Group specified, use "" as core API Group.
+	// e.g. --resource=pods,deployments.extensions
+	resources := cmdutil.GetFlagStringSlice(cmd, "resource")
+	for _, r := range resources {
+		sections := strings.SplitN(r, "/", 2)
+
+		resource := &ResourceOptions{}
+		if len(sections) == 2 {
+			resource.SubResource = sections[1]
+		}
+
+		parts := strings.SplitN(sections[0], ".", 2)
+		if len(parts) == 2 {
+			resource.Group = parts[1]
+		}
+		resource.Resource = parts[0]
+
+		if resource.Resource == "*" && len(parts) == 1 && len(sections) == 1 {
+			o.Resources = []ResourceOptions{*resource}
+			break
+		}
+
+		o.Resources = append(o.Resources, *resource)
+	}
+
+	// Remove duplicate resource names.
+	resourceNames := []string{}
+	for _, n := range o.ResourceNames {
+		if !arrayContains(resourceNames, n) {
+			resourceNames = append(resourceNames, n)
+		}
+	}
+	o.ResourceNames = resourceNames
+
+	// Complete other options for Run.
+	o.Mapper, err = f.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+
+	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	o.OutputFormat = cmdutil.GetFlagString(cmd, "output")
+
+	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+	o.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
+	}
+
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	clientset, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+	o.Client = clientset.RbacV1()
+
+	return nil
+}
+
+// Validate makes sure there is no discrepency in provided option values
+func (o *CreateRoleOptions) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("name must be specified")
+	}
+
+	// validate verbs.
+	if len(o.Verbs) == 0 {
+		return fmt.Errorf("at least one verb must be specified")
+	}
+
+	for _, v := range o.Verbs {
+		if !arrayContains(validResourceVerbs, v) {
+			return fmt.Errorf("invalid verb: '%s'", v)
+		}
+	}
+
+	// validate resources.
+	if len(o.Resources) == 0 {
+		return fmt.Errorf("at least one resource must be specified")
+	}
+
+	return o.validateResource()
+}
+
+func (o *CreateRoleOptions) validateResource() error {
+	for _, r := range o.Resources {
+		if len(r.Resource) == 0 {
+			return fmt.Errorf("resource must be specified if apiGroup/subresource specified")
+		}
+		if r.Resource == "*" {
+			return nil
+		}
+
+		resource := schema.GroupVersionResource{Resource: r.Resource, Group: r.Group}
+		groupVersionResource, err := o.Mapper.ResourceFor(schema.GroupVersionResource{Resource: r.Resource, Group: r.Group})
+		if err == nil {
+			resource = groupVersionResource
+		}
+
+		for _, v := range o.Verbs {
+			if groupResources, ok := specialVerbs[v]; ok {
+				match := false
+				for _, extra := range groupResources {
+					if resource.Resource == extra.Resource && resource.Group == extra.Group {
+						match = true
+						err = nil
+						break
+					}
+				}
+				if !match {
+					return fmt.Errorf("can not perform '%s' on '%s' in group '%s'", v, resource.Resource, resource.Group)
+				}
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunCreateRole performs the execution of 'create role' sub command
+func (o *CreateRoleOptions) RunCreateRole() error {
+	role := &rbacv1.Role{
+		// this is ok because we know exactly how we want to be serialized
+		TypeMeta: metav1.TypeMeta{APIVersion: rbacv1.SchemeGroupVersion.String(), Kind: "Role"},
+	}
+	role.Name = o.Name
+	rules, err := generateResourcePolicyRules(o.Mapper, o.Verbs, o.Resources, o.ResourceNames, []string{})
+	if err != nil {
+		return err
+	}
+	role.Rules = rules
+
+	// Create role.
+	if o.DryRunStrategy != cmdutil.DryRunClient {
+		createOptions := metav1.CreateOptions{}
+		if o.DryRunStrategy == cmdutil.DryRunServer {
+			if err := o.DryRunVerifier.HasSupport(role.GroupVersionKind()); err != nil {
+				return err
+			}
+			createOptions.DryRun = []string{metav1.DryRunAll}
+		}
+		role, err = o.Client.Roles(o.Namespace).Create(context.TODO(), role, createOptions)
+		if err != nil {
+			return err
+		}
+	}
+
+	return o.PrintObj(role)
+}
+
+func arrayContains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func generateResourcePolicyRules(mapper meta.RESTMapper, verbs []string, resources []ResourceOptions, resourceNames []string, nonResourceURLs []string) ([]rbacv1.PolicyRule, error) {
+	// groupResourceMapping is a apigroup-resource map. The key of this map is api group, while the value
+	// is a string array of resources under this api group.
+	// E.g.  groupResourceMapping = {"extensions": ["replicasets", "deployments"], "batch":["jobs"]}
+	groupResourceMapping := map[string][]string{}
+
+	// This loop does the following work:
+	// 1. Constructs groupResourceMapping based on input resources.
+	// 2. Prevents pointing to non-existent resources.
+	// 3. Transfers resource short name to long name. E.g. rs.extensions is transferred to replicasets.extensions
+	for _, r := range resources {
+		resource := schema.GroupVersionResource{Resource: r.Resource, Group: r.Group}
+		groupVersionResource, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: r.Resource, Group: r.Group})
+		if err == nil {
+			resource = groupVersionResource
+		}
+
+		if len(r.SubResource) > 0 {
+			resource.Resource = resource.Resource + "/" + r.SubResource
+		}
+		if !arrayContains(groupResourceMapping[resource.Group], resource.Resource) {
+			groupResourceMapping[resource.Group] = append(groupResourceMapping[resource.Group], resource.Resource)
+		}
+	}
+
+	// Create separate rule for each of the api group.
+	rules := []rbacv1.PolicyRule{}
+	for _, g := range sets.StringKeySet(groupResourceMapping).List() {
+		rule := rbacv1.PolicyRule{}
+		rule.Verbs = verbs
+		rule.Resources = groupResourceMapping[g]
+		rule.APIGroups = []string{g}
+		rule.ResourceNames = resourceNames
+		rules = append(rules, rule)
+	}
+
+	if len(nonResourceURLs) > 0 {
+		rule := rbacv1.PolicyRule{}
+		rule.Verbs = verbs
+		rule.NonResourceURLs = nonResourceURLs
+		rules = append(rules, rule)
+	}
+
+	return rules, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	roleBindingLong = templates.LongDesc(i18n.T(`
+		Create a RoleBinding for a particular Role or ClusterRole.`))
+
+	roleBindingExample = templates.Examples(i18n.T(`
+		  # Create a RoleBinding for user1, user2, and group1 using the admin ClusterRole
+		  kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1`))
+)
+
+// RoleBindingOpts holds the options for 'create rolebinding' sub command
+type RoleBindingOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateRoleBinding returns an initialized Command instance for 'create rolebinding' sub command
+func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := &RoleBindingOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a RoleBinding for a particular Role or ClusterRole"),
+		Long:                  roleBindingLong,
+		Example:               roleBindingExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	o.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.RoleBindingV1GeneratorName)
+	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this RoleBinding should reference"))
+	cmd.Flags().String("role", "", i18n.T("Role this RoleBinding should reference"))
+	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the role")
+	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the role")
+	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the role, in the format <namespace>:<name>")
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *RoleBindingOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.RoleBindingV1GeneratorName:
+		generator = &generateversioned.RoleBindingGeneratorV1{
+			Name:            name,
+			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
+			Role:            cmdutil.GetFlagString(cmd, "role"),
+			Users:           cmdutil.GetFlagStringArray(cmd, "user"),
+			Groups:          cmdutil.GetFlagStringArray(cmd, "group"),
+			ServiceAccounts: cmdutil.GetFlagStringArray(cmd, "serviceaccount"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in RoleBindingOpts instance
+func (o *RoleBindingOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// NewCmdCreateSecret groups subcommands to create various types of secrets
+func NewCmdCreateSecret(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secret",
+		Short: i18n.T("Create a secret using specified subcommand"),
+		Long:  "Create a secret using specified subcommand.",
+		Run:   cmdutil.DefaultSubCommandRun(ioStreams.ErrOut),
+	}
+	cmd.AddCommand(NewCmdCreateSecretDockerRegistry(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateSecretTLS(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateSecretGeneric(f, ioStreams))
+
+	return cmd
+}
+
+var (
+	secretLong = templates.LongDesc(i18n.T(`
+		Create a secret based on a file, directory, or specified literal value.
+
+		A single secret may package one or more key/value pairs.
+
+		When creating a secret based on a file, the key will default to the basename of the file, and the value will
+		default to the file content. If the basename is an invalid key or you wish to chose your own, you may specify
+		an alternate key.
+
+		When creating a secret based on a directory, each file whose basename is a valid key in the directory will be
+		packaged into the secret. Any directory entries except regular files are ignored (e.g. subdirectories,
+		symlinks, devices, pipes, etc).`))
+
+	secretExample = templates.Examples(i18n.T(`
+	  # Create a new secret named my-secret with keys for each file in folder bar
+	  kubectl create secret generic my-secret --from-file=path/to/bar
+
+	  # Create a new secret named my-secret with specified keys instead of names on disk
+	  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-file=ssh-publickey=path/to/id_rsa.pub
+
+	  # Create a new secret named my-secret with key1=supersecret and key2=topsecret
+	  kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
+
+	  # Create a new secret named my-secret using a combination of a file and a literal
+	  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-literal=passphrase=topsecret
+
+	  # Create a new secret named my-secret from an env file
+	  kubectl create secret generic my-secret --from-env-file=path/to/bar.env`))
+)
+
+// SecretGenericOpts holds the options for 'create secret' sub command
+type SecretGenericOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateSecretGeneric is a command to create generic secrets from files, directories, or literal values
+func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &SecretGenericOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a secret from a local file, directory or literal value"),
+		Long:                  secretLong,
+		Example:               secretExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.SecretV1GeneratorName)
+	cmd.Flags().StringSlice("from-file", []string{}, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
+	cmd.Flags().StringArray("from-literal", []string{}, "Specify a key and literal value to insert in secret (i.e. mykey=somevalue)")
+	cmd.Flags().String("from-env-file", "", "Specify the path to a file to read lines of key=val pairs to create a secret (i.e. a Docker .env file).")
+	cmd.Flags().String("type", "", i18n.T("The type of secret to create"))
+	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *SecretGenericOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.SecretV1GeneratorName:
+		generator = &generateversioned.SecretGeneratorV1{
+			Name:           name,
+			Type:           cmdutil.GetFlagString(cmd, "type"),
+			FileSources:    cmdutil.GetFlagStringSlice(cmd, "from-file"),
+			LiteralSources: cmdutil.GetFlagStringArray(cmd, "from-literal"),
+			EnvFileSource:  cmdutil.GetFlagString(cmd, "from-env-file"),
+			AppendHash:     cmdutil.GetFlagBool(cmd, "append-hash"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in SecretGenericOpts instance
+func (o *SecretGenericOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}
+
+var (
+	secretForDockerRegistryLong = templates.LongDesc(i18n.T(`
+		Create a new secret for use with Docker registries.
+
+		Dockercfg secrets are used to authenticate against Docker registries.
+
+		When using the Docker command line to push images, you can authenticate to a given registry by running:
+			'$ docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
+
+	That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to
+		authenticate to the registry. The email address is optional.
+
+		When creating applications, you may have a Docker registry that requires authentication.  In order for the
+		nodes to pull images on your behalf, they have to have the credentials.  You can provide this information
+		by creating a dockercfg secret and attaching it to your service account.`))
+
+	secretForDockerRegistryExample = templates.Examples(i18n.T(`
+		  # If you don't already have a .dockercfg file, you can create a dockercfg secret directly by using:
+		  kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL`))
+)
+
+// SecretDockerRegistryOpts holds the options for 'create secret docker-registry' sub command
+type SecretDockerRegistryOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateSecretDockerRegistry is a macro command for creating secrets to work with Docker registries
+func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &SecretDockerRegistryOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-literal=key1=value1] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a secret for use with a Docker registry"),
+		Long:                  secretForDockerRegistryLong,
+		Example:               secretForDockerRegistryExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.SecretForDockerRegistryV1GeneratorName)
+	cmd.Flags().String("docker-username", "", i18n.T("Username for Docker registry authentication"))
+	cmd.MarkFlagRequired("docker-username")
+	cmd.Flags().String("docker-password", "", i18n.T("Password for Docker registry authentication"))
+	cmd.MarkFlagRequired("docker-password")
+	cmd.Flags().String("docker-email", "", i18n.T("Email for Docker registry"))
+	cmd.Flags().String("docker-server", "https://index.docker.io/v1/", i18n.T("Server location for Docker registry"))
+	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
+	cmd.Flags().StringSlice("from-file", []string{}, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
+
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *SecretDockerRegistryOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	fromFileFlag := cmdutil.GetFlagStringSlice(cmd, "from-file")
+	if len(fromFileFlag) == 0 {
+		requiredFlags := []string{"docker-username", "docker-password", "docker-server"}
+		for _, requiredFlag := range requiredFlags {
+			if value := cmdutil.GetFlagString(cmd, requiredFlag); len(value) == 0 {
+				return cmdutil.UsageErrorf(cmd, "flag %s is required", requiredFlag)
+			}
+		}
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.SecretForDockerRegistryV1GeneratorName:
+		generator = &generateversioned.SecretForDockerRegistryGeneratorV1{
+			Name:        name,
+			Username:    cmdutil.GetFlagString(cmd, "docker-username"),
+			Email:       cmdutil.GetFlagString(cmd, "docker-email"),
+			Password:    cmdutil.GetFlagString(cmd, "docker-password"),
+			Server:      cmdutil.GetFlagString(cmd, "docker-server"),
+			AppendHash:  cmdutil.GetFlagBool(cmd, "append-hash"),
+			FileSources: cmdutil.GetFlagStringSlice(cmd, "from-file"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls CreateSubcommandOptions.Run in SecretDockerRegistryOpts instance
+func (o *SecretDockerRegistryOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}
+
+var (
+	secretForTLSLong = templates.LongDesc(i18n.T(`
+		Create a TLS secret from the given public/private key pair.
+
+		The public/private key pair must exist before hand. The public key certificate must be .PEM encoded and match
+		the given private key.`))
+
+	secretForTLSExample = templates.Examples(i18n.T(`
+	  # Create a new TLS secret named tls-secret with the given key pair:
+	  kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`))
+)
+
+// SecretTLSOpts holds the options for 'create secret tls' sub command
+type SecretTLSOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateSecretTLS is a macro command for creating secrets to work with Docker registries
+func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &SecretTLSOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "tls NAME --cert=path/to/cert/file --key=path/to/key/file [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a TLS secret"),
+		Long:                  secretForTLSLong,
+		Example:               secretForTLSExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.SecretForTLSV1GeneratorName)
+	cmd.Flags().String("cert", "", i18n.T("Path to PEM encoded public key certificate."))
+	cmd.Flags().String("key", "", i18n.T("Path to private key associated with given certificate."))
+	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *SecretTLSOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	requiredFlags := []string{"cert", "key"}
+	for _, requiredFlag := range requiredFlags {
+		if value := cmdutil.GetFlagString(cmd, requiredFlag); len(value) == 0 {
+			return cmdutil.UsageErrorf(cmd, "flag %s is required", requiredFlag)
+		}
+	}
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.SecretForTLSV1GeneratorName:
+		generator = &generateversioned.SecretForTLSGeneratorV1{
+			Name:       name,
+			Key:        cmdutil.GetFlagString(cmd, "key"),
+			Cert:       cmdutil.GetFlagString(cmd, "cert"),
+			AppendHash: cmdutil.GetFlagBool(cmd, "append-hash"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls CreateSubcommandOptions.Run in the SecretTLSOpts instance
+func (o *SecretTLSOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// NewCmdCreateService is a macro command to create a new service
+func NewCmdCreateService(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "service",
+		Aliases: []string{"svc"},
+		Short:   i18n.T("Create a service using specified subcommand."),
+		Long:    "Create a service using specified subcommand.",
+		Run:     cmdutil.DefaultSubCommandRun(ioStreams.ErrOut),
+	}
+	cmd.AddCommand(NewCmdCreateServiceClusterIP(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateServiceNodePort(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateServiceLoadBalancer(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateServiceExternalName(f, ioStreams))
+
+	return cmd
+}
+
+var (
+	serviceClusterIPLong = templates.LongDesc(i18n.T(`
+    Create a ClusterIP service with the specified name.`))
+
+	serviceClusterIPExample = templates.Examples(i18n.T(`
+    # Create a new ClusterIP service named my-cs
+    kubectl create service clusterip my-cs --tcp=5678:8080
+
+    # Create a new ClusterIP service named my-cs (in headless mode)
+    kubectl create service clusterip my-cs --clusterip="None"`))
+)
+
+func addPortFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSlice("tcp", []string{}, "Port pairs can be specified as '<port>:<targetPort>'.")
+}
+
+// ServiceClusterIPOpts holds the options for 'create service clusterip' sub command
+type ServiceClusterIPOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateServiceClusterIP is a command to create a ClusterIP service
+func NewCmdCreateServiceClusterIP(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &ServiceClusterIPOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a ClusterIP service."),
+		Long:                  serviceClusterIPLong,
+		Example:               serviceClusterIPExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceClusterIPGeneratorV1Name)
+	addPortFlags(cmd)
+	cmd.Flags().String("clusterip", "", i18n.T("Assign your own ClusterIP or set to 'None' for a 'headless' service (no loadbalancing)."))
+	return cmd
+}
+
+func errUnsupportedGenerator(cmd *cobra.Command, generatorName string) error {
+	return cmdutil.UsageErrorf(cmd, "Generator %s not supported. ", generatorName)
+}
+
+// Complete completes all the required options
+func (o *ServiceClusterIPOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ServiceClusterIPGeneratorV1Name:
+		generator = &generateversioned.ServiceCommonGeneratorV1{
+			Name:      name,
+			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
+			Type:      v1.ServiceTypeClusterIP,
+			ClusterIP: cmdutil.GetFlagString(cmd, "clusterip"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in ServiceClusterIPOpts instance
+func (o *ServiceClusterIPOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}
+
+var (
+	serviceNodePortLong = templates.LongDesc(i18n.T(`
+    Create a NodePort service with the specified name.`))
+
+	serviceNodePortExample = templates.Examples(i18n.T(`
+    # Create a new NodePort service named my-ns
+    kubectl create service nodeport my-ns --tcp=5678:8080`))
+)
+
+// ServiceNodePortOpts holds the options for 'create service nodeport' sub command
+type ServiceNodePortOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateServiceNodePort is a macro command for creating a NodePort service
+func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &ServiceNodePortOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "nodeport NAME [--tcp=port:targetPort] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a NodePort service."),
+		Long:                  serviceNodePortLong,
+		Example:               serviceNodePortExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceNodePortGeneratorV1Name)
+	cmd.Flags().Int("node-port", 0, "Port used to expose the service on each node in a cluster.")
+	addPortFlags(cmd)
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *ServiceNodePortOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ServiceNodePortGeneratorV1Name:
+		generator = &generateversioned.ServiceCommonGeneratorV1{
+			Name:      name,
+			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
+			Type:      v1.ServiceTypeNodePort,
+			ClusterIP: "",
+			NodePort:  cmdutil.GetFlagInt(cmd, "node-port"),
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in ServiceNodePortOpts instance
+func (o *ServiceNodePortOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}
+
+var (
+	serviceLoadBalancerLong = templates.LongDesc(i18n.T(`
+    Create a LoadBalancer service with the specified name.`))
+
+	serviceLoadBalancerExample = templates.Examples(i18n.T(`
+    # Create a new LoadBalancer service named my-lbs
+    kubectl create service loadbalancer my-lbs --tcp=5678:8080`))
+)
+
+// ServiceLoadBalancerOpts holds the options for 'create service loadbalancer' sub command
+type ServiceLoadBalancerOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateServiceLoadBalancer is a macro command for creating a LoadBalancer service
+func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &ServiceLoadBalancerOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "loadbalancer NAME [--tcp=port:targetPort] [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a LoadBalancer service."),
+		Long:                  serviceLoadBalancerLong,
+		Example:               serviceLoadBalancerExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceLoadBalancerGeneratorV1Name)
+	addPortFlags(cmd)
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *ServiceLoadBalancerOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ServiceLoadBalancerGeneratorV1Name:
+		generator = &generateversioned.ServiceCommonGeneratorV1{
+			Name:      name,
+			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
+			Type:      v1.ServiceTypeLoadBalancer,
+			ClusterIP: "",
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in ServiceLoadBalancerOpts instance
+func (o *ServiceLoadBalancerOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}
+
+var (
+	serviceExternalNameLong = templates.LongDesc(i18n.T(`
+	Create an ExternalName service with the specified name.
+
+	ExternalName service references to an external DNS address instead of
+	only pods, which will allow application authors to reference services
+	that exist off platform, on other clusters, or locally.`))
+
+	serviceExternalNameExample = templates.Examples(i18n.T(`
+	# Create a new ExternalName service named my-ns
+	kubectl create service externalname my-ns --external-name bar.com`))
+)
+
+// ServiceExternalNameOpts holds the options for 'create service externalname' sub command
+type ServiceExternalNameOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateServiceExternalName is a macro command for creating an ExternalName service
+func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &ServiceExternalNameOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "externalname NAME --external-name external.name [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create an ExternalName service."),
+		Long:                  serviceExternalNameLong,
+		Example:               serviceExternalNameExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceExternalNameGeneratorV1Name)
+	addPortFlags(cmd)
+	cmd.Flags().String("external-name", "", i18n.T("External name of service"))
+	cmd.MarkFlagRequired("external-name")
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *ServiceExternalNameOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ServiceExternalNameGeneratorV1Name:
+		generator = &generateversioned.ServiceCommonGeneratorV1{
+			Name:         name,
+			Type:         v1.ServiceTypeExternalName,
+			ExternalName: cmdutil.GetFlagString(cmd, "external-name"),
+			ClusterIP:    "",
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in ServiceExternalNameOpts instance
+func (o *ServiceExternalNameOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	serviceAccountLong = templates.LongDesc(i18n.T(`
+		Create a service account with the specified name.`))
+
+	serviceAccountExample = templates.Examples(i18n.T(`
+	  # Create a new service account named my-service-account
+	  kubectl create serviceaccount my-service-account`))
+)
+
+// ServiceAccountOpts holds the options for 'create serviceaccount' sub command
+type ServiceAccountOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateServiceAccount is a macro command to create a new service account
+func NewCmdCreateServiceAccount(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &ServiceAccountOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "serviceaccount NAME [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"sa"},
+		Short:                 i18n.T("Create a service account with the specified name"),
+		Long:                  serviceAccountLong,
+		Example:               serviceAccountExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceAccountV1GeneratorName)
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *ServiceAccountOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.ServiceAccountV1GeneratorName:
+		generator = &generateversioned.ServiceAccountGeneratorV1{Name: name}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in ServiceAccountOpts instance
+func (o *ServiceAccountOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/generate.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/generate.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generate
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// GeneratorFunc returns the generators for the provided command
+type GeneratorFunc func(cmdName string) map[string]Generator
+
+// GeneratorParam is a parameter for a generator
+// TODO: facilitate structured json generator input schemes
+type GeneratorParam struct {
+	Name     string
+	Required bool
+}
+
+// Generator is an interface for things that can generate API objects from input
+// parameters. One example is the "expose" generator that is capable of exposing
+// new replication controllers and services, among other things.
+type Generator interface {
+	// Generate creates an API object given a set of parameters
+	Generate(params map[string]interface{}) (runtime.Object, error)
+	// ParamNames returns the list of parameters that this generator uses
+	ParamNames() []GeneratorParam
+}
+
+// StructuredGenerator is an interface for things that can generate API objects not using parameter injection
+type StructuredGenerator interface {
+	// StructuredGenerator creates an API object using pre-configured parameters
+	StructuredGenerate() (runtime.Object, error)
+}
+
+func IsZero(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	return reflect.DeepEqual(i, reflect.Zero(reflect.TypeOf(i)).Interface())
+}
+
+// ValidateParams ensures that all required params are present in the params map
+func ValidateParams(paramSpec []GeneratorParam, params map[string]interface{}) error {
+	allErrs := []error{}
+	for ix := range paramSpec {
+		if paramSpec[ix].Required {
+			value, found := params[paramSpec[ix].Name]
+			if !found || IsZero(value) {
+				allErrs = append(allErrs, fmt.Errorf("Parameter: %s is required", paramSpec[ix].Name))
+			}
+		}
+	}
+	return utilerrors.NewAggregate(allErrs)
+}
+
+// AnnotateFlags annotates all flags that are used by generators.
+func AnnotateFlags(cmd *cobra.Command, generators map[string]Generator) {
+	// Iterate over all generators and mark any flags used by them.
+	for name, generator := range generators {
+		generatorParams := map[string]struct{}{}
+		for _, param := range generator.ParamNames() {
+			generatorParams[param.Name] = struct{}{}
+		}
+
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			if _, found := generatorParams[flag.Name]; !found {
+				// This flag is not used by the current generator
+				// so skip it.
+				return
+			}
+			if flag.Annotations == nil {
+				flag.Annotations = map[string][]string{}
+			}
+			if annotations := flag.Annotations["generator"]; annotations == nil {
+				flag.Annotations["generator"] = []string{}
+			}
+			flag.Annotations["generator"] = append(flag.Annotations["generator"], name)
+		})
+	}
+}
+
+// EnsureFlagsValid ensures that no invalid flags are being used against a
+func EnsureFlagsValid(cmd *cobra.Command, generators map[string]Generator, generatorInUse string) error {
+	AnnotateFlags(cmd, generators)
+
+	allErrs := []error{}
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		// If the flag hasn't changed, don't validate it.
+		if !flag.Changed {
+			return
+		}
+		// Look into the flag annotations for the generators that can use it.
+		if annotations := flag.Annotations["generator"]; len(annotations) > 0 {
+			annotationMap := map[string]struct{}{}
+			for _, ann := range annotations {
+				annotationMap[ann] = struct{}{}
+			}
+			// If the current generator is not annotated, then this flag shouldn't
+			// be used with it.
+			if _, found := annotationMap[generatorInUse]; !found {
+				allErrs = append(allErrs, fmt.Errorf("cannot use --%s with --generator=%s", flag.Name, generatorInUse))
+			}
+		}
+	})
+	return utilerrors.NewAggregate(allErrs)
+}
+
+// MakeParams is a utility that creates generator parameters from a command line
+func MakeParams(cmd *cobra.Command, params []GeneratorParam) map[string]interface{} {
+	result := map[string]interface{}{}
+	for ix := range params {
+		f := cmd.Flags().Lookup(params[ix].Name)
+		if f != nil {
+			result[params[ix].Name] = f.Value.String()
+		}
+	}
+	return result
+}
+
+func MakeProtocols(protocols map[string]string) string {
+	out := []string{}
+	for key, value := range protocols {
+		out = append(out, fmt.Sprintf("%s/%s", key, value))
+	}
+	return strings.Join(out, ",")
+}
+
+func ParseProtocols(protocols interface{}) (map[string]string, error) {
+	protocolsString, isString := protocols.(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %v", protocols)
+	}
+	if len(protocolsString) == 0 {
+		return nil, fmt.Errorf("no protocols passed")
+	}
+	portProtocolMap := map[string]string{}
+	protocolsSlice := strings.Split(protocolsString, ",")
+	for ix := range protocolsSlice {
+		portProtocol := strings.Split(protocolsSlice[ix], "/")
+		if len(portProtocol) != 2 {
+			return nil, fmt.Errorf("unexpected port protocol mapping: %s", protocolsSlice[ix])
+		}
+		if len(portProtocol[0]) == 0 {
+			return nil, fmt.Errorf("unexpected empty port")
+		}
+		if len(portProtocol[1]) == 0 {
+			return nil, fmt.Errorf("unexpected empty protocol")
+		}
+		portProtocolMap[portProtocol[0]] = portProtocol[1]
+	}
+	return portProtocolMap, nil
+}
+
+// ParseLabels turns a string representation of a label set into a map[string]string
+func ParseLabels(labelSpec interface{}) (map[string]string, error) {
+	labelString, isString := labelSpec.(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %v", labelSpec)
+	}
+	if len(labelString) == 0 {
+		return nil, fmt.Errorf("no label spec passed")
+	}
+	labels := map[string]string{}
+	labelSpecs := strings.Split(labelString, ",")
+	for ix := range labelSpecs {
+		labelSpec := strings.Split(labelSpecs[ix], "=")
+		if len(labelSpec) != 2 {
+			return nil, fmt.Errorf("unexpected label spec: %s", labelSpecs[ix])
+		}
+		if len(labelSpec[0]) == 0 {
+			return nil, fmt.Errorf("unexpected empty label key")
+		}
+		labels[labelSpec[0]] = labelSpec[1]
+	}
+	return labels, nil
+}
+
+func GetBool(params map[string]string, key string, defValue bool) (bool, error) {
+	if val, found := params[key]; !found {
+		return defValue, nil
+	} else {
+		return strconv.ParseBool(val)
+	}
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/autoscale.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/autoscale.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// HorizontalPodAutoscalerGeneratorV1 supports stable generation of a horizontal pod autoscaler.
+type HorizontalPodAutoscalerGeneratorV1 struct {
+	Name               string
+	ScaleRefKind       string
+	ScaleRefName       string
+	ScaleRefAPIVersion string
+	MinReplicas        int32
+	MaxReplicas        int32
+	CPUPercent         int32
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction.
+var _ generate.StructuredGenerator = &HorizontalPodAutoscalerGeneratorV1{}
+
+// StructuredGenerate outputs a horizontal pod autoscaler object using the configured fields.
+func (s *HorizontalPodAutoscalerGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+
+	scaler := autoscalingv1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.Name,
+		},
+		Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				Kind:       s.ScaleRefKind,
+				Name:       s.ScaleRefName,
+				APIVersion: s.ScaleRefAPIVersion,
+			},
+			MaxReplicas: s.MaxReplicas,
+		},
+	}
+
+	if s.MinReplicas > 0 {
+		v := int32(s.MinReplicas)
+		scaler.Spec.MinReplicas = &v
+	}
+	if s.CPUPercent >= 0 {
+		c := int32(s.CPUPercent)
+		scaler.Spec.TargetCPUUtilizationPercentage = &c
+	}
+
+	return &scaler, nil
+}
+
+// validate check if the caller has set the right fields.
+func (s HorizontalPodAutoscalerGeneratorV1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if s.MaxReplicas < 1 {
+		return fmt.Errorf("'max' is a required parameter and must be at least 1")
+	}
+	if s.MinReplicas > s.MaxReplicas {
+		return fmt.Errorf("'max' must be greater than or equal to 'min'")
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/clusterrolebinding.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/clusterrolebinding.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// ClusterRoleBindingGeneratorV1 supports stable generation of a clusterRoleBinding.
+type ClusterRoleBindingGeneratorV1 struct {
+	// Name of clusterRoleBinding (required)
+	Name string
+	// ClusterRole for the clusterRoleBinding (required)
+	ClusterRole string
+	// Users to derive the clusterRoleBinding from (optional)
+	Users []string
+	// Groups to derive the clusterRoleBinding from (optional)
+	Groups []string
+	// ServiceAccounts to derive the clusterRoleBinding from in namespace:name format(optional)
+	ServiceAccounts []string
+}
+
+// Ensure it supports the generator pattern that uses parameter injection.
+var _ generate.Generator = &ClusterRoleBindingGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction.
+var _ generate.StructuredGenerator = &ClusterRoleBindingGeneratorV1{}
+
+// Generate returns a clusterRoleBinding using the specified parameters.
+func (s ClusterRoleBindingGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &ClusterRoleBindingGeneratorV1{}
+	userStrings, found := genericParams["user"]
+	if found {
+		fromFileArray, isArray := userStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", userStrings)
+		}
+		delegate.Users = fromFileArray
+		delete(genericParams, "user")
+	}
+	groupStrings, found := genericParams["group"]
+	if found {
+		fromLiteralArray, isArray := groupStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", groupStrings)
+		}
+		delegate.Groups = fromLiteralArray
+		delete(genericParams, "group")
+	}
+	saStrings, found := genericParams["serviceaccount"]
+	if found {
+		fromLiteralArray, isArray := saStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", saStrings)
+		}
+		delegate.ServiceAccounts = fromLiteralArray
+		delete(genericParams, "serviceaccount")
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate.Name = params["name"]
+	delegate.ClusterRole = params["clusterrole"]
+	return delegate.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern.
+func (s ClusterRoleBindingGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "clusterrole", Required: false},
+		{Name: "user", Required: false},
+		{Name: "group", Required: false},
+		{Name: "serviceaccount", Required: false},
+	}
+}
+
+// StructuredGenerate outputs a clusterRoleBinding object using the configured fields.
+func (s ClusterRoleBindingGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	clusterRoleBinding.Name = s.Name
+	clusterRoleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "ClusterRole",
+		Name:     s.ClusterRole,
+	}
+	for _, user := range sets.NewString(s.Users...).List() {
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
+			Kind:     rbacv1.UserKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     user,
+		})
+	}
+	for _, group := range sets.NewString(s.Groups...).List() {
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
+			Kind:     rbacv1.GroupKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     group,
+		})
+	}
+	for _, sa := range sets.NewString(s.ServiceAccounts...).List() {
+		tokens := strings.Split(sa, ":")
+		if len(tokens) != 2 || tokens[0] == "" || tokens[1] == "" {
+			return nil, fmt.Errorf("serviceaccount must be <namespace>:<name>")
+		}
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
+			Kind:      rbacv1.ServiceAccountKind,
+			APIGroup:  "",
+			Namespace: tokens[0],
+			Name:      tokens[1],
+		})
+	}
+
+	return clusterRoleBinding, nil
+}
+
+// validate validates required fields are set to support structured generation.
+func (s ClusterRoleBindingGeneratorV1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(s.ClusterRole) == 0 {
+		return fmt.Errorf("clusterrole must be specified")
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/configmap.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/configmap.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"unicode/utf8"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/kubectl/pkg/generate"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/hash"
+)
+
+// ConfigMapGeneratorV1 supports stable generation of a configMap.
+type ConfigMapGeneratorV1 struct {
+	// Name of configMap (required)
+	Name string
+	// Type of configMap (optional)
+	Type string
+	// FileSources to derive the configMap from (optional)
+	FileSources []string
+	// LiteralSources to derive the configMap from (optional)
+	LiteralSources []string
+	// EnvFileSource to derive the configMap from (optional)
+	EnvFileSource string
+	// AppendHash; if true, derive a hash from the ConfigMap and append it to the name
+	AppendHash bool
+}
+
+// Ensure it supports the generator pattern that uses parameter injection.
+var _ generate.Generator = &ConfigMapGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction.
+var _ generate.StructuredGenerator = &ConfigMapGeneratorV1{}
+
+// Generate returns a configMap using the specified parameters.
+func (s ConfigMapGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &ConfigMapGeneratorV1{}
+	fromFileStrings, found := genericParams["from-file"]
+	if found {
+		fromFileArray, isArray := fromFileStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+		}
+		delegate.FileSources = fromFileArray
+		delete(genericParams, "from-file")
+	}
+	fromLiteralStrings, found := genericParams["from-literal"]
+	if found {
+		fromLiteralArray, isArray := fromLiteralStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", fromLiteralStrings)
+		}
+		delegate.LiteralSources = fromLiteralArray
+		delete(genericParams, "from-literal")
+	}
+	fromEnvFileString, found := genericParams["from-env-file"]
+	if found {
+		fromEnvFile, isString := fromEnvFileString.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, found :%v", fromEnvFileString)
+		}
+		delegate.EnvFileSource = fromEnvFile
+		delete(genericParams, "from-env-file")
+	}
+	hashParam, found := genericParams["append-hash"]
+	if found {
+		hashBool, isBool := hashParam.(bool)
+		if !isBool {
+			return nil, fmt.Errorf("expected bool, found :%v", hashParam)
+		}
+		delegate.AppendHash = hashBool
+		delete(genericParams, "append-hash")
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate.Name = params["name"]
+	delegate.Type = params["type"]
+
+	return delegate.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern.
+func (s ConfigMapGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "type", Required: false},
+		{Name: "from-file", Required: false},
+		{Name: "from-literal", Required: false},
+		{Name: "from-env-file", Required: false},
+		{Name: "force", Required: false},
+		{Name: "hash", Required: false},
+	}
+}
+
+// StructuredGenerate outputs a configMap object using the configured fields.
+func (s ConfigMapGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	configMap := &v1.ConfigMap{}
+	configMap.Name = s.Name
+	configMap.Data = map[string]string{}
+	configMap.BinaryData = map[string][]byte{}
+	if len(s.FileSources) > 0 {
+		if err := handleConfigMapFromFileSources(configMap, s.FileSources); err != nil {
+			return nil, err
+		}
+	}
+	if len(s.LiteralSources) > 0 {
+		if err := handleConfigMapFromLiteralSources(configMap, s.LiteralSources); err != nil {
+			return nil, err
+		}
+	}
+	if len(s.EnvFileSource) > 0 {
+		if err := handleConfigMapFromEnvFileSource(configMap, s.EnvFileSource); err != nil {
+			return nil, err
+		}
+	}
+	if s.AppendHash {
+		h, err := hash.ConfigMapHash(configMap)
+		if err != nil {
+			return nil, err
+		}
+		configMap.Name = fmt.Sprintf("%s-%s", configMap.Name, h)
+	}
+	return configMap, nil
+}
+
+// validate validates required fields are set to support structured generation.
+func (s ConfigMapGeneratorV1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(s.EnvFileSource) > 0 && (len(s.FileSources) > 0 || len(s.LiteralSources) > 0) {
+		return fmt.Errorf("from-env-file cannot be combined with from-file or from-literal")
+	}
+	return nil
+}
+
+// handleConfigMapFromLiteralSources adds the specified literal source
+// information into the provided configMap.
+func handleConfigMapFromLiteralSources(configMap *v1.ConfigMap, literalSources []string) error {
+	for _, literalSource := range literalSources {
+		keyName, value, err := util.ParseLiteralSource(literalSource)
+		if err != nil {
+			return err
+		}
+		err = addKeyFromLiteralToConfigMap(configMap, keyName, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// handleConfigMapFromFileSources adds the specified file source information
+// into the provided configMap
+func handleConfigMapFromFileSources(configMap *v1.ConfigMap, fileSources []string) error {
+	for _, fileSource := range fileSources {
+		keyName, filePath, err := util.ParseFileSource(fileSource)
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(filePath)
+		if err != nil {
+			switch err := err.(type) {
+			case *os.PathError:
+				return fmt.Errorf("error reading %s: %v", filePath, err.Err)
+			default:
+				return fmt.Errorf("error reading %s: %v", filePath, err)
+			}
+		}
+		if info.IsDir() {
+			if strings.Contains(fileSource, "=") {
+				return fmt.Errorf("cannot give a key name for a directory path.")
+			}
+			fileList, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				return fmt.Errorf("error listing files in %s: %v", filePath, err)
+			}
+			for _, item := range fileList {
+				itemPath := path.Join(filePath, item.Name())
+				if item.Mode().IsRegular() {
+					keyName = item.Name()
+					err = addKeyFromFileToConfigMap(configMap, keyName, itemPath)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			if err := addKeyFromFileToConfigMap(configMap, keyName, filePath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// handleConfigMapFromEnvFileSource adds the specified env file source information
+// into the provided configMap
+func handleConfigMapFromEnvFileSource(configMap *v1.ConfigMap, envFileSource string) error {
+	info, err := os.Stat(envFileSource)
+	if err != nil {
+		switch err := err.(type) {
+		case *os.PathError:
+			return fmt.Errorf("error reading %s: %v", envFileSource, err.Err)
+		default:
+			return fmt.Errorf("error reading %s: %v", envFileSource, err)
+		}
+	}
+	if info.IsDir() {
+		return fmt.Errorf("env config file cannot be a directory")
+	}
+
+	return addFromEnvFile(envFileSource, func(key, value string) error {
+		return addKeyFromLiteralToConfigMap(configMap, key, value)
+	})
+}
+
+// addKeyFromFileToConfigMap adds a key with the given name to a ConfigMap, populating
+// the value with the content of the given file path, or returns an error.
+func addKeyFromFileToConfigMap(configMap *v1.ConfigMap, keyName, filePath string) error {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	if utf8.Valid(data) {
+		return addKeyFromLiteralToConfigMap(configMap, keyName, string(data))
+	}
+
+	err = validateNewConfigMap(configMap, keyName)
+	if err != nil {
+		return err
+	}
+	configMap.BinaryData[keyName] = data
+	return nil
+}
+
+// addKeyFromLiteralToConfigMap adds the given key and data to the given config map,
+// returning an error if the key is not valid or if the key already exists.
+func addKeyFromLiteralToConfigMap(configMap *v1.ConfigMap, keyName, data string) error {
+	err := validateNewConfigMap(configMap, keyName)
+	if err != nil {
+		return err
+	}
+	configMap.Data[keyName] = data
+	return nil
+}
+
+func validateNewConfigMap(configMap *v1.ConfigMap, keyName string) error {
+	// Note, the rules for ConfigMap keys are the exact same as the ones for SecretKeys.
+	if errs := validation.IsConfigMapKey(keyName); len(errs) != 0 {
+		return fmt.Errorf("%q is not a valid key name for a ConfigMap: %s", keyName, strings.Join(errs, ";"))
+	}
+
+	if _, exists := configMap.Data[keyName]; exists {
+		return fmt.Errorf("cannot add key %q, another key by that name already exists in Data for ConfigMap %q", keyName, configMap.Name)
+	}
+	if _, exists := configMap.BinaryData[keyName]; exists {
+		return fmt.Errorf("cannot add key %q, another key by that name already exists in BinaryData for ConfigMap %q", keyName, configMap.Name)
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/deployment.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/deployment.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	"k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// BaseDeploymentGenerator implements the common functionality of
+// DeploymentBasicGeneratorV1, DeploymentBasicAppsGeneratorV1Beta1 and DeploymentBasicAppsGeneratorV1. To reduce
+// confusion, it's best to keep this struct in the same file as those
+// generators.
+type BaseDeploymentGenerator struct {
+	Name   string
+	Images []string
+}
+
+// validate: check if the caller has forgotten to set one of our fields.
+func (b BaseDeploymentGenerator) validate() error {
+	if len(b.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(b.Images) == 0 {
+		return fmt.Errorf("at least one image must be specified")
+	}
+	return nil
+}
+
+// structuredGenerate: determine the fields of a deployment. The struct that
+// embeds BaseDeploymentGenerator should assemble these pieces into a
+// runtime.Object.
+func (b BaseDeploymentGenerator) structuredGenerate() (
+	podSpec v1.PodSpec,
+	labels map[string]string,
+	selector metav1.LabelSelector,
+	err error,
+) {
+	err = b.validate()
+	if err != nil {
+		return
+	}
+	podSpec = buildPodSpec(b.Images)
+	labels = map[string]string{}
+	labels["app"] = b.Name
+	selector = metav1.LabelSelector{MatchLabels: labels}
+	return
+}
+
+// buildPodSpec: parse the image strings and assemble them into the Containers
+// of a PodSpec. This is all you need to create the PodSpec for a deployment.
+func buildPodSpec(images []string) v1.PodSpec {
+	podSpec := v1.PodSpec{Containers: []v1.Container{}}
+	for _, imageString := range images {
+		// Retain just the image name
+		imageSplit := strings.Split(imageString, "/")
+		name := imageSplit[len(imageSplit)-1]
+		// Remove any tag or hash
+		if strings.Contains(name, ":") {
+			name = strings.Split(name, ":")[0]
+		}
+		if strings.Contains(name, "@") {
+			name = strings.Split(name, "@")[0]
+		}
+		name = sanitizeAndUniquify(name)
+		podSpec.Containers = append(podSpec.Containers, v1.Container{Name: name, Image: imageString})
+	}
+	return podSpec
+}
+
+// sanitizeAndUniquify: replaces characters like "." or "_" into "-" to follow DNS1123 rules.
+// Then add random suffix to make it uniquified.
+func sanitizeAndUniquify(name string) string {
+	if strings.Contains(name, "_") || strings.Contains(name, ".") {
+		name = strings.Replace(name, "_", "-", -1)
+		name = strings.Replace(name, ".", "-", -1)
+		name = fmt.Sprintf("%s-%s", name, utilrand.String(5))
+	}
+	return name
+}
+
+// DeploymentBasicGeneratorV1 supports stable generation of a deployment
+type DeploymentBasicGeneratorV1 struct {
+	BaseDeploymentGenerator
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &DeploymentBasicGeneratorV1{}
+
+// StructuredGenerate outputs a deployment object using the configured fields
+func (s *DeploymentBasicGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	podSpec, labels, selector, err := s.structuredGenerate()
+	one := int32(1)
+	return &extensionsv1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   s.Name,
+			Labels: labels,
+		},
+		Spec: extensionsv1beta1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &selector,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}, err
+}
+
+// DeploymentBasicAppsGeneratorV1Beta1 supports stable generation of a deployment under apps/v1beta1 endpoint
+type DeploymentBasicAppsGeneratorV1Beta1 struct {
+	BaseDeploymentGenerator
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &DeploymentBasicAppsGeneratorV1Beta1{}
+
+// StructuredGenerate outputs a deployment object using the configured fields
+func (s *DeploymentBasicAppsGeneratorV1Beta1) StructuredGenerate() (runtime.Object, error) {
+	podSpec, labels, selector, err := s.structuredGenerate()
+	one := int32(1)
+	return &appsv1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   s.Name,
+			Labels: labels,
+		},
+		Spec: appsv1beta1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &selector,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}, err
+}
+
+// DeploymentBasicAppsGeneratorV1 supports stable generation of a deployment under apps/v1 endpoint
+type DeploymentBasicAppsGeneratorV1 struct {
+	BaseDeploymentGenerator
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &DeploymentBasicAppsGeneratorV1{}
+
+// StructuredGenerate outputs a deployment object using the configured fields
+func (s *DeploymentBasicAppsGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	podSpec, labels, selector, err := s.structuredGenerate()
+	one := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   s.Name,
+			Labels: labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &selector,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}, err
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/env_file.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/env_file.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+var utf8bom = []byte{0xEF, 0xBB, 0xBF}
+
+// proccessEnvFileLine returns a blank key if the line is empty or a comment.
+// The value will be retrieved from the environment if necessary.
+func proccessEnvFileLine(line []byte, filePath string,
+	currentLine int) (key, value string, err error) {
+
+	if !utf8.Valid(line) {
+		return ``, ``, fmt.Errorf("env file %s contains invalid utf8 bytes at line %d: %v",
+			filePath, currentLine+1, line)
+	}
+
+	// We trim UTF8 BOM from the first line of the file but no others
+	if currentLine == 0 {
+		line = bytes.TrimPrefix(line, utf8bom)
+	}
+
+	// trim the line from all leading whitespace first
+	line = bytes.TrimLeftFunc(line, unicode.IsSpace)
+
+	// If the line is empty or a comment, we return a blank key/value pair.
+	if len(line) == 0 || line[0] == '#' {
+		return ``, ``, nil
+	}
+
+	data := strings.SplitN(string(line), "=", 2)
+	key = data[0]
+	if errs := validation.IsEnvVarName(key); len(errs) != 0 {
+		return ``, ``, fmt.Errorf("%q is not a valid key name: %s", key, strings.Join(errs, ";"))
+	}
+
+	if len(data) == 2 {
+		value = data[1]
+	} else {
+		// No value (no `=` in the line) is a signal to obtain the value
+		// from the environment.
+		value = os.Getenv(key)
+	}
+	return
+}
+
+// addFromEnvFile processes an env file allows a generic addTo to handle the
+// collection of key value pairs or returns an error.
+func addFromEnvFile(filePath string, addTo func(key, value string) error) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	currentLine := 0
+	for scanner.Scan() {
+		// Process the current line, retrieving a key/value pair if
+		// possible.
+		scannedBytes := scanner.Bytes()
+		key, value, err := proccessEnvFileLine(scannedBytes, filePath, currentLine)
+		if err != nil {
+			return err
+		}
+		currentLine++
+
+		if len(key) == 0 {
+			// no key means line was empty or a comment
+			continue
+		}
+
+		if err = addTo(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/generator.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/generator.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"io"
+
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// GeneratorFn gives a way to easily override the function for unit testing if needed
+var GeneratorFn generate.GeneratorFunc = DefaultGenerators
+
+const (
+	// TODO(sig-cli): Enforce consistent naming for generators here.
+	// See discussion in https://github.com/kubernetes/kubernetes/issues/46237
+	// before you add any more.
+	RunPodV1GeneratorName                   = "run-pod/v1"
+	ServiceV1GeneratorName                  = "service/v1"
+	ServiceV2GeneratorName                  = "service/v2"
+	ServiceNodePortGeneratorV1Name          = "service-nodeport/v1"
+	ServiceClusterIPGeneratorV1Name         = "service-clusterip/v1"
+	ServiceLoadBalancerGeneratorV1Name      = "service-loadbalancer/v1"
+	ServiceExternalNameGeneratorV1Name      = "service-externalname/v1"
+	ServiceAccountV1GeneratorName           = "serviceaccount/v1"
+	HorizontalPodAutoscalerV1GeneratorName  = "horizontalpodautoscaler/v1"
+	DeploymentBasicV1Beta1GeneratorName     = "deployment-basic/v1beta1"
+	DeploymentBasicAppsV1Beta1GeneratorName = "deployment-basic/apps.v1beta1"
+	DeploymentBasicAppsV1GeneratorName      = "deployment-basic/apps.v1"
+	NamespaceV1GeneratorName                = "namespace/v1"
+	ResourceQuotaV1GeneratorName            = "resourcequotas/v1"
+	SecretV1GeneratorName                   = "secret/v1"
+	SecretForDockerRegistryV1GeneratorName  = "secret-for-docker-registry/v1"
+	SecretForTLSV1GeneratorName             = "secret-for-tls/v1"
+	ConfigMapV1GeneratorName                = "configmap/v1"
+	ClusterRoleBindingV1GeneratorName       = "clusterrolebinding.rbac.authorization.k8s.io/v1alpha1"
+	RoleBindingV1GeneratorName              = "rolebinding.rbac.authorization.k8s.io/v1alpha1"
+	PodDisruptionBudgetV1GeneratorName      = "poddisruptionbudget/v1beta1"
+	PodDisruptionBudgetV2GeneratorName      = "poddisruptionbudget/v1beta1/v2"
+	PriorityClassV1Alpha1GeneratorName      = "priorityclass/v1alpha1"
+	PriorityClassV1Beta1GeneratorName       = "priorityclass/v1beta1"
+	PriorityClassV1GeneratorName            = "priorityclass/v1"
+)
+
+// DefaultGenerators returns the set of default generators for use in Factory instances
+func DefaultGenerators(cmdName string) map[string]generate.Generator {
+	var generator map[string]generate.Generator
+	switch cmdName {
+	case "expose":
+		generator = map[string]generate.Generator{
+			ServiceV1GeneratorName: ServiceGeneratorV1{},
+			ServiceV2GeneratorName: ServiceGeneratorV2{},
+		}
+	case "service-clusterip":
+		generator = map[string]generate.Generator{
+			ServiceClusterIPGeneratorV1Name: ServiceClusterIPGeneratorV1{},
+		}
+	case "service-nodeport":
+		generator = map[string]generate.Generator{
+			ServiceNodePortGeneratorV1Name: ServiceNodePortGeneratorV1{},
+		}
+	case "service-loadbalancer":
+		generator = map[string]generate.Generator{
+			ServiceLoadBalancerGeneratorV1Name: ServiceLoadBalancerGeneratorV1{},
+		}
+	case "deployment":
+		// Create Deployment has only StructuredGenerators and no
+		// param-based Generators.
+		// The StructuredGenerators are as follows (as of 2018-03-16):
+		// DeploymentBasicV1Beta1GeneratorName -> DeploymentBasicGeneratorV1
+		// DeploymentBasicAppsV1Beta1GeneratorName -> DeploymentBasicAppsGeneratorV1Beta1
+		// DeploymentBasicAppsV1GeneratorName -> DeploymentBasicAppsGeneratorV1
+		generator = map[string]generate.Generator{}
+	case "run":
+		generator = map[string]generate.Generator{
+			RunPodV1GeneratorName: BasicPod{},
+		}
+	case "namespace":
+		generator = map[string]generate.Generator{
+			NamespaceV1GeneratorName: NamespaceGeneratorV1{},
+		}
+	case "quota":
+		generator = map[string]generate.Generator{
+			ResourceQuotaV1GeneratorName: ResourceQuotaGeneratorV1{},
+		}
+	case "secret":
+		generator = map[string]generate.Generator{
+			SecretV1GeneratorName: SecretGeneratorV1{},
+		}
+	case "secret-for-docker-registry":
+		generator = map[string]generate.Generator{
+			SecretForDockerRegistryV1GeneratorName: SecretForDockerRegistryGeneratorV1{},
+		}
+	case "secret-for-tls":
+		generator = map[string]generate.Generator{
+			SecretForTLSV1GeneratorName: SecretForTLSGeneratorV1{},
+		}
+	}
+
+	return generator
+}
+
+// FallbackGeneratorNameIfNecessary returns the name of the old generator
+// if server does not support new generator. Otherwise, the
+// generator string is returned unchanged.
+//
+// If the generator name is changed, print a warning message to let the user
+// know.
+func FallbackGeneratorNameIfNecessary(
+	generatorName string,
+	discoveryClient discovery.DiscoveryInterface,
+	cmdErr io.Writer,
+) (string, error) {
+	switch generatorName {
+	case DeploymentBasicAppsV1GeneratorName:
+		hasResource, err := HasResource(discoveryClient, appsv1.SchemeGroupVersion.WithResource("deployments"))
+		if err != nil {
+			return "", err
+		}
+		if !hasResource {
+			return FallbackGeneratorNameIfNecessary(DeploymentBasicAppsV1Beta1GeneratorName, discoveryClient, cmdErr)
+		}
+	case DeploymentBasicAppsV1Beta1GeneratorName:
+		hasResource, err := HasResource(discoveryClient, appsv1beta1.SchemeGroupVersion.WithResource("deployments"))
+		if err != nil {
+			return "", err
+		}
+		if !hasResource {
+			return DeploymentBasicV1Beta1GeneratorName, nil
+		}
+	}
+	return generatorName, nil
+}
+
+func HasResource(client discovery.DiscoveryInterface, resource schema.GroupVersionResource) (bool, error) {
+	resources, err := client.ServerResourcesForGroupVersion(resource.GroupVersion().String())
+	if apierrors.IsNotFound(err) {
+		// entire group is missing
+		return false, nil
+	}
+	if err != nil {
+		// other errors error
+		return false, fmt.Errorf("failed to discover supported resources: %v", err)
+	}
+	for _, serverResource := range resources.APIResources {
+		if serverResource.Name == resource.Resource {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/namespace.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/namespace.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// NamespaceGeneratorV1 supports stable generation of a namespace
+type NamespaceGeneratorV1 struct {
+	// Name of namespace
+	Name string
+}
+
+// Ensure it supports the generator pattern that uses parameter injection
+var _ generate.Generator = &NamespaceGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &NamespaceGeneratorV1{}
+
+// Generate returns a namespace using the specified parameters
+func (g NamespaceGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(g.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate := &NamespaceGeneratorV1{Name: params["name"]}
+	return delegate.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern
+func (g NamespaceGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+	}
+}
+
+// StructuredGenerate outputs a namespace object using the configured fields
+func (g *NamespaceGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := g.validate(); err != nil {
+		return nil, err
+	}
+	namespace := &v1.Namespace{}
+	namespace.Name = g.Name
+	return namespace, nil
+}
+
+// validate validates required fields are set to support structured generation
+func (g *NamespaceGeneratorV1) validate() error {
+	if len(g.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/pdb.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/pdb.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	policy "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// PodDisruptionBudgetV1Generator supports stable generation of a pod disruption budget.
+type PodDisruptionBudgetV1Generator struct {
+	Name         string
+	MinAvailable string
+	Selector     string
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction.
+var _ generate.StructuredGenerator = &PodDisruptionBudgetV1Generator{}
+
+func (PodDisruptionBudgetV1Generator) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "min-available", Required: false},
+		{Name: "selector", Required: true},
+	}
+}
+
+func (s PodDisruptionBudgetV1Generator) Generate(params map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), params)
+	if err != nil {
+		return nil, err
+	}
+	name, isString := params["name"].(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %T for 'name'", params["name"])
+	}
+	minAvailable, isString := params["min-available"].(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %T for 'min-available'", params["min-available"])
+	}
+	selector, isString := params["selector"].(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %T for 'selector'", params["selector"])
+	}
+	delegate := &PodDisruptionBudgetV1Generator{Name: name, MinAvailable: minAvailable, Selector: selector}
+	return delegate.StructuredGenerate()
+}
+
+// StructuredGenerate outputs a pod disruption budget object using the configured fields.
+func (s *PodDisruptionBudgetV1Generator) StructuredGenerate() (runtime.Object, error) {
+	if len(s.MinAvailable) == 0 {
+		// defaulting behavior seen in Kubernetes 1.6 and below.
+		s.MinAvailable = "1"
+	}
+
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+
+	selector, err := metav1.ParseToLabelSelector(s.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	minAvailable := intstr.Parse(s.MinAvailable)
+	return &policy.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.Name,
+		},
+		Spec: policy.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector:     selector,
+		},
+	}, nil
+}
+
+// validate validates required fields are set to support structured generation.
+func (s *PodDisruptionBudgetV1Generator) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(s.Selector) == 0 {
+		return fmt.Errorf("a selector must be specified")
+	}
+	if len(s.MinAvailable) == 0 {
+		return fmt.Errorf("the minimum number of available pods required must be specified")
+	}
+	return nil
+}
+
+// PodDisruptionBudgetV2Generator supports stable generation of a pod disruption budget.
+type PodDisruptionBudgetV2Generator struct {
+	Name           string
+	MinAvailable   string
+	MaxUnavailable string
+	Selector       string
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction.
+var _ generate.StructuredGenerator = &PodDisruptionBudgetV2Generator{}
+
+func (PodDisruptionBudgetV2Generator) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "min-available", Required: false},
+		{Name: "max-unavailable", Required: false},
+		{Name: "selector", Required: true},
+	}
+}
+
+func (s PodDisruptionBudgetV2Generator) Generate(params map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), params)
+	if err != nil {
+		return nil, err
+	}
+
+	name, isString := params["name"].(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %T for 'name'", params["name"])
+	}
+
+	minAvailable, isString := params["min-available"].(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %T for 'min-available'", params["min-available"])
+	}
+
+	maxUnavailable, isString := params["max-unavailable"].(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %T for 'max-unavailable'", params["max-unavailable"])
+	}
+
+	selector, isString := params["selector"].(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %T for 'selector'", params["selector"])
+	}
+	delegate := &PodDisruptionBudgetV2Generator{Name: name, MinAvailable: minAvailable, MaxUnavailable: maxUnavailable, Selector: selector}
+	return delegate.StructuredGenerate()
+}
+
+// StructuredGenerate outputs a pod disruption budget object using the configured fields.
+func (s *PodDisruptionBudgetV2Generator) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+
+	selector, err := metav1.ParseToLabelSelector(s.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(s.MaxUnavailable) > 0 {
+		maxUnavailable := intstr.Parse(s.MaxUnavailable)
+		return &policy.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: s.Name,
+			},
+			Spec: policy.PodDisruptionBudgetSpec{
+				MaxUnavailable: &maxUnavailable,
+				Selector:       selector,
+			},
+		}, nil
+	}
+
+	if len(s.MinAvailable) > 0 {
+		minAvailable := intstr.Parse(s.MinAvailable)
+		return &policy.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: s.Name,
+			},
+			Spec: policy.PodDisruptionBudgetSpec{
+				MinAvailable: &minAvailable,
+				Selector:     selector,
+			},
+		}, nil
+	}
+
+	return nil, err
+}
+
+// validate validates required fields are set to support structured generation.
+func (s *PodDisruptionBudgetV2Generator) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(s.Selector) == 0 {
+		return fmt.Errorf("a selector must be specified")
+	}
+	if len(s.MaxUnavailable) == 0 && len(s.MinAvailable) == 0 {
+		return fmt.Errorf("one of min-available or max-unavailable must be specified")
+	}
+	if len(s.MaxUnavailable) > 0 && len(s.MinAvailable) > 0 {
+		return fmt.Errorf("min-available and max-unavailable cannot be both specified")
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/priorityclass.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/priorityclass.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	scheduling "k8s.io/api/scheduling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// PriorityClassV1Generator supports stable generation of a priorityClass.
+type PriorityClassV1Generator struct {
+	Name             string
+	Value            int32
+	GlobalDefault    bool
+	Description      string
+	PreemptionPolicy apiv1.PreemptionPolicy
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction.
+var _ generate.StructuredGenerator = &PriorityClassV1Generator{}
+
+func (PriorityClassV1Generator) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "value", Required: true},
+		{Name: "global-default", Required: false},
+		{Name: "description", Required: false},
+		{Name: "preemption-policy", Required: false},
+	}
+}
+
+func (s PriorityClassV1Generator) Generate(params map[string]interface{}) (runtime.Object, error) {
+	if err := generate.ValidateParams(s.ParamNames(), params); err != nil {
+		return nil, err
+	}
+
+	name, found := params["name"].(string)
+	if !found {
+		return nil, fmt.Errorf("expected string, saw %v for 'name'", name)
+	}
+
+	value, found := params["value"].(int32)
+	if !found {
+		return nil, fmt.Errorf("expected int32, found %v", value)
+	}
+
+	globalDefault, found := params["global-default"].(bool)
+	if !found {
+		return nil, fmt.Errorf("expected bool, found %v", globalDefault)
+	}
+
+	description, found := params["description"].(string)
+	if !found {
+		return nil, fmt.Errorf("expected string, found %v", description)
+	}
+
+	preemptionPolicy := apiv1.PreemptionPolicy(params["preemption-policy"].(string))
+
+	delegate := &PriorityClassV1Generator{Name: name, Value: value, GlobalDefault: globalDefault, Description: description, PreemptionPolicy: preemptionPolicy}
+	return delegate.StructuredGenerate()
+}
+
+// StructuredGenerate outputs a priorityClass object using the configured fields.
+func (s *PriorityClassV1Generator) StructuredGenerate() (runtime.Object, error) {
+	return &scheduling.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.Name,
+		},
+		Value:            s.Value,
+		GlobalDefault:    s.GlobalDefault,
+		Description:      s.Description,
+		PreemptionPolicy: &s.PreemptionPolicy,
+	}, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/quota.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/quota.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// ResourceQuotaGeneratorV1 supports stable generation of a resource quota
+type ResourceQuotaGeneratorV1 struct {
+	// The name of a quota object.
+	Name string
+
+	// The hard resource limit string before parsing.
+	Hard string
+
+	// The scopes of a quota object before parsing.
+	Scopes string
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern
+func (g ResourceQuotaGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "hard", Required: true},
+		{Name: "scopes", Required: false},
+	}
+}
+
+// Ensure it supports the generator pattern that uses parameter injection
+var _ generate.Generator = &ResourceQuotaGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &ResourceQuotaGeneratorV1{}
+
+func (g ResourceQuotaGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(g.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+
+	delegate := &ResourceQuotaGeneratorV1{}
+	delegate.Name = params["name"]
+	delegate.Hard = params["hard"]
+	delegate.Scopes = params["scopes"]
+	return delegate.StructuredGenerate()
+}
+
+// StructuredGenerate outputs a ResourceQuota object using the configured fields
+func (g *ResourceQuotaGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := g.validate(); err != nil {
+		return nil, err
+	}
+
+	resourceList, err := populateResourceListV1(g.Hard)
+	if err != nil {
+		return nil, err
+	}
+
+	scopes, err := parseScopes(g.Scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceQuota := &v1.ResourceQuota{}
+	resourceQuota.Name = g.Name
+	resourceQuota.Spec.Hard = resourceList
+	resourceQuota.Spec.Scopes = scopes
+	return resourceQuota, nil
+}
+
+// validate validates required fields are set to support structured generation
+func (r *ResourceQuotaGeneratorV1) validate() error {
+	if len(r.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	return nil
+}
+
+func parseScopes(spec string) ([]v1.ResourceQuotaScope, error) {
+	// empty input gets a nil response to preserve generator test expected behaviors
+	if spec == "" {
+		return nil, nil
+	}
+
+	scopes := strings.Split(spec, ",")
+	result := make([]v1.ResourceQuotaScope, 0, len(scopes))
+	for _, scope := range scopes {
+		// intentionally do not verify the scope against the valid scope list. This is done by the apiserver anyway.
+
+		if scope == "" {
+			return nil, fmt.Errorf("invalid resource quota scope \"\"")
+		}
+
+		result = append(result, v1.ResourceQuotaScope(scope))
+	}
+	return result, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/rolebinding.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/rolebinding.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// RoleBindingGeneratorV1 supports stable generation of a roleBinding.
+type RoleBindingGeneratorV1 struct {
+	// Name of roleBinding (required)
+	Name string
+	// ClusterRole for the roleBinding
+	ClusterRole string
+	// Role for the roleBinding
+	Role string
+	// Users to derive the roleBinding from (optional)
+	Users []string
+	// Groups to derive the roleBinding from (optional)
+	Groups []string
+	// ServiceAccounts to derive the roleBinding from in namespace:name format(optional)
+	ServiceAccounts []string
+}
+
+// Ensure it supports the generator pattern that uses parameter injection.
+var _ generate.Generator = &RoleBindingGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction.
+var _ generate.StructuredGenerator = &RoleBindingGeneratorV1{}
+
+// Generate returns a roleBinding using the specified parameters.
+func (s RoleBindingGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &RoleBindingGeneratorV1{}
+	userStrings, found := genericParams["user"]
+	if found {
+		fromFileArray, isArray := userStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", userStrings)
+		}
+		delegate.Users = fromFileArray
+		delete(genericParams, "user")
+	}
+	groupStrings, found := genericParams["group"]
+	if found {
+		fromLiteralArray, isArray := groupStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", groupStrings)
+		}
+		delegate.Groups = fromLiteralArray
+		delete(genericParams, "group")
+	}
+	saStrings, found := genericParams["serviceaccount"]
+	if found {
+		fromLiteralArray, isArray := saStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", saStrings)
+		}
+		delegate.ServiceAccounts = fromLiteralArray
+		delete(genericParams, "serviceaccount")
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate.Name = params["name"]
+	delegate.ClusterRole = params["clusterrole"]
+	delegate.Role = params["role"]
+	return delegate.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern.
+func (s RoleBindingGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "clusterrole", Required: false},
+		{Name: "role", Required: false},
+		{Name: "user", Required: false},
+		{Name: "group", Required: false},
+		{Name: "serviceaccount", Required: false},
+	}
+}
+
+// StructuredGenerate outputs a roleBinding object using the configured fields.
+func (s RoleBindingGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	roleBinding := &rbacv1.RoleBinding{}
+	roleBinding.Name = s.Name
+
+	switch {
+	case len(s.Role) > 0:
+		roleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     s.Role,
+		}
+	case len(s.ClusterRole) > 0:
+		roleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     s.ClusterRole,
+		}
+	}
+
+	for _, user := range sets.NewString(s.Users...).List() {
+		roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
+			Kind:     rbacv1.UserKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     user,
+		})
+	}
+	for _, group := range sets.NewString(s.Groups...).List() {
+		roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
+			Kind:     rbacv1.GroupKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     group,
+		})
+	}
+	for _, sa := range sets.NewString(s.ServiceAccounts...).List() {
+		tokens := strings.Split(sa, ":")
+		if len(tokens) != 2 || tokens[1] == "" {
+			return nil, fmt.Errorf("serviceaccount must be <namespace>:<name>")
+		}
+		roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
+			Kind:      rbacv1.ServiceAccountKind,
+			APIGroup:  "",
+			Namespace: tokens[0],
+			Name:      tokens[1],
+		})
+	}
+
+	return roleBinding, nil
+}
+
+// validate validates required fields are set to support structured generation.
+func (s RoleBindingGeneratorV1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if (len(s.ClusterRole) == 0) == (len(s.Role) == 0) {
+		return fmt.Errorf("exactly one of clusterrole or role must be specified")
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/run.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/run.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// getLabels returns map of labels.
+func getLabels(params map[string]string, name string) (map[string]string, error) {
+	labelString, found := params["labels"]
+	var labels map[string]string
+	var err error
+	if found && len(labelString) > 0 {
+		labels, err = generate.ParseLabels(labelString)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		labels = map[string]string{
+			"run": name,
+		}
+	}
+	return labels, nil
+}
+
+// getName returns the name of newly created resource.
+func getName(params map[string]string) (string, error) {
+	name, found := params["name"]
+	if !found || len(name) == 0 {
+		name, found = params["default-name"]
+		if !found || len(name) == 0 {
+			return "", fmt.Errorf("'name' is a required parameter")
+		}
+	}
+	return name, nil
+}
+
+// getParams returns map of generic parameters.
+func getParams(genericParams map[string]interface{}) (map[string]string, error) {
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	return params, nil
+}
+
+// getArgs returns arguments for the container command.
+func getArgs(genericParams map[string]interface{}) ([]string, error) {
+	args := []string{}
+	val, found := genericParams["args"]
+	if found {
+		var isArray bool
+		args, isArray = val.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found: %v", val)
+		}
+		delete(genericParams, "args")
+	}
+	return args, nil
+}
+
+// getEnvs returns environment variables.
+func getEnvs(genericParams map[string]interface{}) ([]v1.EnvVar, error) {
+	var envs []v1.EnvVar
+	envStrings, found := genericParams["env"]
+	if found {
+		if envStringArray, isArray := envStrings.([]string); isArray {
+			var err error
+			envs, err = parseEnvs(envStringArray)
+			if err != nil {
+				return nil, err
+			}
+			delete(genericParams, "env")
+		} else {
+			return nil, fmt.Errorf("expected []string, found: %v", envStrings)
+		}
+	}
+	return envs, nil
+}
+
+// populateResourceListV1 takes strings of form <resourceName1>=<value1>,<resourceName1>=<value2>
+// and returns ResourceList.
+func populateResourceListV1(spec string) (v1.ResourceList, error) {
+	// empty input gets a nil response to preserve generator test expected behaviors
+	if spec == "" {
+		return nil, nil
+	}
+
+	result := v1.ResourceList{}
+	resourceStatements := strings.Split(spec, ",")
+	for _, resourceStatement := range resourceStatements {
+		parts := strings.Split(resourceStatement, "=")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("Invalid argument syntax %v, expected <resource>=<value>", resourceStatement)
+		}
+		resourceName := v1.ResourceName(parts[0])
+		resourceQuantity, err := resource.ParseQuantity(parts[1])
+		if err != nil {
+			return nil, err
+		}
+		result[resourceName] = resourceQuantity
+	}
+	return result, nil
+}
+
+// HandleResourceRequirementsV1 parses the limits and requests parameters if specified
+// and returns ResourceRequirements.
+func HandleResourceRequirementsV1(params map[string]string) (v1.ResourceRequirements, error) {
+	result := v1.ResourceRequirements{}
+	limits, err := populateResourceListV1(params["limits"])
+	if err != nil {
+		return result, err
+	}
+	result.Limits = limits
+	requests, err := populateResourceListV1(params["requests"])
+	if err != nil {
+		return result, err
+	}
+	result.Requests = requests
+	return result, nil
+}
+
+// updatePodContainers updates PodSpec.Containers with passed parameters.
+func updatePodContainers(params map[string]string, args []string, envs []v1.EnvVar, imagePullPolicy v1.PullPolicy, podSpec *v1.PodSpec) error {
+	if len(args) > 0 {
+		command, err := generate.GetBool(params, "command", false)
+		if err != nil {
+			return err
+		}
+		if command {
+			podSpec.Containers[0].Command = args
+		} else {
+			podSpec.Containers[0].Args = args
+		}
+	}
+
+	if len(envs) > 0 {
+		podSpec.Containers[0].Env = envs
+	}
+
+	if len(imagePullPolicy) > 0 {
+		// imagePullPolicy should be valid here since we have verified it before.
+		podSpec.Containers[0].ImagePullPolicy = imagePullPolicy
+	}
+	return nil
+}
+
+// updatePodContainers updates PodSpec.Containers.Ports with passed parameters.
+func updatePodPorts(params map[string]string, podSpec *v1.PodSpec) (err error) {
+	port := -1
+	hostPort := -1
+	if len(params["port"]) > 0 {
+		port, err = strconv.Atoi(params["port"])
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(params["hostport"]) > 0 {
+		hostPort, err = strconv.Atoi(params["hostport"])
+		if err != nil {
+			return err
+		}
+		if hostPort > 0 && port < 0 {
+			return fmt.Errorf("--hostport requires --port to be specified")
+		}
+	}
+
+	// Don't include the port if it was not specified.
+	if len(params["port"]) > 0 {
+		podSpec.Containers[0].Ports = []v1.ContainerPort{
+			{
+				ContainerPort: int32(port),
+			},
+		}
+		if hostPort > 0 {
+			podSpec.Containers[0].Ports[0].HostPort = int32(hostPort)
+		}
+	}
+	return nil
+}
+
+type BasicPod struct{}
+
+func (BasicPod) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "labels", Required: false},
+		{Name: "default-name", Required: false},
+		{Name: "name", Required: true},
+		{Name: "image", Required: true},
+		{Name: "image-pull-policy", Required: false},
+		{Name: "port", Required: false},
+		{Name: "hostport", Required: false},
+		{Name: "stdin", Required: false},
+		{Name: "leave-stdin-open", Required: false},
+		{Name: "tty", Required: false},
+		{Name: "restart", Required: false},
+		{Name: "command", Required: false},
+		{Name: "args", Required: false},
+		{Name: "env", Required: false},
+		{Name: "requests", Required: false},
+		{Name: "limits", Required: false},
+		{Name: "serviceaccount", Required: false},
+	}
+}
+
+func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	args, err := getArgs(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	envs, err := getEnvs(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	params, err := getParams(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := getName(params)
+	if err != nil {
+		return nil, err
+	}
+
+	labels, err := getLabels(params, name)
+	if err != nil {
+		return nil, err
+	}
+
+	stdin, err := generate.GetBool(params, "stdin", false)
+	if err != nil {
+		return nil, err
+	}
+	leaveStdinOpen, err := generate.GetBool(params, "leave-stdin-open", false)
+	if err != nil {
+		return nil, err
+	}
+
+	tty, err := generate.GetBool(params, "tty", false)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceRequirements, err := HandleResourceRequirementsV1(params)
+	if err != nil {
+		return nil, err
+	}
+
+	restartPolicy := v1.RestartPolicy(params["restart"])
+	if len(restartPolicy) == 0 {
+		restartPolicy = v1.RestartPolicyAlways
+	}
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: params["serviceaccount"],
+			Containers: []v1.Container{
+				{
+					Name:      name,
+					Image:     params["image"],
+					Stdin:     stdin,
+					StdinOnce: !leaveStdinOpen && stdin,
+					TTY:       tty,
+					Resources: resourceRequirements,
+				},
+			},
+			DNSPolicy:     v1.DNSClusterFirst,
+			RestartPolicy: restartPolicy,
+		},
+	}
+	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
+	if err = updatePodContainers(params, args, envs, imagePullPolicy, &pod.Spec); err != nil {
+		return nil, err
+	}
+
+	if err := updatePodPorts(params, &pod.Spec); err != nil {
+		return nil, err
+	}
+	return &pod, nil
+}
+
+// parseEnvs converts string into EnvVar objects.
+func parseEnvs(envArray []string) ([]v1.EnvVar, error) {
+	envs := make([]v1.EnvVar, 0, len(envArray))
+	for _, env := range envArray {
+		pos := strings.Index(env, "=")
+		if pos == -1 {
+			return nil, fmt.Errorf("invalid env: %v", env)
+		}
+		name := env[:pos]
+		value := env[pos+1:]
+		if len(name) == 0 {
+			return nil, fmt.Errorf("invalid env: %v", env)
+		}
+		if len(validation.IsEnvVarName(name)) != 0 {
+			return nil, fmt.Errorf("invalid env: %v", env)
+		}
+		envVar := v1.EnvVar{Name: name, Value: value}
+		envs = append(envs, envVar)
+	}
+	return envs, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/secret.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/secret.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/kubectl/pkg/generate"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/hash"
+)
+
+// SecretGeneratorV1 supports stable generation of an opaque secret
+type SecretGeneratorV1 struct {
+	// Name of secret (required)
+	Name string
+	// Type of secret (optional)
+	Type string
+	// FileSources to derive the secret from (optional)
+	FileSources []string
+	// LiteralSources to derive the secret from (optional)
+	LiteralSources []string
+	// EnvFileSource to derive the secret from (optional)
+	EnvFileSource string
+	// AppendHash; if true, derive a hash from the Secret data and type and append it to the name
+	AppendHash bool
+}
+
+// Ensure it supports the generator pattern that uses parameter injection
+var _ generate.Generator = &SecretGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &SecretGeneratorV1{}
+
+// Generate returns a secret using the specified parameters
+func (s SecretGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &SecretGeneratorV1{}
+	fromFileStrings, found := genericParams["from-file"]
+	if found {
+		fromFileArray, isArray := fromFileStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+		}
+		delegate.FileSources = fromFileArray
+		delete(genericParams, "from-file")
+	}
+	fromLiteralStrings, found := genericParams["from-literal"]
+	if found {
+		fromLiteralArray, isArray := fromLiteralStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", fromLiteralStrings)
+		}
+		delegate.LiteralSources = fromLiteralArray
+		delete(genericParams, "from-literal")
+	}
+	fromEnvFileString, found := genericParams["from-env-file"]
+	if found {
+		fromEnvFile, isString := fromEnvFileString.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, found :%v", fromEnvFileString)
+		}
+		delegate.EnvFileSource = fromEnvFile
+		delete(genericParams, "from-env-file")
+	}
+
+	hashParam, found := genericParams["append-hash"]
+	if found {
+		hashBool, isBool := hashParam.(bool)
+		if !isBool {
+			return nil, fmt.Errorf("expected bool, found :%v", hashParam)
+		}
+		delegate.AppendHash = hashBool
+		delete(genericParams, "append-hash")
+	}
+
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate.Name = params["name"]
+	delegate.Type = params["type"]
+
+	return delegate.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern
+func (s SecretGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "type", Required: false},
+		{Name: "from-file", Required: false},
+		{Name: "from-literal", Required: false},
+		{Name: "from-env-file", Required: false},
+		{Name: "force", Required: false},
+		{Name: "append-hash", Required: false},
+	}
+}
+
+// StructuredGenerate outputs a secret object using the configured fields
+func (s SecretGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	secret := &v1.Secret{}
+	secret.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("Secret"))
+	secret.Name = s.Name
+	secret.Data = map[string][]byte{}
+	if len(s.Type) > 0 {
+		secret.Type = v1.SecretType(s.Type)
+	}
+	if len(s.FileSources) > 0 {
+		if err := handleFromFileSources(secret, s.FileSources); err != nil {
+			return nil, err
+		}
+	}
+	if len(s.LiteralSources) > 0 {
+		if err := handleFromLiteralSources(secret, s.LiteralSources); err != nil {
+			return nil, err
+		}
+	}
+	if len(s.EnvFileSource) > 0 {
+		if err := handleFromEnvFileSource(secret, s.EnvFileSource); err != nil {
+			return nil, err
+		}
+	}
+	if s.AppendHash {
+		h, err := hash.SecretHash(secret)
+		if err != nil {
+			return nil, err
+		}
+		secret.Name = fmt.Sprintf("%s-%s", secret.Name, h)
+	}
+	return secret, nil
+}
+
+// validate validates required fields are set to support structured generation
+func (s SecretGeneratorV1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(s.EnvFileSource) > 0 && (len(s.FileSources) > 0 || len(s.LiteralSources) > 0) {
+		return fmt.Errorf("from-env-file cannot be combined with from-file or from-literal")
+	}
+	return nil
+}
+
+// handleFromLiteralSources adds the specified literal source information into the provided secret
+func handleFromLiteralSources(secret *v1.Secret, literalSources []string) error {
+	for _, literalSource := range literalSources {
+		keyName, value, err := util.ParseLiteralSource(literalSource)
+		if err != nil {
+			return err
+		}
+		if err = addKeyFromLiteralToSecret(secret, keyName, []byte(value)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// handleFromFileSources adds the specified file source information into the provided secret
+func handleFromFileSources(secret *v1.Secret, fileSources []string) error {
+	for _, fileSource := range fileSources {
+		keyName, filePath, err := util.ParseFileSource(fileSource)
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(filePath)
+		if err != nil {
+			switch err := err.(type) {
+			case *os.PathError:
+				return fmt.Errorf("error reading %s: %v", filePath, err.Err)
+			default:
+				return fmt.Errorf("error reading %s: %v", filePath, err)
+			}
+		}
+		if info.IsDir() {
+			if strings.Contains(fileSource, "=") {
+				return fmt.Errorf("cannot give a key name for a directory path")
+			}
+			fileList, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				return fmt.Errorf("error listing files in %s: %v", filePath, err)
+			}
+			for _, item := range fileList {
+				itemPath := path.Join(filePath, item.Name())
+				if item.Mode().IsRegular() {
+					keyName = item.Name()
+					if err = addKeyFromFileToSecret(secret, keyName, itemPath); err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			if err := addKeyFromFileToSecret(secret, keyName, filePath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// handleFromEnvFileSource adds the specified env file source information
+// into the provided secret
+func handleFromEnvFileSource(secret *v1.Secret, envFileSource string) error {
+	info, err := os.Stat(envFileSource)
+	if err != nil {
+		switch err := err.(type) {
+		case *os.PathError:
+			return fmt.Errorf("error reading %s: %v", envFileSource, err.Err)
+		default:
+			return fmt.Errorf("error reading %s: %v", envFileSource, err)
+		}
+	}
+	if info.IsDir() {
+		return fmt.Errorf("env secret file cannot be a directory")
+	}
+
+	return addFromEnvFile(envFileSource, func(key, value string) error {
+		return addKeyFromLiteralToSecret(secret, key, []byte(value))
+	})
+}
+
+func addKeyFromFileToSecret(secret *v1.Secret, keyName, filePath string) error {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	return addKeyFromLiteralToSecret(secret, keyName, data)
+}
+
+func addKeyFromLiteralToSecret(secret *v1.Secret, keyName string, data []byte) error {
+	if errs := validation.IsConfigMapKey(keyName); len(errs) != 0 {
+		return fmt.Errorf("%q is not a valid key name for a Secret: %s", keyName, strings.Join(errs, ";"))
+	}
+
+	if _, entryExists := secret.Data[keyName]; entryExists {
+		return fmt.Errorf("cannot add key %s, another key by that name already exists", keyName)
+	}
+	secret.Data[keyName] = data
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/secret_for_docker_registry.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/secret_for_docker_registry.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/generate"
+	"k8s.io/kubectl/pkg/util/hash"
+)
+
+// SecretForDockerRegistryGeneratorV1 supports stable generation of a docker registry secret
+type SecretForDockerRegistryGeneratorV1 struct {
+	// Name of secret (required)
+	Name string
+	// FileSources to derive the secret from (optional)
+	FileSources []string
+	// Username for registry (required)
+	Username string
+	// Email for registry (optional)
+	Email string
+	// Password for registry (required)
+	Password string
+	// Server for registry (required)
+	Server string
+	// AppendHash; if true, derive a hash from the Secret and append it to the name
+	AppendHash bool
+}
+
+// Ensure it supports the generator pattern that uses parameter injection
+var _ generate.Generator = &SecretForDockerRegistryGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &SecretForDockerRegistryGeneratorV1{}
+
+// Generate returns a secret using the specified parameters
+func (s SecretForDockerRegistryGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &SecretForDockerRegistryGeneratorV1{}
+	hashParam, found := genericParams["append-hash"]
+	if found {
+		hashBool, isBool := hashParam.(bool)
+		if !isBool {
+			return nil, fmt.Errorf("expected bool, found :%v", hashParam)
+		}
+		delegate.AppendHash = hashBool
+		delete(genericParams, "append-hash")
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate.Name = params["name"]
+	delegate.Username = params["docker-username"]
+	delegate.Email = params["docker-email"]
+	delegate.Password = params["docker-password"]
+	delegate.Server = params["docker-server"]
+	return delegate.StructuredGenerate()
+}
+
+// StructuredGenerate outputs a secret object using the configured fields
+func (s SecretForDockerRegistryGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	secret := &v1.Secret{}
+	secret.Name = s.Name
+	secret.Type = v1.SecretTypeDockerConfigJson
+	secret.Data = map[string][]byte{}
+	if len(s.FileSources) > 0 {
+		if err := handleFromFileSources(secret, s.FileSources); err != nil {
+			return nil, err
+		}
+	}
+	if len(s.FileSources) == 0 {
+		dockercfgJSONContent, err := handleDockerCfgJSONContent(s.Username, s.Password, s.Email, s.Server)
+		if err != nil {
+			return nil, err
+		}
+		secret.Data[v1.DockerConfigJsonKey] = dockercfgJSONContent
+	}
+	if s.AppendHash {
+		h, err := hash.SecretHash(secret)
+		if err != nil {
+			return nil, err
+		}
+		secret.Name = fmt.Sprintf("%s-%s", secret.Name, h)
+	}
+	return secret, nil
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern
+func (s SecretForDockerRegistryGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "from-file", Required: false},
+		{Name: "docker-username", Required: true},
+		{Name: "docker-email", Required: false},
+		{Name: "docker-password", Required: true},
+		{Name: "docker-server", Required: true},
+		{Name: "append-hash", Required: false},
+	}
+}
+
+// validate validates required fields are set to support structured generation
+func (s SecretForDockerRegistryGeneratorV1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+
+	if len(s.FileSources) == 0 {
+		if len(s.Username) == 0 {
+			return fmt.Errorf("username must be specified")
+		}
+		if len(s.Password) == 0 {
+			return fmt.Errorf("password must be specified")
+		}
+		if len(s.Server) == 0 {
+			return fmt.Errorf("server must be specified")
+		}
+	}
+	return nil
+}
+
+// handleDockerCfgJSONContent serializes a ~/.docker/config.json file
+func handleDockerCfgJSONContent(username, password, email, server string) ([]byte, error) {
+	dockercfgAuth := DockerConfigEntry{
+		Username: username,
+		Password: password,
+		Email:    email,
+		Auth:     encodeDockerConfigFieldAuth(username, password),
+	}
+
+	dockerCfgJSON := DockerConfigJSON{
+		Auths: map[string]DockerConfigEntry{server: dockercfgAuth},
+	}
+
+	return json.Marshal(dockerCfgJSON)
+}
+
+func encodeDockerConfigFieldAuth(username, password string) string {
+	fieldValue := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(fieldValue))
+}
+
+// DockerConfigJSON represents a local docker auth config file
+// for pulling images.
+type DockerConfigJSON struct {
+	Auths DockerConfig `json:"auths"`
+	// +optional
+	HttpHeaders map[string]string `json:"HttpHeaders,omitempty"`
+}
+
+// DockerConfig represents the config file used by the docker CLI.
+// This config that represents the credentials that should be used
+// when pulling images from specific image repositories.
+type DockerConfig map[string]DockerConfigEntry
+
+type DockerConfigEntry struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/secret_for_tls.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/secret_for_tls.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/generate"
+	"k8s.io/kubectl/pkg/util/hash"
+)
+
+// SecretForTLSGeneratorV1 supports stable generation of a TLS secret.
+type SecretForTLSGeneratorV1 struct {
+	// Name is the name of this TLS secret.
+	Name string
+	// Key is the path to the user's private key.
+	Key string
+	// Cert is the path to the user's public key certificate.
+	Cert string
+	// AppendHash; if true, derive a hash from the Secret and append it to the name
+	AppendHash bool
+}
+
+// Ensure it supports the generator pattern that uses parameter injection
+var _ generate.Generator = &SecretForTLSGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &SecretForTLSGeneratorV1{}
+
+// Generate returns a secret using the specified parameters
+func (s SecretForTLSGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &SecretForTLSGeneratorV1{}
+	hashParam, found := genericParams["append-hash"]
+	if found {
+		hashBool, isBool := hashParam.(bool)
+		if !isBool {
+			return nil, fmt.Errorf("expected bool, found :%v", hashParam)
+		}
+		delegate.AppendHash = hashBool
+		delete(genericParams, "append-hash")
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate.Name = params["name"]
+	delegate.Key = params["key"]
+	delegate.Cert = params["cert"]
+	return delegate.StructuredGenerate()
+}
+
+// StructuredGenerate outputs a secret object using the configured fields
+func (s SecretForTLSGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	tlsCrt, err := readFile(s.Cert)
+	if err != nil {
+		return nil, err
+	}
+	tlsKey, err := readFile(s.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := tls.X509KeyPair(tlsCrt, tlsKey); err != nil {
+		return nil, fmt.Errorf("failed to load key pair %v", err)
+	}
+	// TODO: Add more validation.
+	// 1. If the certificate contains intermediates, it is a valid chain.
+	// 2. Format etc.
+
+	secret := &v1.Secret{}
+	secret.Name = s.Name
+	secret.Type = v1.SecretTypeTLS
+	secret.Data = map[string][]byte{}
+	secret.Data[v1.TLSCertKey] = []byte(tlsCrt)
+	secret.Data[v1.TLSPrivateKeyKey] = []byte(tlsKey)
+	if s.AppendHash {
+		h, err := hash.SecretHash(secret)
+		if err != nil {
+			return nil, err
+		}
+		secret.Name = fmt.Sprintf("%s-%s", secret.Name, h)
+	}
+	return secret, nil
+}
+
+// readFile just reads a file into a byte array.
+func readFile(file string) ([]byte, error) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return []byte{}, fmt.Errorf("Cannot read file %v, %v", file, err)
+	}
+	return b, nil
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern
+func (s SecretForTLSGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "key", Required: true},
+		{Name: "cert", Required: true},
+		{Name: "append-hash", Required: false},
+	}
+}
+
+// validate validates required fields are set to support structured generation
+func (s SecretForTLSGeneratorV1) validate() error {
+	// TODO: This is not strictly necessary. We can generate a self signed cert
+	// if no key/cert is given. The only requirement is that we either get both
+	// or none. See test/e2e/ingress_utils for self signed cert generation.
+	if len(s.Key) == 0 {
+		return fmt.Errorf("key must be specified")
+	}
+	if len(s.Cert) == 0 {
+		return fmt.Errorf("certificate must be specified")
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/service.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/service.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// The only difference between ServiceGeneratorV1 and V2 is that the service port is named "default" in V1, while it is left unnamed in V2.
+type ServiceGeneratorV1 struct{}
+
+func (ServiceGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return paramNames()
+}
+
+func (ServiceGeneratorV1) Generate(params map[string]interface{}) (runtime.Object, error) {
+	params["port-name"] = "default"
+	return generateService(params)
+}
+
+type ServiceGeneratorV2 struct{}
+
+func (ServiceGeneratorV2) ParamNames() []generate.GeneratorParam {
+	return paramNames()
+}
+
+func (ServiceGeneratorV2) Generate(params map[string]interface{}) (runtime.Object, error) {
+	return generateService(params)
+}
+
+func paramNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "default-name", Required: true},
+		{Name: "name", Required: false},
+		{Name: "selector", Required: true},
+		// port will be used if a user specifies --port OR the exposed object
+		// has one port
+		{Name: "port", Required: false},
+		// ports will be used iff a user doesn't specify --port AND the
+		// exposed object has multiple ports
+		{Name: "ports", Required: false},
+		{Name: "labels", Required: false},
+		{Name: "external-ip", Required: false},
+		{Name: "load-balancer-ip", Required: false},
+		{Name: "type", Required: false},
+		{Name: "protocol", Required: false},
+		// protocols will be used to keep port-protocol mapping derived from
+		// exposed object
+		{Name: "protocols", Required: false},
+		{Name: "container-port", Required: false}, // alias of target-port
+		{Name: "target-port", Required: false},
+		{Name: "port-name", Required: false},
+		{Name: "session-affinity", Required: false},
+		{Name: "cluster-ip", Required: false},
+	}
+}
+
+func generateService(genericParams map[string]interface{}) (runtime.Object, error) {
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	selectorString, found := params["selector"]
+	if !found || len(selectorString) == 0 {
+		return nil, fmt.Errorf("'selector' is a required parameter")
+	}
+	selector, err := generate.ParseLabels(selectorString)
+	if err != nil {
+		return nil, err
+	}
+
+	labelsString, found := params["labels"]
+	var labels map[string]string
+	if found && len(labelsString) > 0 {
+		labels, err = generate.ParseLabels(labelsString)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	name, found := params["name"]
+	if !found || len(name) == 0 {
+		name, found = params["default-name"]
+		if !found || len(name) == 0 {
+			return nil, fmt.Errorf("'name' is a required parameter")
+		}
+	}
+
+	isHeadlessService := params["cluster-ip"] == "None"
+
+	ports := []v1.ServicePort{}
+	servicePortName, found := params["port-name"]
+	if !found {
+		// Leave the port unnamed.
+		servicePortName = ""
+	}
+
+	protocolsString, found := params["protocols"]
+	var portProtocolMap map[string]string
+	if found && len(protocolsString) > 0 {
+		portProtocolMap, err = generate.ParseProtocols(protocolsString)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// ports takes precedence over port since it will be
+	// specified only when the user hasn't specified a port
+	// via --port and the exposed object has multiple ports.
+	var portString string
+	if portString, found = params["ports"]; !found {
+		portString, found = params["port"]
+		if !found && !isHeadlessService {
+			return nil, fmt.Errorf("'ports' or 'port' is a required parameter")
+		}
+	}
+
+	if portString != "" {
+		portStringSlice := strings.Split(portString, ",")
+		for i, stillPortString := range portStringSlice {
+			port, err := strconv.Atoi(stillPortString)
+			if err != nil {
+				return nil, err
+			}
+			name := servicePortName
+			// If we are going to assign multiple ports to a service, we need to
+			// generate a different name for each one.
+			if len(portStringSlice) > 1 {
+				name = fmt.Sprintf("port-%d", i+1)
+			}
+			protocol := params["protocol"]
+
+			switch {
+			case len(protocol) == 0 && len(portProtocolMap) == 0:
+				// Default to TCP, what the flag was doing previously.
+				protocol = "TCP"
+			case len(protocol) > 0 && len(portProtocolMap) > 0:
+				// User has specified the --protocol while exposing a multiprotocol resource
+				// We should stomp multiple protocols with the one specified ie. do nothing
+			case len(protocol) == 0 && len(portProtocolMap) > 0:
+				// no --protocol and we expose a multiprotocol resource
+				protocol = "TCP" // have the default so we can stay sane
+				if exposeProtocol, found := portProtocolMap[stillPortString]; found {
+					protocol = exposeProtocol
+				}
+			}
+			ports = append(ports, v1.ServicePort{
+				Name:     name,
+				Port:     int32(port),
+				Protocol: v1.Protocol(protocol),
+			})
+		}
+	}
+
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: v1.ServiceSpec{
+			Selector: selector,
+			Ports:    ports,
+		},
+	}
+	targetPortString := params["target-port"]
+	if len(targetPortString) == 0 {
+		targetPortString = params["container-port"]
+	}
+	if len(targetPortString) > 0 {
+		var targetPort intstr.IntOrString
+		if portNum, err := strconv.Atoi(targetPortString); err != nil {
+			targetPort = intstr.FromString(targetPortString)
+		} else {
+			targetPort = intstr.FromInt(portNum)
+		}
+		// Use the same target-port for every port
+		for i := range service.Spec.Ports {
+			service.Spec.Ports[i].TargetPort = targetPort
+		}
+	} else {
+		// If --target-port or --container-port haven't been specified, this
+		// should be the same as Port
+		for i := range service.Spec.Ports {
+			port := service.Spec.Ports[i].Port
+			service.Spec.Ports[i].TargetPort = intstr.FromInt(int(port))
+		}
+	}
+	if len(params["external-ip"]) > 0 {
+		service.Spec.ExternalIPs = []string{params["external-ip"]}
+	}
+	if len(params["type"]) != 0 {
+		service.Spec.Type = v1.ServiceType(params["type"])
+	}
+	if service.Spec.Type == v1.ServiceTypeLoadBalancer {
+		service.Spec.LoadBalancerIP = params["load-balancer-ip"]
+	}
+	if len(params["session-affinity"]) != 0 {
+		switch v1.ServiceAffinity(params["session-affinity"]) {
+		case v1.ServiceAffinityNone:
+			service.Spec.SessionAffinity = v1.ServiceAffinityNone
+		case v1.ServiceAffinityClientIP:
+			service.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+		default:
+			return nil, fmt.Errorf("unknown session affinity: %s", params["session-affinity"])
+		}
+	}
+	if len(params["cluster-ip"]) != 0 {
+		if params["cluster-ip"] == "None" {
+			service.Spec.ClusterIP = v1.ClusterIPNone
+		} else {
+			service.Spec.ClusterIP = params["cluster-ip"]
+		}
+	}
+	return &service, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+type ServiceCommonGeneratorV1 struct {
+	Name         string
+	TCP          []string
+	Type         v1.ServiceType
+	ClusterIP    string
+	NodePort     int
+	ExternalName string
+}
+
+type ServiceClusterIPGeneratorV1 struct {
+	ServiceCommonGeneratorV1
+}
+
+type ServiceNodePortGeneratorV1 struct {
+	ServiceCommonGeneratorV1
+}
+
+type ServiceLoadBalancerGeneratorV1 struct {
+	ServiceCommonGeneratorV1
+}
+
+// TODO: is this really necessary?
+type ServiceExternalNameGeneratorV1 struct {
+	ServiceCommonGeneratorV1
+}
+
+func (ServiceClusterIPGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "tcp", Required: true},
+		{Name: "clusterip", Required: false},
+	}
+}
+func (ServiceNodePortGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "tcp", Required: true},
+		{Name: "nodeport", Required: true},
+	}
+}
+func (ServiceLoadBalancerGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "tcp", Required: true},
+	}
+}
+
+func (ServiceExternalNameGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+		{Name: "externalname", Required: true},
+	}
+}
+
+func parsePorts(portString string) (int32, intstr.IntOrString, error) {
+	portStringSlice := strings.Split(portString, ":")
+
+	port, err := strconv.Atoi(portStringSlice[0])
+	if err != nil {
+		return 0, intstr.FromInt(0), err
+	}
+
+	if errs := validation.IsValidPortNum(port); len(errs) != 0 {
+		return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
+	}
+
+	if len(portStringSlice) == 1 {
+		return int32(port), intstr.FromInt(int(port)), nil
+	}
+
+	var targetPort intstr.IntOrString
+	if portNum, err := strconv.Atoi(portStringSlice[1]); err != nil {
+		if errs := validation.IsValidPortName(portStringSlice[1]); len(errs) != 0 {
+			return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
+		}
+		targetPort = intstr.FromString(portStringSlice[1])
+	} else {
+		if errs := validation.IsValidPortNum(portNum); len(errs) != 0 {
+			return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
+		}
+		targetPort = intstr.FromInt(portNum)
+	}
+	return int32(port), targetPort, nil
+}
+
+func (s ServiceCommonGeneratorV1) GenerateCommon(params map[string]interface{}) error {
+	name, isString := params["name"].(string)
+	if !isString {
+		return fmt.Errorf("expected string, saw %v for 'name'", name)
+	}
+	tcpStrings, isArray := params["tcp"].([]string)
+	if !isArray {
+		return fmt.Errorf("expected []string, found :%v", tcpStrings)
+	}
+	clusterip, isString := params["clusterip"].(string)
+	if !isString {
+		return fmt.Errorf("expected string, saw %v for 'clusterip'", clusterip)
+	}
+	externalname, isString := params["externalname"].(string)
+	if !isString {
+		return fmt.Errorf("expected string, saw %v for 'externalname'", externalname)
+	}
+	s.Name = name
+	s.TCP = tcpStrings
+	s.ClusterIP = clusterip
+	s.ExternalName = externalname
+	return nil
+}
+
+func (s ServiceLoadBalancerGeneratorV1) Generate(params map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), params)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &ServiceCommonGeneratorV1{Type: v1.ServiceTypeLoadBalancer, ClusterIP: ""}
+	err = delegate.GenerateCommon(params)
+	if err != nil {
+		return nil, err
+	}
+	return delegate.StructuredGenerate()
+}
+
+func (s ServiceNodePortGeneratorV1) Generate(params map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), params)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &ServiceCommonGeneratorV1{Type: v1.ServiceTypeNodePort, ClusterIP: ""}
+	err = delegate.GenerateCommon(params)
+	if err != nil {
+		return nil, err
+	}
+	return delegate.StructuredGenerate()
+}
+
+func (s ServiceClusterIPGeneratorV1) Generate(params map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), params)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &ServiceCommonGeneratorV1{Type: v1.ServiceTypeClusterIP, ClusterIP: ""}
+	err = delegate.GenerateCommon(params)
+	if err != nil {
+		return nil, err
+	}
+	return delegate.StructuredGenerate()
+}
+
+func (s ServiceExternalNameGeneratorV1) Generate(params map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(s.ParamNames(), params)
+	if err != nil {
+		return nil, err
+	}
+	delegate := &ServiceCommonGeneratorV1{Type: v1.ServiceTypeExternalName, ClusterIP: ""}
+	err = delegate.GenerateCommon(params)
+	if err != nil {
+		return nil, err
+	}
+	return delegate.StructuredGenerate()
+}
+
+// validate validates required fields are set to support structured generation
+// TODO(xiangpengzhao): validate ports are identity mapped for headless service when we enforce that in validation.validateServicePort.
+func (s ServiceCommonGeneratorV1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(s.Type) == 0 {
+		return fmt.Errorf("type must be specified")
+	}
+	if s.ClusterIP == v1.ClusterIPNone && s.Type != v1.ServiceTypeClusterIP {
+		return fmt.Errorf("ClusterIP=None can only be used with ClusterIP service type")
+	}
+	if s.ClusterIP != v1.ClusterIPNone && len(s.TCP) == 0 && s.Type != v1.ServiceTypeExternalName {
+		return fmt.Errorf("at least one tcp port specifier must be provided")
+	}
+	if s.Type == v1.ServiceTypeExternalName {
+		if errs := validation.IsDNS1123Subdomain(s.ExternalName); len(errs) != 0 {
+			return fmt.Errorf("invalid service external name %s", s.ExternalName)
+		}
+	}
+	return nil
+}
+
+func (s ServiceCommonGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	err := s.validate()
+	if err != nil {
+		return nil, err
+	}
+	ports := []v1.ServicePort{}
+	for _, tcpString := range s.TCP {
+		port, targetPort, err := parsePorts(tcpString)
+		if err != nil {
+			return nil, err
+		}
+
+		portName := strings.Replace(tcpString, ":", "-", -1)
+		ports = append(ports, v1.ServicePort{
+			Name:       portName,
+			Port:       port,
+			TargetPort: targetPort,
+			Protocol:   v1.Protocol("TCP"),
+			NodePort:   int32(s.NodePort),
+		})
+	}
+
+	// setup default label and selector
+	labels := map[string]string{}
+	labels["app"] = s.Name
+	selector := map[string]string{}
+	selector["app"] = s.Name
+
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   s.Name,
+			Labels: labels,
+		},
+		Spec: v1.ServiceSpec{
+			Type:         v1.ServiceType(s.Type),
+			Selector:     selector,
+			Ports:        ports,
+			ExternalName: s.ExternalName,
+		},
+	}
+	if len(s.ClusterIP) > 0 {
+		service.Spec.ClusterIP = s.ClusterIP
+	}
+	return &service, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/generate/versioned/serviceaccount.go
+++ b/vendor/k8s.io/kubectl/pkg/generate/versioned/serviceaccount.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/generate"
+)
+
+// ServiceAccountGeneratorV1 supports stable generation of a service account
+type ServiceAccountGeneratorV1 struct {
+	// Name of service account
+	Name string
+}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &ServiceAccountGeneratorV1{}
+
+// StructuredGenerate outputs a service account object using the configured fields
+func (g *ServiceAccountGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := g.validate(); err != nil {
+		return nil, err
+	}
+	serviceAccount := &v1.ServiceAccount{}
+	serviceAccount.Name = g.Name
+	return serviceAccount, nil
+}
+
+// validate validates required fields are set to support structured generation
+func (g *ServiceAccountGeneratorV1) validate() error {
+	if len(g.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubectl/pkg/util/hash/hash.go
+++ b/vendor/k8s.io/kubectl/pkg/util/hash/hash.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+// ConfigMapHash returns a hash of the ConfigMap.
+// The Data, Kind, and Name are taken into account.
+func ConfigMapHash(cm *v1.ConfigMap) (string, error) {
+	encoded, err := encodeConfigMap(cm)
+	if err != nil {
+		return "", err
+	}
+	h, err := encodeHash(hash(encoded))
+	if err != nil {
+		return "", err
+	}
+	return h, nil
+}
+
+// SecretHash returns a hash of the Secret.
+// The Data, Kind, Name, and Type are taken into account.
+func SecretHash(sec *v1.Secret) (string, error) {
+	encoded, err := encodeSecret(sec)
+	if err != nil {
+		return "", err
+	}
+	h, err := encodeHash(hash(encoded))
+	if err != nil {
+		return "", err
+	}
+	return h, nil
+}
+
+// encodeConfigMap encodes a ConfigMap.
+// Data, Kind, and Name are taken into account.
+func encodeConfigMap(cm *v1.ConfigMap) (string, error) {
+	// json.Marshal sorts the keys in a stable order in the encoding
+	m := map[string]interface{}{
+		"kind": "ConfigMap",
+		"name": cm.Name,
+		"data": cm.Data,
+	}
+	if cm.Immutable != nil {
+		m["immutable"] = *cm.Immutable
+	}
+	if len(cm.BinaryData) > 0 {
+		m["binaryData"] = cm.BinaryData
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// encodeSecret encodes a Secret.
+// Data, Kind, Name, and Type are taken into account.
+func encodeSecret(sec *v1.Secret) (string, error) {
+	m := map[string]interface{}{
+		"kind": "Secret",
+		"type": sec.Type,
+		"name": sec.Name,
+		"data": sec.Data,
+	}
+	if sec.Immutable != nil {
+		m["immutable"] = *sec.Immutable
+	}
+	// json.Marshal sorts the keys in a stable order in the encoding
+	data, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// encodeHash extracts the first 40 bits of the hash from the hex string
+// (1 hex char represents 4 bits), and then maps vowels and vowel-like hex
+// characters to consonants to prevent bad words from being formed (the theory
+// is that no vowels makes it really hard to make bad words). Since the string
+// is hex, the only vowels it can contain are 'a' and 'e'.
+// We picked some arbitrary consonants to map to from the same character set as GenerateName.
+// See: https://github.com/kubernetes/apimachinery/blob/dc1f89aff9a7509782bde3b68824c8043a3e58cc/pkg/util/rand/rand.go#L75
+// If the hex string contains fewer than ten characters, returns an error.
+func encodeHash(hex string) (string, error) {
+	if len(hex) < 10 {
+		return "", fmt.Errorf("the hex string must contain at least 10 characters")
+	}
+	enc := []rune(hex[:10])
+	for i := range enc {
+		switch enc[i] {
+		case '0':
+			enc[i] = 'g'
+		case '1':
+			enc[i] = 'h'
+		case '3':
+			enc[i] = 'k'
+		case 'a':
+			enc[i] = 'm'
+		case 'e':
+			enc[i] = 't'
+		}
+	}
+	return string(enc), nil
+}
+
+// hash hashes `data` with sha256 and returns the hex string
+func hash(data string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,12 +1,8 @@
 # cloud.google.com/go v0.38.0
 cloud.google.com/go/compute/metadata
-# github.com/Azure/azure-sdk-for-go v16.2.1+incompatible
-## explicit
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
-# github.com/Azure/go-autorest v10.8.1+incompatible => github.com/Azure/go-autorest v12.4.3+incompatible
-## explicit
 # github.com/Azure/go-autorest/autorest v0.9.0
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
@@ -46,49 +42,23 @@ github.com/Microsoft/hcsshim/osversion
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
-# github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d
-## explicit
 # github.com/Shopify/sarama v1.18.0
-## explicit
 github.com/Shopify/sarama
-# github.com/Shopify/toxiproxy v2.1.4+incompatible
-## explicit
 # github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
-## explicit
 github.com/agl/ed25519
 github.com/agl/ed25519/edwards25519
 # github.com/apache/thrift v0.0.0-20171203172758-327ebb6c2b6d
-## explicit
 github.com/apache/thrift/lib/go/thrift
-# github.com/aws/aws-sdk-go v1.15.11
-## explicit
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
-# github.com/bitly/go-hostpool v0.1.0
-## explicit
 # github.com/blang/semver v3.5.1+incompatible
-## explicit
 github.com/blang/semver
-# github.com/bugsnag/bugsnag-go v1.5.3
-## explicit
-# github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b
-## explicit
-# github.com/bugsnag/panicwrap v1.2.0
-## explicit
-# github.com/cenkalti/backoff v2.2.1+incompatible
-## explicit
 # github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1
-## explicit
 github.com/chai2010/gettext-go/gettext
 github.com/chai2010/gettext-go/gettext/mo
 github.com/chai2010/gettext-go/gettext/plural
 github.com/chai2010/gettext-go/gettext/po
-# github.com/cloudflare/cfssl v1.4.1
-## explicit
-# github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-## explicit
 # github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901
-## explicit
 github.com/containerd/cgroups/stats/v1
 # github.com/containerd/containerd v1.3.1-0.20191217142032-9b5581cc9c5b
 github.com/containerd/containerd/archive/compression
@@ -112,30 +82,20 @@ github.com/containerd/containerd/snapshots
 github.com/containerd/containerd/sys
 github.com/containerd/containerd/version
 # github.com/containerd/continuity v0.0.0-20191214063359-1097c8bae83b
-## explicit
 github.com/containerd/continuity/fs
 github.com/containerd/continuity/syscallx
 github.com/containerd/continuity/sysx
 # github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c
-## explicit
 github.com/containerd/ttrpc
 # github.com/cpuguy83/go-md2man v1.0.10
 github.com/cpuguy83/go-md2man/md2man
-# github.com/d4l3k/messagediff v1.2.1
-## explicit
 # github.com/davecgh/go-spew v1.1.1
-## explicit
 github.com/davecgh/go-spew/spew
 # github.com/denisbrodbeck/machineid v1.0.0
 github.com/denisbrodbeck/machineid
-# github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba
-## explicit
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
-# github.com/dnaeon/go-vcr v1.0.1
-## explicit
 # github.com/docker/cli v0.0.0-20191220145525-ba63a92655c0
-## explicit
 github.com/docker/cli/cli/command
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
@@ -157,7 +117,6 @@ github.com/docker/cli/cli/trust
 github.com/docker/cli/cli/version
 github.com/docker/cli/opts
 # github.com/docker/distribution v2.7.1+incompatible
-## explicit
 github.com/docker/distribution
 github.com/docker/distribution/digestset
 github.com/docker/distribution/manifest
@@ -175,7 +134,6 @@ github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
 # github.com/docker/docker v1.4.2-0.20191210192822-1347481b9eb5
-## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
@@ -212,36 +170,26 @@ github.com/docker/docker/registry
 github.com/docker/docker/registry/resumable
 github.com/docker/docker/rootless
 # github.com/docker/docker-credential-helpers v0.6.3
-## explicit
 github.com/docker/docker-credential-helpers/client
 github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go v1.5.1-1
-## explicit
 github.com/docker/go/canonical/json
 # github.com/docker/go-connections v0.4.0
-## explicit
 github.com/docker/go-connections/nat
 github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
-## explicit
 github.com/docker/go-metrics
 # github.com/docker/go-units v0.4.0
-## explicit
 github.com/docker/go-units
-# github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
-## explicit
 # github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/eapache/go-resiliency v1.1.0
-## explicit
 github.com/eapache/go-resiliency/breaker
 # github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
-## explicit
 github.com/eapache/go-xerial-snappy
 # github.com/eapache/queue v1.1.0
-## explicit
 github.com/eapache/queue
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
@@ -251,22 +199,16 @@ github.com/evanphx/json-patch
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 github.com/exponent-io/jsonpath
 # github.com/fatih/color v1.7.0
-## explicit
 github.com/fatih/color
-# github.com/frankban/quicktest v1.7.2
-## explicit
 # github.com/gdamore/encoding v1.0.0
 github.com/gdamore/encoding
 # github.com/gdamore/tcell v1.1.3
-## explicit
 github.com/gdamore/tcell
 github.com/gdamore/tcell/terminfo
 github.com/gdamore/tcell/terminfo/dynamic
 # github.com/gentlemanautomaton/graceful v0.0.0-20170727140743-803ae396410c
-## explicit
 github.com/gentlemanautomaton/graceful
 # github.com/ghodss/yaml v1.0.0
-## explicit
 github.com/ghodss/yaml
 # github.com/go-logfmt/logfmt v0.4.0
 github.com/go-logfmt/logfmt
@@ -278,10 +220,6 @@ github.com/go-openapi/jsonreference
 github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.5
 github.com/go-openapi/swag
-# github.com/go-sql-driver/mysql v1.5.0
-## explicit
-# github.com/gofrs/uuid v3.2.0+incompatible
-## explicit
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/proto
@@ -291,7 +229,6 @@ github.com/gogo/protobuf/types
 # github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.3.2
-## explicit
 github.com/golang/protobuf/descriptor
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
@@ -303,12 +240,10 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
-## explicit
 github.com/golang/snappy
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/go-cmp v0.3.1
-## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -316,23 +251,18 @@ github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/go-github v17.0.0+incompatible
-## explicit
 github.com/google/go-github/github
 # github.com/google/go-github/v29 v29.0.3
-## explicit
 github.com/google/go-github/v29/github
 # github.com/google/go-querystring v1.0.0
 github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
-## explicit
 github.com/google/shlex
 # github.com/google/uuid v1.1.1
-## explicit
 github.com/google/uuid
 # github.com/google/wire v0.3.0
-## explicit
 github.com/google/wire
 # github.com/googleapis/gnostic v0.1.0
 github.com/googleapis/gnostic/OpenAPIv2
@@ -347,25 +277,18 @@ github.com/gophercloud/gophercloud/openstack/identity/v3/tokens
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/mux v1.7.2
-## explicit
 github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.0
-## explicit
 github.com/gorilla/websocket
 # github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
-## explicit
 github.com/gregjones/httpcache
 github.com/gregjones/httpcache/diskcache
 # github.com/grpc-ecosystem/grpc-gateway v1.11.3
-## explicit
 github.com/grpc-ecosystem/grpc-gateway/internal
 github.com/grpc-ecosystem/grpc-gateway/runtime
 github.com/grpc-ecosystem/grpc-gateway/utilities
 # github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
-## explicit
 github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc
-# github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
-## explicit
 # github.com/hashicorp/golang-lru v0.5.1
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
@@ -373,19 +296,11 @@ github.com/hashicorp/golang-lru/simplelru
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jinzhu/gorm v1.9.12
-## explicit
-# github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7
-## explicit
 # github.com/jonboulle/clockwork v0.1.0
-## explicit
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.8
-## explicit
 github.com/json-iterator/go
 github.com/json-iterator/go/extra
-# github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
-## explicit
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
@@ -393,7 +308,6 @@ github.com/kr/logfmt
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/liggitt/tabwriter
 # github.com/lightstep/lightstep-tracer-go v0.15.6
-## explicit
 github.com/lightstep/lightstep-tracer-go
 github.com/lightstep/lightstep-tracer-go/collectorpb
 github.com/lightstep/lightstep-tracer-go/lightstep/rand
@@ -401,7 +315,6 @@ github.com/lightstep/lightstep-tracer-go/lightstep_thrift
 github.com/lightstep/lightstep-tracer-go/lightsteppb
 github.com/lightstep/lightstep-tracer-go/thrift_0_9_2/lib/go/thrift
 # github.com/looplab/tarjan v0.0.0-20161115091335-9cc6d6cebfb5
-## explicit
 github.com/looplab/tarjan
 # github.com/lucasb-eyer/go-colorful v1.0.2
 github.com/lucasb-eyer/go-colorful
@@ -409,31 +322,21 @@ github.com/lucasb-eyer/go-colorful
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
-# github.com/marstr/guid v1.1.0
-## explicit
 # github.com/mattn/go-colorable v0.1.4
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.10
-## explicit
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.4
 github.com/mattn/go-runewidth
-# github.com/mattn/go-sqlite3 v2.0.2+incompatible
-## explicit
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/pkcs11 v0.0.0-20180817151620-df0db7a16a9e
-## explicit
 github.com/miekg/pkcs11
 # github.com/mitchellh/go-homedir v1.1.0
-## explicit
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
-# github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f
-## explicit
 # github.com/moby/buildkit v0.6.3 => github.com/zachbadgett/buildkit v0.6.2-0.20191220071605-814e2794095f
-## explicit
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types
 github.com/moby/buildkit/client/llb
@@ -463,15 +366,10 @@ github.com/moby/buildkit/util/system
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
-## explicit
 github.com/modern-go/reflect2
 # github.com/morikuni/aec v1.0.0
-## explicit
 github.com/morikuni/aec
-# github.com/ncw/swift v1.0.47
-## explicit
 # github.com/opencontainers/go-digest v1.0.0-rc1
-## explicit
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/image-spec/specs-go
@@ -480,18 +378,14 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
 # github.com/opencontainers/runtime-spec v1.0.1
-## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492
-## explicit
 github.com/opentracing-contrib/go-observer
 # github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e
-## explicit
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
 # github.com/openzipkin/zipkin-go-opentracing v0.3.2
-## explicit
 github.com/openzipkin/zipkin-go-opentracing
 github.com/openzipkin/zipkin-go-opentracing/flag
 github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/scribe
@@ -501,14 +395,11 @@ github.com/openzipkin/zipkin-go-opentracing/wire
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pierrec/lz4 v2.4.0+incompatible
-## explicit
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15
-## explicit
 github.com/pkg/browser
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -527,37 +418,26 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
-## explicit
 github.com/rcrowley/go-metrics
 # github.com/rivo/tview v0.0.0-20180926100353-bc39bf8d245d
-## explicit
 github.com/rivo/tview
 # github.com/russross/blackfriday v1.5.2
 github.com/russross/blackfriday
-# github.com/satori/go.uuid v1.2.0
-## explicit
 # github.com/schollz/closestmatch v2.1.0+incompatible
-## explicit
 github.com/schollz/closestmatch
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
-# github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
-## explicit
 # github.com/spf13/cobra v0.0.5
-## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/pflag v1.0.5
-## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.4.0
-## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 github.com/syndtr/gocapability/capability
 # github.com/theupdateframework/notary v0.6.1
-## explicit
 github.com/theupdateframework/notary
 github.com/theupdateframework/notary/client
 github.com/theupdateframework/notary/client/changelist
@@ -575,10 +455,8 @@ github.com/theupdateframework/notary/tuf/validation
 # github.com/tonistiigi/fsutil v0.0.0-20191018213012-0f039a052ca1
 github.com/tonistiigi/fsutil/types
 # github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
-## explicit
 github.com/tonistiigi/units
 # github.com/uber/jaeger-client-go v2.21.1+incompatible
-## explicit
 github.com/uber/jaeger-client-go
 github.com/uber/jaeger-client-go/config
 github.com/uber/jaeger-client-go/internal/baggage
@@ -597,32 +475,25 @@ github.com/uber/jaeger-client-go/thrift-gen/zipkincore
 github.com/uber/jaeger-client-go/transport
 github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.2.0+incompatible
-## explicit
 github.com/uber/jaeger-lib/metrics
 # github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa
-## explicit
 github.com/whilp/git-urls
 # github.com/windmilleng/fsevents v0.0.0-20190206153914-2ad75e5ddeed
-## explicit
 github.com/windmilleng/fsevents
 # github.com/windmilleng/fsnotify v1.4.7
-## explicit
 github.com/windmilleng/fsnotify
 # github.com/windmilleng/wmclient v0.0.0-20200205181513-6c994672553a
-## explicit
 github.com/windmilleng/wmclient/pkg/analytics
 github.com/windmilleng/wmclient/pkg/dirs
 github.com/windmilleng/wmclient/pkg/env
 github.com/windmilleng/wmclient/pkg/os/temp
 # go.opencensus.io v0.22.2
-## explicit
 go.opencensus.io
 go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
 # go.opentelemetry.io/otel v0.2.0
-## explicit
 go.opentelemetry.io/otel/api/core
 go.opentelemetry.io/otel/api/trace
 go.opentelemetry.io/otel/sdk
@@ -631,7 +502,6 @@ go.opentelemetry.io/otel/sdk/internal
 go.opentelemetry.io/otel/sdk/trace
 go.opentelemetry.io/otel/sdk/trace/internal
 # go.starlark.net v0.0.0-20191021185836-28350e608555
-## explicit
 go.starlark.net/internal/compile
 go.starlark.net/internal/spell
 go.starlark.net/resolve
@@ -639,7 +509,6 @@ go.starlark.net/starlark
 go.starlark.net/starlarkstruct
 go.starlark.net/syntax
 # go.uber.org/atomic v1.5.1
-## explicit
 go.uber.org/atomic
 # golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 => golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 golang.org/x/crypto/cast5
@@ -660,11 +529,9 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
-## explicit
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
-## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -682,11 +549,9 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20191220142924-d4481acd189f
-## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/unix
 golang.org/x/sys/windows
@@ -706,7 +571,6 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2
-## explicit
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter
@@ -721,16 +585,12 @@ google.golang.org/appengine/internal/modules
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
-# google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8
-## explicit
 # google.golang.org/genproto v0.0.0-20191220175831-5c49e3ecc1c1
-## explicit
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.26.0
-## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -770,21 +630,12 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # gopkg.in/d4l3k/messagediff.v1 v1.2.1
-## explicit
 gopkg.in/d4l3k/messagediff.v1
-# gopkg.in/dancannon/gorethink.v3 v3.0.5
-## explicit
-# gopkg.in/fatih/pool.v2 v2.0.0
-## explicit
-# gopkg.in/gorethink/gorethink.v3 v3.0.5
-## explicit
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
-## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.0
-## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -829,7 +680,6 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.18.0
-## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -869,6 +719,7 @@ k8s.io/apimachinery/pkg/util/jsonmergepatch
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/remotecommand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
@@ -883,7 +734,6 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/cli-runtime v0.18.0
-## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps
@@ -897,7 +747,6 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.18.0 => github.com/windmilleng/client-go v0.0.0-20200326150806-41017343d309
-## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
@@ -1126,29 +975,30 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.18.0
-## explicit
 k8s.io/component-base/cli/flag
 k8s.io/component-base/version
 # k8s.io/klog v1.0.0
-## explicit
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 # k8s.io/kubectl v0.18.0
-## explicit
 k8s.io/kubectl/pkg/cmd/apply
+k8s.io/kubectl/pkg/cmd/create
 k8s.io/kubectl/pkg/cmd/delete
 k8s.io/kubectl/pkg/cmd/replace
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/cmd/util/editor
 k8s.io/kubectl/pkg/cmd/util/editor/crlf
 k8s.io/kubectl/pkg/cmd/wait
+k8s.io/kubectl/pkg/generate
+k8s.io/kubectl/pkg/generate/versioned
 k8s.io/kubectl/pkg/generated
 k8s.io/kubectl/pkg/rawhttp
 k8s.io/kubectl/pkg/scheme
 k8s.io/kubectl/pkg/util
+k8s.io/kubectl/pkg/util/hash
 k8s.io/kubectl/pkg/util/i18n
 k8s.io/kubectl/pkg/util/interrupt
 k8s.io/kubectl/pkg/util/logs
@@ -1163,7 +1013,6 @@ k8s.io/utils/exec
 k8s.io/utils/integer
 k8s.io/utils/trace
 # sigs.k8s.io/kustomize v2.0.3+incompatible
-## explicit
 sigs.k8s.io/kustomize/pkg/commands/build
 sigs.k8s.io/kustomize/pkg/constants
 sigs.k8s.io/kustomize/pkg/expansion
@@ -1189,13 +1038,6 @@ sigs.k8s.io/kustomize/pkg/types
 # sigs.k8s.io/structured-merge-diff/v3 v3.0.0
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
-## explicit
 sigs.k8s.io/yaml
 # vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787
-## explicit
 vbom.ml/util/sortorder
-# github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.4.3+incompatible
-# github.com/evanphx/json-patch => github.com/windmilleng/json-patch/v4 v4.8.0
-# github.com/moby/buildkit => github.com/zachbadgett/buildkit v0.6.2-0.20191220071605-814e2794095f
-# golang.org/x/crypto => golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
-# k8s.io/client-go => github.com/windmilleng/client-go v0.0.0-20200326150806-41017343d309

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,12 @@
 # cloud.google.com/go v0.38.0
 cloud.google.com/go/compute/metadata
+# github.com/Azure/azure-sdk-for-go v16.2.1+incompatible
+## explicit
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
+# github.com/Azure/go-autorest v10.8.1+incompatible => github.com/Azure/go-autorest v12.4.3+incompatible
+## explicit
 # github.com/Azure/go-autorest/autorest v0.9.0
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
@@ -42,23 +46,49 @@ github.com/Microsoft/hcsshim/osversion
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
+# github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d
+## explicit
 # github.com/Shopify/sarama v1.18.0
+## explicit
 github.com/Shopify/sarama
+# github.com/Shopify/toxiproxy v2.1.4+incompatible
+## explicit
 # github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
+## explicit
 github.com/agl/ed25519
 github.com/agl/ed25519/edwards25519
 # github.com/apache/thrift v0.0.0-20171203172758-327ebb6c2b6d
+## explicit
 github.com/apache/thrift/lib/go/thrift
+# github.com/aws/aws-sdk-go v1.15.11
+## explicit
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
+# github.com/bitly/go-hostpool v0.1.0
+## explicit
 # github.com/blang/semver v3.5.1+incompatible
+## explicit
 github.com/blang/semver
+# github.com/bugsnag/bugsnag-go v1.5.3
+## explicit
+# github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b
+## explicit
+# github.com/bugsnag/panicwrap v1.2.0
+## explicit
+# github.com/cenkalti/backoff v2.2.1+incompatible
+## explicit
 # github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1
+## explicit
 github.com/chai2010/gettext-go/gettext
 github.com/chai2010/gettext-go/gettext/mo
 github.com/chai2010/gettext-go/gettext/plural
 github.com/chai2010/gettext-go/gettext/po
+# github.com/cloudflare/cfssl v1.4.1
+## explicit
+# github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
+## explicit
 # github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901
+## explicit
 github.com/containerd/cgroups/stats/v1
 # github.com/containerd/containerd v1.3.1-0.20191217142032-9b5581cc9c5b
 github.com/containerd/containerd/archive/compression
@@ -82,20 +112,30 @@ github.com/containerd/containerd/snapshots
 github.com/containerd/containerd/sys
 github.com/containerd/containerd/version
 # github.com/containerd/continuity v0.0.0-20191214063359-1097c8bae83b
+## explicit
 github.com/containerd/continuity/fs
 github.com/containerd/continuity/syscallx
 github.com/containerd/continuity/sysx
 # github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c
+## explicit
 github.com/containerd/ttrpc
 # github.com/cpuguy83/go-md2man v1.0.10
 github.com/cpuguy83/go-md2man/md2man
+# github.com/d4l3k/messagediff v1.2.1
+## explicit
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/denisbrodbeck/machineid v1.0.0
 github.com/denisbrodbeck/machineid
+# github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba
+## explicit
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
+# github.com/dnaeon/go-vcr v1.0.1
+## explicit
 # github.com/docker/cli v0.0.0-20191220145525-ba63a92655c0
+## explicit
 github.com/docker/cli/cli/command
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
@@ -117,6 +157,7 @@ github.com/docker/cli/cli/trust
 github.com/docker/cli/cli/version
 github.com/docker/cli/opts
 # github.com/docker/distribution v2.7.1+incompatible
+## explicit
 github.com/docker/distribution
 github.com/docker/distribution/digestset
 github.com/docker/distribution/manifest
@@ -134,6 +175,7 @@ github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
 # github.com/docker/docker v1.4.2-0.20191210192822-1347481b9eb5
+## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
@@ -170,26 +212,36 @@ github.com/docker/docker/registry
 github.com/docker/docker/registry/resumable
 github.com/docker/docker/rootless
 # github.com/docker/docker-credential-helpers v0.6.3
+## explicit
 github.com/docker/docker-credential-helpers/client
 github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go v1.5.1-1
+## explicit
 github.com/docker/go/canonical/json
 # github.com/docker/go-connections v0.4.0
+## explicit
 github.com/docker/go-connections/nat
 github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
+## explicit
 github.com/docker/go-metrics
 # github.com/docker/go-units v0.4.0
+## explicit
 github.com/docker/go-units
+# github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
+## explicit
 # github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/eapache/go-resiliency v1.1.0
+## explicit
 github.com/eapache/go-resiliency/breaker
 # github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
+## explicit
 github.com/eapache/go-xerial-snappy
 # github.com/eapache/queue v1.1.0
+## explicit
 github.com/eapache/queue
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
@@ -199,16 +251,22 @@ github.com/evanphx/json-patch
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 github.com/exponent-io/jsonpath
 # github.com/fatih/color v1.7.0
+## explicit
 github.com/fatih/color
+# github.com/frankban/quicktest v1.7.2
+## explicit
 # github.com/gdamore/encoding v1.0.0
 github.com/gdamore/encoding
 # github.com/gdamore/tcell v1.1.3
+## explicit
 github.com/gdamore/tcell
 github.com/gdamore/tcell/terminfo
 github.com/gdamore/tcell/terminfo/dynamic
 # github.com/gentlemanautomaton/graceful v0.0.0-20170727140743-803ae396410c
+## explicit
 github.com/gentlemanautomaton/graceful
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/go-logfmt/logfmt v0.4.0
 github.com/go-logfmt/logfmt
@@ -220,6 +278,10 @@ github.com/go-openapi/jsonreference
 github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.5
 github.com/go-openapi/swag
+# github.com/go-sql-driver/mysql v1.5.0
+## explicit
+# github.com/gofrs/uuid v3.2.0+incompatible
+## explicit
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/proto
@@ -229,6 +291,7 @@ github.com/gogo/protobuf/types
 # github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.3.2
+## explicit
 github.com/golang/protobuf/descriptor
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
@@ -240,10 +303,12 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
+## explicit
 github.com/golang/snappy
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/go-cmp v0.3.1
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -251,18 +316,23 @@ github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/go-github v17.0.0+incompatible
+## explicit
 github.com/google/go-github/github
 # github.com/google/go-github/v29 v29.0.3
+## explicit
 github.com/google/go-github/v29/github
 # github.com/google/go-querystring v1.0.0
 github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
+## explicit
 github.com/google/shlex
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/google/wire v0.3.0
+## explicit
 github.com/google/wire
 # github.com/googleapis/gnostic v0.1.0
 github.com/googleapis/gnostic/OpenAPIv2
@@ -277,18 +347,25 @@ github.com/gophercloud/gophercloud/openstack/identity/v3/tokens
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/mux v1.7.2
+## explicit
 github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.0
+## explicit
 github.com/gorilla/websocket
 # github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
+## explicit
 github.com/gregjones/httpcache
 github.com/gregjones/httpcache/diskcache
 # github.com/grpc-ecosystem/grpc-gateway v1.11.3
+## explicit
 github.com/grpc-ecosystem/grpc-gateway/internal
 github.com/grpc-ecosystem/grpc-gateway/runtime
 github.com/grpc-ecosystem/grpc-gateway/utilities
 # github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
+## explicit
 github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc
+# github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
+## explicit
 # github.com/hashicorp/golang-lru v0.5.1
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
@@ -296,11 +373,19 @@ github.com/hashicorp/golang-lru/simplelru
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
+# github.com/jinzhu/gorm v1.9.12
+## explicit
+# github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7
+## explicit
 # github.com/jonboulle/clockwork v0.1.0
+## explicit
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.8
+## explicit
 github.com/json-iterator/go
 github.com/json-iterator/go/extra
+# github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
+## explicit
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
@@ -308,6 +393,7 @@ github.com/kr/logfmt
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/liggitt/tabwriter
 # github.com/lightstep/lightstep-tracer-go v0.15.6
+## explicit
 github.com/lightstep/lightstep-tracer-go
 github.com/lightstep/lightstep-tracer-go/collectorpb
 github.com/lightstep/lightstep-tracer-go/lightstep/rand
@@ -315,6 +401,7 @@ github.com/lightstep/lightstep-tracer-go/lightstep_thrift
 github.com/lightstep/lightstep-tracer-go/lightsteppb
 github.com/lightstep/lightstep-tracer-go/thrift_0_9_2/lib/go/thrift
 # github.com/looplab/tarjan v0.0.0-20161115091335-9cc6d6cebfb5
+## explicit
 github.com/looplab/tarjan
 # github.com/lucasb-eyer/go-colorful v1.0.2
 github.com/lucasb-eyer/go-colorful
@@ -322,21 +409,31 @@ github.com/lucasb-eyer/go-colorful
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+# github.com/marstr/guid v1.1.0
+## explicit
 # github.com/mattn/go-colorable v0.1.4
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.10
+## explicit
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.4
 github.com/mattn/go-runewidth
+# github.com/mattn/go-sqlite3 v2.0.2+incompatible
+## explicit
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/pkcs11 v0.0.0-20180817151620-df0db7a16a9e
+## explicit
 github.com/miekg/pkcs11
 # github.com/mitchellh/go-homedir v1.1.0
+## explicit
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
+# github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f
+## explicit
 # github.com/moby/buildkit v0.6.3 => github.com/zachbadgett/buildkit v0.6.2-0.20191220071605-814e2794095f
+## explicit
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types
 github.com/moby/buildkit/client/llb
@@ -366,10 +463,15 @@ github.com/moby/buildkit/util/system
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
+## explicit
 github.com/modern-go/reflect2
 # github.com/morikuni/aec v1.0.0
+## explicit
 github.com/morikuni/aec
+# github.com/ncw/swift v1.0.47
+## explicit
 # github.com/opencontainers/go-digest v1.0.0-rc1
+## explicit
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/image-spec/specs-go
@@ -378,14 +480,18 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
 # github.com/opencontainers/runtime-spec v1.0.1
+## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492
+## explicit
 github.com/opentracing-contrib/go-observer
 # github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e
+## explicit
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
 # github.com/openzipkin/zipkin-go-opentracing v0.3.2
+## explicit
 github.com/openzipkin/zipkin-go-opentracing
 github.com/openzipkin/zipkin-go-opentracing/flag
 github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/scribe
@@ -395,11 +501,14 @@ github.com/openzipkin/zipkin-go-opentracing/wire
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pierrec/lz4 v2.4.0+incompatible
+## explicit
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15
+## explicit
 github.com/pkg/browser
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -418,26 +527,37 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
+## explicit
 github.com/rcrowley/go-metrics
 # github.com/rivo/tview v0.0.0-20180926100353-bc39bf8d245d
+## explicit
 github.com/rivo/tview
 # github.com/russross/blackfriday v1.5.2
 github.com/russross/blackfriday
+# github.com/satori/go.uuid v1.2.0
+## explicit
 # github.com/schollz/closestmatch v2.1.0+incompatible
+## explicit
 github.com/schollz/closestmatch
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
+# github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
+## explicit
 # github.com/spf13/cobra v0.0.5
+## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 github.com/syndtr/gocapability/capability
 # github.com/theupdateframework/notary v0.6.1
+## explicit
 github.com/theupdateframework/notary
 github.com/theupdateframework/notary/client
 github.com/theupdateframework/notary/client/changelist
@@ -455,8 +575,10 @@ github.com/theupdateframework/notary/tuf/validation
 # github.com/tonistiigi/fsutil v0.0.0-20191018213012-0f039a052ca1
 github.com/tonistiigi/fsutil/types
 # github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
+## explicit
 github.com/tonistiigi/units
 # github.com/uber/jaeger-client-go v2.21.1+incompatible
+## explicit
 github.com/uber/jaeger-client-go
 github.com/uber/jaeger-client-go/config
 github.com/uber/jaeger-client-go/internal/baggage
@@ -475,25 +597,32 @@ github.com/uber/jaeger-client-go/thrift-gen/zipkincore
 github.com/uber/jaeger-client-go/transport
 github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.2.0+incompatible
+## explicit
 github.com/uber/jaeger-lib/metrics
 # github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa
+## explicit
 github.com/whilp/git-urls
 # github.com/windmilleng/fsevents v0.0.0-20190206153914-2ad75e5ddeed
+## explicit
 github.com/windmilleng/fsevents
 # github.com/windmilleng/fsnotify v1.4.7
+## explicit
 github.com/windmilleng/fsnotify
 # github.com/windmilleng/wmclient v0.0.0-20200205181513-6c994672553a
+## explicit
 github.com/windmilleng/wmclient/pkg/analytics
 github.com/windmilleng/wmclient/pkg/dirs
 github.com/windmilleng/wmclient/pkg/env
 github.com/windmilleng/wmclient/pkg/os/temp
 # go.opencensus.io v0.22.2
+## explicit
 go.opencensus.io
 go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
 # go.opentelemetry.io/otel v0.2.0
+## explicit
 go.opentelemetry.io/otel/api/core
 go.opentelemetry.io/otel/api/trace
 go.opentelemetry.io/otel/sdk
@@ -502,6 +631,7 @@ go.opentelemetry.io/otel/sdk/internal
 go.opentelemetry.io/otel/sdk/trace
 go.opentelemetry.io/otel/sdk/trace/internal
 # go.starlark.net v0.0.0-20191021185836-28350e608555
+## explicit
 go.starlark.net/internal/compile
 go.starlark.net/internal/spell
 go.starlark.net/resolve
@@ -509,6 +639,7 @@ go.starlark.net/starlark
 go.starlark.net/starlarkstruct
 go.starlark.net/syntax
 # go.uber.org/atomic v1.5.1
+## explicit
 go.uber.org/atomic
 # golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 => golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 golang.org/x/crypto/cast5
@@ -529,9 +660,11 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+## explicit
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -549,9 +682,11 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20191220142924-d4481acd189f
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/unix
 golang.org/x/sys/windows
@@ -571,6 +706,7 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2
+## explicit
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter
@@ -585,12 +721,16 @@ google.golang.org/appengine/internal/modules
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
+# google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8
+## explicit
 # google.golang.org/genproto v0.0.0-20191220175831-5c49e3ecc1c1
+## explicit
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.26.0
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -630,12 +770,21 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # gopkg.in/d4l3k/messagediff.v1 v1.2.1
+## explicit
 gopkg.in/d4l3k/messagediff.v1
+# gopkg.in/dancannon/gorethink.v3 v3.0.5
+## explicit
+# gopkg.in/fatih/pool.v2 v2.0.0
+## explicit
+# gopkg.in/gorethink/gorethink.v3 v3.0.5
+## explicit
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
+## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.0
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -680,6 +829,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.18.0
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -734,6 +884,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/cli-runtime v0.18.0
+## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps
@@ -747,6 +898,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.18.0 => github.com/windmilleng/client-go v0.0.0-20200326150806-41017343d309
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
@@ -975,15 +1127,18 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.18.0
+## explicit
 k8s.io/component-base/cli/flag
 k8s.io/component-base/version
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 # k8s.io/kubectl v0.18.0
+## explicit
 k8s.io/kubectl/pkg/cmd/apply
 k8s.io/kubectl/pkg/cmd/create
 k8s.io/kubectl/pkg/cmd/delete
@@ -1013,6 +1168,7 @@ k8s.io/utils/exec
 k8s.io/utils/integer
 k8s.io/utils/trace
 # sigs.k8s.io/kustomize v2.0.3+incompatible
+## explicit
 sigs.k8s.io/kustomize/pkg/commands/build
 sigs.k8s.io/kustomize/pkg/constants
 sigs.k8s.io/kustomize/pkg/expansion
@@ -1038,6 +1194,13 @@ sigs.k8s.io/kustomize/pkg/types
 # sigs.k8s.io/structured-merge-diff/v3 v3.0.0
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787
+## explicit
 vbom.ml/util/sortorder
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.4.3+incompatible
+# github.com/evanphx/json-patch => github.com/windmilleng/json-patch/v4 v4.8.0
+# github.com/moby/buildkit => github.com/zachbadgett/buildkit v0.6.2-0.20191220071605-814e2794095f
+# golang.org/x/crypto => golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
+# k8s.io/client-go => github.com/windmilleng/client-go v0.0.0-20200326150806-41017343d309


### PR DESCRIPTION
Fixes #2173

### Problem

`kubectl apply` saves a copy of the previous config in `metadata.annotations`, but `metadata.annotations` has a max length of 256k. This means that tilt is unable to apply any objects whose config is >256k (e.g., big configMaps)

### Solution

When kubectl tells us that metadata.annotations is too long, fall back to delete + create.
Log a message like this:
```
uncategorized │      Falling back to 'kubectl delete && create': The ConfigMap "postgres-config" is invalid: metadata.annotations: Too long: must have at most 262144 bytes (https://github.com/kubernetes/kubectl/issues/712)
Succeeded!
```

### Notes

1. I changed the fallback from `delete && apply` to `delete && create` since, well, `apply` would just fail with the same error! We could have separate fallback paths depending on reason, but I'm not sure how much we really care about apply vs create.
2. This has the potentially unfortunate consequence that a single large configmap in uncategorized will cause *all* uncategorized yaml (or, at least, all mutable uncategorized yaml) to be deleted + created, since we do it all as one lump. We could fix this by applying each entity one at a time, but it's not clear that's worth it.