### PR TITLE
engine: use the simpler test store instead of the real store for testing

### DIFF
--- a/internal/cloud/update_uploader_test.go
+++ b/internal/cloud/update_uploader_test.go
@@ -99,7 +99,7 @@ type updateFixture struct {
 	ctx        context.Context
 	httpClient *httptest.FakeClient
 	uu         *UpdateUploader
-	store      *store.Store
+	store      *store.TestingStore
 	clock      clockwork.FakeClock
 }
 
@@ -108,7 +108,7 @@ func newUpdateFixture(t *testing.T) *updateFixture {
 	httpClient := httptest.NewFakeClient()
 	addr := cloudurl.Address("cloud-test.tilt.dev")
 	uu := NewUpdateUploader(httpClient, addr)
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 
 	state := st.LockMutableStateForTesting()

--- a/internal/containerupdate/synclet_manager_test.go
+++ b/internal/containerupdate/synclet_manager_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/windmilleng/tilt/internal/testutils"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/windmilleng/tilt/internal/docker"
@@ -57,7 +55,7 @@ type smFixture struct {
 	kCli   *k8s.FakeK8sClient
 	sCli   *synclet.TestSyncletClient
 	sm     SyncletManager
-	store  *store.Store
+	store  *store.TestingStore
 }
 
 func newSMFixture(t *testing.T) *smFixture {
@@ -69,14 +67,10 @@ func newSMFixture(t *testing.T) *smFixture {
 	sGRPCCli, err := synclet.FakeGRPCWrapper(ctx, sCli)
 	assert.NoError(t, err)
 	sm := NewSyncletManagerForTests(kCli, sGRPCCli, sCli)
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 
 	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
 	ctx = logger.WithLogger(ctx, l)
-	go func() {
-		err := st.Loop(ctx)
-		testutils.FailOnNonCanceledErr(t, err, "store.Loop failed")
-	}()
 
 	return &smFixture{
 		TempDirFixture: f,

--- a/internal/engine/analytics/analytics_reporter.go
+++ b/internal/engine/analytics/analytics_reporter.go
@@ -15,7 +15,7 @@ const analyticsReportingInterval = time.Minute * 15
 
 type AnalyticsReporter struct {
 	a       *analytics.TiltAnalytics
-	store   *store.Store
+	store   store.RStore
 	kClient k8s.Client
 	env     k8s.Env
 	started bool
@@ -55,7 +55,7 @@ func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore) {
 
 var _ store.Subscriber = &AnalyticsReporter{}
 
-func ProvideAnalyticsReporter(a *analytics.TiltAnalytics, st *store.Store, kClient k8s.Client, env k8s.Env) *AnalyticsReporter {
+func ProvideAnalyticsReporter(a *analytics.TiltAnalytics, st store.RStore, kClient k8s.Client, env k8s.Env) *AnalyticsReporter {
 	return &AnalyticsReporter{
 		a:       a,
 		store:   st,

--- a/internal/engine/analytics/analytics_updater_test.go
+++ b/internal/engine/analytics/analytics_updater_test.go
@@ -18,7 +18,7 @@ func TestOnChange(t *testing.T) {
 	_, a := tiltanalytics.NewMemoryTiltAnalyticsForTest(to)
 	cmdUpTags := CmdTags(map[string]string{"watch": "true"})
 	au := NewAnalyticsUpdater(a, cmdUpTags)
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 	setUserOpt(st, analytics.OptOut)
 	au.OnChange(context.Background(), st)
 
@@ -33,7 +33,7 @@ func TestReportOnOptIn(t *testing.T) {
 
 	cmdUpTags := CmdTags(map[string]string{"watch": "true"})
 	au := NewAnalyticsUpdater(a, cmdUpTags)
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 	setUserOpt(st, analytics.OptIn)
 	au.OnChange(context.Background(), st)
 
@@ -52,7 +52,7 @@ func TestReportOnOptIn(t *testing.T) {
 	assert.Equal(t, 1, len(mem.Counts))
 }
 
-func setUserOpt(st *store.Store, opt analytics.Opt) {
+func setUserOpt(st *store.TestingStore, opt analytics.Opt) {
 	state := st.LockMutableStateForTesting()
 	defer st.UnlockMutableState()
 	state.AnalyticsUserOpt = opt

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -1005,7 +1005,7 @@ type bdFixture struct {
 	k8s    *k8s.FakeK8sClient
 	sCli   *synclet.TestSyncletClient
 	bd     BuildAndDeployer
-	st     *store.Store
+	st     *store.TestingStore
 	dcCli  *dockercompose.FakeDCClient
 	logs   *bytes.Buffer
 }
@@ -1035,7 +1035,7 @@ func newBDFixture(t *testing.T, env k8s.Env, runtime container.Runtime) *bdFixtu
 		t.Fatal(err)
 	}
 
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 
 	return &bdFixture{
 		TempDirFixture: f,

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -89,7 +89,7 @@ type ccFixture struct {
 
 func newCCFixture(t *testing.T) *ccFixture {
 	f := tempdir.NewTempDirFixture(t)
-	st, getActions := store.NewStoreForTesting()
+	st, getActions := store.NewStoreWithFakeReducer()
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	d := docker.NewFakeClient()
 	cc := NewConfigsController(tfl, d)

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -175,7 +175,7 @@ type dcbdFixture struct {
 	dcCli *dockercompose.FakeDCClient
 	dCli  *docker.FakeClient
 	dcbad *DockerComposeBuildAndDeployer
-	st    *store.Store
+	st    *store.TestingStore
 }
 
 func newDCBDFixture(t *testing.T) *dcbdFixture {
@@ -190,7 +190,7 @@ func newDCBDFixture(t *testing.T) *dcbdFixture {
 	if err != nil {
 		t.Fatal(err)
 	}
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 	return &dcbdFixture{
 		TempDirFixture: f,
 		ctx:            ctx,

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -374,7 +374,7 @@ type dockerPruneFixture struct {
 	t    *testing.T
 	ctx  context.Context
 	logs *bytes.Buffer
-	st   *store.Store
+	st   *store.TestingStore
 
 	dCli *docker.FakeClient
 	dp   *DockerPruner
@@ -383,7 +383,7 @@ type dockerPruneFixture struct {
 func newFixture(t *testing.T) *dockerPruneFixture {
 	logs := new(bytes.Buffer)
 	ctx, _, _ := testutils.ForkedCtxAndAnalyticsForTest(logs)
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 
 	dCli := docker.NewFakeClient()
 	dp := NewDockerPruner(dCli)

--- a/internal/engine/fswatch/watchmanager_test.go
+++ b/internal/engine/fswatch/watchmanager_test.go
@@ -129,7 +129,7 @@ type wmFixture struct {
 }
 
 func newWMFixture(t *testing.T) *wmFixture {
-	st, getActions := store.NewStoreForTesting()
+	st, getActions := store.NewStoreWithFakeReducer()
 	timerMaker := MakeFakeTimerMaker(t)
 	fakeMultiWatcher := NewFakeMultiWatcher()
 	wm := NewWatchManager(fakeMultiWatcher.NewSub, timerMaker.Maker())

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -169,7 +169,7 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 		storeLoopErrCh: storeLoopErrCh,
 	}
 
-	ret.store, ret.getActions = store.NewStoreForTesting()
+	ret.store, ret.getActions = store.NewStoreWithFakeReducer()
 	state := ret.store.LockMutableStateForTesting()
 	state.TiltStartTime = clock.Now()
 	ret.store.UnlockMutableState()

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -132,7 +132,7 @@ func newSWFixture(t *testing.T) *swFixture {
 		t:       t,
 	}
 
-	ret.store, ret.getActions = store.NewStoreForTesting()
+	ret.store, ret.getActions = store.NewStoreWithFakeReducer()
 	go func() {
 		err := ret.store.Loop(ctx)
 		testutils.FailOnNonCanceledErr(t, err, "store.Loop failed")

--- a/internal/engine/live_update_build_and_deployer_test.go
+++ b/internal/engine/live_update_build_and_deployer_test.go
@@ -350,7 +350,7 @@ type lcbadFixture struct {
 	*tempdir.TempDirFixture
 	t     testing.TB
 	ctx   context.Context
-	st    *store.Store
+	st    *store.TestingStore
 	cu    *containerupdate.FakeContainerUpdater
 	ps    *build.PipelineState
 	lubad *LiveUpdateBuildAndDeployer
@@ -362,7 +362,7 @@ func newFixture(t testing.TB) *lcbadFixture {
 	lubad := NewLiveUpdateBuildAndDeployer(nil, nil, nil, buildcontrol.UpdateModeAuto, k8s.EnvDockerDesktop, container.RuntimeDocker, fakeClock{})
 	fakeContainerUpdater := &containerupdate.FakeContainerUpdater{}
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 	return &lcbadFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,

--- a/internal/engine/local_target_build_and_deployer_test.go
+++ b/internal/engine/local_target_build_and_deployer_test.go
@@ -123,7 +123,7 @@ type ltFixture struct {
 	ctx   context.Context
 	out   *bytes.Buffer
 	ltbad *LocalTargetBuildAndDeployer
-	st    *store.Store
+	st    *store.TestingStore
 }
 
 func newLTFixture(t *testing.T) *ltFixture {
@@ -134,7 +134,7 @@ func newLTFixture(t *testing.T) *ltFixture {
 	clock := fakeClock{time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC)}
 
 	ltbad := NewLocalTargetBuildAndDeployer(clock)
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 	return &ltFixture{
 		TempDirFixture: f,
 		ctx:            ctx,

--- a/internal/engine/portforwardcontroller_test.go
+++ b/internal/engine/portforwardcontroller_test.go
@@ -246,14 +246,14 @@ type plcFixture struct {
 	ctx    context.Context
 	cancel func()
 	kCli   *k8s.FakeK8sClient
-	st     *store.Store
+	st     *store.TestingStore
 	plc    *PortForwardController
 	out    *bufsync.ThreadSafeBuffer
 }
 
 func newPLCFixture(t *testing.T) *plcFixture {
 	f := tempdir.NewTempDirFixture(t)
-	st, _ := store.NewStoreForTesting()
+	st := store.NewTestingStore()
 	kCli := k8s.NewFakeK8sClient()
 	plc := NewPortForwardController(kCli)
 

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -431,7 +431,7 @@ type serverFixture struct {
 }
 
 func newTestFixture(t *testing.T) *serverFixture {
-	st, getActions := store.NewStoreForTesting()
+	st, getActions := store.NewStoreWithFakeReducer()
 	go func() {
 		err := st.Loop(context.Background())
 		testutils.FailOnNonCanceledErr(t, err, "store.Loop failed")

--- a/internal/hud/server/websocket_test.go
+++ b/internal/hud/server/websocket_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestWebsocketCloseOnReadErr(t *testing.T) {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	st, _ := store.NewStoreForTesting()
+	st, _ := store.NewStoreWithFakeReducer()
 	st.SetUpSubscribersForTesting(ctx)
 
 	conn := newFakeConn()
@@ -41,7 +41,7 @@ func TestWebsocketCloseOnReadErr(t *testing.T) {
 
 func TestWebsocketReadErrDuringMsg(t *testing.T) {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	st, _ := store.NewStoreForTesting()
+	st, _ := store.NewStoreWithFakeReducer()
 	st.SetUpSubscribersForTesting(ctx)
 
 	conn := newFakeConn()
@@ -72,7 +72,7 @@ func TestWebsocketReadErrDuringMsg(t *testing.T) {
 
 func TestWebsocketNextWriterError(t *testing.T) {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	st, _ := store.NewStoreForTesting()
+	st, _ := store.NewStoreWithFakeReducer()
 	st.SetUpSubscribersForTesting(ctx)
 
 	conn := newFakeConn()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -52,9 +52,14 @@ func NewStore(reducer Reducer, logActions LogActionsFlag) *Store {
 	}
 }
 
-// Returns a Store for testing that saves observed actions and makes them available
-// via the return value `getActions`
-func NewStoreForTesting() (st *Store, getActions func() []Action) {
+// Returns a Store with a fake reducer that saves observed actions and makes
+// them available via the return value `getActions`.
+//
+// Tests should only use this if they:
+// 1) want to test the Store itself, or
+// 2) want to test subscribers with the particular async behavior of a real Store
+// Otherwise, use NewTestingStore().
+func NewStoreWithFakeReducer() (st *Store, getActions func() []Action) {
 	var mu sync.Mutex
 	actions := []Action{}
 	reducer := Reducer(func(ctx context.Context, s *EngineState, action Action) {

--- a/internal/store/subscriber_test.go
+++ b/internal/store/subscriber_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSubscriber(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(ctx, s)
@@ -22,7 +22,7 @@ func TestSubscriber(t *testing.T) {
 }
 
 func TestSubscriberInterleavedCalls(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(ctx, s)
@@ -45,7 +45,7 @@ func TestSubscriberInterleavedCalls(t *testing.T) {
 }
 
 func TestAddSubscriberToAlreadySetUpListCallsSetUp(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 	st.subscribers.SetUp(ctx)
 
@@ -56,7 +56,7 @@ func TestAddSubscriberToAlreadySetUpListCallsSetUp(t *testing.T) {
 }
 
 func TestAddSubscriberBeforeSetupNoop(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 
 	s := newFakeSubscriber()
@@ -67,7 +67,7 @@ func TestAddSubscriberBeforeSetupNoop(t *testing.T) {
 }
 
 func TestRemoveSubscriber(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 
@@ -82,7 +82,7 @@ func TestRemoveSubscriber(t *testing.T) {
 }
 
 func TestRemoveSubscriberNotFound(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	s := newFakeSubscriber()
 	ctx := context.Background()
 	err := st.RemoveSubscriber(ctx, s)
@@ -92,7 +92,7 @@ func TestRemoveSubscriberNotFound(t *testing.T) {
 }
 
 func TestSubscriberSetup(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(ctx, s)
@@ -103,7 +103,7 @@ func TestSubscriberSetup(t *testing.T) {
 }
 
 func TestSubscriberTeardown(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(ctx, s)
@@ -118,7 +118,7 @@ func TestSubscriberTeardown(t *testing.T) {
 }
 
 func TestSubscriberTeardownOnRemove(t *testing.T) {
-	st, _ := NewStoreForTesting()
+	st, _ := NewStoreWithFakeReducer()
 	ctx := context.Background()
 	s := newFakeSubscriber()
 	st.AddSubscriber(ctx, s)

--- a/internal/store/testing_store.go
+++ b/internal/store/testing_store.go
@@ -24,6 +24,15 @@ func NewTestingStore() *TestingStore {
 	}
 }
 
+func (s *TestingStore) LockMutableStateForTesting() *EngineState {
+	s.stateMu.Lock()
+	return s.state
+}
+
+func (s *TestingStore) UnlockMutableState() {
+	s.stateMu.Unlock()
+}
+
 func (s *TestingStore) SetState(state EngineState) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/testingstore:

f30184734ca55270500edada49ae463be3c94a7d (2020-04-29 11:16:52 -0400)
engine: use the simpler test store instead of the real store for testing

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics