### PR TITLE
engine: move WatchManager into its own package

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -27,6 +27,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/dcwatch"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
 	"github.com/windmilleng/tilt/internal/engine/exit"
+	"github.com/windmilleng/tilt/internal/engine/fswatch"
 	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
@@ -106,9 +107,9 @@ var BaseWireSet = wire.NewSet(
 	engineanalytics.NewAnalyticsUpdater,
 	engineanalytics.ProvideAnalyticsReporter,
 	provideUpdateModeFlag,
-	engine.NewWatchManager,
-	engine.ProvideFsWatcherMaker,
-	engine.ProvideTimerMaker,
+	fswatch.NewWatchManager,
+	fswatch.ProvideFsWatcherMaker,
+	fswatch.ProvideTimerMaker,
 
 	provideWebVersion,
 	provideWebMode,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -32,6 +32,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/dcwatch"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
 	"github.com/windmilleng/tilt/internal/engine/exit"
+	"github.com/windmilleng/tilt/internal/engine/fswatch"
 	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
@@ -170,9 +171,9 @@ func wireCmdUp(ctx context.Context, hudEnabled hud.HudEnabled, analytics3 *analy
 	serviceWatcher := k8swatch.NewServiceWatcher(client, ownerFetcher)
 	podLogManager := runtimelog.NewPodLogManager(client)
 	portForwardController := engine.NewPortForwardController(client)
-	fsWatcherMaker := engine.ProvideFsWatcherMaker()
-	timerMaker := engine.ProvideTimerMaker()
-	watchManager := engine.NewWatchManager(fsWatcherMaker, timerMaker)
+	fsWatcherMaker := fswatch.ProvideFsWatcherMaker()
+	timerMaker := fswatch.ProvideTimerMaker()
+	watchManager := fswatch.NewWatchManager(fsWatcherMaker, timerMaker)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
 	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
@@ -326,9 +327,9 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics) (CmdCID
 	serviceWatcher := k8swatch.NewServiceWatcher(client, ownerFetcher)
 	podLogManager := runtimelog.NewPodLogManager(client)
 	portForwardController := engine.NewPortForwardController(client)
-	fsWatcherMaker := engine.ProvideFsWatcherMaker()
-	timerMaker := engine.ProvideTimerMaker()
-	watchManager := engine.NewWatchManager(fsWatcherMaker, timerMaker)
+	fsWatcherMaker := fswatch.ProvideFsWatcherMaker()
+	timerMaker := fswatch.ProvideTimerMaker()
+	watchManager := fswatch.NewWatchManager(fsWatcherMaker, timerMaker)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
 	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
@@ -616,7 +617,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics) (
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, exit.NewController, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, engine.NewWatchManager, engine.ProvideFsWatcherMaker, engine.ProvideTimerMaker, provideWebVersion,
+	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, engine.NewPortForwardController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, engine.NewGithubClientFactory, engine.NewTiltVersionChecker, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, exit.NewController, provideClock, hud.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, fswatch.NewWatchManager, fswatch.ProvideFsWatcherMaker, fswatch.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -38,7 +38,7 @@ func TestBuildControllerOnePod(t *testing.T) {
 
 	pod := podbuilder.New(f.T(), manifest).Build()
 	f.podEvent(pod, manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	assert.Equal(t, pod.Name, call.oneState().OneContainerInfo().PodID.String())
@@ -65,7 +65,7 @@ func TestBuildControllerTooManyPodsForLiveUpdateErrorMessage(t *testing.T) {
 
 	f.podEvent(p1, manifest.Name)
 	f.podEvent(p2, manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	// Should not have sent container info b/c too many pods
@@ -99,7 +99,7 @@ func TestBuildControllerTooManyPodsForDockerBuildNoErrorMessage(t *testing.T) {
 
 	f.podEvent(p1, manifest.Name)
 	f.podEvent(p2, manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	// Should not have sent container info b/c too many pods
@@ -131,7 +131,7 @@ func TestBuildControllerIgnoresImageTags(t *testing.T) {
 		WithImage("image-foo:othertag").
 		Build()
 	f.podEvent(pod, manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	assert.Equal(t, "pod-id", call.oneState().OneContainerInfo().PodID.String())
@@ -152,7 +152,7 @@ func TestBuildControllerDockerCompose(t *testing.T) {
 	imageTarget := manifest.ImageTargetAt(0)
 	assert.Equal(t, imageTarget, call.firstImgTarg())
 
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	imageState := call.state[imageTarget.ID()]
@@ -176,7 +176,7 @@ func TestBuildControllerLocalResource(t *testing.T) {
 	lt := manifest.LocalTarget()
 	assert.Equal(t, lt, call.local())
 
-	f.fsWatcher.events <- watch.NewFileEvent(dep)
+	f.fsWatcher.Events <- watch.NewFileEvent(dep)
 
 	call = f.nextCall()
 	assert.Equal(t, lt, call.local())
@@ -203,7 +203,7 @@ func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	f.podEvent(podA, manifest.Name)
 	f.podEvent(podB, manifest.Name)
 
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	// We expect two pods associated with this manifest. We don't want to container-build
 	// if there are multiple pods, so make sure we're not sending deploy info (i.e. that
@@ -249,7 +249,7 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 		ContainerID: "docker://cID-different-image",
 	})
 	f.podEvent(pod, manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	runningContainers := call.oneState().RunningContainers
@@ -295,7 +295,7 @@ func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *te
 		ContainerID: "docker://cID-same-image",
 	})
 	f.podEvent(pod, manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	// If even one of the containers matching this image is !ready, we have to do a
 	// full rebuild, so don't return ANY RunningContainers.
@@ -324,7 +324,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	pb := podbuilder.New(f.T(), manifest)
 	pod := pb.Build()
 	f.podEvent(pod, manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	assert.Equal(t, pod.Name, call.oneState().OneContainerInfo().PodID.String())
@@ -369,7 +369,7 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
 		Build(), manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	f.waitForCompletedBuildCount(2)
@@ -418,7 +418,7 @@ func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
 		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
 		Build(), manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	f.waitForCompletedBuildCount(2)
@@ -466,7 +466,7 @@ func TestRecordLiveUpdatedContainerIDsForFailedLiveUpdate(t *testing.T) {
 		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
 		Build(), manifest.Name)
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
 	f.waitForCompletedBuildCount(2)
@@ -540,7 +540,7 @@ func TestBuildControllerImageBuildTrigger(t *testing.T) {
 			expectedFiles := []string{}
 			if tc.filesChanged {
 				expectedFiles = append(expectedFiles, f.JoinPath("main.go"))
-				f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+				f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 			}
 			f.WaitUntil("pending change appears", func(st store.EngineState) bool {
 				return len(st.BuildStatus(manifest.ImageTargetAt(0).ID()).PendingFileChanges) >= len(expectedFiles)
@@ -582,7 +582,7 @@ func TestBuildControllerManualTriggerWithFileChangesSinceLastSuccessfulBuildButB
 	f.nextCallComplete()
 
 	f.b.nextBuildFailure = errors.New("build failure!")
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 	f.nextCallComplete()
 
 	f.store.Dispatch(server.AppendToTriggerQueueAction{Name: mName})
@@ -628,7 +628,7 @@ func TestBuildQueueOrdering(t *testing.T) {
 
 	f.waitForCompletedBuildCount(expectedInitialBuildCount)
 
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
 		return len(st.BuildStatus(m1.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
 			len(st.BuildStatus(m2.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
@@ -685,7 +685,7 @@ func TestBuildQueueAndAutobuildOrdering(t *testing.T) {
 
 	f.waitForCompletedBuildCount(expectedInitialBuildCount)
 
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("dirManual/main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("dirManual/main.go"))
 	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
 		return len(st.BuildStatus(m1.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
 			len(st.BuildStatus(m2.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
@@ -698,7 +698,7 @@ func TestBuildQueueAndAutobuildOrdering(t *testing.T) {
 	f.store.Dispatch(server.AppendToTriggerQueueAction{Name: "manifest2"})
 	// make our one auto-trigger manifest build - should be evaluated LAST, after
 	// all the manual manifests waiting in the queue
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("dirAuto/main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("dirAuto/main.go"))
 	f.store.Dispatch(server.AppendToTriggerQueueAction{Name: "manifest3"})
 	f.store.Dispatch(server.AppendToTriggerQueueAction{Name: "manifest4"})
 
@@ -963,12 +963,12 @@ func TestBuildControllerResourceDepTrumpsInitialBuild(t *testing.T) {
 	call := f.nextCall()
 	require.Equal(t, "foo", call.local().Name.String())
 
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("foo", "main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("foo", "main.go"))
 	f.b.nextBuildFailure = errors.New("failure")
 	call = f.nextCall()
 	require.Equal(t, "foo", call.local().Name.String())
 
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("foo", "main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("foo", "main.go"))
 	call = f.nextCall()
 	require.Equal(t, "foo", call.local().Name.String())
 
@@ -995,17 +995,17 @@ func TestBuildControllerResourceDepTrumpsPendingBuild(t *testing.T) {
 	f.Start(manifests)
 
 	// trigger a change for bar so that it would try to build if not for its resource dep
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("bar", "main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("bar", "main.go"))
 
 	call := f.nextCall()
 	require.Equal(t, "foo", call.local().Name.String())
 
 	f.b.nextBuildFailure = errors.New("failure")
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("foo", "main.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("foo", "main.go"))
 	call = f.nextCall()
 	require.Equal(t, "foo", call.local().Name.String())
 
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("foo", "main2.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("foo", "main2.go"))
 	call = f.nextCall()
 	require.Equal(t, "foo", call.local().Name.String())
 
@@ -1060,7 +1060,7 @@ func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 	f.waitUntilNumBuildSlots(2)
 
 	// a second file change doesn't start a second build, b/c 'fe' is already building
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("B.txt"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("B.txt"))
 	f.waitUntilNumBuildSlots(2) // still two build slots available
 
 	// complete the first build
@@ -1141,7 +1141,7 @@ func TestCurrentlyBuildingMayExceedMaxParallelUpdates(t *testing.T) {
 	f.waitUntilNumBuildSlots(0)
 
 	// another file change for manB -- will try to start another build as soon as possible
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath("b/other.go"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("b/other.go"))
 
 	f.completeBuildForManifest(manB)
 	call := f.nextCall("expect manB build complete")
@@ -1290,12 +1290,12 @@ func (f *testFixture) waitUntilNumBuildSlots(expected int) {
 }
 
 func (f *testFixture) editFileAndWaitForManifestBuilding(name model.ManifestName, path string) {
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath(path))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath(path))
 	f.waitUntilManifestBuilding(name)
 }
 
 func (f *testFixture) editFileAndAssertManifestNotBuilding(name model.ManifestName, path string) {
-	f.fsWatcher.events <- watch.NewFileEvent(f.JoinPath(path))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath(path))
 	f.waitUntilManifestNotBuilding(name)
 }
 

--- a/internal/engine/fswatch/action.go
+++ b/internal/engine/fswatch/action.go
@@ -1,0 +1,23 @@
+package fswatch
+
+import (
+	"time"
+
+	"github.com/windmilleng/tilt/pkg/model"
+)
+
+type TargetFilesChangedAction struct {
+	TargetID model.TargetID
+	Files    []string
+	Time     time.Time
+}
+
+func (TargetFilesChangedAction) Action() {}
+
+func NewTargetFilesChangedAction(targetID model.TargetID, files ...string) TargetFilesChangedAction {
+	return TargetFilesChangedAction{
+		TargetID: targetID,
+		Files:    files,
+		Time:     time.Now(),
+	}
+}

--- a/internal/engine/fswatch/factories.go
+++ b/internal/engine/fswatch/factories.go
@@ -1,0 +1,24 @@
+package fswatch
+
+import (
+	"time"
+
+	"github.com/windmilleng/tilt/internal/watch"
+	"github.com/windmilleng/tilt/pkg/logger"
+)
+
+type FsWatcherMaker func(paths []string, ignore watch.PathMatcher, l logger.Logger) (watch.Notify, error)
+
+type TimerMaker func(d time.Duration) <-chan time.Time
+
+func ProvideFsWatcherMaker() FsWatcherMaker {
+	return func(paths []string, ignore watch.PathMatcher, l logger.Logger) (watch.Notify, error) {
+		return watch.NewWatcher(paths, ignore, l)
+	}
+}
+
+func ProvideTimerMaker() TimerMaker {
+	return func(t time.Duration) <-chan time.Time {
+		return time.After(t)
+	}
+}

--- a/internal/engine/fswatch/fake.go
+++ b/internal/engine/fswatch/fake.go
@@ -1,0 +1,45 @@
+package fswatch
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+type FakeTimerMaker struct {
+	RestTimerLock *sync.Mutex
+	MaxTimerLock  *sync.Mutex
+	t             *testing.T
+}
+
+func (f FakeTimerMaker) Maker() TimerMaker {
+	return func(d time.Duration) <-chan time.Time {
+		var lock *sync.Mutex
+		// we have separate locks for the separate uses of timer so that tests can control the timers independently
+		switch d {
+		case BufferMinRestDuration:
+			lock = f.RestTimerLock
+		case BufferMaxDuration:
+			lock = f.MaxTimerLock
+		default:
+			// if you hit this, someone (you!?) might have added a new timer with a new duration, and you probably
+			// want to add a case above
+			f.t.Error("makeTimer called on unsupported duration")
+		}
+		ret := make(chan time.Time, 1)
+		go func() {
+			lock.Lock()
+			ret <- time.Unix(0, 0)
+			lock.Unlock()
+			close(ret)
+		}()
+		return ret
+	}
+}
+
+func MakeFakeTimerMaker(t *testing.T) FakeTimerMaker {
+	restTimerLock := new(sync.Mutex)
+	maxTimerLock := new(sync.Mutex)
+
+	return FakeTimerMaker{restTimerLock, maxTimerLock, t}
+}

--- a/internal/engine/subscribers.go
+++ b/internal/engine/subscribers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/windmilleng/tilt/internal/engine/dcwatch"
 	"github.com/windmilleng/tilt/internal/engine/dockerprune"
 	"github.com/windmilleng/tilt/internal/engine/exit"
+	"github.com/windmilleng/tilt/internal/engine/fswatch"
 	"github.com/windmilleng/tilt/internal/engine/k8srollout"
 	"github.com/windmilleng/tilt/internal/engine/k8swatch"
 	"github.com/windmilleng/tilt/internal/engine/local"
@@ -24,7 +25,7 @@ func ProvideSubscribers(
 	sw *k8swatch.ServiceWatcher,
 	plm *runtimelog.PodLogManager,
 	pfc *PortForwardController,
-	fwm *WatchManager,
+	fwm *fswatch.WatchManager,
 	bc *BuildController,
 	cc *configs.ConfigsController,
 	dcw *dcwatch.EventWatcher,

--- a/internal/engine/version_checker.go
+++ b/internal/engine/version_checker.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/windmilleng/tilt/internal/engine/fswatch"
 	"github.com/windmilleng/tilt/internal/github"
 	"github.com/windmilleng/tilt/internal/store"
 	"github.com/windmilleng/tilt/pkg/logger"
@@ -18,10 +19,10 @@ type TiltVersionChecker struct {
 	started       bool
 	clientFactory GithubClientFactory
 	client        github.Client
-	timerMaker    timerMaker
+	timerMaker    fswatch.TimerMaker
 }
 
-func NewTiltVersionChecker(ghcf GithubClientFactory, timerMaker timerMaker) *TiltVersionChecker {
+func NewTiltVersionChecker(ghcf GithubClientFactory, timerMaker fswatch.TimerMaker) *TiltVersionChecker {
 	return &TiltVersionChecker{clientFactory: ghcf, timerMaker: timerMaker}
 }
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/watchmanager:

b75cd3cf2d6867a2a3aa746e0e208d90a0af17da (2020-04-28 19:04:57 -0400)
engine: move WatchManager into its own package

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics