### PR TITLE
model: custom_build should be stored as a Cmd instead of a string, and support :bat:s

### DIFF
--- a/internal/build/custom_builder.go
+++ b/internal/build/custom_builder.go
@@ -34,9 +34,7 @@ func NewExecCustomBuilder(dCli docker.Client, clock Clock) *ExecCustomBuilder {
 func (b *ExecCustomBuilder) Build(ctx context.Context, refs container.RefSet, cb model.CustomBuild) (container.TaggedRefs, error) {
 	workDir := cb.WorkDir
 	expectedTag := cb.Tag
-
-	// TODO(nick): this should be stored in the data model as a Cmd
-	command := model.ToHostCmd(cb.Command)
+	command := cb.Command
 
 	skipsLocalDocker := cb.SkipsLocalDocker
 

--- a/internal/build/custom_builder_test.go
+++ b/internal/build/custom_builder_test.go
@@ -27,7 +27,7 @@ func TestCustomBuildSuccess(t *testing.T) {
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 0"}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 0")}
 	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestCustomBuildSuccessClusterRefTaggedWithDigest(t *testing.T) {
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["localhost:1234/foo_bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 0"}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 0")}
 	refs, err := f.cb.Build(f.ctx, refSetWithRegistryFromString("foo/bar", TwoURLRegistry), cb)
 	require.NoError(t, err)
 
@@ -55,7 +55,7 @@ func TestCustomBuildSuccessClusterRefWithCustomTag(t *testing.T) {
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:my-tag"] = types.ImageInspect{ID: string(sha)}
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 0", Tag: "my-tag"}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 0"), Tag: "my-tag"}
 	refs, err := f.cb.Build(f.ctx, refSetWithRegistryFromString("gcr.io/foo/bar", TwoURLRegistry), cb)
 	require.NoError(t, err)
 
@@ -67,7 +67,7 @@ func TestCustomBuildSuccessSkipsLocalDocker(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
 	defer f.teardown()
 
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 0", SkipsLocalDocker: true}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 0"), SkipsLocalDocker: true}
 	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	require.NoError(f.t, err)
 
@@ -79,7 +79,7 @@ func TestCustomBuildSuccessClusterRefTaggedIfSkipsLocalDocker(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
 	defer f.teardown()
 
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 0", SkipsLocalDocker: true}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 0"), SkipsLocalDocker: true}
 	refs, err := f.cb.Build(f.ctx, refSetWithRegistryFromString("foo/bar", TwoURLRegistry), cb)
 	require.NoError(f.t, err)
 
@@ -91,7 +91,7 @@ func TestCustomBuildCmdFails(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
 	defer f.teardown()
 
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 1"}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 1")}
 	_, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	// TODO(dmiller) better error message
 	assert.EqualError(t, err, "Custom build command failed: exit status 1")
@@ -101,7 +101,7 @@ func TestCustomBuildImgNotFound(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
 	defer f.teardown()
 
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 0"}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 0")}
 	_, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	assert.Contains(t, err.Error(), "fake docker client error: object not found")
 }
@@ -112,7 +112,7 @@ func TestCustomBuildExpectedTag(t *testing.T) {
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:the-tag"] = types.ImageInspect{ID: string(sha)}
-	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: "exit 0", Tag: "the-tag"}
+	cb := model.CustomBuild{WorkDir: f.tdf.Path(), Command: model.ToHostCmd("exit 0"), Tag: "the-tag"}
 	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestCustomBuilderExecsRelativeToTiltfile(t *testing.T) {
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
-	cb := model.CustomBuild{WorkDir: filepath.Join(f.tdf.Path(), "proj"), Command: "./build.sh"}
+	cb := model.CustomBuild{WorkDir: filepath.Join(f.tdf.Path(), "proj"), Command: model.ToHostCmd("./build.sh")}
 	refs, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb)
 	if err != nil {
 		f.t.Fatal(err)

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -399,7 +399,7 @@ func TestCustomBuildSkipsLocalDocker(t *testing.T) {
 	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build"] = types.ImageInspect{ID: string(sha)}
 
 	cb := model.CustomBuild{
-		Command:          "exit 0",
+		Command:          model.ToHostCmd("exit 0"),
 		Deps:             []string{f.JoinPath("app")},
 		SkipsLocalDocker: true,
 		Tag:              "tilt-build",

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -109,7 +109,7 @@ func NewSanchoCustomBuildImageTarget(fixture Fixture) model.ImageTarget {
 
 func NewSanchoCustomBuildImageTargetWithTag(fixture Fixture, tag string) model.ImageTarget {
 	cb := model.CustomBuild{
-		Command: "exit 0",
+		Command: model.ToHostCmd("exit 0"),
 		Deps:    []string{fixture.JoinPath("app")},
 		Tag:     tag,
 	}
@@ -125,7 +125,7 @@ func NewSanchoCustomBuildManifestWithTag(fixture Fixture, tag string) model.Mani
 
 func NewSanchoCustomBuildManifestWithLiveUpdate(fixture Fixture) model.Manifest {
 	cb := model.CustomBuild{
-		Command:    "exit 0",
+		Command:    model.ToHostCmd("exit 0"),
 		Deps:       []string{fixture.JoinPath("app")},
 		LiveUpdate: NewSanchoLiveUpdate(fixture),
 	}
@@ -138,7 +138,7 @@ func NewSanchoCustomBuildManifestWithLiveUpdate(fixture Fixture) model.Manifest 
 
 func NewSanchoCustomBuildManifestWithPushDisabled(fixture Fixture) model.Manifest {
 	cb := model.CustomBuild{
-		Command:     "exit 0",
+		Command:     model.ToHostCmd("exit 0"),
 		Deps:        []string{fixture.JoinPath("app")},
 		DisablePush: true,
 		Tag:         "tilt-build",

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5259,11 +5259,11 @@ func hotReload(on bool) hotReloadHelper {
 }
 
 type cmdHelper struct {
-	cmd string
+	cmd model.Cmd
 }
 
 func cmd(cmd string) cmdHelper {
-	return cmdHelper{cmd}
+	return cmdHelper{cmd: model.ToHostCmd(cmd)}
 }
 
 type workDirHelper struct {

--- a/pkg/model/custom_build_test.go
+++ b/pkg/model/custom_build_test.go
@@ -14,7 +14,7 @@ func TestEmptyLiveUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	cb := CustomBuild{
-		Command:    "true",
+		Command:    ToHostCmd("exit 0"),
 		Deps:       []string{"foo", "bar"},
 		LiveUpdate: lu,
 	}
@@ -27,7 +27,7 @@ func TestEmptyLiveUpdate(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	cb := CustomBuild{
-		Command: "true",
+		Command: ToHostCmd("exit 0"),
 		Deps:    []string{"foo", "bar"},
 	}
 	it := MustNewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).
@@ -38,7 +38,7 @@ func TestValidate(t *testing.T) {
 
 func TestDoesNotValidate(t *testing.T) {
 	cb := CustomBuild{
-		Command: "",
+		Command: ToHostCmd(""),
 		Deps:    []string{"foo", "bar"},
 	}
 	it := MustNewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -83,7 +83,7 @@ func (i ImageTarget) Validate() error {
 			return fmt.Errorf("[Validate] Image %q missing build path", confRef)
 		}
 	case CustomBuild:
-		if bd.Command == "" {
+		if bd.Command.Empty() {
 			return fmt.Errorf(
 				"[Validate] CustomBuild command must not be empty",
 			)
@@ -248,7 +248,7 @@ func (s DockerBuildTarget) String() string { return string(s) }
 
 type CustomBuild struct {
 	WorkDir string
-	Command string
+	Command Cmd
 	// Deps is a list of file paths that are dependencies of this command.
 	Deps []string
 


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/custombuild:

08fcd0edb100924ca3bf7db3a4e3c35a7cffba57 (2020-05-08 19:29:41 -0400)
model: custom_build should be stored as a Cmd instead of a string, and support :bat:s

39f947801c713307434f03e1ff349535b57bfd66 (2020-05-08 18:44:28 -0400)
tiltfile: support batch commands in the same way as Bazel and Buck

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics