### PR TITLE
store: clear pending files even on error builds

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -590,7 +590,7 @@ func TestBuildControllerManualTriggerWithFileChangesSinceLastSuccessfulBuildButB
 	f.store.Dispatch(server.AppendToTriggerQueueAction{Name: mName})
 	call := f.nextCallComplete()
 	state := call.oneState()
-	assert.Equal(t, []string{f.JoinPath("main.go")}, state.FilesChanged())
+	assert.Equal(t, []string{}, state.FilesChanged())
 	assert.True(t, state.ImageBuildTriggered)
 
 	f.WaitUntil("manifest removed from queue", func(st store.EngineState) bool {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -640,10 +640,9 @@ func TestRebuildWithChangedFiles(t *testing.T) {
 	// Simulate a change to b.go
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("b.go"))
 
-	// The next build should treat both a.go and b.go as changed, and build
-	// on the last successful result, from before a.go changed.
+	// The next build should only treat b.go as changed.
 	call = f.nextCallComplete("build on last successful result")
-	assert.Equal(t, []string{f.JoinPath("a.go"), f.JoinPath("b.go")}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{f.JoinPath("b.go")}, call.oneState().FilesChanged())
 	assert.Equal(t, "gcr.io/some-project-162817/sancho:tilt-1", call.oneState().LastLocalImageAsString())
 
 	err := f.Stop()

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -512,13 +512,6 @@ func (mt *ManifestTarget) NextBuildReason() model.BuildReason {
 	return reason
 }
 
-// Whether a change at the given time should trigger a build.
-// Used to determine if changes to synced files or config files
-// should kick off a new build.
-func (ms *ManifestState) IsPendingTime(t time.Time) bool {
-	return !t.IsZero() && AfterOrEqual(t, ms.LastBuild().StartTime)
-}
-
 // Whether changes have been made to this Manifest's synced files
 // or config since the last build.
 //
@@ -534,14 +527,14 @@ func (ms *ManifestState) HasPendingChangesBeforeOrEqual(highWaterMark time.Time)
 	ok := false
 	earliest := highWaterMark
 	t := ms.PendingManifestChange
-	if BeforeOrEqual(t, earliest) && ms.IsPendingTime(t) {
+	if !t.IsZero() && BeforeOrEqual(t, earliest) {
 		ok = true
 		earliest = t
 	}
 
 	for _, status := range ms.BuildStatuses {
 		for _, t := range status.PendingFileChanges {
-			if BeforeOrEqual(t, earliest) && ms.IsPendingTime(t) {
+			if !t.IsZero() && BeforeOrEqual(t, earliest) {
 				ok = true
 				earliest = t
 			}


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/pendingfiles:

63326b11462767611e4740c40d9ff31dfd53d2b5 (2020-05-06 12:39:24 -0400)
store: clear pending files even on error builds
This is a small code change, but should make the possible build control states
much easier to reason about and display.

This logic is vetigial from the days when we had fast_build and incremental
image builds. If your image build failed, and you wanted to retry it, then Tilt
would need to sync both the recently changed files and the files from the
*failed* build.

This can't really happen anymore where you have partial failed syncs.
If the sync step fails, we'll fall back to an image build.
If the run step fails, we don't need to re-sync the same files.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics