### PR TITLE
engine: pull time.Now out of the state loop, to make it easier to test

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -56,6 +56,7 @@ func NewHudStoppedAction(err error) HudStoppedAction {
 
 type DockerComposeEventAction struct {
 	Event dockercompose.Event
+	Time  time.Time
 }
 
 func (DockerComposeEventAction) Action() {}

--- a/internal/engine/buildcontrol/actions.go
+++ b/internal/engine/buildcontrol/actions.go
@@ -22,6 +22,7 @@ type BuildCompleteAction struct {
 	ManifestName model.ManifestName
 	SpanID       logstore.SpanID
 	Result       store.BuildResultSet
+	FinishTime   time.Time
 	Error        error
 }
 
@@ -32,6 +33,7 @@ func NewBuildCompleteAction(mn model.ManifestName, spanID logstore.SpanID, resul
 		ManifestName: mn,
 		SpanID:       spanID,
 		Result:       result,
+		FinishTime:   time.Now(),
 		Error:        err,
 	}
 }

--- a/internal/engine/docker_compose_event_watcher.go
+++ b/internal/engine/docker_compose_event_watcher.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -70,9 +71,16 @@ func dispatchDockerComposeEventLoop(ctx context.Context, ch <-chan string, st st
 				continue
 			}
 
-			st.Dispatch(DockerComposeEventAction{evt})
+			st.Dispatch(NewDockerComposeEventAction(evt))
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+func NewDockerComposeEventAction(evt dockercompose.Event) DockerComposeEventAction {
+	return DockerComposeEventAction{
+		Event: evt,
+		Time:  time.Now(),
 	}
 }


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/time:

baa91cc3f3954be8301fcee3866c29e2800d9118 (2020-04-14 17:20:58 -0400)
engine: pull time.Now out of the state loop, to make it easier to test subtle timing issues

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics