### PR TITLE
tiltfile: add os.name built-in

### DIFF
--- a/internal/tiltfile/os/os.go
+++ b/internal/tiltfile/os/os.go
@@ -3,6 +3,7 @@ package os
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"go.starlark.net/starlark"
@@ -37,7 +38,21 @@ func (e Extension) OnStart(env *starkit.Environment) error {
 	if err != nil {
 		return err
 	}
-	return env.AddValue("os.environ", environValue)
+	err = env.AddValue("os.environ", environValue)
+	if err != nil {
+		return err
+	}
+
+	return env.AddValue("os.name", starlark.String(osName()))
+}
+
+// For consistency with
+// https://docs.python.org/3/library/os.html#os.name
+func osName() string {
+	if runtime.GOOS == "windows" {
+		return "nt"
+	}
+	return "posix"
 }
 
 func environ() (starlark.Value, error) {

--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -82,6 +82,18 @@ print(os.path.realpath('.'))
 	assert.Equal(t, fmt.Sprintf("%s\n", f.Path()), f.PrintOutput())
 }
 
+func TestName(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+print(os.name)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("%s\n", osName()), f.PrintOutput())
+}
+
 func NewFixture(tb testing.TB) *starkit.Fixture {
 	return starkit.NewFixture(tb, NewExtension())
 }


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/osname:

c19a9a35c9744f697136c20e0f6bed1586ae5ec0 (2020-04-20 18:56:53 -0400)
tiltfile: add os.name built-in

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics