### PR TITLE
engine: revamp how we compute RuntimeStatus

### DIFF
--- a/internal/engine/k8swatch/pod_watch.go
+++ b/internal/engine/k8swatch/pod_watch.go
@@ -18,6 +18,15 @@ import (
 	"github.com/windmilleng/tilt/internal/k8s"
 )
 
+var errorWaitingReasons = map[string]bool{
+	"CrashLoopBackOff":  true,
+	"ErrImagePull":      true,
+	"ImagePullBackOff":  true,
+	"RunContainerError": true,
+	"StartError":        true,
+	"Error":             true,
+}
+
 type PodWatcher struct {
 	kCli         k8s.Client
 	ownerFetcher k8s.OwnerFetcher
@@ -346,6 +355,30 @@ func PodStatusToString(pod v1.Pod) string {
 	return reason
 }
 
+func ContainerStatusToRuntimeState(status v1.ContainerStatus) model.RuntimeStatus {
+	state := status.State
+	if state.Terminated != nil {
+		if state.Terminated.ExitCode == 0 {
+			return model.RuntimeStatusOK
+		} else {
+			return model.RuntimeStatusError
+		}
+	}
+
+	if state.Waiting != nil {
+		if errorWaitingReasons[state.Waiting.Reason] {
+			return model.RuntimeStatusError
+		}
+		return model.RuntimeStatusPending
+	}
+
+	if state.Running != nil {
+		return model.RuntimeStatusOK
+	}
+
+	return model.RuntimeStatusUnknown
+}
+
 // Pull out interesting error messages from the pod status
 func PodStatusErrorMessages(pod v1.Pod) []string {
 	result := []string{}
@@ -372,9 +405,10 @@ func containerStatusErrorMessages(container v1.ContainerStatus) []string {
 			result = append(result, lastState.Terminated.Message)
 		}
 
-		// If we're in CrashLoopBackOff mode, also include the error message
-		// so we know when the pod will get rescheduled.
-		if state.Waiting.Message != "" && state.Waiting.Reason == "CrashLoopBackOff" {
+		// If we're in an error mode, also include the error message.
+		// Many error modes put important information in the error message,
+		// like when the pod will get rescheduled.
+		if state.Waiting.Message != "" && errorWaitingReasons[state.Waiting.Reason] {
 			result = append(result, state.Waiting.Message)
 		}
 	} else if state.Terminated != nil &&

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -25,6 +25,46 @@ import (
 	"github.com/windmilleng/tilt/pkg/model"
 )
 
+func TestContainerStatusToRuntimeState(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Status v1.ContainerStatus
+		Result model.RuntimeStatus
+	}{
+		{
+			"ok-running", v1.ContainerStatus{
+				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			}, model.RuntimeStatusOK,
+		},
+		{
+			"ok-terminated", v1.ContainerStatus{
+				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{}},
+			}, model.RuntimeStatusOK,
+		},
+		{
+			"error-terminated", v1.ContainerStatus{
+				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 1}},
+			}, model.RuntimeStatusError,
+		},
+		{
+			"error-waiting", v1.ContainerStatus{
+				State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+			}, model.RuntimeStatusError,
+		},
+		{
+			"pending-waiting", v1.ContainerStatus{
+				State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "Initializing"}},
+			}, model.RuntimeStatusPending,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			assert.Equal(t, c.Result, ContainerStatusToRuntimeState(c.Status))
+		})
+	}
+}
+
 func TestPodWatch(t *testing.T) {
 	f := newPWFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch5970/status:

7a152be27e17620fbcc81b74eff45d5848af3ce3 (2020-04-03 14:39:42 -0400)
engine: revamp how we compute RuntimeStatus
In the old way, we would convert a Pod Status struct into a human-readable
reason string. Then we would try to convert the reason string into a
model.RuntimeStatus (one of OK, Pending, Error).

This was fragile and confusing, because the reason string had conflicting
needs. When we made the human-readable bit more descriptive (e.g., including
init container info), we'd break the RuntimeStatus conversion.

In the new way, we compute both RuntimeStatus and the reason string directly
from the PodStatus struct.

Fixes https://github.com/windmilleng/tilt/issues/3177

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics