### PR TITLE
bump version to 0.13.5

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,7 @@ import (
 // For distributed binaries, version is automatically baked
 // into the binary with goreleaser. If this doesn't get updated
 // on every release, it's often not that big a deal.
-const devVersion = "0.13.4"
+const devVersion = "0.13.5"
 
 var commitSHA string
 var globalTiltInfo model.TiltBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 # When releasing Tilt, the releaser should update this version number
 # AFTER they upload new binaries.
-VERSION="0.13.4"
+VERSION="0.13.5"
 BREW=$(command -v brew)
 
 set -e


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch bump-v0.13.5:

66e83c16c014d1e9392e1d57acc9f5faf880d39d (2020-05-07 17:28:34 -0400)
bump version to 0.13.5

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics