### PR TITLE
dockerprune: add a setting to keep the most recent N builds of a tag. Fixes https://github.com/windmilleng/tilt/issues/3211

### DIFF
--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -68,7 +68,7 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	dp := dockerprune.NewDockerPruner(deps.dCli)
 
 	// TODO: print the commands being run
-	dp.Prune(ctx, tlr.DockerPruneSettings.MaxAge, imgSelectors)
+	dp.Prune(ctx, tlr.DockerPruneSettings.MaxAge, tlr.DockerPruneSettings.KeepRecent, imgSelectors)
 
 	return nil
 }

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -3,6 +3,7 @@ package dockerprune
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -91,7 +92,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 
 	// Prune as soon after startup as we can (waiting until we've built SOMETHING)
 	if dp.lastPruneTime.IsZero() && curBuildCount > 0 {
-		dp.PruneAndRecordState(ctx, settings.MaxAge, imgSelectors, curBuildCount)
+		dp.PruneAndRecordState(ctx, settings.MaxAge, settings.KeepRecent, imgSelectors, curBuildCount)
 		return
 	}
 
@@ -99,7 +100,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 	if settings.NumBuilds != 0 {
 		buildsSince := curBuildCount - dp.lastPruneBuildCount
 		if buildsSince >= settings.NumBuilds {
-			dp.PruneAndRecordState(ctx, settings.MaxAge, imgSelectors, curBuildCount)
+			dp.PruneAndRecordState(ctx, settings.MaxAge, settings.KeepRecent, imgSelectors, curBuildCount)
 		}
 		return
 	}
@@ -110,26 +111,26 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
 	}
 
 	if time.Since(dp.lastPruneTime) >= interval {
-		dp.PruneAndRecordState(ctx, settings.MaxAge, imgSelectors, curBuildCount)
+		dp.PruneAndRecordState(ctx, settings.MaxAge, settings.KeepRecent, imgSelectors, curBuildCount)
 	}
 }
 
-func (dp *DockerPruner) PruneAndRecordState(ctx context.Context, maxAge time.Duration, imgSelectors []container.RefSelector, curBuildCount int) {
-	dp.Prune(ctx, maxAge, imgSelectors)
+func (dp *DockerPruner) PruneAndRecordState(ctx context.Context, maxAge time.Duration, keepRecent int, imgSelectors []container.RefSelector, curBuildCount int) {
+	dp.Prune(ctx, maxAge, keepRecent, imgSelectors)
 	dp.lastPruneTime = time.Now()
 	dp.lastPruneBuildCount = curBuildCount
 }
 
-func (dp *DockerPruner) Prune(ctx context.Context, maxAge time.Duration, imgSelectors []container.RefSelector) {
+func (dp *DockerPruner) Prune(ctx context.Context, maxAge time.Duration, keepRecent int, imgSelectors []container.RefSelector) {
 	// For future: dispatch event with output/errors to be recorded
 	//   in engineState.TiltSystemState on store (analogous to TiltfileState)
-	err := dp.prune(ctx, maxAge, imgSelectors)
+	err := dp.prune(ctx, maxAge, keepRecent, imgSelectors)
 	if err != nil {
 		logger.Get(ctx).Infof("[Docker Prune] error running docker prune: %v", err)
 	}
 }
 
-func (dp *DockerPruner) prune(ctx context.Context, maxAge time.Duration, imgSelectors []container.RefSelector) error {
+func (dp *DockerPruner) prune(ctx context.Context, maxAge time.Duration, keepRecent int, imgSelectors []container.RefSelector) error {
 	l := logger.Get(ctx)
 	if err := dp.sufficientVersionError(); err != nil {
 		l.Debugf("[Docker Prune] skipping Docker prune, Docker API version too low:\t%v", err)
@@ -149,7 +150,7 @@ func (dp *DockerPruner) prune(ctx context.Context, maxAge time.Duration, imgSele
 	prettyPrintContainersPruneReport(containerReport, l)
 
 	// PRUNE IMAGES
-	imageReport, err := dp.deleteOldImages(ctx, maxAge, imgSelectors)
+	imageReport, err := dp.deleteOldImages(ctx, maxAge, keepRecent, imgSelectors)
 	if err != nil {
 		return err
 	}
@@ -170,28 +171,25 @@ func (dp *DockerPruner) prune(ctx context.Context, maxAge time.Duration, imgSele
 	return nil
 }
 
-func (dp *DockerPruner) deleteOldImages(ctx context.Context, maxAge time.Duration, selectors []container.RefSelector) (types.ImagesPruneReport, error) {
-	opts := types.ImageListOptions{
-		Filters: filters.NewArgs(
-			filters.Arg("label", docker.BuiltByTiltLabelStr),
-		),
-	}
-	imgs, err := dp.dCli.ImageList(ctx, opts)
-	if err != nil {
-		return types.ImagesPruneReport{}, err
-	}
-
-	toDelete := make(map[string]uint64) // map imageID to size in bytes
+func (dp *DockerPruner) inspectImages(ctx context.Context, imgs []types.ImageSummary) []types.ImageInspect {
+	result := []types.ImageInspect{}
 	for _, imgSummary := range imgs {
 		inspect, _, err := dp.dCli.ImageInspectWithRaw(ctx, imgSummary.ID)
 		if err != nil {
 			logger.Get(ctx).Debugf("[Docker Prune] error inspecting image '%s': %v", imgSummary.ID, err)
 			continue
 		}
+		result = append(result, inspect)
+	}
+	return result
+}
 
+func (dp *DockerPruner) filterImageInspects(ctx context.Context, inspects []types.ImageInspect, maxAge time.Duration, selectors []container.RefSelector) []types.ImageInspect {
+	result := []types.ImageInspect{}
+	for _, inspect := range inspects {
 		namedRefs, err := container.ParseNamedMulti(inspect.RepoTags)
 		if err != nil {
-			logger.Get(ctx).Debugf("[Docker Prune] error parsing repo tags for '%s': %v", imgSummary.ID, err)
+			logger.Get(ctx).Debugf("[Docker Prune] error parsing repo tags for '%s': %v", inspect.ID, err)
 			continue
 		}
 
@@ -203,25 +201,49 @@ func (dp *DockerPruner) deleteOldImages(ctx context.Context, maxAge time.Duratio
 					inspect.ID, strings.Join(inspect.RepoTags, ", "))
 				continue
 			}
-			toDelete[inspect.ID] = uint64(inspect.Size)
+			result = append(result, inspect)
 		}
 	}
+	return result
+}
+
+func (dp *DockerPruner) deleteOldImages(ctx context.Context, maxAge time.Duration, keepRecent int, selectors []container.RefSelector) (types.ImagesPruneReport, error) {
+	opts := types.ImageListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("label", docker.BuiltByTiltLabelStr),
+		),
+	}
+	imgs, err := dp.dCli.ImageList(ctx, opts)
+	if err != nil {
+		return types.ImagesPruneReport{}, err
+	}
+
+	inspects := dp.inspectImages(ctx, imgs)
+	toDelete := dp.filterImageInspects(ctx, inspects, maxAge, selectors)
+	sort.SliceStable(toDelete, func(a, b int) bool {
+		return toDelete[a].Metadata.LastTagTime.Before(toDelete[b].Metadata.LastTagTime)
+	})
+
+	if len(toDelete) <= keepRecent {
+		return types.ImagesPruneReport{}, nil
+	}
+	toDelete = toDelete[:len(toDelete)-keepRecent]
 
 	rmOpts := types.ImageRemoveOptions{PruneChildren: true}
 	var responseItems []types.ImageDeleteResponseItem
 	var reclaimedBytes uint64
 
-	for imgID, bytes := range toDelete {
-		items, err := dp.dCli.ImageRemove(ctx, imgID, rmOpts)
+	for _, inspect := range toDelete {
+		items, err := dp.dCli.ImageRemove(ctx, inspect.ID, rmOpts)
 		if err != nil {
 			// No good way to detect in-use images from `inspect` output, so just ignore those errors
 			if !strings.Contains(err.Error(), "image is being used by running container") {
-				logger.Get(ctx).Debugf("[Docker Prune] error removing image '%s': %v", imgID, err)
+				logger.Get(ctx).Debugf("[Docker Prune] error removing image '%s': %v", inspect.ID, err)
 			}
 			continue
 		}
 		responseItems = append(responseItems, items...)
-		reclaimedBytes += bytes
+		reclaimedBytes += uint64(inspect.Size)
 	}
 
 	return types.ImagesPruneReport{

--- a/internal/tiltfile/dockerprune/docker_prune_test.go
+++ b/internal/tiltfile/dockerprune/docker_prune_test.go
@@ -28,6 +28,23 @@ docker_prune_settings(disable=True, max_age_mins=1)
 	assert.Equal(t, model.DockerPruneDefaultMaxAge, MustState(result).MaxAge)
 }
 
+func TestDockerPruneKeepRecent(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+docker_prune_settings(keep_recent=5)
+`)
+	result, err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.True(t, MustState(result).Enabled)
+	assert.Equal(t, 5, MustState(result).KeepRecent)
+
+	f.File("Tiltfile.empty", `
+`)
+	result, err = f.ExecFile("Tiltfile.empty")
+	assert.NoError(t, err)
+	assert.Equal(t, model.DockerPruneDefaultKeepRecent, MustState(result).KeepRecent)
+}
+
 func NewFixture(tb testing.TB) *starkit.Fixture {
 	return starkit.NewFixture(tb, NewExtension())
 }

--- a/pkg/model/docker_prune.go
+++ b/pkg/model/docker_prune.go
@@ -8,11 +8,15 @@ const DockerPruneDefaultMaxAge = time.Hour * 6
 // How often to prune Docker images while Tilt is running
 const DockerPruneDefaultInterval = time.Hour
 
+// Keep the last 2 builds of an image
+const DockerPruneDefaultKeepRecent = 2
+
 type DockerPruneSettings struct {
-	Enabled   bool
-	MaxAge    time.Duration // "prune Docker objects older than X"
-	NumBuilds int           // "prune every Y builds" (takes precedence over "prune every Z hours")
-	Interval  time.Duration // "prune every Z hours"
+	Enabled    bool
+	MaxAge     time.Duration // "prune Docker objects older than X"
+	NumBuilds  int           // "prune every Y builds" (takes precedence over "prune every Z hours")
+	Interval   time.Duration // "prune every Z hours"
+	KeepRecent int           // Keep the most recent N builds of a tag.
 }
 
 func DefaultDockerPruneSettings() DockerPruneSettings {


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch6284/prune:

d82b6ca288c45aacfc6519d3576db683dc8231d9 (2020-04-16 10:43:03 -0400)
dockerprune: add a setting to keep the most recent N builds of a tag. Fixes https://github.com/windmilleng/tilt/issues/3211

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics