### PR TITLE
web: warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,8 @@ dev-js:
 
 check-js:
 	cd web && yarn install --frozen-lockfile
+	# make sure there are no compilation errors or lint warnings
+	cd web && CI=true yarn build
 	cd web && yarn run check
 
 build-js:

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -17,14 +17,12 @@ import SocketBar from "./SocketBar"
 import "./HUD.scss"
 import {
   LogLine,
-  LogTrace,
-  LogTraceNav,
   ResourceView,
   ShowFatalErrorModal,
   SnapshotHighlight,
   SocketState,
 } from "./types"
-import { logLinesFromString, isBuildSpanId } from "./logs"
+import { logLinesFromString } from "./logs"
 import HudState from "./HudState"
 import AlertPane from "./AlertPane"
 import AnalyticsNudge from "./AnalyticsNudge"
@@ -227,7 +225,6 @@ class HUD extends Component<HudProps, HudState> {
     let view = this.state.view
 
     let needsNudge = view?.needsAnalyticsNudge ?? false
-    let logStore = this.state.logStore ?? null
     let resources = view?.resources ?? []
     if (!resources?.length) {
       return <HeroScreen message={"Loading…"} />
@@ -447,7 +444,6 @@ class HUD extends Component<HudProps, HudState> {
     let view = this.state.view
     let resources = (view && view.resources) || []
     let snapshotHighlight = this.state.snapshotHighlight || null
-    let showSnapshotModal = !!this.state.showSnapshotModal
     let isSnapshot = this.pathBuilder.isSnapshot()
 
     let traceRoute = (props: RouteComponentProps<any>) => {

--- a/web/src/LogPane.tsx
+++ b/web/src/LogPane.tsx
@@ -1,11 +1,11 @@
-import React, { Component, PureComponent } from "react"
+import React, { Component } from "react"
 import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark-gray.svg"
 import ReactDOM from "react-dom"
 import { LogLine, SnapshotHighlight } from "./types"
 import LogPaneLine from "./LogPaneLine"
 import findLogLineID from "./findLogLine"
 import styled, { keyframes } from "styled-components"
-import { Color, ColorRGBA, ColorAlpha, SizeUnit } from "./style-helpers"
+import { SizeUnit } from "./style-helpers"
 import selection from "./selection"
 import "./LogPane.scss"
 
@@ -143,7 +143,7 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
   }
 
   componentDidUpdate(prevProps: LogPaneProps) {
-    if (prevProps.manifestName != this.props.manifestName) {
+    if (prevProps.manifestName !== this.props.manifestName) {
       this.setState({ renderWindow: renderWindowDefault })
       this.autoscroll = true
       this.pageYOffset = -1
@@ -347,7 +347,7 @@ class LogPane extends Component<LogPaneProps, LogPaneState> {
         }
       }
 
-      let isContextChange = i > 0 && l.manifestName != lastManifestName
+      let isContextChange = i > 0 && l.manifestName !== lastManifestName
       let el = (
         <LogPaneLine
           ref={maybeHighlightRef}

--- a/web/src/LogPaneLine.tsx
+++ b/web/src/LogPaneLine.tsx
@@ -45,18 +45,18 @@ class LogPaneLine extends PureComponent<LogPaneProps> {
     if (props.shouldHighlight) {
       classes.push("is-highlighted")
     }
-    if (props.level == "WARN") {
+    if (props.level === "WARN") {
       classes.push("is-warning")
-    } else if (props.level == "ERROR") {
+    } else if (props.level === "ERROR") {
       classes.push("is-error")
     }
     if (props.isContextChange) {
       classes.push("is-contextChange")
     }
-    if (props.buildEvent == "init") {
+    if (props.buildEvent === "init") {
       classes.push("is-buildEvent-init")
     }
-    if (props.buildEvent == "fallback") {
+    if (props.buildEvent === "fallback") {
       classes.push("is-buildEvent-fallback")
     }
 

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -321,7 +321,7 @@ class LogStore {
 
       if (
         candidate.firstLineIndex > startSpan.firstLineIndex &&
-        (nextBuildSpan === null ||
+        (!nextBuildSpan ||
           candidate.firstLineIndex < nextBuildSpan.firstLineIndex)
       ) {
         spans[key] = candidate

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -50,11 +50,11 @@ class StoredLine {
   }
 
   isComplete() {
-    return this.text[this.text.length - 1] == "\n"
+    return this.text[this.text.length - 1] === "\n"
   }
 
   canContinueLine(other: StoredLine) {
-    return this.level == other.level && this.spanId == other.spanId
+    return this.level === other.level && this.spanId === other.spanId
   }
 }
 
@@ -160,7 +160,7 @@ class LogStore {
         return
       }
       let isStartingNewLine = false
-      if (span.lastLineIndex == -1) {
+      if (span.lastLineIndex === -1) {
         isStartingNewLine = true
       } else {
         let line = this.lines[span.lastLineIndex]
@@ -175,7 +175,7 @@ class LogStore {
         }
       }
 
-      if (span.firstLineIndex == -1) {
+      if (span.firstLineIndex === -1) {
         span.firstLineIndex = this.lines.length
       }
 
@@ -197,7 +197,7 @@ class LogStore {
     // Iterate backwards and figure out which line to overwrite.
     for (let i = span.lastLineIndex; i >= span.firstLineIndex; i--) {
       let cur = this.lines[i]
-      if (cur.spanId != candidate.spanId) {
+      if (cur.spanId !== candidate.spanId) {
         // skip lines from other spans
         // TODO(nick): maybe we should track if spans are interleaved, and rearrange the
         // lines to make more sense?
@@ -210,7 +210,7 @@ class LogStore {
         return false
       }
 
-      if (progressId != curProgressId) {
+      if (progressId !== curProgressId) {
         continue
       }
 
@@ -242,7 +242,7 @@ class LogStore {
     let result: { [key: string]: LogSpan } = {}
     for (let spanId in this.spans) {
       let span = this.spans[spanId]
-      if (span.manifestName == mn) {
+      if (span.manifestName === mn) {
         result[spanId] = span
       }
     }
@@ -263,7 +263,7 @@ class LogStore {
       }
 
       let span = this.spans[key]
-      if (span.manifestName != manifestName) {
+      if (span.manifestName !== manifestName) {
         continue
       }
 
@@ -283,7 +283,7 @@ class LogStore {
   nextBuildSpan(spanId: string): LogSpan | null {
     let spanIds = this.getOrderedBuildSpanIds(spanId)
     let currentIndex = spanIds.indexOf(spanId)
-    if (currentIndex == -1 || currentIndex == spanIds.length - 1) {
+    if (currentIndex === -1 || currentIndex === spanIds.length - 1) {
       return null
     }
     return this.spans[spanIds[currentIndex + 1]]
@@ -315,13 +315,13 @@ class LogStore {
     // is uncertain. We should be more intelligent about sucking in events.
     for (let key in this.spans) {
       let candidate = this.spans[key]
-      if (candidate.manifestName != startSpan.manifestName) {
+      if (candidate.manifestName !== startSpan.manifestName) {
         continue
       }
 
       if (
         candidate.firstLineIndex > startSpan.firstLineIndex &&
-        (nextBuildSpan == null ||
+        (nextBuildSpan === null ||
           candidate.firstLineIndex < nextBuildSpan.firstLineIndex)
       ) {
         spans[key] = candidate
@@ -354,28 +354,28 @@ class LogStore {
     let startIndex = 0
     let lastIndex = this.lines.length - 1
     let isFilteredLog =
-      Object.keys(spansToLog).length != Object.keys(this.spans).length
+      Object.keys(spansToLog).length !== Object.keys(this.spans).length
     if (isFilteredLog) {
       let earliestStartIndex = -1
       let latestEndIndex = -1
       for (let spanId in spansToLog) {
         let span = spansToLog[spanId]
         if (
-          earliestStartIndex == -1 ||
+          earliestStartIndex === -1 ||
           (span.firstLineIndex !== -1 &&
             span.firstLineIndex < earliestStartIndex)
         ) {
           earliestStartIndex = span.firstLineIndex
         }
         if (
-          latestEndIndex == -1 ||
+          latestEndIndex === -1 ||
           (span.lastLineIndex !== -1 && span.lastLineIndex > latestEndIndex)
         ) {
           latestEndIndex = span.lastLineIndex
         }
       }
 
-      if (earliestStartIndex == -1) {
+      if (earliestStartIndex === -1) {
         return []
       }
 
@@ -383,7 +383,6 @@ class LogStore {
       lastIndex = latestEndIndex
     }
 
-    let currentLine = {}
     for (let i = startIndex; i <= lastIndex; i++) {
       let storedLine = this.lines[i]
       let spanId = storedLine.spanId
@@ -396,7 +395,7 @@ class LogStore {
       if (!line) {
         let text = storedLine.text
         // strip off the newline
-        if (text[text.length - 1] == "\n") {
+        if (text[text.length - 1] === "\n") {
           text = text.substring(0, text.length - 1)
         }
         line = {

--- a/web/src/SecondaryNav.tsx
+++ b/web/src/SecondaryNav.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react"
 import styled from "styled-components"
 import { Link } from "react-router-dom"
-import { LogTrace, LogTraceNav, ResourceView } from "./types"
+import { LogTraceNav, ResourceView } from "./types"
 import * as s from "./style-helpers"
 
 type NavProps = {

--- a/web/src/SidebarIcon.tsx
+++ b/web/src/SidebarIcon.tsx
@@ -7,11 +7,9 @@ import {
   ColorRGBA,
   Font,
   FontSize,
-  SizeUnit,
 } from "./style-helpers"
 import styled, { keyframes } from "styled-components"
 import { Width } from "./style-helpers"
-import { Link } from "react-router-dom"
 
 type SidebarIconProps = {
   status: ResourceStatus

--- a/web/src/analytics.ts
+++ b/web/src/analytics.ts
@@ -11,34 +11,34 @@ const incr = (name: string, tags: Tags = {}): void => {
 }
 
 const pathToTag = (path: string): string => {
-  if (path.indexOf("/") == 0) {
+  if (path.indexOf("/") === 0) {
     path = path.substring(1) // chop off the leading /
   }
   let parts = path.split("/")
-  if (parts[0] == "") {
+  if (parts[0] === "") {
     return "all"
   }
-  if (parts[0] == "alerts") {
+  if (parts[0] === "alerts") {
     return "errors"
   }
-  if (parts[0] == "facets") {
+  if (parts[0] === "facets") {
     return "facets"
   }
-  if (parts[0] == "trace") {
+  if (parts[0] === "trace") {
     return "trace"
   }
 
-  if (parts[0] == "r") {
+  if (parts[0] === "r") {
     if (parts.length <= 2) {
       return "log"
     }
-    if (parts[2] == "alerts" || parts[2] == "errors") {
+    if (parts[2] === "alerts" || parts[2] === "errors") {
       return "errors"
     }
-    if (parts[2] == "facets") {
+    if (parts[2] === "facets") {
       return "facets"
     }
-    if (parts[2] == "trace") {
+    if (parts[2] === "trace") {
       return "trace"
     }
   }

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -33,7 +33,7 @@ export function logLinesToString(
 }
 
 export function sourcePrefix(n: string) {
-  if (n == "" || n == "(Tiltfile)") {
+  if (n === "" || n === "(Tiltfile)") {
     return ""
   }
   let max = 12
@@ -47,5 +47,5 @@ export function sourcePrefix(n: string) {
 }
 
 export function isBuildSpanId(spanId: string): boolean {
-  return spanId.indexOf("build:") != -1
+  return spanId.indexOf("build:") !== -1
 }

--- a/web/src/selection.ts
+++ b/web/src/selection.ts
@@ -21,7 +21,7 @@ function allNodes(selection: Selection): Node[] {
 // the ranges and get the earliest node in document-space.
 function startNode(selection: Selection): Node | null {
   let startNode = selection.focusNode
-  allNodes(selection).map(candidate => {
+  allNodes(selection).forEach(candidate => {
     if (startNode == null) return
     if (
       startNode?.compareDocumentPosition(candidate) &
@@ -40,7 +40,7 @@ function startNode(selection: Selection): Node | null {
 // the ranges and get the last node in document-space.
 function endNode(selection: Selection): Node | null {
   let endNode = selection.focusNode
-  allNodes(selection).map(candidate => {
+  allNodes(selection).forEach(candidate => {
     if (endNode == null) return
     if (
       candidate.compareDocumentPosition(endNode) &

--- a/web/src/trace.ts
+++ b/web/src/trace.ts
@@ -24,7 +24,7 @@ function traceNav(
   }
 
   let spans = logStore.getOrderedBuildSpans(spanId)
-  let currentIndex = spans.findIndex(span => span.spanId == spanId)
+  let currentIndex = spans.findIndex(span => span.spanId === spanId)
   let span = spans[currentIndex]
   if (!span) {
     return null

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,6 +1,3 @@
-import { Alert } from "./alerts"
-import { Facet } from "./facets"
-
 export enum SocketState {
   Loading,
   Reconnecting,


### PR DESCRIPTION
1. ensure js warnings cause `make check-js` to fail
2. fix any such warnings. these fell into a few camps:
   - `==` / `!=` instead of `===` / `!==`
   - unused variables / imports
   - using `.map` on a side-effecting func w/ no return, instead of `.forEach`