### PR TITLE
build: fix tar code on windows

### DIFF
--- a/internal/build/buildkit_printer_test.go
+++ b/internal/build/buildkit_printer_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package build
 
 import (
@@ -13,6 +11,7 @@ import (
 	"testing"
 
 	controlapi "github.com/moby/buildkit/api/services/control"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/tilt/pkg/logger"
 )
@@ -96,9 +95,7 @@ func TestBuildkitPrinter(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if output.String() != string(expected) {
-				t.Errorf("EXPECTED:\n%s\nGOT:\n%s\n", expected, output.String())
-			}
+			assert.Equal(t, normalize(string(expected)), normalize(output.String()))
 		})
 	}
 }

--- a/internal/build/image_builder_test.go
+++ b/internal/build/image_builder_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package build
 
 import (

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package build
 
 import (
@@ -17,9 +15,9 @@ func TestFilesToPathMappings(t *testing.T) {
 	defer f.TearDown()
 
 	paths := []string{
-		"sync1/fileA",
-		"sync1/child/fileB",
-		"sync2/fileC",
+		filepath.Join("sync1", "fileA"),
+		filepath.Join("sync1", "child", "fileB"),
+		filepath.Join("sync2", "fileC"),
 	}
 	f.TouchFiles(paths)
 
@@ -29,7 +27,7 @@ func TestFilesToPathMappings(t *testing.T) {
 	}
 	// Add a file that doesn't exist on local -- but we still expect it to successfully
 	// map to a ContainerPath.
-	absPaths = append(absPaths, filepath.Join(f.Path(), "sync2/file_deleted"))
+	absPaths = append(absPaths, filepath.Join(f.Path(), "sync2", "file_deleted"))
 
 	syncs := []model.Sync{
 		model.Sync{
@@ -48,19 +46,19 @@ func TestFilesToPathMappings(t *testing.T) {
 
 	expected := []PathMapping{
 		PathMapping{
-			LocalPath:     filepath.Join(f.Path(), "sync1/fileA"),
+			LocalPath:     f.JoinPath("sync1", "fileA"),
 			ContainerPath: "/dest1/fileA",
 		},
 		PathMapping{
-			LocalPath:     filepath.Join(f.Path(), "sync1/child/fileB"),
+			LocalPath:     f.JoinPath("sync1", "child", "fileB"),
 			ContainerPath: "/dest1/child/fileB",
 		},
 		PathMapping{
-			LocalPath:     filepath.Join(f.Path(), "sync2/fileC"),
+			LocalPath:     f.JoinPath("sync2", "fileC"),
 			ContainerPath: "/nested/dest2/fileC",
 		},
 		PathMapping{
-			LocalPath:     filepath.Join(f.Path(), "sync2/file_deleted"),
+			LocalPath:     f.JoinPath("sync2", "file_deleted"),
 			ContainerPath: "/nested/dest2/file_deleted",
 		},
 	}
@@ -74,7 +72,7 @@ func TestFileToDirectoryPathMapping(t *testing.T) {
 	defer f.TearDown()
 
 	paths := []string{
-		"sync1/fileA",
+		filepath.Join("sync1", "fileA"),
 	}
 	f.TouchFiles(paths)
 
@@ -97,7 +95,7 @@ func TestFileToDirectoryPathMapping(t *testing.T) {
 
 	expected := []PathMapping{
 		PathMapping{
-			LocalPath:     filepath.Join(f.Path(), "sync1/fileA"),
+			LocalPath:     filepath.Join(f.Path(), "sync1", "fileA"),
 			ContainerPath: "/dest1/fileA",
 		},
 	}

--- a/internal/build/pipeline_state_test.go
+++ b/internal/build/pipeline_state_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package build
 
 import (
@@ -7,7 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/tilt/pkg/logger"
 )
@@ -69,7 +70,9 @@ func assertSnapshot(t *testing.T, output string) {
 		t.Fatal(err)
 	}
 
-	if string(expected) != output {
-		t.Errorf("Expected: %s != Output: %s", expected, output)
-	}
+	assert.Equal(t, normalize(string(expected)), normalize(output))
+}
+
+func normalize(str string) string {
+	return strings.Replace(str, "\r\n", "\n", -1)
 }

--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -120,48 +121,38 @@ type archiveEntry struct {
 // tarPath writes the given source path into tarWriter at the given dest (recursively for directories).
 // e.g. tarring my_dir --> dest d: d/file_a, d/file_b
 // If source path does not exist, quietly skips it and returns no err
-func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string) ([]archiveEntry, error) {
-	// (PL) convert \ to / in case of windows path
-	source = filepath.ToSlash(source)
-
-	sourceInfo, err := os.Stat(source)
+func (a *ArchiveBuilder) entriesForPath(ctx context.Context, localPath, containerPath string) ([]archiveEntry, error) {
+	localInfo, err := os.Stat(localPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(err, "%s: stat", source)
+		return nil, errors.Wrapf(err, "%s: stat", localPath)
 	}
 
-	sourceIsDir := sourceInfo.IsDir()
-	if sourceIsDir {
+	localPathIsDir := localInfo.IsDir()
+	if localPathIsDir {
 		// Make sure we can trim this off filenames to get valid relative filepaths
-		if !strings.HasSuffix(source, "/") {
-			source += "/"
+		if !strings.HasSuffix(localPath, string(filepath.Separator)) {
+			localPath += string(filepath.Separator)
 		}
 	}
 
-	// (PL) convert \ to / in case of windows path
-	dest = filepath.ToSlash(dest)
-
-	// (PL) remove volume name + / so if we got a windows path C:\foo it becomes foo
-	dest = strings.TrimPrefix(dest, filepath.VolumeName(dest)+"/")
+	containerPath = strings.TrimPrefix(containerPath, "/")
 
 	result := make([]archiveEntry, 0)
-	err = filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(localPath, func(curLocalPath string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "error walking to %s", path)
+			return errors.Wrapf(err, "error walking to %s", curLocalPath)
 		}
 
-		// (PL) convert \ to / in case of windows path
-		path = filepath.ToSlash(path)
-
-		matches, err := a.filter.Matches(path)
+		matches, err := a.filter.Matches(curLocalPath)
 		if err != nil {
 			return err
 		}
 		if matches {
-			if info.IsDir() && path != source {
-				shouldSkip, err := a.filter.MatchesEntireDir(path)
+			if info.IsDir() && curLocalPath != localPath {
+				shouldSkip, err := a.filter.MatchesEntireDir(curLocalPath)
 				if err != nil {
 					return err
 				}
@@ -175,7 +166,7 @@ func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string
 		linkname := ""
 		if info.Mode()&os.ModeSymlink != 0 {
 			var err error
-			linkname, err = os.Readlink(path)
+			linkname, err = os.Readlink(curLocalPath)
 			if err != nil {
 				return err
 			}
@@ -185,28 +176,28 @@ func (a *ArchiveBuilder) entriesForPath(ctx context.Context, source, dest string
 		if err != nil {
 			// Not all types of files are allowed in a tarball. That's OK.
 			// Mimic the Docker behavior and just skip the file.
-			logger.Get(ctx).Debugf("Skipping file %s: %v", path, err)
+			logger.Get(ctx).Debugf("Skipping file %s: %v", curLocalPath, err)
 			return nil
 		}
 
 		clearUIDAndGID(header)
 
-		if sourceIsDir {
+		if localPathIsDir {
 			// Name of file in tar should be relative to source directory...
-			tmp, err := filepath.Rel(source, path)
+			tmp, err := filepath.Rel(localPath, curLocalPath)
 			if err != nil {
-				return errors.Wrapf(err, "making rel path source:%s path:%s", source, path)
+				return errors.Wrapf(err, "making rel path source:%s path:%s", localPath, curLocalPath)
 			}
 			// ...and live inside `dest`
-			header.Name = filepath.Join(dest, tmp)
-		} else if strings.HasSuffix(dest, "/") {
-			header.Name = dest + filepath.Base(path)
+			header.Name = path.Join(containerPath, filepath.ToSlash(tmp))
+		} else if strings.HasSuffix(containerPath, "/") {
+			header.Name = containerPath + filepath.Base(curLocalPath)
 		} else {
-			header.Name = dest
+			header.Name = containerPath
 		}
-		header.Name = filepath.ToSlash(filepath.Clean(header.Name))
+		header.Name = path.Clean(header.Name)
 		result = append(result, archiveEntry{
-			path:   path,
+			path:   curLocalPath,
 			info:   info,
 			header: header,
 		})

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package build
 
 import (
@@ -8,6 +6,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -128,6 +127,10 @@ func TestDontArchiveTiltfile(t *testing.T) {
 }
 
 func TestArchiveOverlapping(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Cannot create a symlink on windows")
+	}
+
 	f := newFixture(t)
 	buf := new(bytes.Buffer)
 	ab := NewArchiveBuilder(buf, model.EmptyMatcher)
@@ -163,6 +166,10 @@ func TestArchiveOverlapping(t *testing.T) {
 }
 
 func TestArchiveSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Cannot create a symlink on windows")
+	}
+
 	f := newFixture(t)
 	buf := new(bytes.Buffer)
 	ab := NewArchiveBuilder(buf, model.EmptyMatcher)
@@ -192,6 +199,10 @@ func TestArchiveSymlink(t *testing.T) {
 }
 
 func TestArchiveSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Cannot create a unix socket on windows")
+	}
+
 	f := newFixture(t)
 	buf := new(bytes.Buffer)
 	ab := NewArchiveBuilder(buf, model.EmptyMatcher)


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/windows5:

37f98b610fde67fb7780445347b81c3ba530943c (2020-04-24 21:28:58 -0400)
build: fix tar code on windows
now that we fixed the path mapping code to handle paths
correctly, we don't need a lot of these workarounds

ebcbd16941bfb1b565e960e7460b0aed13d562e8 (2020-04-24 20:50:03 -0400)
build: fix path mapping on windows

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics