### PR TITLE
up: add --default-tui arg

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -89,8 +89,8 @@ In that case, see https://tilt.dev/user_config.html and/or comments in your Tilt
 
 	// this is to test the new behavior before enabling it in Tilt 1.0
 	// https://app.clubhouse.io/windmill/epic/5549/make-tui-hard-to-find-in-tilt-1-0
-	cmd.Flags().BoolVar(&c.defaultTUI, "default-tui", true, "If false, we'll hide the TUI by default")
-	cmd.Flags().Lookup("default-tui").Hidden = true
+	cmd.Flags().BoolVar(&c.defaultTUI, "default-hud", true, "If false, we'll hide the TUI by default")
+	cmd.Flags().Lookup("default-hud").Hidden = true
 
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.hudFlagExplicitlySet = cmd.Flag("hud").Changed

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -47,12 +47,12 @@ func TestHudEnabled(t *testing.T) {
 		args             string
 		expectHUDEnabled bool
 	}{
-		{"old behavior: no --hud", "--default-tui", true},
-		{"old behavior: --hud", "--default-tui --hud", true},
-		{"old behavior: --hud=false", "--default-tui --hud=false", false},
-		{"new behavior: no --hud", "--default-tui=false", false},
-		{"new behavior: --hud", "--default-tui=false --hud", true},
-		{"new behavior: --hud=false", "--default-tui=false --hud=false", false},
+		{"old behavior: no --hud", "--default-hud", true},
+		{"old behavior: --hud", "--default-hud --hud", true},
+		{"old behavior: --hud=false", "--default-hud --hud=false", false},
+		{"new behavior: no --hud", "--default-hud=false", false},
+		{"new behavior: --hud", "--default-hud=false --hud", true},
+		{"new behavior: --hud=false", "--default-hud=false --hud=false", false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := upCmd{}

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -1,16 +1,18 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/windmilleng/tilt/internal/engine/analytics"
 	"github.com/windmilleng/tilt/internal/hud"
 	"github.com/windmilleng/tilt/internal/testutils"
 )
 
-func TestHudEnabled(t *testing.T) {
+func TestHudWiring(t *testing.T) {
 	ctx, _, ta := testutils.CtxAndAnalyticsForTest()
 
 	tests := []struct {
@@ -35,6 +37,35 @@ func TestHudEnabled(t *testing.T) {
 			}
 
 			assert.IsType(t, expectedType, threads.Hud)
+		})
+	}
+}
+
+func TestHudEnabled(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		args             string
+		expectHUDEnabled bool
+	}{
+		{"old behavior: no --hud", "--default-tui", true},
+		{"old behavior: --hud", "--default-tui --hud", true},
+		{"old behavior: --hud=false", "--default-tui --hud=false", false},
+		{"new behavior: no --hud", "--default-tui=false", false},
+		{"new behavior: --hud", "--default-tui=false --hud", true},
+		{"new behavior: --hud=false", "--default-tui=false --hud=false", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := upCmd{}
+
+			args := strings.Split(test.args, " ")
+
+			c := cmd.register()
+			err := c.Flags().Parse(args)
+			require.NoError(t, err)
+
+			c.PreRun(c, args)
+
+			require.Equal(t, test.expectHUDEnabled, cmd.isHudEnabledByConfig(), test.args)
 		})
 	}
 }


### PR DESCRIPTION
### Problem

In Tilt 1.0, we'll hide the HUD by default and make it opt-in via `--hud`. We want to develop the new, hidden-HUD UI prior to actually launching it.

### Solution

Add a new `--default-tui` argument which is hidden and defaults to true. This is basically a feature flag to enable the 1.0 behavior prior to release. (not using a Tiltfile feature flag since this decision needs to be made before we load the Tiltfile)