### PR TITLE
fix an embarrassing typo in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 **/testdata/* binary
 
-*.sh test eol=lf
+*.sh text eol=lf
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/lineendings:

ce9c10d6b3d62684c2d0c104cb899c1ead37312e (2020-05-06 12:14:16 -0400)
fix an embarrassing typo in gitattributes

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics