### PR TITLE
snapshots: scroll to highlighted section on load

### DIFF
--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -441,12 +441,12 @@ it.each(["update", "mount"])(
         showManifestPrefix={false}
         handleSetHighlight={fakeHandleSetHighlight}
         handleClearHighlight={fakeHandleClearHighlight}
-        highlight={verb == "mount" ? highlight : null}
+        highlight={verb === "mount" ? highlight : null}
         isSnapshot={true}
       />
     )
 
-    if (verb == "update") {
+    if (verb === "update") {
       fakeScrollIntoView.mockClear()
       root.setProps({ highlight: highlight })
     }

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -423,40 +423,43 @@ it("renders highlighted lines", () => {
   expect(hLines).toHaveLength(2)
 })
 
-it.each(["update", "mount"])("scrolls to highlighted lines in snapshot", (verb) => {
-  const fakeScrollIntoView = jest.fn()
-  Element.prototype.scrollIntoView = fakeScrollIntoView
+it.each(["update", "mount"])(
+  "scrolls to highlighted lines in snapshot",
+  verb => {
+    const fakeScrollIntoView = jest.fn()
+    Element.prototype.scrollIntoView = fakeScrollIntoView
 
-  const highlight = {
-    beginningLogID: "2",
-    endingLogID: "3",
-    text: "foo\nbar",
+    const highlight = {
+      beginningLogID: "2",
+      endingLogID: "3",
+      text: "foo\nbar",
+    }
+    const root = mount<LogPane>(
+      <LogPane
+        manifestName={""}
+        logLines={logLinesFromString(longLog)}
+        showManifestPrefix={false}
+        handleSetHighlight={fakeHandleSetHighlight}
+        handleClearHighlight={fakeHandleClearHighlight}
+        highlight={verb == "mount" ? highlight : null}
+        isSnapshot={true}
+      />
+    )
+
+    if (verb == "update") {
+      fakeScrollIntoView.mockClear()
+      root.setProps({ highlight: highlight })
+    }
+
+    expect(root.instance().highlightRef.current).not.toBeNull()
+    expect(fakeScrollIntoView.mock.instances).toHaveLength(1)
+    expect(fakeScrollIntoView.mock.instances[0]).toBeInstanceOf(HTMLSpanElement)
+    expect(fakeScrollIntoView.mock.instances[0].innerHTML).toContain(
+      '[Tiltfile] Running `"whoami"`'
+    )
+    expect(fakeScrollIntoView).toBeCalledTimes(1)
   }
-  const root = mount<LogPane>(
-    <LogPane
-      manifestName={""}
-      logLines={logLinesFromString(longLog)}
-      showManifestPrefix={false}
-      handleSetHighlight={fakeHandleSetHighlight}
-      handleClearHighlight={fakeHandleClearHighlight}
-      highlight={verb == "mount" ? highlight : null}
-      isSnapshot={true}
-    />
-  )
-
-  if (verb == "update") {
-    fakeScrollIntoView.mockClear()
-    root.setProps({ highlight: highlight })
-  }
-
-  expect(root.instance().highlightRef.current).not.toBeNull()
-  expect(fakeScrollIntoView.mock.instances).toHaveLength(1)
-  expect(fakeScrollIntoView.mock.instances[0]).toBeInstanceOf(HTMLSpanElement)
-  expect(fakeScrollIntoView.mock.instances[0].innerHTML).toContain(
-    '[Tiltfile] Running `"whoami"`'
-  )
-  expect(fakeScrollIntoView).toBeCalledTimes(1)
-})
+)
 
 it("does not scroll to highlighted lines if not snapshot", () => {
   const fakeScrollIntoView = jest.fn()

--- a/web/src/LogPane.test.tsx
+++ b/web/src/LogPane.test.tsx
@@ -423,7 +423,7 @@ it("renders highlighted lines", () => {
   expect(hLines).toHaveLength(2)
 })
 
-it("scrolls to highlighted lines in snapshot", () => {
+it.each(["update", "mount"])("scrolls to highlighted lines in snapshot", (verb) => {
   const fakeScrollIntoView = jest.fn()
   Element.prototype.scrollIntoView = fakeScrollIntoView
 
@@ -439,10 +439,15 @@ it("scrolls to highlighted lines in snapshot", () => {
       showManifestPrefix={false}
       handleSetHighlight={fakeHandleSetHighlight}
       handleClearHighlight={fakeHandleClearHighlight}
-      highlight={highlight}
+      highlight={verb == "mount" ? highlight : null}
       isSnapshot={true}
     />
   )
+
+  if (verb == "update") {
+    fakeScrollIntoView.mockClear()
+    root.setProps({ highlight: highlight })
+  }
 
   expect(root.instance().highlightRef.current).not.toBeNull()
   expect(fakeScrollIntoView.mock.instances).toHaveLength(1)

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -156,6 +156,15 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
       this.scrollLastElementIntoView()
     }
 
+    if (
+      prevProps.highlight != this.props.highlight &&
+      this.props.highlight &&
+      this.props.isSnapshot &&
+      this.highlightRef.current
+    ) {
+      this.highlightRef.current.scrollIntoView()
+    }
+
     this.maybeExpandRenderWindow()
   }
 

--- a/web/src/LogPaneLine.tsx
+++ b/web/src/LogPaneLine.tsx
@@ -30,7 +30,7 @@ class LogPaneLine extends PureComponent<LogPaneProps> {
 
   scrollIntoView() {
     if (this.ref.current) {
-      this.ref.current.scrollIntoView()
+      this.ref.current.scrollIntoView({ block: "center" })
     }
   }
 


### PR DESCRIPTION
### Repro
Scroll up in the tilt log, highlight some lines, share a snapshot, open the snapshot.

### Expected
When opening the snapshot, the view scrolls to the highlighted lines

### Observed
The view scrolls to the bottom of the log

### Fix
It turns out that we're only scrolling to highlight on componentDidMount, except the highlight state is null at that point, so there's nothing to scroll to. So, let's scroll there on componentDidUpdate.
Also, when we call scrollIntoView, it was putting the top of the highlight at the top of the browser window, so the first few lines were hidden underneath the header (which also means if the highlight was only a couple lines, it'd be entirely hidden under the header!) - I moved it to the center of the screen, instead.