### PR TITLE
tiltfile: fix the last tiltfile tests on windows

### DIFF
--- a/internal/tiltfile/docker_test.go
+++ b/internal/tiltfile/docker_test.go
@@ -1,8 +1,7 @@
-// +build !windows
-
 package tiltfile
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,8 +25,8 @@ docker_build('gcr.io/fe', '.', live_update=[
 ])
 `)
 	f.file(".dockerignore", "build")
-	f.file("src/index.html", "Hello world!")
-	f.file("src/.dockerignore", "**")
+	f.file(filepath.Join("src", "index.html"), "Hello world!")
+	f.file(filepath.Join("src", ".dockerignore"), "**")
 
 	f.load()
 	m := f.assertNextManifest("fe")
@@ -55,8 +54,8 @@ k8s_yaml('fe.yaml')
 custom_build('gcr.io/fe', 'docker build -t $EXPECTED_REF .', ['src'])
 `)
 	f.file(".dockerignore", "build")
-	f.file("src/index.html", "Hello world!")
-	f.file("src/.git/hi", "hi")
+	f.file(filepath.Join("src", "index.html"), "Hello world!")
+	f.file(filepath.Join("src", ".git", "hi"), "hi")
 
 	f.load()
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/windows8:

033fad4130fd2ff9d8ba7c707c1b36664e771435 (2020-04-28 22:31:23 -0400)
tiltfile: fix the last tiltfile tests on windows

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics