### PR TITLE
tiltfile: tweak os.path.exists to return false on permission denied

### DIFF
--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -175,6 +175,26 @@ print(result5)
 	assert.Equal(t, f.JoinPath("foo", "foo", "Tiltfile"), readState.Files[2])
 }
 
+func TestPermissionDenied(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Test relies on Unix /root permissions")
+	}
+	f := NewFixture(t)
+	f.UseRealFS()
+
+	f.File("Tiltfile", `
+print(os.path.exists('/root/x'))
+`)
+
+	model, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, "False\n", f.PrintOutput())
+
+	readState, err := io.GetState(model)
+	require.NoError(t, err)
+	assert.Equal(t, []string{f.JoinPath("Tiltfile")}, readState.Files)
+}
+
 func TestRealpath(t *testing.T) {
 	f := NewFixture(t)
 


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/exists:

01d200aa210029399cf06f8845f74f1f5e4dc238 (2020-04-30 15:47:32 -0400)
tiltfile: tweak os.path.exists to return false on permission denied

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics