### PR TITLE
tiltfile: add a bunch of os.path functions, and fix bugs in os.path.realpath

### DIFF
--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -3,11 +3,14 @@ package os
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/windmilleng/tilt/internal/tiltfile/io"
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
 )
 
@@ -70,6 +73,108 @@ print(get_cwd_wrapper())
 	assert.Equal(t, fmt.Sprintf("%s\n", f.Path()), f.PrintOutput())
 }
 
+func TestAbspath(t *testing.T) {
+	f := NewFixture(t)
+	f.UseRealFS()
+
+	f.File("foo/Tiltfile", `
+path = os.path.abspath('.')
+`)
+	f.File("Tiltfile", `
+load('./foo/Tiltfile', 'path')
+print(path)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s\n", f.JoinPath("foo")), f.PrintOutput())
+}
+
+func TestAbspathSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no user-land symlink support on windows")
+	}
+
+	f := NewFixture(t)
+	f.UseRealFS()
+
+	f.File("foo/Tiltfile", `
+path = os.path.abspath('.')
+`)
+	f.Symlink("foo", "bar")
+	f.File("Tiltfile", `
+load('./bar/Tiltfile', 'path')
+print(path)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s\n", f.JoinPath("bar")), f.PrintOutput())
+}
+
+func TestBasename(t *testing.T) {
+	f := NewFixture(t)
+	f.UseRealFS()
+
+	f.File("foo/Tiltfile", `
+path = os.path.basename(os.path.abspath('.'))
+`)
+	f.File("Tiltfile", `
+load('./foo/Tiltfile', 'path')
+print(path)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, "foo\n", f.PrintOutput())
+}
+
+func TestDirname(t *testing.T) {
+	f := NewFixture(t)
+	f.UseRealFS()
+
+	f.File("foo/Tiltfile", `
+path = os.path.dirname(os.path.abspath('.'))
+`)
+	f.File("Tiltfile", `
+load('./foo/Tiltfile', 'path')
+print(path)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, f.Path()+"\n", f.PrintOutput())
+}
+
+func TestExists(t *testing.T) {
+	f := NewFixture(t)
+	f.UseRealFS()
+
+	f.File("foo/Tiltfile", `
+result1 = os.path.exists('foo/Tiltfile')
+result2 = os.path.exists('./Tiltfile')
+result3 = os.path.exists('../Tiltfile')
+result4 = os.path.exists('../foo')
+result5 = os.path.exists('../bar')
+`)
+	f.File("Tiltfile", `
+load('./foo/Tiltfile', 'result1', 'result2', 'result3', 'result4', 'result5')
+print(result1)
+print(result2)
+print(result3)
+print(result4)
+print(result5)
+`)
+
+	model, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, "False\nTrue\nTrue\nTrue\nFalse\n", f.PrintOutput())
+
+	readState, err := io.GetState(model)
+	require.NoError(t, err)
+	assert.Equal(t, f.JoinPath("foo", "foo", "Tiltfile"), readState.Files[2])
+}
+
 func TestRealpath(t *testing.T) {
 	f := NewFixture(t)
 
@@ -80,6 +185,27 @@ print(os.path.realpath('.'))
 	_, err := f.ExecFile("Tiltfile")
 	require.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%s\n", f.Path()), f.PrintOutput())
+}
+
+func TestRealpathSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no user-land symlink support on windows")
+	}
+	f := NewFixture(t)
+	f.UseRealFS()
+
+	f.File("foo/Tiltfile", `
+path = os.path.realpath('.')
+`)
+	f.Symlink("foo", "bar")
+	f.File("Tiltfile", `
+load('./bar/Tiltfile', 'path')
+print(path)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s\n", f.JoinPath("foo")), f.PrintOutput())
 }
 
 func TestName(t *testing.T) {
@@ -94,6 +220,18 @@ print(os.name)
 	assert.Equal(t, fmt.Sprintf("%s\n", osName()), f.PrintOutput())
 }
 
+func TestJoin(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+print(os.path.join("foo", "bar", "baz"))
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("%s\n", filepath.Join("foo", "bar", "baz")), f.PrintOutput())
+}
+
 func NewFixture(tb testing.TB) *starkit.Fixture {
-	return starkit.NewFixture(tb, NewExtension())
+	return starkit.NewFixture(tb, NewExtension(), io.NewExtension())
 }

--- a/internal/tiltfile/starkit/fixture.go
+++ b/internal/tiltfile/starkit/fixture.go
@@ -93,6 +93,14 @@ func (f *Fixture) File(name, contents string) {
 	f.fs[fullPath] = contents
 }
 
+func (f *Fixture) Symlink(old, new string) {
+	if !f.useRealFS {
+		panic("Can only use symlinks with a real FS")
+	}
+	err := os.Symlink(f.JoinPath(old), f.JoinPath(new))
+	assert.NoError(f.tb, err)
+}
+
 func (f *Fixture) UseRealFS() {
 	path, err := ioutil.TempDir("", tempdir.SanitizeFileName(f.tb.Name()))
 	require.NoError(f.tb, err)


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/ch6674/path:

308614ed38fc990021d2aa73a42b1f2d4a16399c (2020-04-29 18:17:27 -0400)
tiltfile: add a bunch of os.path functions, and fix bugs in os.path.realpath
Fixes https://github.com/windmilleng/tilt/issues/3173
Fixes https://github.com/windmilleng/tilt/issues/3086

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics