### PR TITLE
dockerprune: add a setting to keep the most recent N builds of a tag. Fixes https://github.com/windmilleng/tilt/issues/3211

### DIFF
--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -68,7 +68,7 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	dp := dockerprune.NewDockerPruner(deps.dCli)
 
 	// TODO: print the commands being run
-	dp.Prune(ctx, tlr.DockerPruneSettings.MaxAge, imgSelectors)
+	dp.Prune(ctx, tlr.DockerPruneSettings.MaxAge, tlr.DockerPruneSettings.KeepRecent, imgSelectors)
 
 	return nil
 }

--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -54,6 +54,15 @@ func (s RefSelector) WithExactMatch() RefSelector {
 	return s
 }
 
+func (s RefSelector) MatchesAny(toMatch []reference.Named) bool {
+	for _, ref := range toMatch {
+		if s.Matches(ref) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s RefSelector) Matches(toMatch reference.Named) bool {
 	if s.ref == nil {
 		return false

--- a/internal/tiltfile/dockerprune/docker_prune_test.go
+++ b/internal/tiltfile/dockerprune/docker_prune_test.go
@@ -28,6 +28,23 @@ docker_prune_settings(disable=True, max_age_mins=1)
 	assert.Equal(t, model.DockerPruneDefaultMaxAge, MustState(result).MaxAge)
 }
 
+func TestDockerPruneKeepRecent(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+docker_prune_settings(keep_recent=5)
+`)
+	result, err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.True(t, MustState(result).Enabled)
+	assert.Equal(t, 5, MustState(result).KeepRecent)
+
+	f.File("Tiltfile.empty", `
+`)
+	result, err = f.ExecFile("Tiltfile.empty")
+	assert.NoError(t, err)
+	assert.Equal(t, model.DockerPruneDefaultKeepRecent, MustState(result).KeepRecent)
+}
+
 func NewFixture(tb testing.TB) *starkit.Fixture {
 	return starkit.NewFixture(tb, NewExtension())
 }

--- a/pkg/model/docker_prune.go
+++ b/pkg/model/docker_prune.go
@@ -8,11 +8,15 @@ const DockerPruneDefaultMaxAge = time.Hour * 6
 // How often to prune Docker images while Tilt is running
 const DockerPruneDefaultInterval = time.Hour
 
+// Keep the last 2 builds of an image
+const DockerPruneDefaultKeepRecent = 2
+
 type DockerPruneSettings struct {
-	Enabled   bool
-	MaxAge    time.Duration // "prune Docker objects older than X"
-	NumBuilds int           // "prune every Y builds" (takes precedence over "prune every Z hours")
-	Interval  time.Duration // "prune every Z hours"
+	Enabled    bool
+	MaxAge     time.Duration // "prune Docker objects older than X"
+	NumBuilds  int           // "prune every Y builds" (takes precedence over "prune every Z hours")
+	Interval   time.Duration // "prune every Z hours"
+	KeepRecent int           // Keep the most recent N builds of a tag.
 }
 
 func DefaultDockerPruneSettings() DockerPruneSettings {


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch6284/prune:

ff8774c73af994c3f591f346ab75e203a94b4db1 (2020-04-16 19:19:35 -0400)
dockerprune: add a setting to keep the most recent N builds of a tag. Fixes https://github.com/windmilleng/tilt/issues/3211

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics