### PR TITLE
windows is no longer alpha. Fixes https://github.com/windmilleng/tilt/issues/1961

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,11 +17,14 @@ builds:
 archives:
 - name_template: "{{ .ProjectName }}.{{ .Version }}.{{ .Os }}.{{ .Arch }}"
   replacements:
-    windows: windows_ALPHA
+    windows: windows
     darwin: mac
     linux: linux
     386: i386
     amd64: x86_64
+  format_overrides:
+    - goos: windows
+      format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Hello @jazzdan, @victorwuky,

Please review the following commits I made in branch nicks/alpha:

f5345ef9cf32d291843fb399a6d2822a8f1b28ac (2020-05-13 18:05:28 -0400)
windows is no longer alpha. Fixes https://github.com/windmilleng/tilt/issues/1961

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics