### PR TITLE
bump version to v0.13.1

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.13.0"
+const devVersion = "0.13.1"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.13.0"
+VERSION="0.13.1"
 BREW=$(command -v brew)
 
 set -e


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/v0.13.1:

11a0f2e8586f6fd3429f0f388159774c35b1033b (2020-04-09 15:45:27 -0400)
bump version to v0.13.1

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics