### PR TITLE
re-enable buildkit on minikube v1.8.0+. Fixes https://github.com/windmilleng/tilt/issues/3192

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -50,7 +50,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	env := k8s.EnvGKE
 
-	dEnv := docker.ProvideClusterEnv(ctx, env, wmcontainer.RuntimeDocker, k8s.FakeMinkube{})
+	dEnv := docker.ProvideClusterEnv(ctx, env, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
 	dCli := docker.NewDockerClient(ctx, docker.Env(dEnv))
 	_, ok := dCli.(*docker.Cli)
 	// If it wasn't an actual Docker client, it's an exploding client

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -217,10 +217,9 @@ func getDockerBuilderVersion(v types.Version, env Env) (types.BuilderVersion, er
 // Inferred from release notes
 // https://docs.docker.com/engine/release-notes/
 func SupportsBuildkit(v types.Version, env Env) bool {
-	if env.IsMinikube {
-		// Buildkit for Minikube is currently busted. Follow
+	if env.IsOldMinikube {
+		// Buildkit for Minikube is busted on some versions. See
 		// https://github.com/kubernetes/minikube/issues/4143
-		// for updates.
 		return false
 	}
 

--- a/internal/k8s/minikube_fake.go
+++ b/internal/k8s/minikube_fake.go
@@ -2,16 +2,21 @@ package k8s
 
 import "context"
 
-type FakeMinkube struct {
+type FakeMinikube struct {
+	FakeVersion  string
 	DockerEnvMap map[string]string
 }
 
-func (c FakeMinkube) DockerEnv(ctx context.Context) (map[string]string, error) {
+func (c FakeMinikube) Version(ctx context.Context) (string, error) {
+	return c.FakeVersion, nil
+}
+
+func (c FakeMinikube) DockerEnv(ctx context.Context) (map[string]string, error) {
 	return c.DockerEnvMap, nil
 }
 
-func (c FakeMinkube) NodeIP(ctx context.Context) (NodeIP, error) {
+func (c FakeMinikube) NodeIP(ctx context.Context) (NodeIP, error) {
 	return "", nil
 }
 
-var _ MinikubeClient = FakeMinkube{}
+var _ MinikubeClient = FakeMinikube{}

--- a/internal/k8s/minikube_test.go
+++ b/internal/k8s/minikube_test.go
@@ -1,6 +1,19 @@
 package k8s
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinikubeVersion(t *testing.T) {
+	v, err := minikubeVersionFromOutput([]byte(`
+minikube version: v1.8.2
+commit: eb13446e786c9ef70cb0a9f85a633194e62396a1
+`))
+	assert.NoError(t, err)
+	assert.Equal(t, v, "1.8.2")
+}
 
 func TestDockerEnv(t *testing.T) {
 	output := []byte(`


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch6163:

ee9f8629c328611ea1b06ddfcdc862ff3fe2c958 (2020-04-10 10:17:26 -0400)
re-enable buildkit on minikube v1.8.0+. Fixes https://github.com/windmilleng/tilt/issues/3192

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics