### PR TITLE
cli: add -f short flag for --file

### DIFF
--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -12,7 +12,6 @@ import (
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/cloud"
 	"github.com/windmilleng/tilt/internal/store"
-	"github.com/windmilleng/tilt/internal/tiltfile"
 	"github.com/windmilleng/tilt/pkg/logger"
 )
 
@@ -40,10 +39,10 @@ While Tilt is running, you can view the UI at %s:%d
 	}
 
 	addWebServerFlags(cmd)
+	addTiltfileFlag(cmd, &c.fileName)
 
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
 	cmd.Flags().Lookup("logactions").Hidden = true
-	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "",
 		"If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
 

--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -39,7 +39,7 @@ func (c *dockerPruneCmd) register() *cobra.Command {
 		Short: "Run docker prune as Tilt does",
 	}
 
-	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")
+	addTiltfileFlag(cmd, &c.fileName)
 
 	return cmd
 }

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -12,7 +12,6 @@ import (
 	"github.com/windmilleng/tilt/internal/analytics"
 	"github.com/windmilleng/tilt/internal/engine"
 	"github.com/windmilleng/tilt/internal/k8s"
-	"github.com/windmilleng/tilt/internal/tiltfile"
 	"github.com/windmilleng/tilt/pkg/logger"
 	"github.com/windmilleng/tilt/pkg/model"
 )
@@ -50,7 +49,7 @@ In that case, see https://tilt.dev/user_config.html and/or comments in your Tilt
 `,
 	}
 
-	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")
+	addTiltfileFlag(cmd, &c.fileName)
 	cmd.Flags().BoolVar(&c.deleteNamespaces, "delete-namespaces", false, "delete namespaces defined in the Tiltfile (by default, don't)")
 
 	return cmd

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,8 +1,17 @@
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/windmilleng/tilt/internal/tiltfile"
+)
 
 // Common flags used across multiple commands.
+
+// s: address of the field to populate
+func addTiltfileFlag(cmd *cobra.Command, s *string) {
+	cmd.Flags().StringVarP(s, "file", "f", tiltfile.FileName, "Path to Tiltfile")
+}
 
 func addWebPortFlag(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server. Set to 0 to disable.")

--- a/internal/cli/tiltfile_result.go
+++ b/internal/cli/tiltfile_result.go
@@ -52,7 +52,7 @@ Exit code 5: error when evaluating the Tiltfile, such as syntax error, illegal T
 Run with -v | --verbose to print Tiltfile execution logs on stderr, regardless of whether there was an error.`,
 	}
 
-	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")
+	addTiltfileFlag(cmd, &c.fileName)
 
 	return cmd
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -22,7 +22,6 @@ import (
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/k8s"
 	"github.com/windmilleng/tilt/internal/store"
-	"github.com/windmilleng/tilt/internal/tiltfile"
 	"github.com/windmilleng/tilt/internal/tracer"
 	"github.com/windmilleng/tilt/pkg/assets"
 	"github.com/windmilleng/tilt/pkg/logger"
@@ -79,8 +78,8 @@ In that case, see https://tilt.dev/user_config.html and/or comments in your Tilt
 	cmd.Flags().BoolVar(&c.hud, "hud", true, "If true, tilt will open in HUD mode.")
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
 	addWebServerFlags(cmd)
+	addTiltfileFlag(cmd, &c.fileName)
 	cmd.Flags().Lookup("logactions").Hidden = true
-	cmd.Flags().StringVar(&c.fileName, "file", tiltfile.FileName, "Path to Tiltfile")
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "If true, web UI will not open on startup.")
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "", "If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
 


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/file:

124942e3abd23273fa8d92029df0374222a5fe50 (2020-04-02 19:25:57 -0400)
cli: add -f short flag for --file

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics