### PR TITLE
tiltfile: support batch commands in the same way as Bazel and Buck

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -285,7 +285,7 @@ func (s *tiltfileState) parseOnly(val starlark.Value) ([]string, error) {
 
 func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var dockerRef string
-	var command string
+	var command string // TODO(nick): Parse command at a model.Cmd
 	var deps *starlark.List
 	var tag string
 	var disablePush bool

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -22,17 +22,18 @@ import (
 const localLogPrefix = " → "
 
 func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var commandValue starlark.Value
+	var commandValue, commandBatValue starlark.Value
 	quiet := false
 	err := s.unpackArgs(fn.Name(), args, kwargs,
 		"command", &commandValue,
 		"quiet?", &quiet,
+		"command_bat", &commandBatValue,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd, err := value.ValueToHostCmd(commandValue)
+	cmd, err := value.ValueGroupToCmdHelper(commandValue, commandBatValue)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -27,7 +27,7 @@ type localResource struct {
 
 func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var name string
-	var updateCmdVal, serveCmdVal starlark.Value
+	var updateCmdVal, updateCmdBatVal, serveCmdVal, serveCmdBatVal starlark.Value
 	var triggerMode triggerMode
 	var deps starlark.Value
 	var resourceDepsVal starlark.Sequence
@@ -43,6 +43,8 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		"ignore?", &ignoresVal,
 		"auto_init?", &autoInit,
 		"serve_cmd?", &serveCmdVal,
+		"cmd_bat?", &updateCmdBatVal,
+		"serve_cmd_bat?", &serveCmdBatVal,
 	); err != nil {
 		return nil, err
 	}
@@ -69,11 +71,11 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
-	updateCmd, err := value.ValueToHostCmd(updateCmdVal)
+	updateCmd, err := value.ValueGroupToCmdHelper(updateCmdVal, updateCmdBatVal)
 	if err != nil {
 		return nil, err
 	}
-	serveCmd, err := value.ValueToHostCmd(serveCmdVal)
+	serveCmd, err := value.ValueGroupToCmdHelper(serveCmdVal, serveCmdBatVal)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/telemetry/telemetry.go
+++ b/internal/tiltfile/telemetry/telemetry.go
@@ -26,13 +26,15 @@ func (Extension) OnStart(env *starkit.Environment) error {
 }
 
 func setTelemetryCmd(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var cmdVal starlark.Value
-	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "cmd", &cmdVal)
+	var cmdVal, cmdBatVal starlark.Value
+	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
+		"cmd", &cmdVal,
+		"cmd_bat?", &cmdBatVal)
 	if err != nil {
 		return starlark.None, err
 	}
 
-	cmd, err := value.ValueToHostCmd(cmdVal)
+	cmd, err := value.ValueGroupToCmdHelper(cmdVal, cmdBatVal)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -368,10 +368,20 @@ func ToHostCmd(cmd string) Cmd {
 		return Cmd{}
 	}
 	if runtime.GOOS == "windows" {
-		// from https://docs.docker.com/engine/reference/builder/#run
-		return Cmd{Argv: []string{"cmd", "/S", "/C", cmd}}
+		return ToBatCmd(cmd)
 	}
 	return ToUnixCmd(cmd)
+}
+
+// 🦇🦇🦇
+// Named in honor of Bazel
+// https://docs.bazel.build/versions/master/be/general.html#genrule.cmd_bat
+func ToBatCmd(cmd string) Cmd {
+	if cmd == "" {
+		return Cmd{}
+	}
+	// from https://docs.docker.com/engine/reference/builder/#run
+	return Cmd{Argv: []string{"cmd", "/S", "/C", cmd}}
 }
 
 func ToUnixCmd(cmd string) Cmd {


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/bat:

39f947801c713307434f03e1ff349535b57bfd66 (2020-05-08 18:44:28 -0400)
tiltfile: support batch commands in the same way as Bazel and Buck

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics