### PR TITLE
upper: remove redundant+flaky init test

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2430,27 +2430,6 @@ func TestK8sEventDoNotLogNormalEvents(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestInitSetsTiltfilePath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(nick): investigate")
-	}
-	f := newTestFixture(t)
-	defer f.TearDown()
-
-	f.Start([]model.Manifest{})
-	f.store.Dispatch(InitAction{
-		EngineMode:   store.EngineModeApply,
-		TiltfilePath: "/Tiltfile",
-		StartTime:    f.Now(),
-	})
-	f.WaitUntil("tiltfile path gets set on init", func(st store.EngineState) bool {
-		return st.TiltfilePath == "/Tiltfile"
-	})
-
-	err := f.Stop()
-	assert.NoError(t, err)
-}
-
 func TestHudExitNoError(t *testing.T) {
 	f := newTestFixture(t)
 	f.Start([]model.Manifest{})


### PR DESCRIPTION
1. This test is flaky. `f.Start` dispatches an `InitAction` from a goroutine with one value for TiltfilePath, and the test itself dispatches its own `InitAction` with a different value for TiltfilePath, so when we check TiltfilePath at the end, we get the winner of a race.
2. This behavior is covered by [`TestUpperStart`](https://github.com/windmilleng/tilt/blob/947966d6638eeb07f04e4121751dc50036a14803/internal/engine/upper_test.go#L2768) anyway, so it's not worth fixing.