### PR TITLE
cli: allow 'tilt ci' to use the --web-mode flag for serving local vs prod js

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -21,4 +21,5 @@ func addWebServerFlags(cmd *cobra.Command) {
 	addWebPortFlag(cmd)
 	cmd.Flags().StringVar(&webHost, "host", DefaultWebHost, "Host for the Tilt HTTP server and default host for any port-forwards. Set to 0.0.0.0 to listen on all interfaces.")
 	cmd.Flags().IntVar(&webDevPort, "webdev-port", DefaultWebDevPort, "Port for the Tilt Dev Webpack server. Only applies when using --web-mode=local")
+	cmd.Flags().Var(&webModeFlag, "web-mode", "Values: local, prod. Controls whether to use prod assets or a local dev server")
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -72,14 +72,13 @@ By default:
 This default behavior does not apply if the Tiltfile uses config.parse or config.set_enabled_resources.
 In that case, see https://tilt.dev/user_config.html and/or comments in your Tiltfile
 
-When you exit Tilt (using Ctrl+C), Kubernetes resources and Docker Compose resources continue running; 
-you can use tilt down (https://docs.tilt.dev/cli/tilt_down.html) to delete these resources. Any long-running 
+When you exit Tilt (using Ctrl+C), Kubernetes resources and Docker Compose resources continue running;
+you can use tilt down (https://docs.tilt.dev/cli/tilt_down.html) to delete these resources. Any long-running
 local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 `,
 	}
 
 	cmd.Flags().BoolVar(&c.watch, "watch", true, "If true, services will be automatically rebuilt and redeployed when files change. Otherwise, each service will be started once.")
-	cmd.Flags().Var(&webModeFlag, "web-mode", "Values: local, prod. Controls whether to use prod assets or a local dev server")
 	cmd.Flags().StringVar(&updateModeFlag, "update-mode", string(buildcontrol.UpdateModeAuto),
 		fmt.Sprintf("Control the strategy Tilt uses for updating instances. Possible values: %v", buildcontrol.AllUpdateModes))
 	cmd.Flags().StringVar(&c.traceTags, "traceTags", "", "tags to add to spans for easy querying, of the form: key1=val1,key2=val2")


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/cimode:

8fb1cf062923121e831b0673f20c8d8c45edec6f (2020-05-05 19:15:17 -0400)
cli: allow 'tilt ci' to use the --web-mode flag for serving local vs prod js

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics