### PR TITLE
testutils: ignore a spurious error

### DIFF
--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -162,7 +162,8 @@ func (f *TempDirFixture) TearDown() {
 
 	err := f.dir.TearDown()
 	if err != nil && runtime.GOOS == "windows" &&
-		strings.Contains(err.Error(), "The process cannot access the file") {
+		(strings.Contains(err.Error(), "The process cannot access the file") ||
+			strings.Contains(err.Error(), "Access is denied")) {
 		// NOTE(nick): I'm not convinced that this is a real problem.
 		// I think it might just be clean up of file notification I/O.
 	} else if err != nil {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/flake:

bcab97f47a54a584483a446b479e6526f26b3794 (2020-05-14 16:08:03 -0400)
testutils: ignore a spurious error

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics