### PR TITLE
circleci: upgrade integration tests to kind 0.8

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -41,6 +41,6 @@ RUN go get gotest.tools/gotestsum
 RUN apt update && apt install -y jq
 
 # install Kind (Kubernetes in Docker)
-RUN curl -fLo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64 \
+RUN curl -fLo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.8.0/kind-linux-amd64 \
   && chmod +x ./kind-linux-amd64 \
   && mv ./kind-linux-amd64 /go/bin/kind

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
 
   build-integration:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:67d6cb938c2333c1483cfc6afbf2ef08a95e937ef4feafe15f8a0adf02596a89
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:fc9ce82789419e2c507f79e799c94bf942714ff2cad79b433a0b351b860cec54
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -54,8 +54,15 @@ func TestEvent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.WaitUntil(ctx, "unschedulable pod event", func() (string, error) {
-		return f.logs.String(), nil
-	}, "had taints that the pod didn't tolerate")
+		logs := strings.Split(f.logs.String(), "\n")
+		for _, log := range logs {
+			if strings.Contains(log, "K8s EVENT") && strings.Contains(log, "the pod didn't tolerate") {
+				return "unschedulable event", nil
+			}
+		}
+
+		return "", nil
+	}, "unschedulable event")
 
 	markNodeSchedulable(f, node)
 

--- a/scripts/goreleaser.Dockerfile
+++ b/scripts/goreleaser.Dockerfile
@@ -6,6 +6,6 @@
 #
 # Built with goreleaser.
 
-FROM tiltdev/circleci-kind:v1.0.0
+FROM tiltdev/circleci-kind:v1.1.0
 
 COPY tilt /usr/local/bin/tilt


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/kind8:

532550e3107470bd29b1f02ee6473e7004fee91f (2020-05-01 16:35:04 -0400)
circleci: upgrade integration tests to kind 0.8

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics