### PR TITLE
Recognize Red Hat CodeReady Containers as a local cluster

### DIFF
--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -23,6 +23,7 @@ const (
 	EnvMinikube      Env = "minikube"
 	EnvDockerDesktop Env = "docker-for-desktop"
 	EnvMicroK8s      Env = "microk8s"
+	EnvCRC           Env = "crc"
 
 	// Kind v0.6 substantially changed the protocol for detecting and pulling,
 	// so we represent them as two separate envs.
@@ -37,7 +38,7 @@ func (e Env) UsesLocalDockerRegistry() bool {
 }
 
 func (e Env) IsLocalCluster() bool {
-	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s || e == EnvKIND5 || e == EnvKIND6 || e == EnvK3D
+	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s || e == EnvCRC || e == EnvKIND5 || e == EnvKIND6 || e == EnvK3D
 }
 
 func ProvideKubeContext(config *api.Config) (KubeContext, error) {
@@ -91,6 +92,8 @@ func ProvideEnv(ctx context.Context, config *api.Config) Env {
 		return EnvKIND6
 	} else if strings.HasPrefix(cn, "microk8s-cluster") {
 		return EnvMicroK8s
+	} else if strings.HasPrefix(cn, "api-crc-testing") {
+		return EnvCRC
 	}
 
 	loc := c.LocationOfOrigin

--- a/internal/k8s/env_test.go
+++ b/internal/k8s/env_test.go
@@ -66,6 +66,16 @@ func TestProvideEnv(t *testing.T) {
 			Cluster: "microk8s-cluster-dev-cluster-1",
 		},
 	}
+	crcContexts := map[string]*api.Context{
+		"api-crc-testing": &api.Context{
+			Cluster: "api-crc-testing",
+		},
+	}
+	crcPrefixContexts := map[string]*api.Context{
+		"api-crc-testing:6443": &api.Context{
+			Cluster: "api-crc-testing:6443",
+		},
+	}
 
 	homedir, err := homedir.Dir()
 	assert.NoError(t, err)
@@ -99,6 +109,8 @@ func TestProvideEnv(t *testing.T) {
 		{EnvKIND5, &api.Config{CurrentContext: "kubernetes-admin@kind-1", Contexts: kind5Contexts}},
 		{EnvMicroK8s, &api.Config{CurrentContext: "microk8s", Contexts: microK8sContexts}},
 		{EnvMicroK8s, &api.Config{CurrentContext: "microk8s-dev-cluster-1", Contexts: microK8sPrefixContexts}},
+		{EnvCRC, &api.Config{CurrentContext: "api-crc-testing", Contexts: crcContexts}},
+		{EnvCRC, &api.Config{CurrentContext: "api-crc-testing:6443", Contexts: crcPrefixContexts}},
 		{EnvK3D, &api.Config{CurrentContext: "default", Contexts: k3dContexts}},
 		{EnvKIND5, &api.Config{CurrentContext: "default", Contexts: kind5NamedClusterContexts}},
 		{EnvKIND6, &api.Config{CurrentContext: "kind-custom-name", Contexts: kind6Contexts}},


### PR DESCRIPTION
Hi there,

I tried to use tilt in combination with a CodeReady Containers (CRC) cluster. CRC is a slimmed down OpenShift cluster meant to be used for local development, see also [Red Hat CodeReady Containers](https://developers.redhat.com/products/codeready-containers)

Based on my testing, tilt works very weill with CRC. I encountered only one trivial glitch: tilt didn't recognize CRC as a local cluster. This pull request fixes it.

Thanks,
Ales