### PR TITLE
k8s: make it easier to create a new K8sTarget with the right internal data structures set

### DIFF
--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -70,7 +70,7 @@ func TestDownArgs(t *testing.T) {
 }
 
 func newK8sManifest() []model.Manifest {
-	return []model.Manifest{model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{YAML: testyaml.SanchoYAML})}
+	return []model.Manifest{model.Manifest{Name: "fe"}.WithDeployTarget(k8s.MustTarget("fe", testyaml.SanchoYAML))}
 }
 
 func newDCManifest() []model.Manifest {

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/windmilleng/tilt/internal/container"
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/k8s/testyaml"
 	"github.com/windmilleng/tilt/internal/testutils/manifestbuilder"
 	"github.com/windmilleng/tilt/pkg/model"
@@ -263,7 +264,7 @@ func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {
 		WithBuildDetails(dbInfo).
 		WithDependencyIDs([]model.TargetID{baseImage.ID()})
 
-	kTarget := model.K8sTarget{YAML: SanchoYAML}.
+	kTarget := k8s.MustTarget("sancho", SanchoYAML).
 		WithDependencyIDs([]model.TargetID{srcImage.ID()})
 
 	return model.Manifest{Name: "sancho"}.

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1412,9 +1412,7 @@ func TestPodEventContainerStatusWithoutImage(t *testing.T) {
 	defer f.TearDown()
 	manifest := model.Manifest{
 		Name: model.ManifestName("foobar"),
-	}.WithDeployTarget(model.K8sTarget{
-		YAML: SanchoYAML,
-	})
+	}.WithDeployTarget(k8s.MustTarget("foobar", SanchoYAML))
 	ref := container.MustParseNamedTagged("dockerhub/we-didnt-build-this:foo")
 	f.Start([]model.Manifest{manifest})
 

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -1,12 +1,27 @@
 package k8s
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/pkg/errors"
 
 	"github.com/windmilleng/tilt/pkg/model"
 )
+
+func MustTarget(name model.TargetName, yaml string) model.K8sTarget {
+	entities, err := ParseYAML(strings.NewReader(yaml))
+	if err != nil {
+		panic(fmt.Errorf("MustTarget: %v", err))
+	}
+	target, err := NewTarget(name, entities, nil, nil, nil, nil)
+	if err != nil {
+		panic(fmt.Errorf("MustTarget: %v", err))
+	}
+	return target
+}
 
 func NewTarget(
 	name model.TargetName,

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
@@ -111,9 +112,11 @@ func (b ManifestBuilder) Build() model.Manifest {
 	}
 
 	if b.k8sYAML != "" {
+		k8sTarget := k8s.MustTarget(model.TargetName(b.name), b.k8sYAML)
+		k8sTarget.ExtraPodSelectors = b.k8sPodSelectors
 		return assembleK8s(
 			model.Manifest{Name: b.name, ResourceDependencies: rds},
-			model.K8sTarget{YAML: b.k8sYAML, ExtraPodSelectors: b.k8sPodSelectors},
+			k8sTarget,
 			b.iTargets...)
 	}
 

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/labels"
-
-	"github.com/windmilleng/tilt/internal/yaml"
 )
 
 type K8sTarget struct {
@@ -66,15 +64,6 @@ func (k8s K8sTarget) WithDependencyIDs(ids []TargetID) K8sTarget {
 
 func (k8s K8sTarget) WithRefInjectCounts(ric map[string]int) K8sTarget {
 	k8s.refInjectCounts = ric
-	return k8s
-}
-
-func (k8s K8sTarget) AppendYAML(y string) K8sTarget {
-	if k8s.YAML == "" {
-		k8s.YAML = y
-	} else {
-		k8s.YAML = yaml.ConcatYAML(k8s.YAML, y)
-	}
 	return k8s
 }
 


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/yaml:

33c9ffb9969fd93ac9c26d4925bf7266f9b64cfe (2020-04-01 12:30:17 -0400)
k8s: make it easier to create a new K8sTarget with the right internal data structures set

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics