### PR TITLE
engine: switch more tests to use the simpler store

### DIFF
--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -69,7 +69,7 @@ func TestEventWatchManager_watchError(t *testing.T) {
 	expectedErr := errors.Wrap(err, "Error watching k8s events\n")
 	expected := store.ErrorAction{Error: expectedErr}
 	f.assertActions(expected)
-	<-f.storeLoopErrCh // consume the error
+	f.store.ClearActions()
 }
 
 func TestEventWatchManager_eventBeforeUID(t *testing.T) {
@@ -136,15 +136,13 @@ func (f *ewmFixture) makeEvent(obj k8s.K8sEntity) *v1.Event {
 
 type ewmFixture struct {
 	*tempdir.TempDirFixture
-	t              *testing.T
-	kClient        *k8s.FakeK8sClient
-	ewm            *EventWatchManager
-	ctx            context.Context
-	cancel         func()
-	store          *store.Store
-	storeLoopErrCh chan error
-	getActions     func() []store.Action
-	clock          clockwork.FakeClock
+	t       *testing.T
+	kClient *k8s.FakeK8sClient
+	ewm     *EventWatchManager
+	ctx     context.Context
+	cancel  func()
+	store   *store.TestingStore
+	clock   clockwork.FakeClock
 }
 
 func newEWMFixture(t *testing.T) *ewmFixture {
@@ -156,8 +154,8 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 	of := k8s.ProvideOwnerFetcher(kClient)
 
 	clock := clockwork.NewFakeClock()
+	st := store.NewTestingStore()
 
-	storeLoopErrCh := make(chan error, 1)
 	ret := &ewmFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		kClient:        kClient,
@@ -166,27 +164,21 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 		cancel:         cancel,
 		t:              t,
 		clock:          clock,
-		storeLoopErrCh: storeLoopErrCh,
+		store:          st,
 	}
 
-	ret.store, ret.getActions = store.NewStoreWithFakeReducer()
 	state := ret.store.LockMutableStateForTesting()
 	state.TiltStartTime = clock.Now()
 	ret.store.UnlockMutableState()
-	go func() {
-		ret.storeLoopErrCh <- ret.store.Loop(ctx)
-		close(ret.storeLoopErrCh)
-	}()
 
 	return ret
 }
 
 func (f *ewmFixture) TearDown() {
 	f.cancel()
-	err := <-f.storeLoopErrCh
-	testutils.FailOnNonCanceledErr(f.t, err, "store.Loop returned an error")
 	f.TempDirFixture.TearDown()
 	f.kClient.TearDown()
+	f.store.AssertNoErrorActions(f.t)
 }
 
 func (f *ewmFixture) addManifest(manifestName model.ManifestName) model.Manifest {
@@ -220,7 +212,7 @@ func (f *ewmFixture) assertNoActions() {
 func (f *ewmFixture) assertActions(expected ...store.Action) {
 	start := time.Now()
 	for time.Since(start) < time.Second {
-		actions := f.getActions()
+		actions := f.store.Actions()
 		if len(actions) >= len(expected) {
 			break
 		}
@@ -231,7 +223,7 @@ func (f *ewmFixture) assertActions(expected ...store.Action) {
 
 	// NOTE(maia): this test will break if this the code ever returns other
 	// correct-but-incidental-to-this-test actions, but for now it's fine.
-	actual := f.getActions()
+	actual := f.store.Actions()
 	if !assert.Len(f.t, actual, len(expected)) {
 		f.t.FailNow()
 	}

--- a/internal/store/testing_store.go
+++ b/internal/store/testing_store.go
@@ -79,6 +79,16 @@ func (s *TestingStore) Actions() []Action {
 	return append([]Action{}, s.actions...)
 }
 
+func (s *TestingStore) AssertNoErrorActions(t testing.TB) {
+	t.Helper()
+	for _, action := range s.actions {
+		errAction, ok := action.(ErrorAction)
+		if ok {
+			t.Errorf("Error action: %s", errAction)
+		}
+	}
+}
+
 // for use by tests (with a real channel-based store, NOT a TestingStore), to wait until
 // an action of the specified type comes out of the given chan at some point we might want
 // it to return the index it was found at, and then take an index, so that we can start


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/testingstore2:

5ad218630039b9e79774a292c32405d6bfaed752 (2020-04-29 11:40:06 -0400)
engine: switch more tests to use the simpler store

f30184734ca55270500edada49ae463be3c94a7d (2020-04-29 11:16:52 -0400)
engine: use the simpler test store instead of the real store for testing

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics