### PR TITLE
tiltfile: distinguish host commands from container commands

### DIFF
--- a/internal/build/boil_runs_test.go
+++ b/internal/build/boil_runs_test.go
@@ -13,7 +13,7 @@ import (
 func TestBoilRunsNoTrigger(t *testing.T) {
 	runs := []model.Run{
 		model.Run{
-			Cmd: model.ToShellCmd("echo hello"),
+			Cmd: model.ToUnixCmd("echo hello"),
 		},
 	}
 
@@ -24,7 +24,7 @@ func TestBoilRunsNoTrigger(t *testing.T) {
 		},
 	}
 
-	expected := []model.Cmd{model.ToShellCmd("echo hello")}
+	expected := []model.Cmd{model.ToUnixCmd("echo hello")}
 
 	actual, err := BoilRuns(runs, pathMappings)
 	if err != nil {
@@ -37,13 +37,13 @@ func TestBoilRunsNoTrigger(t *testing.T) {
 func TestBoilRunsNoFilesChanged(t *testing.T) {
 	runs := []model.Run{
 		model.Run{
-			Cmd: model.ToShellCmd("echo hello"),
+			Cmd: model.ToUnixCmd("echo hello"),
 		},
 	}
 
 	pathMappings := []PathMapping{}
 
-	expected := []model.Cmd{model.ToShellCmd("echo hello")}
+	expected := []model.Cmd{model.ToUnixCmd("echo hello")}
 
 	actual, err := BoilRuns(runs, pathMappings)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestBoilRunsOneTriggerFilesDontMatch(t *testing.T) {
 	triggers := []string{"bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:      model.ToShellCmd("echo hello"),
+			Cmd:      model.ToUnixCmd("echo hello"),
 			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
 		},
 	}
@@ -83,7 +83,7 @@ func TestBoilRunsOneTriggerMatchingFile(t *testing.T) {
 	triggers := []string{"bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:      model.ToShellCmd("echo world"),
+			Cmd:      model.ToUnixCmd("echo world"),
 			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
 		},
 	}
@@ -95,7 +95,7 @@ func TestBoilRunsOneTriggerMatchingFile(t *testing.T) {
 		},
 	}
 
-	expected := []model.Cmd{model.ToShellCmd("echo world")}
+	expected := []model.Cmd{model.ToUnixCmd("echo world")}
 
 	actual, err := BoilRuns(runs, pathMappings)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestBoilRunsTriggerMatchingAbsPath(t *testing.T) {
 	triggers := []string{"/home/tilt/code/test/bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:      model.ToShellCmd("echo world"),
+			Cmd:      model.ToUnixCmd("echo world"),
 			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
 		},
 	}
@@ -121,7 +121,7 @@ func TestBoilRunsTriggerMatchingAbsPath(t *testing.T) {
 		},
 	}
 
-	expected := []model.Cmd{model.ToShellCmd("echo world")}
+	expected := []model.Cmd{model.ToUnixCmd("echo world")}
 
 	actual, err := BoilRuns(runs, pathMappings)
 	if err != nil {
@@ -135,7 +135,7 @@ func TestBoilRunsTriggerNestedPathNoMatch(t *testing.T) {
 	triggers := []string{"bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:      model.ToShellCmd("echo world"),
+			Cmd:      model.ToUnixCmd("echo world"),
 			Triggers: model.NewPathSet(triggers, "/home/tilt/code/test"),
 		},
 	}
@@ -163,11 +163,11 @@ func TestBoilRunsManyTriggersManyFiles(t *testing.T) {
 	triggers2 := []string{"bar"}
 	runs := []model.Run{
 		model.Run{
-			Cmd:      model.ToShellCmd("echo hello"),
+			Cmd:      model.ToUnixCmd("echo hello"),
 			Triggers: model.NewPathSet(triggers1, wd),
 		},
 		model.Run{
-			Cmd:      model.ToShellCmd("echo world"),
+			Cmd:      model.ToUnixCmd("echo world"),
 			Triggers: model.NewPathSet(triggers2, wd),
 		},
 	}
@@ -183,7 +183,7 @@ func TestBoilRunsManyTriggersManyFiles(t *testing.T) {
 		},
 	}
 
-	expected := []model.Cmd{model.ToShellCmd("echo world")}
+	expected := []model.Cmd{model.ToUnixCmd("echo world")}
 
 	actual, err := BoilRuns(runs, pathMappings)
 	if err != nil {

--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -247,7 +247,7 @@ func containerConfigRunCmd(imgRef reference.NamedTagged, cmd model.Cmd) *contain
 	//
 	// https://github.com/opencontainers/image-spec/blob/master/config.md#properties
 	if cmd.Empty() {
-		config.Cmd = model.ToShellCmd("# NOTE(nick): a fake cmd").Argv
+		config.Cmd = model.ToUnixCmd("# NOTE(nick): a fake cmd").Argv
 	} else {
 		config.Cmd = cmd.Argv
 	}

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -757,9 +757,9 @@ func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
 	defer f.TearDown()
 
 	runs := []model.LiveUpdateRunStep{
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo hello")},
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
+		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo hello")},
+		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
+		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
 	}
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), runs, true, nil, f)
 	tCase := testCase{
@@ -783,9 +783,9 @@ func TestLiveUpdateRunTriggerSynclet(t *testing.T) {
 	defer f.TearDown()
 
 	runs := []model.LiveUpdateRunStep{
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo hello")},
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
+		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo hello")},
+		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
+		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
 	}
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), runs, true, nil, f)
 	tCase := testCase{

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -934,7 +934,7 @@ func TestLocalTargetDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
 	defer f.TearDown()
 
-	lt := model.LocalTarget{UpdateCmd: model.ToShellCmd("echo hello world")}
+	lt := model.LocalTarget{UpdateCmd: model.ToHostCmd("echo hello world")}
 	res, err := f.bd.BuildAndDeploy(f.ctx, f.st, []model.TargetSpec{lt}, store.BuildStateSet{})
 	require.Nil(t, err)
 
@@ -949,7 +949,7 @@ func TestLocalTargetFailure(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
 	defer f.TearDown()
 
-	lt := model.LocalTarget{UpdateCmd: model.ToShellCmd("echo oh no; false")}
+	lt := model.LocalTarget{UpdateCmd: model.ToHostCmd("echo oh no; false")}
 	res, err := f.bd.BuildAndDeploy(f.ctx, f.st, []model.TargetSpec{lt}, store.BuildStateSet{})
 	assert.Empty(t, res, "expect empty result for failed command")
 

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -516,7 +516,7 @@ func TestDeployInjectsOverrideCommand(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	cmd := model.ToShellCmd("./foo.sh bar")
+	cmd := model.ToUnixCmd("./foo.sh bar")
 	manifest := NewSanchoDockerBuildManifest(f)
 	iTarg := manifest.ImageTargetAt(0).WithOverrideCommand(cmd)
 	manifest = manifest.WithImageTarget(iTarg)
@@ -611,7 +611,7 @@ func TestDeployInjectOverrideCommandClearsOldCommandButNotArgs(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	cmd := model.ToShellCmd("./foo.sh bar")
+	cmd := model.ToUnixCmd("./foo.sh bar")
 	manifest := NewSanchoDockerBuildManifestWithYaml(f, testyaml.SanchoYAMLWithCommand)
 	iTarg := manifest.ImageTargetAt(0).WithOverrideCommand(cmd)
 	manifest = manifest.WithImageTarget(iTarg)
@@ -644,7 +644,7 @@ func TestDeployInjectOverrideCommandAndArgs(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	cmd := model.ToShellCmd("./foo.sh bar")
+	cmd := model.ToUnixCmd("./foo.sh bar")
 	manifest := NewSanchoDockerBuildManifestWithYaml(f, testyaml.SanchoYAMLWithCommand)
 	iTarg := manifest.ImageTargetAt(0).WithOverrideCommand(cmd)
 	iTarg.OverrideArgs = model.OverrideArgs{ShouldOverride: true}
@@ -683,7 +683,7 @@ func TestCantInjectOverrideCommandWithoutContainer(t *testing.T) {
 	// expect an error when we try
 	crdYamlWithSanchoImage := strings.ReplaceAll(testyaml.CRDYAML, testyaml.CRDImage, testyaml.SanchoImage)
 
-	cmd := model.ToShellCmd("./foo.sh bar")
+	cmd := model.ToUnixCmd("./foo.sh bar")
 	manifest := NewSanchoDockerBuildManifestWithYaml(f, crdYamlWithSanchoImage)
 	iTarg := manifest.ImageTargetAt(0).WithOverrideCommand(cmd)
 	manifest = manifest.WithImageTarget(iTarg)
@@ -698,8 +698,8 @@ func TestInjectOverrideCommandsMultipleImages(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()
 
-	cmd1 := model.ToShellCmd("./command1.sh foo")
-	cmd2 := model.ToShellCmd("./command2.sh bar baz")
+	cmd1 := model.ToUnixCmd("./command1.sh foo")
+	cmd2 := model.ToUnixCmd("./command2.sh bar baz")
 
 	iTarget1 := NewSanchoDockerBuildImageTarget(f).WithOverrideCommand(cmd1)
 	iTarget2 := NewSanchoSidecarDockerBuildImageTarget(f).WithOverrideCommand(cmd2)

--- a/internal/engine/live_update_build_and_deployer_test.go
+++ b/internal/engine/live_update_build_and_deployer_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var rsf = build.RunStepFailure{
-	Cmd:      model.ToShellCmd("omgwtfbbq"),
+	Cmd:      model.ToUnixCmd("omgwtfbbq"),
 	ExitCode: 123,
 }
 
@@ -48,9 +48,9 @@ func TestBuildAndDeployBoilsSteps(t *testing.T) {
 
 	packageJson := build.PathMapping{LocalPath: f.JoinPath("package.json"), ContainerPath: "/src/package.json"}
 	runs := []model.Run{
-		model.ToRun(model.ToShellCmd("./foo.sh bar")),
-		model.Run{Cmd: model.ToShellCmd("yarn install"), Triggers: f.newPathSet("package.json")},
-		model.Run{Cmd: model.ToShellCmd("pip install"), Triggers: f.newPathSet("requirements.txt")},
+		model.ToRun(model.ToUnixCmd("./foo.sh bar")),
+		model.Run{Cmd: model.ToUnixCmd("yarn install"), Triggers: f.newPathSet("package.json")},
+		model.Run{Cmd: model.ToUnixCmd("pip install"), Triggers: f.newPathSet("requirements.txt")},
 	}
 
 	err := f.lubad.buildAndDeploy(f.ctx, f.ps, f.cu, model.ImageTarget{}, TestBuildState, []build.PathMapping{packageJson}, runs, false)
@@ -64,8 +64,8 @@ func TestBuildAndDeployBoilsSteps(t *testing.T) {
 
 	call := f.cu.Calls[0]
 	expectedCmds := []model.Cmd{
-		model.ToShellCmd("./foo.sh bar"), // should always run
-		model.ToShellCmd("yarn install"), // should run b/c we changed `package.json`
+		model.ToUnixCmd("./foo.sh bar"), // should always run
+		model.ToUnixCmd("yarn install"), // should run b/c we changed `package.json`
 		// `pip install` should NOT run b/c we didn't change `requirements.txt`
 	}
 	assert.Equal(t, expectedCmds, call.Cmds)
@@ -167,7 +167,7 @@ func TestUpdateMultipleRunningContainers(t *testing.T) {
 		build.PathMapping{LocalPath: f.JoinPath("does-not-exist"), ContainerPath: "/src/does-not-exist"},
 	}
 
-	cmd := model.ToShellCmd("./foo.sh bar")
+	cmd := model.ToUnixCmd("./foo.sh bar")
 	runs := []model.Run{model.ToRun(cmd)}
 
 	err := f.lubad.buildAndDeploy(f.ctx, f.ps, f.cu, model.ImageTarget{}, state, paths, runs, true)

--- a/internal/engine/local/controller_test.go
+++ b/internal/engine/local/controller_test.go
@@ -142,7 +142,7 @@ func (f *fixture) resource(name string, cmd string, lastDeploy time.Time) {
 	m := model.Manifest{
 		Name: n,
 	}.WithDeployTarget(model.NewLocalTarget(
-		model.TargetName(name), model.Cmd{}, model.ToShellCmd(cmd), nil, ""))
+		model.TargetName(name), model.Cmd{}, model.ToHostCmd(cmd), nil, ""))
 	f.state.UpsertManifestTarget(&store.ManifestTarget{
 		Manifest: m,
 		State: &store.ManifestState{

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -126,7 +126,7 @@ func (f *processExecFixture) startMalformedCommand() {
 }
 
 func (f *processExecFixture) start(cmd string) {
-	c := model.ToShellCmd(cmd)
+	c := model.ToHostCmd(cmd)
 	f.execer.Start(f.ctx, c, f.testWriter, f.statusCh, model.LogSpanID("rt1"))
 }
 

--- a/internal/engine/local_target_build_and_deployer_test.go
+++ b/internal/engine/local_target_build_and_deployer_test.go
@@ -150,7 +150,7 @@ func (f *ltFixture) localTarget(cmd string) model.LocalTarget {
 
 func (f *ltFixture) localTargetWithWorkdir(cmd string, workdir string) model.LocalTarget {
 	return model.LocalTarget{
-		UpdateCmd: model.ToShellCmd(cmd),
+		UpdateCmd: model.ToHostCmd(cmd),
 		Workdir:   workdir,
 	}
 }

--- a/internal/engine/telemetry/controller_test.go
+++ b/internal/engine/telemetry/controller_test.go
@@ -164,7 +164,7 @@ func (tcf *tcFixture) run() {
 	}
 
 	ts := model.TelemetrySettings{
-		Cmd:     model.ToShellCmd(tcf.cmd),
+		Cmd:     model.ToHostCmd(tcf.cmd),
 		Workdir: tcf.temp.Path(),
 	}
 	tcf.st.SetState(store.EngineState{

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -62,13 +62,13 @@ func NewSanchoLiveUpdateManifestWithTriggeredRuns(f Fixture, shouldRestart bool)
 		},
 	}
 	runs := []model.LiveUpdateRunStep{
-		model.LiveUpdateRunStep{Command: model.ToShellCmd("echo hello")},
+		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo hello")},
 		model.LiveUpdateRunStep{
-			Command:  model.ToShellCmd("echo a"),
+			Command:  model.ToUnixCmd("echo a"),
 			Triggers: model.NewPathSet([]string{"a.txt"}, f.Path()),
 		},
 		model.LiveUpdateRunStep{
-			Command:  model.ToShellCmd("echo b"),
+			Command:  model.ToUnixCmd("echo b"),
 			Triggers: model.NewPathSet([]string{"b.txt"}, f.Path()),
 		},
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -972,7 +972,7 @@ k8s_yaml('snack.yaml')
 	})
 
 	f.withManifestTarget("snack", func(mt store.ManifestTarget) {
-		expectedCmd := model.ToShellCmd("changed")
+		expectedCmd := model.ToUnixCmd("changed")
 		assert.Equal(t, expectedCmd, mt.Manifest.ImageTargetAt(0).LiveUpdateInfo().RunSteps()[0].Cmd,
 			"Tiltfile change should have propagated to manifest")
 	})

--- a/internal/testutils/assert.go
+++ b/internal/testutils/assert.go
@@ -7,13 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func IsNotExistMessage() string {
+	if runtime.GOOS == "windows" {
+		return "The system cannot find" // some error messages use "path" and some use "file"
+	} else {
+		return "no such file or directory"
+	}
+
+}
+
 // Asserts the given error indicates a file doesn't exist.
 // Uses string matching instead of type-checking, to workaround
 // libraries that wrap the error.
 func AssertIsNotExist(t *testing.T, err error) {
-	if runtime.GOOS == "windows" {
-		assert.Contains(t, err.Error(), "The system cannot find the file specified")
-	} else {
-		assert.Contains(t, err.Error(), "no such file or directory")
-	}
+	assert.Contains(t, err.Error(), IsNotExistMessage())
 }

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -133,8 +133,8 @@ func (b ManifestBuilder) Build() model.Manifest {
 	if b.localCmd != "" || b.localServeCmd != "" {
 		lt := model.NewLocalTarget(
 			model.TargetName(b.name),
-			model.ToShellCmd(b.localCmd),
-			model.ToShellCmd(b.localServeCmd),
+			model.ToHostCmd(b.localCmd),
+			model.ToHostCmd(b.localServeCmd),
 			b.localDeps,
 			b.f.Path())
 		return model.Manifest{Name: b.name, ResourceDependencies: rds}.WithDeployTarget(lt)

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package config
 
 import (

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -210,7 +210,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		}
 	}
 
-	entrypointCmd, err := value.ValueToCmd(entrypoint)
+	entrypointCmd, err := value.ValueToUnixCmd(entrypoint)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +347,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	entrypointCmd, err := value.ValueToCmd(entrypoint)
+	entrypointCmd, err := value.ValueToUnixCmd(entrypoint)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -32,7 +32,7 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 		return nil, err
 	}
 
-	cmd, err := value.ValueToCmd(commandValue)
+	cmd, err := value.ValueToHostCmd(commandValue)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -166,7 +166,7 @@ func (s *tiltfileState) liveUpdateRun(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
-	command, err := value.ValueToCmd(commandVal)
+	command, err := value.ValueToUnixCmd(commandVal)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package tiltfile
 
 import (
@@ -231,7 +229,7 @@ func TestLiveUpdateRun(t *testing.T) {
 		tiltfileText string
 		expectedCmd  model.Cmd
 	}{
-		{"string cmd", `"echo hi"`, model.ToShellCmd("echo hi")},
+		{"string cmd", `"echo hi"`, model.ToUnixCmd("echo hi")},
 		{"array cmd", `["echo", "hi"]`, model.Cmd{Argv: []string{"echo", "hi"}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -352,7 +350,7 @@ func newLiveUpdateFixture(t *testing.T) *liveUpdateFixture {
 		},
 		model.LiveUpdateSyncStep{Source: f.JoinPath("foo", "b"), Dest: "/c"},
 		model.LiveUpdateRunStep{
-			Command:  model.ToShellCmd("f"),
+			Command:  model.ToUnixCmd("f"),
 			Triggers: model.NewPathSet([]string{"g", "h"}, f.Path()),
 		},
 		model.LiveUpdateRestartContainerStep{},

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -69,11 +69,11 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
-	updateCmd, err := value.ValueToCmd(updateCmdVal)
+	updateCmd, err := value.ValueToHostCmd(updateCmdVal)
 	if err != nil {
 		return nil, err
 	}
-	serveCmd, err := value.ValueToCmd(serveCmdVal)
+	serveCmd, err := value.ValueToHostCmd(serveCmdVal)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/telemetry/telemetry.go
+++ b/internal/tiltfile/telemetry/telemetry.go
@@ -32,7 +32,7 @@ func setTelemetryCmd(thread *starlark.Thread, fn *starlark.Builtin, args starlar
 		return starlark.None, err
 	}
 
-	cmd, err := value.ValueToCmd(cmdVal)
+	cmd, err := value.ValueToHostCmd(cmdVal)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/telemetry/telemetry_test.go
+++ b/internal/tiltfile/telemetry/telemetry_test.go
@@ -17,7 +17,7 @@ func TestTelemetryCmdString(t *testing.T) {
 	result, err := f.ExecFile("Tiltfile")
 
 	assert.NoError(t, err)
-	assert.Equal(t, model.ToShellCmd("foo.sh"), MustState(result).Cmd)
+	assert.Equal(t, model.ToHostCmd("foo.sh"), MustState(result).Cmd)
 }
 
 func TestTelemetryCmdArray(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package tiltfile
 
 import (
@@ -9,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -68,7 +67,7 @@ docker_build('gcr.io/foo', 'foo')
 k8s_resource('foo', 'foo.yaml')
 `)
 
-	f.loadErrString("foo/Dockerfile", "no such file or directory", "error reading dockerfile")
+	f.loadErrString(filepath.Join("foo", "Dockerfile"), testutils.IsNotExistMessage(), "error reading dockerfile")
 }
 
 func TestCustomBuildBadMethodCall(t *testing.T) {
@@ -255,6 +254,9 @@ func TestVerifiesGitRepo(t *testing.T) {
 }
 
 func TestLocal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("need per-OS local commands")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -277,6 +279,9 @@ k8s_yaml(yaml)
 }
 
 func TestLocalQuiet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("need per-OS local commands")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -293,6 +298,9 @@ local('echo foobar', quiet=True)
 }
 
 func TestLocalArgvCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows doesn't support argv commands. Go converts it to a single string")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -324,6 +332,9 @@ k8s_yaml(yaml)
 }
 
 func TestKustomize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - install kustomize on windows ci")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -344,6 +355,9 @@ k8s_resource("the-deployment", "foo")
 }
 
 func TestKustomizeError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - install kustomize on windows ci")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -352,6 +366,9 @@ func TestKustomizeError(t *testing.T) {
 }
 
 func TestKustomization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - install kustomize on windows ci")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1004,7 +1021,11 @@ k8s_yaml(str(read_file('foo.yaml')))
 docker_build("gcr.io/foo", "foo", cache='/paths/to/cache')
 `)
 
-	f.loadErrString("no such file or directory")
+	if runtime.GOOS == "windows" {
+		f.loadErrString("The filename, directory name, or volume label syntax is incorrect")
+	} else {
+		f.loadErrString("no such file or directory")
+	}
 }
 
 func TestFilterYamlByLabel(t *testing.T) {
@@ -1162,6 +1183,9 @@ x = 2
 }
 
 func TestHelm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1183,6 +1207,9 @@ k8s_yaml(yml)
 }
 
 func TestHelmArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1213,6 +1240,9 @@ k8s_yaml(yml)
 }
 
 func TestHelmNamespaceFlagDoesNotInsertNSEntityIfNSInChart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1245,6 +1275,9 @@ k8s_yaml(yml)
 }
 
 func TestHelmNamespaceFlagInsertsNSEntityIfDifferentNSInChart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1267,6 +1300,9 @@ k8s_yaml(yml)
 }
 
 func TestHelmInvalidDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1279,6 +1315,9 @@ k8s_yaml(yml)
 }
 
 func TestHelmFromRepoPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -1925,7 +1964,7 @@ func TestYamlErrorFromLocal(t *testing.T) {
 yaml = local('echo hi')
 k8s_yaml(yaml)
 `)
-	f.loadErrString("local: echo hi")
+	f.loadErrString("echo hi")
 }
 
 func TestYamlErrorFromReadFile(t *testing.T) {
@@ -1939,6 +1978,9 @@ k8s_yaml(read_file('foo.yaml'))
 }
 
 func TestYamlErrorFromHelm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 	f.setupHelm()
@@ -2536,6 +2578,9 @@ k8s_yaml('foo.yaml')
 }
 
 func TestLocalRegistryDockerCompose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - install docker-compose on windows ci")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -3183,6 +3228,9 @@ trigger_mode(TRIGGER_MODE_MANUAL)
 }
 
 func TestHelmSkipsTests(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -3215,6 +3263,9 @@ func isBuggyHelm(t *testing.T) bool {
 }
 
 func TestHelmIncludesRequirements(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - get helm in windows build")
+	}
 	if isBuggyHelm(t) {
 		t.Skipf("Helm v2.15.0 has a major regression, skipping test. See: https://github.com/helm/helm/issues/6708")
 	}
@@ -3605,7 +3656,7 @@ k8s_yaml('foo.yaml')
 `)
 
 	f.load()
-	f.assertNextManifest("foo", db(image("gcr.io/foo"), entrypoint(model.ToShellCmd("/bin/the_app"))))
+	f.assertNextManifest("foo", db(image("gcr.io/foo"), entrypoint(model.ToUnixCmd("/bin/the_app"))))
 }
 
 func TestDockerBuildContainerArgs(t *testing.T) {
@@ -3643,6 +3694,9 @@ k8s_yaml('foo.yaml')
 }
 
 func TestDockerBuild_buildArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO - windows-specific commands")
+	}
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -3679,7 +3733,7 @@ k8s_yaml('foo.yaml')
 		image("gcr.io/foo"),
 		deps(f.JoinPath("foo")),
 		cmd("docker build -t $EXPECTED_REF foo"),
-		entrypoint(model.ToShellCmd("/bin/the_app"))),
+		entrypoint(model.ToUnixCmd("/bin/the_app"))),
 	)
 }
 
@@ -5215,7 +5269,7 @@ type updateCmdHelper struct {
 }
 
 func updateCmd(cmd string) updateCmdHelper {
-	return updateCmdHelper{model.ToShellCmd(cmd)}
+	return updateCmdHelper{model.ToHostCmd(cmd)}
 }
 
 func updateCmdArray(cmd ...string) updateCmdHelper {
@@ -5227,7 +5281,7 @@ type serveCmdHelper struct {
 }
 
 func serveCmd(cmd string) serveCmdHelper {
-	return serveCmdHelper{model.ToShellCmd(cmd)}
+	return serveCmdHelper{model.ToHostCmd(cmd)}
 }
 
 func serveCmdArray(cmd ...string) serveCmdHelper {

--- a/internal/tiltfile/value/value.go
+++ b/internal/tiltfile/value/value.go
@@ -118,7 +118,15 @@ func StringSliceToList(slice []string) *starlark.List {
 // provides dockerfile-style behavior of:
 // a string gets interpreted as a shell command (like, sh -c 'foo bar $X')
 // an array of strings gets interpreted as a raw argv to exec
-func ValueToCmd(v starlark.Value) (model.Cmd, error) {
+func ValueToHostCmd(v starlark.Value) (model.Cmd, error) {
+	return valueToCmdHelper(v, model.ToHostCmd)
+}
+
+func ValueToUnixCmd(v starlark.Value) (model.Cmd, error) {
+	return valueToCmdHelper(v, model.ToUnixCmd)
+}
+
+func valueToCmdHelper(v starlark.Value, stringToCmd func(string) model.Cmd) (model.Cmd, error) {
 	switch x := v.(type) {
 	// If a starlark function takes an optional command argument, then UnpackArgs will set its starlark.Value to nil
 	// we convert nils here to an empty Cmd, since otherwise every callsite would have to do a nil check with presumably
@@ -126,7 +134,7 @@ func ValueToCmd(v starlark.Value) (model.Cmd, error) {
 	case nil:
 		return model.Cmd{}, nil
 	case starlark.String:
-		return model.ToShellCmd(string(x)), nil
+		return stringToCmd(string(x)), nil
 	case starlark.Sequence:
 		argv, err := SequenceToStringSlice(x)
 		if err != nil {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -275,36 +275,36 @@ var equalitytests = []struct {
 	},
 	{
 		"LocalTarget equal",
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		true,
 		false,
 	},
 	{
 		"LocalTarget.Name unequal",
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		Manifest{}.WithDeployTarget(NewLocalTarget("foooooo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foooooo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		false,
 		true,
 	},
 	{
 		"LocalTarget.UpdateCmd unequal",
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("bippity boppity"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("bippity boppity"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		false,
 		true,
 	},
 	{
 		"LocalTarget.Deps unequal",
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"quux", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"quux", "baz"}, "path/to/tiltfile")),
 		false,
 		true,
 	},
 	{
 		"LocalTarget.workdir unequal",
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToShellCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "some/other/path")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
+		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "some/other/path")),
 		false,
 		true,
 	},
@@ -345,4 +345,9 @@ func TestDCTargetValidate(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "missing name")
 	}
+}
+
+func TestHostCmdToString(t *testing.T) {
+	cmd := ToHostCmd("echo hi")
+	assert.Equal(t, "echo hi", cmd.String())
 }

--- a/pkg/model/service_test.go
+++ b/pkg/model/service_test.go
@@ -23,7 +23,7 @@ func TestEscapingRun(t *testing.T) {
 }
 
 func TestNormalFormRun(t *testing.T) {
-	cmd := ToShellCmd("echo \"hi\"")
+	cmd := ToUnixCmd("echo \"hi\"")
 	actual := cmd.RunStr()
 	expected := `RUN echo "hi"`
 	if actual != expected {

--- a/pkg/model/squash_test.go
+++ b/pkg/model/squash_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSquash(t *testing.T) {
-	cmds := ToShellCmds([]string{"echo a", "echo b", "echo c"})
+	cmds := ToUnixCmds([]string{"echo a", "echo b", "echo c"})
 	cmds = TrySquash(cmds)
 	assert.Equal(t, []Cmd{Cmd{
 		Argv: []string{
@@ -19,13 +19,13 @@ func TestSquash(t *testing.T) {
 }
 
 func TestSquashFail(t *testing.T) {
-	cmds := []Cmd{ToShellCmd("echo a"), Cmd{Argv: []string{"echo"}}, ToShellCmd("echo c")}
+	cmds := []Cmd{ToUnixCmd("echo a"), Cmd{Argv: []string{"echo"}}, ToUnixCmd("echo c")}
 	cmds2 := TrySquash(cmds)
 	assert.Equal(t, cmds, cmds2)
 }
 
 func TestSquashPartial(t *testing.T) {
-	cmds := []Cmd{ToShellCmd("echo a"), ToShellCmd("echo c"), Cmd{Argv: []string{"echo"}}}
+	cmds := []Cmd{ToUnixCmd("echo a"), ToUnixCmd("echo c"), Cmd{Argv: []string{"echo"}}}
 	cmds2 := TrySquash(cmds)
 	assert.Equal(t, []Cmd{
 		Cmd{


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch6271/cmd:

f7e7c0a13a73dbab6bc4329589c227236bbd3054 (2020-04-15 11:41:41 -0400)
tiltfile: distinguish host commands from container commands

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics