### PR TITLE
windows: shell scripts should always use unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 **/testdata/* binary
+
+*.sh test eol=lf
+


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/lineendings:

f3f4c282b9af6d58b85f68202a8ffd3eda8527fc (2020-05-05 19:05:23 -0400)
windows: shell scripts should always use unix line endings

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics