### PR TITLE
engine: more gracefully handle equal time values

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -229,11 +229,15 @@ func EarliestPendingAutoTriggerTarget(targets []*store.ManifestTarget) *store.Ma
 	earliest := time.Now()
 
 	for _, mt := range targets {
-		ok, newTime := mt.State.HasPendingChangesBefore(earliest)
+		ok, newTime := mt.State.HasPendingChangesBeforeOrEqual(earliest)
 		if ok {
 			if !mt.Manifest.TriggerMode.AutoOnChange() {
 				// Don't trigger update of a manual manifest just b/c if has
 				// pending changes; must come through the TriggerQueue, above.
+				continue
+			}
+			if choice != nil && newTime.Equal(earliest) {
+				// If two choices are equal, use the first one in target order.
 				continue
 			}
 			choice = mt

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -269,14 +269,14 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		// Remove pending file changes that were consumed by this build.
 		for _, status := range ms.BuildStatuses {
 			for file, modTime := range status.PendingFileChanges {
-				if modTime.Before(bs.StartTime) {
+				if store.BeforeOrEqual(modTime, bs.StartTime) {
 					delete(status.PendingFileChanges, file)
 				}
 			}
 		}
 
 		if !ms.PendingManifestChange.IsZero() &&
-			ms.PendingManifestChange.Before(bs.StartTime) {
+			store.BeforeOrEqual(ms.PendingManifestChange, bs.StartTime) {
 			ms.PendingManifestChange = time.Time{}
 		}
 
@@ -305,7 +305,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		}
 
 		bestPod := ms.MostRecentPod()
-		if bestPod.StartedAt.After(bs.StartTime) ||
+		if store.AfterOrEqual(bestPod.StartedAt, bs.StartTime) ||
 			bestPod.UpdateStartTime.Equal(bs.StartTime) {
 			checkForContainerCrash(ctx, engineState, mt)
 		}
@@ -555,7 +555,7 @@ func handleConfigsReloaded(
 
 	// Remove pending file changes that were consumed by this build.
 	for file, modTime := range state.PendingConfigFileChanges {
-		if modTime.Before(state.TiltfileState.LastBuild().StartTime) {
+		if store.BeforeOrEqual(modTime, state.TiltfileState.LastBuild().StartTime) {
 			delete(state.PendingConfigFileChanges, file)
 		}
 	}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -516,7 +516,7 @@ func (mt *ManifestTarget) NextBuildReason() model.BuildReason {
 // Used to determine if changes to synced files or config files
 // should kick off a new build.
 func (ms *ManifestState) IsPendingTime(t time.Time) bool {
-	return !t.IsZero() && t.After(ms.LastBuild().StartTime)
+	return !t.IsZero() && AfterOrEqual(t, ms.LastBuild().StartTime)
 }
 
 // Whether changes have been made to this Manifest's synced files
@@ -526,22 +526,22 @@ func (ms *ManifestState) IsPendingTime(t time.Time) bool {
 // bool: whether changes have been made
 // Time: the time of the earliest change
 func (ms *ManifestState) HasPendingChanges() (bool, time.Time) {
-	return ms.HasPendingChangesBefore(time.Now())
+	return ms.HasPendingChangesBeforeOrEqual(time.Now())
 }
 
 // Like HasPendingChanges, but relative to a particular time.
-func (ms *ManifestState) HasPendingChangesBefore(highWaterMark time.Time) (bool, time.Time) {
+func (ms *ManifestState) HasPendingChangesBeforeOrEqual(highWaterMark time.Time) (bool, time.Time) {
 	ok := false
 	earliest := highWaterMark
 	t := ms.PendingManifestChange
-	if t.Before(earliest) && ms.IsPendingTime(t) {
+	if BeforeOrEqual(t, earliest) && ms.IsPendingTime(t) {
 		ok = true
 		earliest = t
 	}
 
 	for _, status := range ms.BuildStatuses {
 		for _, t := range status.PendingFileChanges {
-			if t.Before(earliest) && ms.IsPendingTime(t) {
+			if BeforeOrEqual(t, earliest) && ms.IsPendingTime(t) {
 				ok = true
 				earliest = t
 			}

--- a/internal/store/time.go
+++ b/internal/store/time.go
@@ -1,0 +1,16 @@
+package store
+
+import (
+	"time"
+)
+
+// Helper functions for comparing times in the store.
+// On Windows, time instants aren't monotonic, so we need to be
+// more tolerant of equal times.
+func AfterOrEqual(a, b time.Time) bool {
+	return a.After(b) || a.Equal(b)
+}
+
+func BeforeOrEqual(a, b time.Time) bool {
+	return a.Before(b) || a.Equal(b)
+}


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/ch4893/windows:

264039ba50f6cbe66765efcdd5d0e25b605df70a (2020-05-04 23:28:46 -0400)
engine: more gracefully handle equal time values
Fixes issues on Windows, where the clocks are not strictly monotonic,
and two consecutive time.Now() calls might return the same value

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics