### PR TITLE
engine: only edit k8s yaml image pull policies if we're editing images. Fixes https://github.com/windmilleng/tilt/issues/3209

### DIFF
--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -138,6 +138,10 @@ func TestNoImageTargets(t *testing.T) {
 	expectedLabelStr := fmt.Sprintf("%s: %s", k8s.ManagedByLabel, k8s.ManagedByValue)
 	assert.Equalf(t, 1, strings.Count(f.k8s.Yaml, expectedLabelStr),
 		"Expected \"%s\" label to appear once in YAML: %s", expectedLabelStr, f.k8s.Yaml)
+
+	// If we're not making updates in response to an image change, it's OK to
+	// leave the existing image pull policy.
+	assert.Contains(t, f.k8s.Yaml, "imagePullPolicy: Always")
 }
 
 func TestImageIsClean(t *testing.T) {

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -591,6 +591,7 @@ spec:
   containers:
   - name: lonely-pod
     image: gcr.io/windmill-public-containers/lonely-pod
+    imagePullPolicy: Always
     command: ["/go/bin/lonely-pod"]
     ports:
     - containerPort: 8001


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch6438/pullpolicy:

7d10e9273a5eb5f5489a8f2f4bc372f6f8d05cf2 (2020-04-20 19:41:29 -0400)
engine: only edit k8s yaml image pull policies if we're editing images. Fixes https://github.com/windmilleng/tilt/issues/3209

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics