### PR TITLE
store: add named execution modes

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -152,9 +152,15 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		})
 	}
 
+	engineMode := store.EngineModeUp
+	if !c.watch {
+		engineMode = store.EngineModeApply
+	}
+
 	g.Go(func() error {
 		defer cancel()
-		return upper.Start(ctx, args, cmdUpDeps.TiltBuild, c.watch, c.fileName, hudEnabled, a.UserOpt(), cmdUpDeps.Token, string(cmdUpDeps.CloudAddress))
+		return upper.Start(ctx, args, cmdUpDeps.TiltBuild, engineMode,
+			c.fileName, hudEnabled, a.UserOpt(), cmdUpDeps.Token, string(cmdUpDeps.CloudAddress))
 	})
 
 	err = g.Wait()

--- a/internal/containerupdate/synclet_manager.go
+++ b/internal/containerupdate/synclet_manager.go
@@ -91,7 +91,7 @@ func (sm SyncletManager) diff(ctx context.Context, st store.RStore) (setup []syn
 	defer st.RUnlockState()
 
 	// We don't need synclets if we're not watching the FS for changes.
-	if !state.WatchFiles {
+	if !state.EngineMode.WatchesFiles() {
 		return
 	}
 

--- a/internal/containerupdate/synclet_manager_test.go
+++ b/internal/containerupdate/synclet_manager_test.go
@@ -26,7 +26,6 @@ func TestSyncletSubscriptions(t *testing.T) {
 	defer f.TearDown()
 
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
 		model.Manifest{Name: "server"},
 		store.Pod{

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -19,7 +19,7 @@ func NewErrorAction(err error) store.ErrorAction {
 }
 
 type InitAction struct {
-	WatchFiles   bool
+	EngineMode   store.EngineMode
 	TiltfilePath string
 	ConfigFiles  []string
 	UserArgs     []string

--- a/internal/engine/docker_compose_event_watcher.go
+++ b/internal/engine/docker_compose_event_watcher.go
@@ -24,7 +24,7 @@ func NewDockerComposeEventWatcher(dcc dockercompose.DockerComposeClient) *Docker
 func (w *DockerComposeEventWatcher) needsWatch(st store.RStore) bool {
 	state := st.RLockState()
 	defer st.RUnlockState()
-	return state.WatchFiles && !w.watching
+	return state.EngineMode.WatchesRuntime() && !w.watching
 }
 
 func (w *DockerComposeEventWatcher) OnChange(ctx context.Context, st store.RStore) {

--- a/internal/engine/exit/controller_test.go
+++ b/internal/engine/exit/controller_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestExitControlAllSuccess(t *testing.T) {
-	f := newFixture(t)
+	f := newFixture(t, store.EngineModeApply)
 	defer f.TearDown()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -48,7 +48,7 @@ func TestExitControlAllSuccess(t *testing.T) {
 }
 
 func TestExitControlFirstFailure(t *testing.T) {
-	f := newFixture(t)
+	f := newFixture(t, store.EngineModeApply)
 	defer f.TearDown()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -82,10 +82,14 @@ type fixture struct {
 	c     *Controller
 }
 
-func newFixture(t *testing.T) *fixture {
+func newFixture(t *testing.T, engineMode store.EngineMode) *fixture {
 	f := tempdir.NewTempDirFixture(t)
 
 	st := NewTestingStore()
+	st.WithState(func(state *store.EngineState) {
+		state.EngineMode = engineMode
+	})
+
 	c := NewController()
 	ctx := context.Background()
 

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -191,7 +191,6 @@ func (f *ewmFixture) TearDown() {
 
 func (f *ewmFixture) addManifest(manifestName model.ManifestName) model.Manifest {
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 
 	m := manifestbuilder.New(f, manifestName).
 		WithK8sYAML(testyaml.SanchoYAML).

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -269,7 +269,6 @@ func TestPodStatus(t *testing.T) {
 
 func (f *pwFixture) addManifestWithSelectors(manifestName string, ls ...labels.Selector) model.Manifest {
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 	m := manifestbuilder.New(f, model.ManifestName(manifestName)).
 		WithK8sYAML(testyaml.SanchoYAML).
 		WithK8sPodSelectors(ls).

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -81,7 +81,6 @@ func TestServiceWatchUIDDelayed(t *testing.T) {
 func (f *swFixture) addManifest(manifestName string) model.Manifest {
 	state := f.store.LockMutableStateForTesting()
 	defer f.store.UnlockMutableState()
-	state.WatchFiles = true
 	dt := model.K8sTarget{Name: model.TargetName(manifestName)}
 	m := model.Manifest{Name: model.ManifestName(manifestName)}.WithDeployTarget(dt)
 	state.UpsertManifestTarget(store.NewManifestTarget(m))

--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -37,7 +37,7 @@ func createWatcherTaskList(state store.EngineState, knownDeployedUIDs map[types.
 		}
 	}
 
-	needsWatch := atLeastOneK8s && state.WatchFiles
+	needsWatch := atLeastOneK8s && state.EngineMode.WatchesRuntime()
 	return watcherTaskList{
 		needsWatch: needsWatch,
 		newUIDs:    newUIDs,

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -33,8 +33,7 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 	state := st.RLockState()
 	defer st.RUnlockState()
 
-	// If we're not watching the FS for changes, then don't bother watching logs.
-	if !state.WatchFiles {
+	if !state.EngineMode.WatchesRuntime() {
 		return nil, nil
 	}
 

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -43,8 +43,7 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 	state := st.RLockState()
 	defer st.RUnlockState()
 
-	// If we're not watching the FS for changes, then don't bother watching logs.
-	if !state.WatchFiles {
+	if !state.EngineMode.WatchesRuntime() {
 		return nil, nil
 	}
 

--- a/internal/engine/runtimelog/podlogmanager_test.go
+++ b/internal/engine/runtimelog/podlogmanager_test.go
@@ -36,7 +36,6 @@ func TestLogs(t *testing.T) {
 	start := time.Now()
 	state := f.store.LockMutableStateForTesting()
 	state.TiltStartTime = start
-	state.WatchFiles = true
 
 	p := store.Pod{
 		PodID: podID,
@@ -59,7 +58,6 @@ func TestLogActions(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!\ngoodbye world!\n")
 
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 
 	p := store.Pod{
 		PodID: podID,
@@ -81,7 +79,6 @@ func TestLogsFailed(t *testing.T) {
 	f.kClient.ContainerLogsError = fmt.Errorf("my-error")
 
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 
 	p := store.Pod{
 		PodID: podID,
@@ -104,7 +101,6 @@ func TestLogsCanceledUnexpectedly(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!\n")
 
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 
 	p := store.Pod{
 		PodID: podID,
@@ -133,7 +129,6 @@ func TestMultiContainerLogs(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(podID, "cont2", "goodbye world!")
 
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 
 	p := store.Pod{
 		PodID: podID,
@@ -167,7 +162,6 @@ func TestContainerPrefixes(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(pID2, cNameNoPrefix, "hello jupiter!")
 
 	state := f.store.LockMutableStateForTesting()
-	state.WatchFiles = true
 
 	podMultiC := store.Pod{
 		PodID: pID1,
@@ -225,7 +219,6 @@ func TestLogsByPodPhase(t *testing.T) {
 			f.kClient.SetLogsForPodContainer(podID, cName, "hello world!")
 
 			state := f.store.LockMutableStateForTesting()
-			state.WatchFiles = true
 
 			p := store.Pod{
 				PodID: podID,

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -89,7 +89,7 @@ func (u Upper) Start(
 	ctx context.Context,
 	args []string,
 	b model.TiltBuild,
-	watch bool,
+	engineMode store.EngineMode,
 	fileName string,
 	hudEnabled bool,
 	analyticsUserOpt analytics.Opt,
@@ -110,7 +110,7 @@ func (u Upper) Start(
 	configFiles := []string{absTfPath}
 
 	return u.Init(ctx, InitAction{
-		WatchFiles:       watch,
+		EngineMode:       engineMode,
 		TiltfilePath:     absTfPath,
 		ConfigFiles:      configFiles,
 		UserArgs:         args,
@@ -641,7 +641,7 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 	engineState.ConfigFiles = action.ConfigFiles
 	engineState.UserConfigState.Args = action.UserArgs
 	engineState.AnalyticsUserOpt = action.AnalyticsUserOpt
-	engineState.WatchFiles = action.WatchFiles
+	engineState.EngineMode = action.EngineMode
 	engineState.CloudAddress = action.CloudAddress
 	engineState.Token = action.Token
 	engineState.HUDEnabled = action.HUDEnabled

--- a/internal/engine/watchmanager_test.go
+++ b/internal/engine/watchmanager_test.go
@@ -230,7 +230,6 @@ func (f *wmFixture) SetManifestTarget(target model.DockerComposeTarget) {
 	mt := store.ManifestTarget{Manifest: m}
 	state := f.store.LockMutableStateForTesting()
 	state.UpsertManifestTarget(&mt)
-	state.WatchFiles = true
 	f.store.UnlockMutableState()
 	f.wm.OnChange(f.ctx, f.store)
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -33,7 +33,7 @@ type EngineState struct {
 	ManifestTargets map[model.ManifestName]*ManifestTarget
 
 	CurrentlyBuilding map[model.ManifestName]bool
-	WatchFiles        bool
+	EngineMode        EngineMode
 
 	// For synchronizing BuildController -- wait until engine records all builds started
 	// so far before starting another build

--- a/internal/store/mode.go
+++ b/internal/store/mode.go
@@ -1,0 +1,28 @@
+package store
+
+// Defines different executions modes for running Tilt,
+// and deciding when to exit.
+type EngineMode struct {
+	Name string
+}
+
+var (
+	// "up" is an interactive dev mode that watches files and resources.
+	EngineModeUp = EngineMode{}
+
+	// "apply" is a dev mode that builds and applies all resources,
+	// but doesn't wait to see if they come up.
+	EngineModeApply = EngineMode{Name: "apply"}
+)
+
+func (m EngineMode) WatchesFiles() bool {
+	return m == EngineModeUp
+}
+
+func (m EngineMode) WatchesRuntime() bool {
+	return m == EngineModeUp
+}
+
+func (m EngineMode) IsApplyMode() bool {
+	return m == EngineModeApply
+}


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/enginemode:

0f575734a07faa0d1bca4293b616a742a7191a0f (2020-03-31 12:30:42 -0400)
store: add named execution modes
Make the default mode ("up") on the CLI the same as the default mode in the engine

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics